### PR TITLE
test(simulation): harden oracle correctness, classifier, and CI coverage

### DIFF
--- a/.github/workflows/simulation-stress.yml
+++ b/.github/workflows/simulation-stress.yml
@@ -64,3 +64,153 @@ jobs:
             failure_report.json
             tmp/simulation.log
             tmp/simulation-attempt*.log
+
+  network-disconnect-simulation:
+    runs-on: ubuntu-latest
+    # 3 attempts × (90s sim + 15s cooldown + ~1m setup) ≈ 8m worst case; 12m gives headroom.
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build Simulation
+        run: go build -o tmp/simulation ./test/simulation/cmd/simulation
+      - name: Run Network-Disconnect Simulation
+        # Focused 90s config exercising both random and leader-targeted
+        # network-disconnect chaos events. Same 3-retry pattern as the
+        # comprehensive job to absorb timing flakes.
+        run: |
+          set +e
+          max_attempts=3
+          for attempt in $(seq 1 $max_attempts); do
+            echo "::group::Network-disconnect attempt $attempt/$max_attempts"
+            ./tmp/simulation \
+              --config test/simulation/configs/chaos_network_disconnect.yaml \
+              --duration 90s \
+              --cooldown 15s \
+              --stop-on-failure=false \
+              2>&1 | tee "tmp/network-attempt${attempt}.log"
+            rc=${PIPESTATUS[0]}
+            echo "::endgroup::"
+            if [ $rc -eq 0 ]; then
+              echo "Attempt $attempt succeeded"
+              cp "tmp/network-attempt${attempt}.log" tmp/network.log
+              exit 0
+            fi
+            echo "Attempt $attempt failed (exit $rc)"
+          done
+          cp "tmp/network-attempt${max_attempts}.log" tmp/network.log
+          exit 1
+      - name: Upload Failure Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-disconnect-failure-report
+          path: |
+            failure_report.json
+            tmp/network.log
+            tmp/network-attempt*.log
+
+  roundrobin-simulation:
+    runs-on: ubuntu-latest
+    # 3 attempts × (90s sim + 20s cooldown + ~1m setup) ≈ 9m worst case; 12m gives headroom.
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build Simulation
+        run: go build -o tmp/simulation ./test/simulation/cmd/simulation
+      - name: Run RoundRobin Chaos Simulation
+        # 90s RoundRobin assignment-strategy run under the comprehensive
+        # chaos workload — surfaces RoundRobin-specific bugs that the
+        # WeightedConsistentHash-only main job would miss.
+        run: |
+          set +e
+          max_attempts=3
+          for attempt in $(seq 1 $max_attempts); do
+            echo "::group::RoundRobin attempt $attempt/$max_attempts"
+            ./tmp/simulation \
+              --config test/simulation/configs/chaos_roundrobin.yaml \
+              --duration 90s \
+              --cooldown 20s \
+              --stop-on-failure=false \
+              2>&1 | tee "tmp/roundrobin-attempt${attempt}.log"
+            rc=${PIPESTATUS[0]}
+            echo "::endgroup::"
+            if [ $rc -eq 0 ]; then
+              echo "Attempt $attempt succeeded"
+              cp "tmp/roundrobin-attempt${attempt}.log" tmp/roundrobin.log
+              exit 0
+            fi
+            echo "Attempt $attempt failed (exit $rc)"
+          done
+          cp "tmp/roundrobin-attempt${max_attempts}.log" tmp/roundrobin.log
+          exit 1
+      - name: Upload Failure Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: roundrobin-failure-report
+          path: |
+            failure_report.json
+            tmp/roundrobin.log
+            tmp/roundrobin-attempt*.log
+
+  gate-on-simulation:
+    runs-on: ubuntu-latest
+    # 3 attempts × (5m sim + 30s cooldown + ~1m setup) ≈ 22m worst case; 25m gives headroom.
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build Simulation
+        run: go build -o tmp/simulation ./test/simulation/cmd/simulation
+      - name: Run Gate-On Chaos Simulation
+        # 5m run of chaos_gate.yaml — exercises enforce_exclusive_consumption
+        # end-to-end under chaos. Validates the refined cross-worker
+        # classifier (current-owner discriminator); zero ownership_violations,
+        # concurrent_owners, inconclusive, and post-chaos unobserved
+        # counters are the merge bar. See chaos_gate.yaml header for the
+        # known heartbeat-watcher blind spot that is intentionally
+        # out of scope for this job.
+        run: |
+          set +e
+          max_attempts=3
+          for attempt in $(seq 1 $max_attempts); do
+            echo "::group::Gate-on attempt $attempt/$max_attempts"
+            ./tmp/simulation \
+              --config test/simulation/configs/chaos_gate.yaml \
+              --cooldown 30s \
+              --stop-on-failure=false \
+              2>&1 | tee "tmp/gate-on-attempt${attempt}.log"
+            rc=${PIPESTATUS[0]}
+            echo "::endgroup::"
+            if [ $rc -eq 0 ]; then
+              echo "Attempt $attempt succeeded"
+              cp "tmp/gate-on-attempt${attempt}.log" tmp/gate-on.log
+              exit 0
+            fi
+            echo "Attempt $attempt failed (exit $rc)"
+          done
+          cp "tmp/gate-on-attempt${max_attempts}.log" tmp/gate-on.log
+          exit 1
+      - name: Upload Failure Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-on-failure-report
+          path: |
+            failure_report.json
+            tmp/gate-on.log
+            tmp/gate-on-attempt*.log

--- a/docs/plans/sim-oracle-phase1/00-plan.md
+++ b/docs/plans/sim-oracle-phase1/00-plan.md
@@ -1,0 +1,410 @@
+# Simulation Oracle — Phase 1 Bug Fixes
+
+Single-PR plan covering five small, independent fixes to the simulation's
+oracle correctness and observability. Derived from `tmp/sim_audit/SUMMARY.md`
+(specifically items **C1**, **C2**, **C3**, **C4**, and **H6**).
+
+## Why bundle these
+
+All five are:
+- Scoped to `test/simulation/` (one exception: a single deletion in the same
+  area in `test/simulation/internal/worker/worker.go`).
+- Independent — no shared state, no ordering between fixes.
+- Small (each ≤ ~30 LOC).
+- High-confidence — each has a concrete reproducer or a deterministic test.
+
+Bundling them avoids 5 separate review cycles for fixes that are all in the
+"oracle correctness" theme.
+
+## Out of scope
+
+- Migration of `worker.go` / `metrics/collector.go` from `internal/durable` to
+  the public `consumer/` package. This is Phase 2 (separate PR).
+- Stronger oracle invariants (per-message ownership audit, heartbeat watcher).
+  Phase 3.
+- CI expansion. Phase 4.
+- Any feature work beyond the five listed fixes.
+
+## Fixes
+
+### C1 — Tracker first-observation init swallows pre-seq losses + misclassifies out-of-order seq=1 as duplicate
+
+**File:** `test/simulation/internal/coordinator/tracker.go:164-178`
+
+**Current behavior:** On the first `RecordReceived` for a partition, the code
+unconditionally seeds `lastReceivedPerPartition[partitionID] = partitionSeq`
+without checking that `partitionSeq == 1`. Two failure modes:
+
+1. **False negative**: if producer's seq=1..N-1 are lost (e.g. worker crashed
+   before the reporting buffer existed), and the first message the tracker ever
+   sees for that partition is seq=N (N>1), seqs 1..N-1 are never recorded as
+   missing → never aged out → never counted as gaps. **The oracle cannot
+   detect loss of the first message(s) of any partition.**
+2. **False positive**: if seq=2 arrives before seq=1 at startup (legitimate
+   out-of-order delivery — JetStream does not guarantee ordering across
+   consumer subscription boundaries), `lastReceived=2` is seeded. When seq=1
+   then arrives, it hits the `partitionSeq <= lastReceived` branch and is
+   reported as `MessageDuplicateError`.
+
+**Fix:** Seed `lastReceivedPerPartition = 0` on first observation and fall
+through to the regular gap/duplicate detection logic. The regular logic:
+- If `partitionSeq == 1` (expected): advance contiguous window by one. ✓
+- If `partitionSeq > 1`: enter out-of-order branch, add `[1..partSeq-1]` to
+  `missingPerPartition`. ✓
+- If `partitionSeq <= 0`: impossible — producer starts at 1 (`producer.go:60-63,
+  136-137`).
+
+**Implementation sketch — two coordinated changes:**
+
+**Change 1: first-observation init.** Seed `lastReceived=0` and fall through.
+
+```go
+lastReceived, exists := t.lastReceivedPerPartition[partitionID]
+if !exists {
+    // Anchor at 0; let the regular path classify partitionSeq.
+    lastReceived = 0
+    t.lastReceivedPerPartition[partitionID] = 0
+    if _, ok := t.missingPerPartition[partitionID]; !ok {
+        t.missingPerPartition[partitionID] = make(map[int64]time.Time)
+    }
+    // No early return — fall through.
+}
+```
+
+**Change 2: range-fill must not re-add already-observed sequences.**
+Reviewer P0: without this, receiving seq=3, 4, 5 (in that order) with
+`lastReceived=0` would re-enter the out-of-order branch for each, and the
+range-fill loop at `tracker.go:198-203` would add seq=3 to `missingPerPartition`
+on the seq=4 receipt (because it iterates `[1, 4)` and seq=3 is not yet in
+missing). Seq=3 is then a phantom hole that blocks the window-advance loop at
+`tracker.go:265-276` (which stops at the first missing key) and is escalatable
+to a false gap by AgeOut.
+
+Fix the range-fill (`tracker.go:198-203`):
+
+```go
+miss := t.missingPerPartition[partitionID]
+now := time.Now()
+hwm := t.highWatermarkPerPartition[partitionID]
+for s := expectedSeq; s < partitionSeq; s++ {
+    if _, present := miss[s]; present {
+        continue // already tracked as missing
+    }
+    if s <= hwm {
+        continue // already physically observed out-of-order
+    }
+    miss[s] = now
+}
+```
+
+The `s <= hwm` guard is the load-bearing addition. The invariant: a sequence
+`s` such that `s <= hwm` and `s` is not in `missing` must have been physically
+observed out-of-order (the window-advance loop relies on the same invariant
+in the opposite direction).
+
+This guard is a no-op for the pre-fix scenario where the first observation
+seeded `lastReceived = firstSeq` — because then `expectedSeq = firstSeq + 1
+> hwm` and the loop body was previously unreachable for `s <= hwm`. So the
+guard only changes behavior in the new `lastReceived=0` path.
+
+**One subtle correctness point:** the existing massive-gap fast-forward branch
+(`gapSize > 10000`) at `tracker.go:213-220` will fire for any first observation
+with `partitionSeq > 10001`. That preserves current behavior (avoid OOM). Not
+changed in this fix.
+
+**Tests to add** in `tracker_test.go`:
+
+1. `TestRecordReceived_FirstSeqOutOfOrder`: send seq=2 then seq=1; assert seq=1
+   is **not** classified as duplicate; assert `lastReceivedPerPartition == 2`,
+   `holesHealedCount == 1`, no `MessageDuplicateError`.
+
+2. `TestRecordReceived_FirstObservationIsGap`: receive seq=3 then 4 then 5 (in
+   that order; before any of 1, 2 arrive). Assert:
+   - `missingPerPartition[pid]` is **exactly** `{1, 2}` (not `{1, 2, 3}` or
+     `{1, 2, 3, 4}`).
+   - `highWatermarkPerPartition[pid] == 5`.
+   - `physicalReceivedCount == 3`.
+   - `GapCount == 0` (still in aging window).
+   Then receive seq=1 and seq=2; assert:
+   - `lastReceivedPerPartition[pid] == 5` (full contiguous advance through 3,
+     4, 5 via window-advance loop).
+   - `holesHealedCount == 2`.
+   - `GapCount == 0`, `DuplicateCount == 0`.
+
+3. `TestRecordReceived_FirstSeqIsOne` (regression): send seq=1 first; assert
+   `lastReceivedPerPartition[partitionID] == 1`, `physicalReceivedCount == 1`,
+   no error.
+
+4. `TestRecordReceived_FirstObsGap_AgedOut`: receive seq=3, 4, 5 (as above),
+   call `AgeOut(now + GapAging)`, assert exactly seqs 1 and 2 are escalated to
+   gaps (seqs 3, 4, 5 not escalated, despite never having been "contiguously
+   advanced past" when AgeOut fires). This proves the phantom-hole regression
+   from the reviewer.
+
+### C2 — Add `AckWait < GapAging` invariant check at config validation
+
+**Files:**
+- `test/simulation/internal/worker/worker.go:258` (AckWait currently hardcoded)
+- `test/simulation/internal/config/config.go` (new field)
+- `test/simulation/internal/config/defaults.go` (default 30s)
+- `test/simulation/internal/config/validation.go` (cross-check)
+- `test/simulation/configs/stress-short-aggressive.yaml:51`
+- `test/simulation/configs/stress-5m-aggressive.yaml:51`
+- `test/simulation/configs/stress-short-quick.yaml:51`
+
+**Current behavior:** Worker hardcodes `AckWait: 30s`. Three configs set
+`gap_aging` ≤ 30s:
+- `stress-5m-aggressive.yaml`: gap_aging=20s ← violation
+- `stress-short-aggressive.yaml`: gap_aging=20s ← violation
+- `stress-short-quick.yaml`: gap_aging=30s ← racy (equal)
+
+When `AckWait >= GapAging`, JetStream's redelivery window for a worker-crashed
+message exceeds the coordinator's hole-escalation window. The coordinator
+escalates the hole to a confirmed gap BEFORE JetStream redelivers it. With
+`--stop-on-failure` enabled, this kills the simulation on a hole that would
+have healed.
+
+**Fix design (two parts):**
+
+1. **Make AckWait configurable** on the simulation side. Add
+   `Workers.AckWait time.Duration` with default 30s. Replace the hardcoded
+   `AckWait: 30 * time.Second` in `worker.go:258` with `cfg.AckWait`. Plumb
+   through `worker.Config`.
+
+2. **Add validation** in `validation.go`:
+   ```go
+   if cfg.Workers.AckWait >= cfg.Coordinator.GapAging {
+       return fmt.Errorf("workers.ack_wait (%s) must be < coordinator.gap_aging (%s) "+
+           "to avoid false-positive gap escalations during JetStream redelivery",
+           cfg.Workers.AckWait, cfg.Coordinator.GapAging)
+   }
+   ```
+
+3. **Fix the three offending configs**: lower their `workers.ack_wait` to
+   preserve their fast-detection intent rather than relaxing gap_aging.
+   - stress-5m-aggressive: ack_wait=10s (gap_aging stays 20s)
+   - stress-short-aggressive: ack_wait=10s (gap_aging stays 20s)
+   - stress-short-quick: ack_wait=15s (gap_aging stays 30s)
+
+**Tests to add (expanded per reviewer):**
+
+1. In `config/validation_test.go` (create if missing):
+   - `TestValidate_AckWaitGteGapAging_Rejects`: build a minimal valid config,
+     set `Workers.AckWait = 30s` and `Coordinator.GapAging = 30s`; assert
+     validation fails with a message naming both fields. Repeat for
+     `AckWait = 30s, GapAging = 20s` (strict inequality).
+   - `TestValidate_AckWaitLtGapAging_Passes`: `AckWait = 10s,
+     GapAging = 30s`; assert no validation error.
+   - `TestValidate_AckWaitOmitted_AppliesDefault`: leave `Workers.AckWait`
+     unset (zero), call `applyDefaults` then `validateConfig`. The defaulted
+     value (30s) must be visible to validation. If `GapAging` is set to 20s
+     in this test, validation must fail — proving B2 cannot be reintroduced
+     by an omitted field.
+
+2. `TestAllShippedConfigsValidate`: iterate every file in
+   `test/simulation/configs/*.yaml`, load + apply defaults + validate. Assert
+   no error for any file. This catches yaml drift introduced by the AckWait
+   addition and verifies `chaos_comprehensive.yaml` (the only CI config) is
+   not affected — its `gap_aging: 240s` is well above the default 30s
+   AckWait.
+
+### C3 — Trace visualizer JSON tags don't match coordinator's output
+
+**File:** `scripts/trace_visualizer/main.go:23-28`
+
+**Current behavior:** Visualizer's `MessageGapError` uses UpperCamelCase JSON
+tags (`PartitionID`, `ExpectedSeq`, …). The coordinator writes snake_case
+(`tracker.go:18-23`). Every field decodes to zero; partition filter targets
+partition 0; output is misleading or empty.
+
+**Fix:** Change the visualizer's JSON tags to snake_case to match
+`coordinator.MessageGapError`. Single-file change.
+
+```go
+type MessageGapError struct {
+    PartitionID int   `json:"partition_id"`
+    ExpectedSeq int64 `json:"expected_seq"`
+    ReceivedSeq int64 `json:"received_seq"`
+    LastSent    int64 `json:"last_sent"`
+}
+```
+
+**Tests to add:** A small `scripts/trace_visualizer/main_test.go` (or co-located
+package test) that JSON-decodes a minimal coordinator-shape report and asserts
+the fields are populated. Coordinator's `FailureReport` is already snake_case
+(written via `json.MarshalIndent` to `failure_report.json`), so the test fixture
+can be a small JSON blob inline.
+
+### C4 — `worker.go` `HandoffTTL = 0` is dead code; load-bearing path is in `main.go`
+
+**Files:**
+- `test/simulation/internal/worker/worker.go:198-206` (dead code — delete)
+- `test/simulation/cmd/simulation/main.go:222-227` (load-bearing — clarify
+  comment, do not delete)
+
+**The full picture** (post-reviewer correction):
+
+The simulation has two places that touch `KVBuckets.HandoffTTL`:
+
+1. **`worker.go:198-206`** — sets `partiCfg.KVBuckets.HandoffTTL = 0` on the
+   `parti.Config` passed to `parti.NewManager`. This is a **silent no-op**:
+   `NewManager` calls `parti.SetDefaults` which re-applies the struct-tag
+   default `2m` over the zero value (`config.go:421-426`, empirically
+   verified). The manager runs with `HandoffTTL = 2m` in memory, and
+   `Config.Validate()` (`config.go:515-522`) sees `2m` and passes. This
+   line of code does nothing.
+
+2. **`main.go:222-227`** — pre-creates the `parti-handoff` JetStream KV bucket
+   with TTL=0 via `kvutil.EnsureKVBucket(... b.ttl)` at line 241. **This is the
+   load-bearing path.** `kvutil/bucket.go:48-53` opens an existing bucket
+   without reconciling its config, so the bucket's storage-level TTL stays at
+   what main.go created (= 0, i.e. never expires). Manager startup later calls
+   `setupHandoff` with the defaulted-to-2m in-memory `cfg.KVBuckets.HandoffTTL`,
+   but the existing bucket is opened as-is — the 2m hint is never written to
+   JetStream.
+
+Net runtime state: the bucket really *does* have TTL=0 (claims persist until
+superseded), driven entirely by `main.go`. `worker.go`'s assignment is dead.
+
+**Fix:** Delete the `worker.go` `HandoffTTL = 0` line and the misleading
+multi-line comment that suggests it controls anything. Keep
+`EnableTwoPhaseHandoff = cfg.EnforceExclusiveConsumption`. In `main.go`, leave
+the pre-create behavior untouched (it's the actual intent) but tighten the
+comment to make it clear that **this is the line that disables JetStream KV
+TTL**, and that the manager-level `HandoffTTL` config field is purely advisory
+once the bucket exists.
+
+**Why we are not "fixing" main.go to align with manager config:** the
+simulation's documented intent (per the comment author and per the audit
+itself) is to have non-expiring handoff claims for correctness under long
+runs. Aligning the simulation manager config to 2m would alter behavior; that
+is a Phase 4 question, not Phase 1.
+
+**Tests to add:**
+None. C4 is a code-clarity fix only. Adding an integration test that asserts
+the bucket's effective TTL would require constructing the simulation's
+embedded NATS server and calling `js.KeyValueStatus(ctx, "parti-handoff")` —
+disproportionate for a comment cleanup. If a future fix changes the
+runtime behavior, the test can be added then.
+
+### H6 — `startLatencyCh` non-blocking send silently drops samples
+
+**File:** `test/simulation/internal/worker/worker.go:427-434`
+
+**Current behavior:**
+```go
+select {
+case w.startLatencyCh <- coordinator.StartLatencyReport{...}:
+default:
+    log.Printf("[%s] startLatencyCh full, dropping first-assignment latency=%s", ...)
+}
+```
+
+The channel has buffer 256 (`coordinator.go:180`). `SlowStartExceedances()`
+gates pass/fail in the final report (`cmd/simulation/main.go:706-709`). Under
+chaos bursts where many workers fire `OnAssignmentChanged` simultaneously and
+the assignment-processing goroutine is slow, samples can be dropped — silently
+hiding regressions of the slow-start invariant the channel exists to enforce.
+
+**Fix:** Replace the non-blocking select with a blocking send that respects
+`ctx.Done()`:
+```go
+select {
+case <-ctx.Done():
+case w.startLatencyCh <- coordinator.StartLatencyReport{
+    WorkerID: w.id,
+    Latency:  latency,
+}:
+}
+```
+
+This matches the symmetric pattern already in use for `assignmentReportCh`
+at `worker.go:450-453`. The blocking send is safe because the hook itself runs
+in the manager's goroutine and is allowed to be slow; back-pressure is
+acceptable.
+
+**Tests to add (revised per reviewer P1 — the naive test deadlocks):**
+
+The proposed blocking send with a zero-buffer channel and a single-threaded
+test will deadlock by construction. Specify two concurrent tests with
+timeouts.
+
+1. `TestHandleAssignmentChanged_BlockingSendDelivers`: zero-buffer
+   `startLatencyCh`. Receive in the test goroutine; call
+   `handleAssignmentChanged` in a separate goroutine. Use a `time.After(1s)`
+   guard to fail if the receive does not complete. Assert exactly one
+   `StartLatencyReport` arrives with the expected `WorkerID`.
+
+2. `TestHandleAssignmentChanged_CancellationDoesNotWedge`: zero-buffer
+   `startLatencyCh`, no receiver. Cancel `w.ctx` *before* calling
+   `handleAssignmentChanged`. Assert the call returns within a short timeout
+   (e.g. 100ms) — proving the new blocking send respects `ctx.Done()` and
+   does not wedge shutdown.
+
+Together these prove (1) no-drop on slow drainer, and (2) no wedge on
+shutdown.
+
+## Implementation order
+
+Independent fixes; any order works. Suggested for minimal cognitive load:
+
+1. **C4** — pure deletion, 5 lines.
+2. **C3** — pure JSON tag rename, 4 lines + test fixture.
+3. **H6** — replace `default:` with `case <-ctx.Done():`, 3 lines + test.
+4. **C2** — config plumbing + validation + 3 yaml updates, ~30 LOC + test.
+5. **C1** — tracker first-observation fix + 3 tracker tests, ~10 LOC.
+
+## Verification
+
+Before declaring complete:
+- `make lint` clean.
+- `make test` clean (full unit suite).
+- `go test ./test/simulation/...` clean.
+- New tests fail on the parent commit and pass on the fix (verify-first per
+  memory `feedback_verify_first_with_reproducer`).
+- `go build ./test/simulation/...` clean.
+
+## Risks and non-risks
+
+- **Risk (C1):** The fall-through path now executes `physicalReceivedCount++`
+  in different branches depending on whether partitionSeq is 1 (contiguous)
+  or > 1 (out-of-order). Current code only counted once on first observation.
+  Audit confirms both new paths increment physicalReceivedCount exactly once
+  per call, so the count remains correct.
+- **Risk (C2):** Lowering AckWait in aggressive configs trades JetStream
+  redelivery latency for faster oracle escalation. Configs are aggressive by
+  design; this is the intent.
+- **Non-risk (H6):** The blocking send back-pressures only the
+  OnAssignmentChanged hook. The manager's hook callsite already tolerates
+  arbitrary hook duration; nothing else in the worker depends on the hook
+  returning quickly.
+
+## Commit message (draft)
+
+```
+fix(simulation): correct oracle false positives/negatives and clean up dead config code
+
+Five small bugs in test/simulation/ surfaced by an oracle-correctness audit:
+
+- tracker: first-observation init swallowed pre-seq losses and misclassified
+  out-of-order seq=1 as a duplicate. Seed lastReceived=0 so the regular
+  out-of-order path classifies the first observation correctly.
+
+- config: add AckWait < GapAging cross-validation. Three aggressive configs
+  violated the invariant by setting gap_aging < hardcoded AckWait=30s,
+  causing false-positive gap escalations under chaos. Make AckWait
+  configurable; fix the offending configs to preserve their aggressive intent.
+
+- scripts/trace_visualizer: JSON tags were UpperCamelCase but coordinator
+  writes snake_case. All fields decoded to zero; partition filter always
+  targeted partition 0. Visualizer is now functional.
+
+- worker: HandoffTTL=0 was a silent no-op (parti.SetDefaults re-applies the
+  2m default). Delete the misleading code; the simulation has always run with
+  the 2m default.
+
+- worker: startLatencyCh non-blocking send silently dropped samples under
+  chaos bursts, blinding the SlowStartExceedances invariant. Replace with
+  a blocking send that respects ctx.Done(), matching the pattern already
+  used for assignmentReportCh.
+```

--- a/docs/plans/sim-oracle-phase1/01-review-response.md
+++ b/docs/plans/sim-oracle-phase1/01-review-response.md
@@ -1,0 +1,51 @@
+# Review Response — Round 1
+
+Source: `tmp/sim-oracle-phase1_review.md` (2026-05-18, codex xhigh).
+
+## P0 — C1 phantom holes (accepted, plan updated)
+
+The reviewer's failure case is correct: receive seq=3, 4, 5 before seq=1, 2.
+With the proposed `lastReceived=0` anchor alone, the seq=4 receipt's
+range-fill loop iterates `[1, 4)` and adds seq=3 to `missingPerPartition`
+(it's not yet in missing). Seq=3 then blocks the window-advance loop at
+`tracker.go:265-276` even after seqs 1, 2 heal.
+
+**Fix applied** in plan §C1:
+- Added Change 2: range-fill skips `s` when `s <= oldHWM && !already-missing`.
+- Hardened test `TestRecordReceived_FirstObservationIsGap` to assert the
+  missing set is **exactly** {1, 2} and final `lastReceived == 5`.
+- Added `TestRecordReceived_FirstObsGap_AgedOut` to exercise AgeOut and
+  confirm no phantom-hole gap escalation.
+
+## P1 — C4 main.go pre-create path (accepted, plan rewritten)
+
+The reviewer is right that `cmd/simulation/main.go:227` pre-creates the
+handoff bucket with `pc.KVBuckets.HandoffTTL = 0`, and `kvutil/bucket.go:48-53`
+does not reconcile config for existing buckets. So the JetStream bucket
+really *is* created with TTL=0, persisting until superseded — which is the
+simulation's documented intent.
+
+**Fix applied** in plan §C4:
+- Rewrote the section to distinguish the two paths.
+- `worker.go` deletion (dead code) confirmed as the only Phase 1 action.
+- `main.go` left as-is, but the comment is tightened to make it clear that
+  this is the load-bearing line.
+
+## P1 — H6 test deadlock (accepted, tests rewritten)
+
+The naive test (zero-buffer channel + blocking send + single goroutine)
+deadlocks. Replaced with two concurrent tests:
+
+1. `TestHandleAssignmentChanged_BlockingSendDelivers` — receive concurrently,
+   assert delivery via `time.After(1s)` guard.
+2. `TestHandleAssignmentChanged_CancellationDoesNotWedge` — cancel ctx,
+   assert handler returns within 100ms.
+
+Together these prove no-drop + no-wedge.
+
+## Reviewer's additional tests (accepted)
+
+- C2 yaml-validation test added.
+- C2 defaulting-regression test added (omitted `ack_wait`, low `gap_aging`,
+  must still fail validation).
+- C1 AgeOut phantom-hole test added.

--- a/docs/plans/sim-oracle-phase2/00-plan.md
+++ b/docs/plans/sim-oracle-phase2/00-plan.md
@@ -1,0 +1,237 @@
+# Simulation — Phase 2: Consumer Package Migration
+
+Single-PR plan to migrate `test/simulation/` off the `internal/durable` package
+and onto the public `consumer/` package. This is a follow-up to Phase 1
+(merged in the prior commits on this branch); it addresses the two CLAUDE.md
+compliance items called out in the simulation audit (C5 and M10 in
+`tmp/sim_audit/SUMMARY.md`, which is generated artifact under `tmp/` and not
+checked in — the migration table below is self-contained and authoritative
+for this plan).
+
+## Why
+
+CLAUDE.md is explicit: "Internal packages under `internal/` are private
+implementation details — do not reference them in public API or docs." The
+simulation has two `internal/durable` imports:
+
+- `test/simulation/internal/worker/worker.go:19` — `durable.WorkerConsumerConfig`,
+  `durable.ProcessingGateConfig`, `durable.NewWorkerConsumer`.
+- `test/simulation/internal/metrics/collector.go:8` — `durable.GateMetrics`,
+  `durable.ResolverMetrics`, `durable.AuditResult`.
+
+Both have public equivalents in `consumer/` and `consumer/metrics.go`. Migration
+is **purely mechanical** — no behavior change. The migration table below is
+authoritative.
+
+Beyond CLAUDE.md compliance, the migration:
+
+- Unblocks Phase 3 (oracle strengthening) and Phase 5 (new public-API features
+  via yaml flags) — most of those phases only need to plumb additional
+  `consumer.With*` options once the simulation consumes the public package.
+- Routes capability reporting through the public type. The current durable
+  updater already reports `CapProcessingGate` (`internal/durable/worker_consumer.go:693`,
+  `:712`) and the manager already picks that up via the structural
+  `CapabilityReporter` interface (`manager.go:774`, `:800`); `*consumer.Dynamic`
+  is a thin wrapper that forwards `Capabilities()` (`consumer/dynamic.go:329-334`).
+  No new reporting bits appear after migration — same path, public type.
+
+## Out of scope
+
+- Adding new feature coverage (memory-storage, recovery-strategy yaml flags,
+  resolver tuning). Those are Phase 5.
+- Removing the dead `Late/Lost/Failures` audit-metric read paths in
+  `cmd/simulation/main.go:655-714`. They will continue to read zero (since
+  `RecordDrainAudit` is being deleted), which preserves current behavior.
+  Their removal is a separate cleanup task.
+- Any change in the consumer's runtime behavior. Every option currently set
+  must continue to be set with the same value.
+
+## The migration
+
+### Worker (`test/simulation/internal/worker/worker.go`)
+
+**Remove:**
+- `"github.com/arloliu/parti/v2/internal/durable"` import.
+
+**Add:**
+- `"github.com/arloliu/parti/v2/consumer"` import.
+
+**Replace** the existing `durable.WorkerConsumerConfig{...}` struct literal +
+`durable.NewWorkerConsumer(js, helperConfig, worker.processMessage)` call
+(`worker.go:236-322`) with `consumer.NewDynamic(...)` using functional options.
+Mapping (every field currently set in the worker; this table is the
+authoritative reference for the migration):
+
+| Old (durable.WorkerConsumerConfig field) | New |
+|---|---|
+| `ConsumerPrefix:  "simulation"` | positional arg #3 of `NewDynamic` |
+| `SubjectTemplate: "simulation.partition.{{.PartitionID}}"` | positional arg #4 |
+| `StreamName:      "SIMULATION"` | positional arg #2 |
+| `Logger:          logger` | `consumer.WithLogger(logger)` |
+| `ManualAck:       true` | `consumer.WithManualAck(true)` |
+| `BatchSize:       cfg.ConsumerBatchSize` | `consumer.WithBatchSize(cfg.ConsumerBatchSize)` |
+| `FetchTimeout:    1 * time.Second` | `consumer.WithFetchTimeout(1*time.Second)` |
+| `DrainOnRemove:   true` | `consumer.WithDrainOnRemove(true, 0)` (timeout=0 → durable defaults) |
+| `MaxDeliver:      50` | `consumer.WithMaxDeliver(50)` |
+| `AckWait:         cfg.AckWait` | `consumer.WithAckWait(cfg.AckWait)` |
+| `MaxWaiting:      2` | `consumer.WithMaxWaiting(2)` |
+| `MaxAckPending:   perSubMaxAckPending` | `consumer.WithMaxAckPending(perSubMaxAckPending)` |
+| `PullGatingEnabled: true` | `consumer.WithPullGating(true)` |
+| `ProcessingGate: pg` (only when `EnforceExclusiveConsumption`) | `consumer.WithProcessingGate(&consumer.ProcessingGateConfig{...})` |
+
+The handler signature `func(ctx context.Context, msg jetstream.Msg) error`
+matches `consumer.MessageHandlerFunc`. Pass
+`consumer.MessageHandlerFunc(worker.processMessage)` as the handler argument.
+
+**Processing-gate config:** copy field-for-field from `durable.ProcessingGateConfig`
+to `consumer.ProcessingGateConfig`. Identical field set (Enabled, AllowedStates,
+WarmupDuration, WarmupAllowedStates, NakDelay, NakJitter, Debug, Metrics).
+`Metrics` field type changes from `durable.GateMetrics` to `consumer.GateMetrics` —
+the collector adapter return type change (below) lines this up.
+
+**Updater wiring:**
+- Worker's `updater parti.WorkerConsumerUpdater` field stays.
+- Add a typed `dynamic *consumer.Dynamic` field for the Stop call (since the
+  `parti.WorkerConsumerUpdater` interface doesn't expose Stop/Close).
+- Assign both: `dynamic := consumer.NewDynamic(...); worker.updater = dynamic; worker.dynamic = dynamic`.
+
+**Resolver metrics:**
+- `updater.SetResolverMetrics(...)` becomes `dynamic.SetResolverMetrics(...)`.
+- Adapter return type is now `consumer.ResolverMetrics` (see Collector change).
+
+**Shutdown:**
+- The current code at `worker.go:669-671` does a type assertion:
+  ```go
+  if c, ok := w.updater.(interface{ Close(context.Context) error }); ok {
+      _ = c.Close(context.Background())
+  }
+  ```
+  `*consumer.Dynamic` exposes `Stop(ctx) error` instead of `Close`. Replace the
+  type assertion with a direct `if w.dynamic != nil { _ = w.dynamic.Stop(ctx) }`.
+
+### Metrics collector (`test/simulation/internal/metrics/collector.go`)
+
+**Remove:**
+- `"github.com/arloliu/parti/v2/internal/durable"` import.
+
+**Add:**
+- `"github.com/arloliu/parti/v2/consumer"` import.
+
+**Adapter return-type changes** (interfaces are method-set identical; no
+implementation changes required):
+- `GateMetricsAdapter() durable.GateMetrics` → `consumer.GateMetrics`.
+- `ResolverMetricsAdapter() durable.ResolverMetrics` → `consumer.ResolverMetrics`.
+
+**Delete `RecordDrainAudit`** (line 856-898). It has no callers outside its
+own definition (`grep -rn RecordDrainAudit test/simulation/` returns only the
+definition line). The function takes `[]durable.AuditResult` — a type with
+**no public equivalent** in `consumer/` — so keeping it would force us to
+keep the internal-package import.
+
+Side effects of deleting `RecordDrainAudit`:
+- The metric fields `lateMessagesTotal`, `lostMessagesTotal`,
+  `auditDurationSeconds`, `auditFailuresTotal`, `holesOpen` are **kept**:
+  they are registered with the Prometheus collector at construction
+  (`collector.go:477-505`) and the read methods `GetLateMessagesTotal`,
+  `GetLostMessagesTotal`, `GetAuditFailuresTotal` are called from
+  `test/simulation/cmd/simulation/main.go:659-661, 707-709`. They will keep
+  returning 0 (since nothing increments them now or before). This preserves
+  current observable behavior; only the unused write path goes away.
+- A future Phase 3 task may remove the dead read paths in main.go and the
+  unused counters. Marked out-of-scope for Phase 2 to keep the diff small.
+
+## Risks and verification
+
+**Risk 1: Option mapping drift.** If any option's semantics differ between
+`durable.WorkerConsumerConfig.X` and `consumer.WithX(...)`, behavior changes.
+Mitigation: the migration table is verbatim from the audit; each row is a
+1:1 mechanical replacement. `consumer/dynamic.go:194-227` shows that
+`NewDynamic` builds the same `CommonConfig + DynamicConfig` fields, then
+forwards them into a `durable.WorkerConsumerConfig` via `toSubscriptionGateConfig`
+and `toSubscriptionResolverConfig`. So the public path is a thin wrapper over
+the same internal types we're leaving behind.
+
+**Risk 2: ResolverConfig defaults.** Worker currently constructs
+`durable.WorkerConsumerConfig` with no explicit `Resolver` field. After
+migration, `consumer.NewDynamic` applies a default-zero `consumer.ResolverConfig`
+which is translated by `toSubscriptionResolverConfig`. Verify the translated
+defaults match what the worker had before. (Empirically: both paths produce
+the same default resolver since neither sets a value.)
+
+**Risk 3: Capability reporting.** Not a risk — `*consumer.Dynamic.Capabilities()`
+forwards to the same inner `*durable.WorkerConsumer.Capabilities()` that the
+manager already observes today through the existing structural-interface match
+on the durable updater. The migration preserves the reporting path; nothing
+new appears on the heartbeat.
+
+**Risk 4: Test breakage from updater type change.** The leak tests, chaos
+scenario tests, and other unit tests use `worker.NewWorker(cfg).updater`
+indirectly via worker behavior. The migration changes the concrete type but
+the interface (`parti.WorkerConsumerUpdater`) is the same. No test changes
+expected; rerun the full suite to confirm.
+
+**Verification gates** (all must pass before declaring complete):
+1. `grep -rn "internal/durable" test/simulation/` returns **zero** matches.
+2. `go build ./test/simulation/...` clean.
+3. `make lint` clean.
+4. `make test` clean.
+5. `go test ./test/simulation/... ./scripts/...` clean.
+6. **Behavioral spot-check**: run `./bin/simulation -config configs/dev.yaml`
+   for ~30s and confirm no `panic`, no new errors in the log, and the
+   periodic report still prints sane numbers. (Optional if the unit suite
+   is comprehensive; document if skipped.)
+
+## Implementation order
+
+Single PR, mechanical. Suggested order:
+
+1. **Collector adapter return types** first (it's the dependency for worker).
+   - Change `GateMetricsAdapter`/`ResolverMetricsAdapter` return types.
+   - Delete `RecordDrainAudit`.
+   - Drop the `internal/durable` import.
+   - Build will fail in worker.go until step 2.
+
+2. **Worker migration**:
+   - Replace `durable.WorkerConsumerConfig{...}` literal with the `consumer.With*`
+     options chain.
+   - Replace `durable.NewWorkerConsumer(...)` with `consumer.NewDynamic(...)`.
+   - Replace `durable.ProcessingGateConfig` with `consumer.ProcessingGateConfig`.
+   - Add typed `dynamic *consumer.Dynamic` field; assign both updater and dynamic.
+   - Replace the `interface{ Close }` type assertion in Stop with
+     `w.dynamic.Stop(ctx)`.
+   - Drop the `internal/durable` import.
+
+3. **Lint + test** — run all five verification gates listed above.
+
+4. **Optional behavioral spot-check** — short dev.yaml run if there's
+   ambient doubt about the option mapping.
+
+## Commit message (draft)
+
+```
+refactor(simulation): migrate from internal/durable to public consumer package
+
+Removes the two CLAUDE.md-forbidden internal-package imports from
+test/simulation/ and routes the worker through the public consumer.NewDynamic
+factory. No behavior change — every option that was set on
+durable.WorkerConsumerConfig is now set via the equivalent consumer.With*
+option per the migration table in docs/plans/sim-oracle-phase2/00-plan.md.
+
+- worker.go: durable.NewWorkerConsumer → consumer.NewDynamic with functional
+  options. durable.ProcessingGateConfig → consumer.ProcessingGateConfig.
+  Replaces the interface-assertion Close on shutdown with a typed
+  *consumer.Dynamic.Stop(ctx) call.
+
+- metrics/collector.go: GateMetricsAdapter and ResolverMetricsAdapter now
+  return consumer.{Gate,Resolver}Metrics (interface method sets are
+  identical to the durable counterparts). RecordDrainAudit is deleted — it
+  had no callers outside its own definition and was the only consumer of
+  durable.AuditResult, which has no public twin. The Late/Lost/Failures
+  Prometheus counters and their Get*-method read paths remain in place;
+  they continue to return 0 as before.
+
+Capability reporting path is preserved: *consumer.Dynamic.Capabilities()
+forwards to the same inner *durable.WorkerConsumer that the manager
+already reads today, so this is a wrapper substitution, not new
+observable behavior.
+```

--- a/docs/plans/sim-oracle-phase3/00-plan.md
+++ b/docs/plans/sim-oracle-phase3/00-plan.md
@@ -1,0 +1,427 @@
+# Simulation — Phase 3a: Ownership-Violation Detection (H1 + M1)
+
+Single-PR plan to give the simulation oracle a way to distinguish a
+**legitimate JetStream redelivery** from a **real ownership violation** (two
+workers processing the same `(partition, seq)`). Items **H1** and **M1** in
+the audit summary.
+
+## Why
+
+The current tracker treats every `partitionSeq <= lastReceived` as
+`duplicateCount++` (`test/simulation/internal/coordinator/tracker.go:222-240`).
+JetStream's at-least-once contract makes plain redelivery common (worker
+crashed before ACK, NAK delays, etc.), so `DuplicateCount > 0` is uninformative —
+the simulation cannot tell a Processing-Gate regression that briefly lets two
+workers process the same seq apart from ordinary redelivery noise.
+
+Splitting the counter is the **strongest invariant the oracle can express
+today** that maps directly to the parti library's core exclusivity contract.
+With this, `OwnershipViolationCount > 0` becomes a hard test failure signal,
+distinct from informational `RedeliveryCount`.
+
+## Out of scope
+
+- **H2 (heartbeat-watcher invariants)**: Phase 3b. Requires a new goroutine
+  decoding KV heartbeats; bigger scope.
+- **H7 (checkpoint completeness)**: Phase 3c. Only matters on the crash-resume
+  path.
+- **R5 (FailureReport enrichment with attribution)** beyond what the new
+  ownership-violation events add naturally. The reviewer-promised WorkerID +
+  ProducerID + timeline overhaul is a separate PR.
+- **DupTracer rework**: the existing `coordinator/duptrace.go` records
+  per-duplicate sliding-window samples. It stays as-is for now; the new
+  ownership-violation path is independent and additive.
+
+## Design
+
+### Tracker signature change
+
+```go
+// Old:
+func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]time.Duration, error)
+// New:
+func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64, workerID string) ([]time.Duration, error)
+```
+
+The simulation already has `WorkerID` at the call site
+(`coordinator.go:928` reads `msg.WorkerID`), so threading it through is
+trivial.
+
+### Tracker state additions
+
+```go
+// lastWorkerPerSeq is a bounded per-partition map of (seq → worker that
+// first processed it). Used to classify a partitionSeq<=lastReceived
+// observation as either redelivery (same worker) or ownership violation
+// (different worker). When the per-partition map exceeds workerCacheMax,
+// the smallest-seq entry is evicted.
+lastWorkerPerSeq map[int]map[int64]string
+workerCacheMax   int  // default 4096; configurable for stress tests
+
+// New counters:
+redeliveryCount         int64 // partitionSeq<=lastReceived AND originalWorker==currentWorker
+ownershipViolationCount int64 // partitionSeq<=lastReceived AND originalWorker!=currentWorker
+// duplicateCount is retained for fallback when the original worker is
+// pruned (no data). Existing callers continue to see it.
+```
+
+### Classification logic
+
+Replace the existing duplicate branch (`tracker.go:222-240`) with:
+
+```go
+if partitionSeq <= lastReceived {
+    // Gap-healed path first (unchanged).
+    if escalatedSet, ok := t.gapEscalated[partitionID]; ok {
+        if _, wasGap := escalatedSet[partitionSeq]; wasGap {
+            // Late arrival heals an escalated gap.
+            delete(escalatedSet, partitionSeq)
+            t.gapsHealedCount++
+            t.physicalReceivedCount++
+            // Record the worker that actually healed it.
+            t.recordWorkerForSeq(partitionID, partitionSeq, workerID)
+            return healedDurations, nil
+        }
+    }
+
+    // Classify the duplicate. Empty workerID is unclassifiable (e.g.,
+    // checkpoint restore replay); fall back to legacy duplicate counter
+    // to avoid manufacturing false-positive ownership violations.
+    var origWorker string
+    var known bool
+    if pmap, ok := t.lastWorkerPerSeq[partitionID]; ok {
+        origWorker, known = pmap[partitionSeq]
+    }
+    switch {
+    case !known, origWorker == "", workerID == "":
+        // Pruned out, or one side has no worker info — legacy duplicate.
+        t.duplicateCount++
+        return healedDurations, &MessageDuplicateError{PartitionID: partitionID, Sequence: partitionSeq}
+    case origWorker == workerID:
+        // Same worker reprocessing — JetStream redelivery, expected.
+        // Returns a typed event-as-error so the coordinator can dispatch
+        // to RecordRedelivery() via errors.Is(err, ErrMessageRedelivery).
+        // Not treated as a failure; not subject to stop-on-failure.
+        t.redeliveryCount++
+        return healedDurations, &MessageRedeliveryEvent{PartitionID: partitionID, Sequence: partitionSeq, WorkerID: workerID}
+    default:
+        // Different worker — exclusivity contract violated.
+        t.ownershipViolationCount++
+        return healedDurations, &MessageOwnershipViolationError{
+            PartitionID:    partitionID,
+            Sequence:       partitionSeq,
+            OriginalWorker: origWorker,
+            CurrentWorker:  workerID,
+        }
+    }
+}
+```
+
+`recordWorkerForSeq` is a no-op when `workerID == ""` — restore replay
+populates seqs without worker attribution, so future duplicates of those
+seqs fall through the `origWorker == ""` arm above and remain plain
+duplicates. This preserves the "detection horizon" semantic the
+pruning strategy already establishes.
+
+On the contiguous-advance path (`tracker.go:242-263`) and the out-of-order
+arrival path (`tracker.go:187-211`), call `t.recordWorkerForSeq(...)` once
+per physical receipt to populate the map.
+
+### Pruning
+
+When `len(t.lastWorkerPerSeq[pid]) > workerCacheMax`, evict the lowest-seq
+entry. O(N) walk; only fires after the cache fills, so amortized cost is low.
+
+For the default (4096), per partition memory ≈ 4096 × (8 byte int64 + ~16
+byte string header) ≈ 100 KB. Total across 1500 partitions ≈ 150 MB. For
+shorter configs, the cap is rarely reached.
+
+The cap is exposed as `cfg.Coordinator.WorkerCacheMaxPerPartition` (default
+4096) so stress runs can tune it.
+
+**Config changes required:**
+
+- `test/simulation/internal/config/config.go` — add
+  `WorkerCacheMaxPerPartition int yaml:"worker_cache_max_per_partition"`
+  to `CoordinatorConfig`.
+- `test/simulation/internal/config/defaults.go` — apply default of 4096
+  when zero (analogous to the existing `GapAging` / `ValidationWindow`
+  defaulting blocks).
+- `test/simulation/internal/config/validation.go` — reject values ≤ 0 with a
+  clear message; zero would mean "evict immediately" which is meaningless.
+
+**Detection horizon (acknowledged limit):** beyond the cache window,
+duplicate-of-very-old-seq falls through to the legacy `DuplicateCount`
+counter and is **not** classified as a violation even if the workers
+differ. This is an explicit trade-off — bounded memory in exchange for a
+finite detection horizon. Operators of long-running stress configs should
+raise `worker_cache_max_per_partition` accordingly. Treat the value as a
+guaranteed-detection lookback, not full-history ownership proof.
+
+**Same logical worker-ID, different instance:** if chaos restarts worker-X
+with the same `workerID`, a JetStream redelivery to the restarted instance
+is classified as redelivery (not violation), because the simulation
+identifies workers by logical ID, not process instance. This matches
+parti's ownership semantics (stable worker IDs across restarts) and is
+intentional. Documented here for completeness.
+
+### New error/event types
+
+```go
+var ErrMessageOwnershipViolation = errors.New("ownership violation: same sequence processed by different workers")
+var ErrMessageRedelivery         = errors.New("at-least-once redelivery") // informational
+
+type MessageOwnershipViolationError struct {
+    PartitionID    int    `json:"partition_id"`
+    Sequence       int64  `json:"sequence"`
+    OriginalWorker string `json:"original_worker"`
+    CurrentWorker  string `json:"current_worker"`
+}
+
+func (e *MessageOwnershipViolationError) Error() string { ... }
+func (e *MessageOwnershipViolationError) Unwrap() error { return ErrMessageOwnershipViolation }
+
+// MessageRedeliveryEvent is returned as the error value when the same worker
+// reprocesses a sequence. It is *informational* — not a failure. The
+// coordinator dispatches it via errors.Is to record a Prometheus metric
+// and does NOT propagate it to the stop-on-failure path or the failure
+// report. Using the error channel for this keeps the dispatch shape
+// consistent with gaps/duplicates/violations and avoids growing the
+// RecordReceived return signature.
+type MessageRedeliveryEvent struct {
+    PartitionID int    `json:"partition_id"`
+    Sequence    int64  `json:"sequence"`
+    WorkerID    string `json:"worker_id"`
+}
+
+func (e *MessageRedeliveryEvent) Error() string { ... }
+func (e *MessageRedeliveryEvent) Unwrap() error { return ErrMessageRedelivery }
+```
+
+### TrackerStats / GetStats additions
+
+```go
+type TrackerStats struct {
+    // ... existing fields ...
+    DuplicateCount          int   `json:"duplicate_count"`           // unchanged; pruned fallback
+    RedeliveryCount         int64 `json:"redelivery_count"`          // NEW
+    OwnershipViolationCount int64 `json:"ownership_violation_count"` // NEW
+}
+```
+
+`GetStats()` populates the new fields. A new method `GetOwnershipViolationCount()`
+exposed for the main-loop invariants check.
+
+### Coordinator wiring
+
+`coordinator.go:928` changes from:
+```go
+healed, err := c.tracker.RecordReceived(msg.PartitionID, msg.PartitionSequence)
+```
+to:
+```go
+healed, err := c.tracker.RecordReceived(msg.PartitionID, msg.PartitionSequence, msg.WorkerID)
+```
+
+The error-branch dispatch grows two new arms (in addition to the existing
+`ErrMessageGap` / `ErrMessageDuplicate` ones):
+
+```go
+// Redelivery — informational; record metric and continue. NOT a failure.
+if errors.Is(err, ErrMessageRedelivery) {
+    if c.metricsCollector != nil {
+        c.metricsCollector.RecordRedelivery()
+    }
+    // do not propagate to dup tracer or stop-on-failure
+    continue receive loop
+}
+// Ownership violation — a real exclusivity failure.
+if errors.Is(err, ErrMessageOwnershipViolation) {
+    var ove *MessageOwnershipViolationError
+    if errors.As(err, &ove) {
+        if c.metricsCollector != nil {
+            c.metricsCollector.RecordOwnershipViolation()
+        }
+        c.appendOwnershipViolation(*ove)  // bounded slice, cap 1000
+        log.Printf("[Coordinator] OWNERSHIP VIOLATION: partition=%d seq=%d original=%s current=%s",
+            ove.PartitionID, ove.Sequence, ove.OriginalWorker, ove.CurrentWorker)
+        if c.stopOnFailure {
+            c.internalTriggerFailure("Ownership violation", err)
+            return
+        }
+    }
+}
+```
+
+Order matters: the redelivery check must happen before the generic `err != nil`
+gate so the existing gap/duplicate dispatch doesn't re-fire on a redelivery
+event. Place the new arms at the top of the `if err != nil { ... }` block.
+
+**DupTracer remains as-is.** It only records `ErrMessageDuplicate` —
+i.e., the pruned-fallback case. Same-worker redeliveries (return
+`ErrMessageRedelivery`) and ownership violations (return
+`ErrMessageOwnershipViolation`) bypass it. This is intentional: the new
+ownership-violation list in `FailureReport` is the structured replacement,
+and dup-tracer's sliding-window dump remains useful for the legacy
+pruned-duplicate path that has no per-event attribution.
+
+### Failure report enrichment
+
+`FailureReport` (`coordinator.go:863`) gets one new field:
+```go
+type FailureReport struct {
+    // ... existing fields ...
+    OwnershipViolations []MessageOwnershipViolationError `json:"ownership_violations,omitempty"`
+}
+```
+
+Populated from a coordinator-side slice that the receive loop appends to on
+each violation event. Bounded at N=1000 to cap report size.
+
+### Main-loop invariants
+
+`cmd/simulation/main.go:663-666` and `:711-714` currently check
+`failures > 0 || late > 0 || lost > 0`. Add `ownershipViolations > 0` (new
+condition):
+```go
+violations := coord.GetTracker().GetOwnershipViolationCount()
+if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 {
+    return fmt.Errorf("stability invariants failed: ... ownership_violations=%d", ..., violations)
+}
+```
+
+`RedeliveryCount` is **not** part of the invariants — it's informational and
+expected to be > 0 under chaos.
+
+### Prometheus metrics
+
+Add two Counter metrics in `metrics/collector.go`:
+- `simulation_redeliveries_total` — informational.
+- `simulation_ownership_violations_total` — alertable.
+
+Plus a `RecordOwnershipViolation()` and `RecordRedelivery()` method on the
+Collector. Coordinator calls these when classifying.
+
+## TDD plan
+
+1. **TestRecordReceived_SameWorkerDuplicate_IsRedelivery**: receive seq=1
+   from worker-A. Receive seq=1 again from worker-A. Assert
+   `RedeliveryCount == 1`, `OwnershipViolationCount == 0`, and the
+   returned error satisfies `errors.Is(err, ErrMessageRedelivery)` and
+   `errors.As(&MessageRedeliveryEvent{})` with WorkerID="worker-A".
+   (Redelivery is signaled as an event-as-error per the design above.)
+
+2. **TestRecordReceived_DifferentWorkerDuplicate_IsOwnershipViolation**:
+   receive seq=1 from worker-A. Receive seq=1 from worker-B. Assert
+   `OwnershipViolationCount == 1`, `RedeliveryCount == 0`, error is
+   `*MessageOwnershipViolationError` with `OriginalWorker="worker-A"`,
+   `CurrentWorker="worker-B"`.
+
+3. **TestRecordReceived_PrunedWorker_FallsBackToLegacyDuplicate**: set
+   `workerCacheMax=2`, receive seqs 1,2,3 from worker-A. Receive seq=1 again
+   (now pruned). Assert `DuplicateCount == 1`, no
+   `OwnershipViolationCount` increment, error is `*MessageDuplicateError`.
+
+4. **TestRecordReceived_GapHealRecordsWorker**: build a gap, escalate via
+   AgeOut, then late-arrival heals it from worker-A. Assert the worker is
+   stored for that seq. Receive same seq from worker-B → ownership violation.
+
+5. **TestRecordReceived_OutOfOrderRecordsWorker**: receive seq=2 from
+   worker-A (exercises **out-of-order branch** worker recording — this is
+   what the test is targeting). Receive seq=1 from worker-B (closes the
+   window via the contiguous-advance loop; window advances to 2). Now
+   `lastReceived=2`. Receive seq=2 again from worker-C: classification
+   path lookup finds `origWorker = "worker-A"` (set by the out-of-order
+   branch); assert `*MessageOwnershipViolationError` with
+   `OriginalWorker="worker-A"`, `CurrentWorker="worker-C"`. A broken
+   implementation that omits worker-recording in the out-of-order branch
+   would have `origWorker = ""` and the test would see a plain
+   `*MessageDuplicateError` instead, failing the assertion. This is the
+   targeted regression guard for the out-of-order branch.
+
+6. **TestRecordReceived_OwnershipViolationFlowsToFailureReport**: end-to-end
+   via Coordinator — inject a ReceivedMessage that triggers the violation
+   path; assert the failure report (on TriggerFailure) contains the
+   violation entry with both worker IDs.
+
+7. **TestCheckpointRestore_EmptyWorkerID_FallsBackToLegacyDuplicate**:
+   exercise the restore replay path (`checkpoint.go:170-183`) which
+   passes `""` as workerID. Assert that a subsequent duplicate of a
+   restored seq classifies as `*MessageDuplicateError` (legacy fallback),
+   NOT as `*MessageOwnershipViolationError`. Pre-fix-of-P0 the
+   pseudocode would have generated a false-positive violation; this
+   test guards against that regression.
+
+**Parent-fail expectation table** (verify-first per project memory):
+
+| Test | Fails on parent commit? | Why |
+|---|---|---|
+| #1 same-worker redelivery | yes | parent has no RedeliveryCount; counts as DuplicateCount instead |
+| #2 different-worker violation | **yes (critical)** | parent has no violation detection at all |
+| #3 pruned fallback | n/a (constructive) | exercises new field; no parent equivalent |
+| #4 gap-heal worker recording | yes | parent doesn't track worker on heal |
+| #5 out-of-order worker recording | **yes (critical)** | parent's out-of-order branch never recorded workers |
+| #6 violation in FailureReport | yes | FailureReport.OwnershipViolations field doesn't exist on parent |
+| #7 empty-workerID fallback | n/a (constructive) | exercises new field |
+
+## Risks
+
+- **Risk 1 (signature change)**: every call site of `RecordReceived` must
+  pass a workerID. Touch points: `coordinator.go:928`, `checkpoint.go:170-183`
+  (restore loop), all tracker tests. The restore loop currently has no
+  worker info — passes `""` (empty) which exercises the pruned-fallback
+  path. Document that ownership-violation detection does not span restart;
+  checkpoint completeness (Phase 3c) addresses this.
+
+- **Risk 2 (gap-heal classification)**: the existing `gapEscalated` heal
+  path is independent of the new worker-tracking. The plan inserts the
+  worker recording **after** the gap-heal early return so heals are
+  unaffected. Verified in test #4.
+
+- **Risk 3 (memory growth on long stress runs)**: pruning caps
+  per-partition map size. The `WorkerCacheMaxPerPartition` knob lets
+  operators raise it for very long runs that should retain history.
+
+- **Risk 4 (existing tests using seq=0)**: not relevant — Phase 1 already
+  shifted them to seq=1. The signature change requires updating every
+  existing tracker test to pass a workerID though; trivial sed.
+
+## Verification gates
+
+1. `make lint` clean.
+2. `make test` clean.
+3. `go test ./test/simulation/...` clean.
+4. All 6 new TDD tests pass; the bug-exposing ones (#2, #5) fail on the
+   parent commit (verify-first per project memory).
+5. No regressions in existing tracker tests after the signature change.
+
+## Commit message (draft)
+
+```
+feat(simulation): classify duplicates as redelivery vs ownership violation
+
+The simulation tracker treated every late-arrival sequence as a generic
+"duplicate". Under at-least-once delivery, JetStream legitimately
+redelivers messages (worker crashed before ACK, NAK delays, etc.), so
+DuplicateCount > 0 told the oracle nothing — masking the failure mode
+the simulation is supposed to catch: two workers concurrently processing
+the same (partition, seq), which is a Processing-Gate / handoff
+regression.
+
+Tracker now records the WorkerID that first processed each sequence
+(bounded LRU per partition, cap 4096 by default) and on a later same-seq
+receipt classifies:
+  - same worker  → RedeliveryCount++  (informational, expected)
+  - other worker → OwnershipViolationCount++ + ErrMessageOwnershipViolation
+  - pruned       → DuplicateCount++   (legacy fallback)
+
+OwnershipViolationCount > 0 is now a hard stability-invariant failure
+in the main loop; the FailureReport lists each violation with both
+worker IDs. RedeliveryCount is exposed but not gated on, since it
+correlates with chaos intensity rather than parti correctness.
+
+Adds Prometheus counters simulation_redeliveries_total and
+simulation_ownership_violations_total.
+
+Plan and review history: docs/plans/sim-oracle-phase3/
+```

--- a/docs/plans/sim-oracle-phase3/01-review-response.md
+++ b/docs/plans/sim-oracle-phase3/01-review-response.md
@@ -1,0 +1,76 @@
+# Review Response — Round 1 (Phase 3a)
+
+Source: `tmp/sim-oracle-phase3_review.md`.
+
+## P0 — Empty WorkerID fallback contradicted by pseudocode (accepted)
+
+The classification arm `case !known` only triggered when the seq was pruned.
+Restore replay (`checkpoint.go:170-183`) passes `""` and the
+contiguous-advance/out-of-order paths would call `recordWorkerForSeq(..., "")`,
+populating `lastWorkerPerSeq[pid][seq] = ""`. A later real-worker duplicate
+would then be `known=true`, `origWorker=""`, `current!=""` → false-positive
+ownership violation.
+
+**Fix applied**:
+- Classification arm widened to `case !known, origWorker == "", workerID == ""`.
+- `recordWorkerForSeq` is a no-op for empty workerID (plan now explicitly
+  states this).
+- New TDD test #7 (`TestCheckpointRestore_EmptyWorkerID_FallsBackToLegacyDuplicate`)
+  guards the restore-replay path.
+
+## P1 — Redelivery metric has no coordinator-visible signal (accepted)
+
+The original pseudocode returned `nil` for redelivery, so the coordinator's
+`if err != nil` dispatch couldn't fire `RecordRedelivery()`.
+
+**Fix applied**:
+- Introduce a `MessageRedeliveryEvent` typed value with `Error()`/`Unwrap()`
+  that satisfies the error interface, and a sentinel
+  `ErrMessageRedelivery` for `errors.Is` dispatch.
+- Coordinator wiring section now shows two new dispatch arms (redelivery
+  + violation) added at the top of the existing `if err != nil` block,
+  with explicit note that the redelivery arm does NOT propagate to
+  stop-on-failure or DupTracer.
+- Plan now documents that "error" semantically means "event of note" not
+  "call failed" for these two cases.
+
+## P1 — TDD #5 doesn't actually prove out-of-order worker recording (accepted)
+
+The reviewer's reasoning: my test #5 set seq=2 then seq=1 then duplicated
+seq=1; the lookup of seq=1 succeeds via the contiguous-advance path, not
+the out-of-order path. A broken implementation that omits worker recording
+in the out-of-order branch would still pass.
+
+**Fix applied**: redesigned #5 to set seq=2 via out-of-order, advance via
+seq=1, then duplicate **seq=2** (not seq=1). The seq=2 lookup must come
+from the out-of-order branch's recording; if that recording is missing,
+the duplicate falls back to a plain `MessageDuplicateError` (test fails)
+rather than the expected `MessageOwnershipViolationError`. Added an
+explicit parent-fail table at the end of the TDD section listing which
+tests are the critical regression guards.
+
+## P1 — WorkerCacheMaxPerPartition needs config default + validation (accepted)
+
+**Fix applied**: explicit "Config changes required" subsection in the
+Pruning section lists the three files that need edits:
+`config.go` (new field), `defaults.go` (default=4096), `validation.go`
+(reject ≤0). Plan also explicitly notes that zero is meaningless.
+
+## P2 — Same-ID restarts classified as redelivery, not violation
+
+Accepted as documented behavior. The plan now states that "same logical
+worker-ID, different instance" is treated as redelivery — matches parti's
+own stable-worker-ID semantics.
+
+## P2 — Pruning trade-off (detection horizon)
+
+Accepted as documented. The plan now describes the cache as a
+"guaranteed-detection lookback, not full-history ownership proof."
+
+## P2 — DupTracer remains legacy-only
+
+Accepted as documented. Plan's Coordinator wiring section now explicitly
+states that redeliveries and ownership violations bypass DupTracer, and
+explains the rationale (the FailureReport ownership-violations list is
+the structured replacement; DupTracer remains useful for the legacy
+pruned-duplicate path).

--- a/docs/plans/sim-oracle-phase4/00-plan.md
+++ b/docs/plans/sim-oracle-phase4/00-plan.md
@@ -1,0 +1,419 @@
+# Simulation — Phase 4: CI Coverage Expansion
+
+Single-PR plan to widen what the parti simulation actually exercises **in
+CI**, addressing audit items **H3** (one-config CI), **H4** (network_disconnect
+targets random worker, not leader), and the processing-gate-on / RoundRobin
+gaps called out under coverage_gaps §3 (Processing Gate) and §8 (Strategy
+coverage).
+
+## Why
+
+Phase 1–3 made the oracle correct, the code CLAUDE.md-compliant, and the
+ownership-violation invariant verifiable. But CI today runs **one** YAML
+(`chaos_comprehensive.yaml`) with:
+
+- `network_disconnect` commented out (`chaos_comprehensive.yaml:38`)
+- No `enforce_exclusive_consumption` (defaults to false — Processing Gate
+  is OFF in CI)
+- `WeightedConsistentHash` only (the other two strategies have **zero**
+  CI coverage)
+
+The audit's strongest claim was that this combination "lets every chaos
+primitive other than worker_crash / leader_failure / scale_up / scale_down /
+producer_crash / worker_pause / slow_consumer go untested in CI." That's
+what Phase 4 fixes.
+
+The new `OwnershipViolationCount > 0` invariant from Phase 3 will start
+firing in CI **only** when the gate is actually enabled — making Phase 4 the
+phase that turns Phase 3's oracle into a real CI signal.
+
+## Out of scope
+
+- **Abrupt-kill semantics** (H5): all chaos events are still `cancel()`-based
+  in all-in-one mode. Real SIGKILL behavior (where the manager doesn't get
+  to release its claim) needs a different worker-control surface. Separate
+  PR.
+- **Heartbeat-watcher invariants** (H2): Phase 5.
+- **Checkpoint completeness** (H7): Phase 5.
+- **Removing the dead `Late/Lost/Failures` audit-metric read paths** in
+  `cmd/simulation/main.go:659-661`: cosmetic; out of scope here.
+- **Stop-on-failure tightening** (R11): out of scope; CI uses
+  `--stop-on-failure=false` so this doesn't bite today.
+
+## Changes
+
+### 1. Enable `network_disconnect` in the primary CI config
+
+**File:** `test/simulation/configs/chaos_comprehensive.yaml`
+
+Uncomment the existing line:
+```yaml
+# - network_disconnect
+```
+→
+```yaml
+- network_disconnect
+- network_disconnect_leader   # NEW — see §3 below
+```
+
+Both random-target and leader-target variants will fire under the existing
+15s–25s chaos interval. Combined chaos exposure stays the same scale
+(events of varying intensity), but coverage now includes network-isolation
+recovery.
+
+### 2. Processing-Gate CI coverage (DEFERRED to Phase 5)
+
+**Original intent:** turn on the Processing Gate in
+`chaos_comprehensive.yaml` so Phase 3's `OwnershipViolationCount > 0`
+invariant has actual CI signal.
+
+**Empirical finding during gate-4 verification:** enabling
+`enforce_exclusive_consumption: true` in the 8-minute comprehensive
+chaos workload produced two distinct failure modes across local 8m runs:
+
+1. **Run 1**: total Sent==Received (59887/59887), no message loss, but
+   tracker over-escalated 64 holes to gaps at shutdown — a tracker
+   accounting drift (FN4 in the original audit) amplified by gate-on
+   NAK retries.
+2. **Run 2**: catastrophic — only 34,034 of 58,437 messages delivered
+   (40% loss). Gate-driven NAK loops under aggressive 15-25s chaos
+   prevented drain.
+
+A lighter focused config (`chaos_gate.yaml`, 2m duration, moderate
+20-30s chaos interval) ran cleanly on message-delivery — but consistently
+surfaced a **real ownership violation**: `partition=19 seq=153 processed
+by both worker-5 and worker-0` after a graceful restart + network
+disconnect. Phase 3's invariant did its job and caught a previously
+undetected cross-worker collision pattern.
+
+**This finding is what Phase 3 was built to surface, and it needs
+Phase 5 investigation.** Two hypotheses:
+- A real parti exclusivity-contract bug (Processing Gate failing under
+  the specific handoff race that combines a graceful worker restart with
+  a subsequent network disconnect).
+- A simulation-oracle gap: the chaos worker-restart handler may allocate
+  a fresh worker ID for the replacement instance, making JetStream
+  redelivery to that new ID look like a cross-worker collision even
+  though parti's stable-worker-ID model would treat them as the same
+  logical worker.
+
+Either way, the right Phase 4 outcome is **don't ship a CI job that
+fails on every run while the root cause is unknown**.
+
+**Phase 4 action:**
+- Keep `chaos_gate.yaml` in the repo as a developer-run config with a
+  header explaining the gate-on situation and how to reproduce.
+- Do NOT add a CI job that runs it.
+- Document the gate-on finding as Phase 5's first investigation item.
+
+### 3. Add a leader-targeted `network_disconnect_leader` chaos event
+
+**Files:**
+- `test/simulation/internal/coordinator/chaos.go` — register the new event type
+- `test/simulation/cmd/simulation/main.go` — dispatch handler (mirrors
+  `LeaderFailureEvent`'s leader-selection pattern)
+
+**Why a new event type rather than a `target:` parameter on the existing
+one:** the chaos YAML format is event-name driven (no per-event params in
+the config). Adding `network_disconnect_leader` is the smallest API
+extension and keeps configs readable.
+
+**Required registration sites** (round-1 reviewer correction —
+`generateEventParams` and `String()` were missed in the original plan):
+
+| File:Symbol | Why |
+|---|---|
+| `coordinator/chaos.go` — `ChaosEvent` constants | Defines the new typed name. |
+| `coordinator/chaos.go` — `generateEventParams` switch (~line 177) | The existing `NetworkDisconnectEvent` arm produces a randomized 5–30s duration; without an entry for the leader variant, scheduled events arrive with empty params and the dispatcher's fallback (10s fixed) doesn't mirror the existing behavior. |
+| `coordinator/chaos.go` — `String()` switch (~line 307) | Without an entry, logs use the "Unknown Event" path. |
+| `cmd/simulation/main.go` — three switch case statements (~lines 947, 1040, 1141) | The process-mode fallback, the goroutine guard, and the goroutine dispatcher. The new variant is **all-in-one only** (see "Process-mode behavior" note below); the process-mode fallback should log+skip. |
+
+Chaos config storage is plain `[]string` (`config.go:176`) cast to
+`ChaosEvent` (`chaos.go:82`), so there is no typed YAML parser to update.
+
+**Implementation sketch** (in `main.go`, alongside the existing
+`NetworkDisconnectEvent` case at line 1141):
+
+```go
+case coordinator.NetworkDisconnectLeaderEvent:
+    workers := registry.GetByType(coordinator.WorkerGoroutine)
+    var leader *coordinator.GoroutineInfo
+    for _, w := range workers {
+        if wobj, ok := w.Obj.(*worker.Worker); ok && wobj.IsLeader() {
+            leader = w
+            break
+        }
+    }
+    if leader == nil {
+        log.Println("[Chaos] No leader worker found to disconnect")
+        return
+    }
+    dur, ok := params["duration"].(time.Duration)
+    if !ok || dur <= 0 {
+        dur = 10 * time.Second
+    }
+    if wobj, ok := leader.Obj.(*worker.Worker); ok {
+        log.Printf("[Chaos] Disconnecting LEADER worker %s for %v", leader.ID, dur)
+        wobj.Disconnect()
+        time.AfterFunc(dur, func() {
+            log.Printf("[Chaos] Reconnecting LEADER worker %s", leader.ID)
+            wobj.Reconnect()
+        })
+    }
+```
+
+The chaos `events:` list now accepts `network_disconnect_leader` as a
+keyword. The scheduler treats it as a separate event with its own
+interval slot (sharing the global chaos interval — no new tuning needed).
+
+**Process-mode behavior:** the new event is **all-in-one only**.
+Process-mode's existing `leader_failure` handler at
+`main.go:1598-1602` is not a real leader lookup (it kills the first
+running worker process). Rather than approximate leader-disconnect via
+the same approximation, the process-mode case statement for
+`NetworkDisconnectLeaderEvent` will log a "process mode does not
+support leader-disconnect; skipping" message and return. All Phase 4
+CI configs use `mode: all-in-one`, so the skip is invisible in CI.
+
+**Unit test** (round-1 reviewer P1.3 — events need a deterministic
+proof, not just probabilistic CI exposure):
+
+Add `test/simulation/internal/coordinator/chaos_test.go` (or extend
+existing) — `TestNetworkDisconnectLeaderEvent_ParamsAndStringer`:
+construct a `ChaosController`, generate params for
+`NetworkDisconnectLeaderEvent` via the same path the scheduler uses
+(`generateEventParams`), assert (a) the duration param is in the
+expected range, (b) `String()` returns the human-readable name (not
+"Unknown Event"), (c) the event is in the global event-list constant.
+
+This guards against the registration sites becoming stale on future
+refactors.
+
+**Out-of-scope variants:**
+- `worker_crash_leader` (could mirror this pattern) — not done; the
+  existing `leader_failure` covers cancel-based crashes.
+- `worker_pause_leader` — could be useful for slow-leader scenarios, but
+  pausing the leader without freezing its heartbeat is the same
+  "Slow Neighbor" gap the audit also flagged. Out of scope.
+
+### 4. Add a CI job for the `chaos_network_disconnect.yaml` config
+
+**File:** `.github/workflows/simulation-stress.yml`
+
+The current workflow has one job (`chaos-simulation`) running
+`chaos_comprehensive.yaml`. Add a sibling job that runs the existing
+`chaos_network_disconnect.yaml`.
+
+**Config update (round-1 reviewer P1.3 — 30s without cooldown is
+probabilistic and may not exercise the leader-disconnect arm at all):**
+extend the focused config to 90s duration with a 15s cooldown. Chaos
+fires every 5–10s, so over 90s the scheduler injects ~10 events; with
+two configured event names the leader-disconnect arm should fire at
+least once with high probability. The 15s cooldown gives the last
+disconnect time to reconnect and the workers time to drain before the
+final report. Also set `coordinator.gap_aging: 60s` explicitly (current
+config relies on the 45s default — too aggressive given the chaos
+interval).
+
+```yaml
+jobs:
+  chaos-simulation:
+    # existing job
+    ...
+
+  network-disconnect-simulation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build Simulation
+        run: go build -o tmp/simulation ./test/simulation/cmd/simulation
+      - name: Run Network-Disconnect Simulation
+        run: |
+          set +e
+          max_attempts=3
+          for attempt in $(seq 1 $max_attempts); do
+            echo "::group::Attempt $attempt/$max_attempts"
+            ./tmp/simulation \
+              --config test/simulation/configs/chaos_network_disconnect.yaml \
+              --duration 90s --cooldown 15s \
+              --stop-on-failure=false \
+              2>&1 | tee "tmp/network-attempt${attempt}.log"
+            rc=${PIPESTATUS[0]}
+            echo "::endgroup::"
+            if [ $rc -eq 0 ]; then exit 0; fi
+          done
+          exit 1
+      - name: Upload Failure Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-disconnect-failure-report
+          path: |
+            failure_report.json
+            tmp/network-attempt*.log
+```
+
+This job runs ~1.5–2 minutes per attempt (90s simulation + 15s cooldown
++ a few seconds of setup); 10-min timeout gives 3-retry headroom matching
+the existing job's pattern. CLI flags `--duration 90s` and `--cooldown 15s`
+override the YAML defaults to keep the exact verification contract in one
+place (in step with the comprehensive job's `--duration 8m --cooldown 90s`
+override pattern).
+
+The existing `chaos_network_disconnect.yaml` currently picks **random**
+workers (uses the existing `network_disconnect` event). Update that
+config to also include `network_disconnect_leader` so the new event is
+exercised end-to-end.
+
+### 5. Add a `RoundRobin` strategy CI job
+
+**Files:**
+- `test/simulation/configs/chaos_roundrobin.yaml` (new)
+- `.github/workflows/simulation-stress.yml` (new job)
+
+`RoundRobin` is implemented (`worker.go:185-186`) but has zero config
+coverage. Add a focused config that:
+- Same partition/worker count as `chaos_comprehensive.yaml`
+- `assignment_strategy: RoundRobin`
+- Same chaos events as comprehensive (to surface strategy-specific bugs
+  under chaos)
+- 90-second duration (shorter than comprehensive's 8m to bound CI cost)
+
+**Drain/gap-aging contract (round-1 reviewer P2.1):** RoundRobin
+intentionally does not preserve cache affinity on rebalance
+(`strategy/round_robin.go:14-16`), so chaos churn produces more
+reassignment than WeightedConsistentHash. Don't copy comprehensive's
+`gap_aging: 240s` blindly (way too long for a 90s run — would never
+escalate) and don't use the 45s default (too aggressive under the
+larger reassignment volume). Set explicitly:
+
+```yaml
+simulation:
+  duration: 90s
+coordinator:
+  gap_aging: 60s
+  # final cooldown so the post-chaos drain has time to fill holes
+  # the simulation framework reads --cooldown from CLI; the CI job
+  # passes 20s.
+chaos:
+  enabled: true
+  interval: "10s-15s"   # roughly 6–9 events over 90s
+```
+
+CI invocation passes `--cooldown 20s` (matching the comprehensive job's
+pattern but scaled to the shorter run).
+
+Add a sibling CI job mirroring §4's pattern. Total CI added: ~3–5 minutes
+per PR.
+
+## Risks and verification
+
+**Risk 1 (gate-on CI flakiness):** Enabling `enforce_exclusive_consumption`
+in `chaos_comprehensive.yaml` adds NAK retries under handoff. The audit's
+own e2e validation (Phase 3 prep, 30s with this config) showed clean
+runs, but production stress at 50 partitions × 5 msg/sec × 8m may behave
+differently. **Mitigation:** the existing CI workflow already retries 3
+times. If flakiness appears, the warmup duration (10s) and `gap_aging`
+(240s) give large headroom. A pre-merge dry run of the updated config in
+the worktree (locally) will catch obvious regressions.
+
+**Risk 2 (new chaos event missing from a typed switch):** Adding
+`NetworkDisconnectLeaderEvent` requires updating all four current
+`chaos.go` typed surfaces plus the three `main.go` case statements —
+see the table in §3 above. There is no typed YAML parser (events are
+stored as `[]string` and cast to `ChaosEvent` at the boundary), so
+the plan does **not** include a parser edit. The implementation will
+grep for `NetworkDisconnectEvent` and ensure each occurrence has a
+matching new-variant entry.
+
+**Risk 3 (cold-start window vs gate warmup):** The default `ColdStartWindow`
+in the simulation is 10s (`worker.go:215`). The gate warmup is also 10s
+in the new config. These run independently — warmup is per-worker, cold
+start is global. No coupling concern.
+
+**Verification gates** (all must pass):
+1. `make lint` clean.
+2. `make test` clean.
+3. `go test ./test/simulation/...` clean (includes the new
+   `TestNetworkDisconnectLeaderEvent_ParamsAndStringer`).
+4. **Full 8-minute gate-on dry run** of `chaos_comprehensive.yaml` —
+   matching the exact CI invocation:
+   ```bash
+   ./bin/simulation \
+     --config test/simulation/configs/chaos_comprehensive.yaml \
+     --duration 8m --cooldown 90s --stop-on-failure=false
+   ```
+   No ownership violations, no gaps, stability invariants pass. This is
+   the merge gate that the 30s authoring run could not provide.
+   Round-1 reviewer P1.2 explicitly required matching the CI 8m+cooldown
+   shape — accepted as a hard prerequisite.
+5. Local 90-second dry run of `chaos_network_disconnect.yaml` (new shape)
+   — both `network_disconnect` and `network_disconnect_leader` events
+   observed in the log, no gaps, no violations.
+6. Local 90-second dry run of `chaos_roundrobin.yaml` — no gaps, no
+   violations.
+
+## Implementation order
+
+1. Define `NetworkDisconnectLeaderEvent` constant in `chaos.go`.
+2. Add the new event to **all four** `chaos.go` surfaces: constant,
+   `generateEventParams` switch (duration 5–30s, same as random variant),
+   `String()` switch (human-readable name), and the global event-list.
+3. Wire dispatcher in `main.go` (3 case statements): goroutine
+   dispatcher (~line 1141) implements the disconnect; goroutine guard
+   (~line 1040) includes the new event; process-mode fallback
+   (~line 947) logs+skips.
+4. Add `TestNetworkDisconnectLeaderEvent_ParamsAndStringer` unit test.
+5. Update `chaos_comprehensive.yaml`: enable gate + add both
+   network_disconnect events.
+6. Update `chaos_network_disconnect.yaml`: extend duration to 90s,
+   set `gap_aging: 60s`, include the new leader variant.
+7. Create `chaos_roundrobin.yaml`: per §5 contract above.
+8. Update `.github/workflows/simulation-stress.yml`: 2 new jobs
+   (network-disconnect, roundrobin), each with the build step inline
+   (matrix would conflate failure attribution).
+9. `make lint` + `make test` (gates 1–3).
+10. **Full 8m gate-on local dry run** (gate 4 — the merge prerequisite).
+11. Local dry runs for §4 and §5 configs (gates 5–6).
+
+## Commit message (draft)
+
+```
+ci(simulation): expand CI coverage — network disconnect, gate-on, RoundRobin
+
+Closes audit gaps H3 (single-config CI), H4 (network_disconnect targets
+random instead of leader), coverage_gaps §3 (Processing Gate gate-off in
+CI), and §8 (RoundRobin has zero CI coverage).
+
+- chaos_comprehensive.yaml (the existing CI config):
+  - Enable network_disconnect (previously commented out).
+  - Add new network_disconnect_leader event (see below).
+  - Turn on enforce_exclusive_consumption with allowed_states
+    ["commit", "stable"] — the production-recommended setting and the
+    only way Phase 3's OwnershipViolationCount > 0 invariant produces
+    real CI signal.
+
+- New chaos event NetworkDisconnectLeaderEvent: mirrors LeaderFailureEvent's
+  leader-selection logic but calls wobj.Disconnect() instead of Cancel(),
+  exercising the "split brain" scenario the audit's DESIGN_REVIEW.md called
+  for. Registered in coordinator/chaos.go and dispatched in main.go.
+
+- chaos_network_disconnect.yaml: add the new leader-targeted variant so
+  this focused config exercises both random and leader disconnect.
+
+- chaos_roundrobin.yaml (new): RoundRobin strategy + the comprehensive
+  chaos workload at 90s duration.
+
+- .github/workflows/simulation-stress.yml: two new jobs running the
+  network-disconnect and RoundRobin configs alongside the existing
+  comprehensive job. Each gets the same 3-retry pattern. Total CI time
+  budget ~+5 minutes per PR.
+
+Plan: docs/plans/sim-oracle-phase4/00-plan.md
+```

--- a/docs/plans/sim-oracle-phase4/01-review-response.md
+++ b/docs/plans/sim-oracle-phase4/01-review-response.md
@@ -1,0 +1,70 @@
+# Review Response — Round 1 (Phase 4)
+
+Source: `tmp/sim-oracle-phase4_review.md`.
+
+## P1 — Missed chaos.go registration sites (accepted)
+
+Round-1 reviewer correctly noted that `chaos.go` has more typed
+surfaces than the plan called out:
+
+- `generateEventParams` switch (~chaos.go:177): the existing
+  `NetworkDisconnectEvent` arm produces a randomized 5–30s duration.
+  Without an entry for the leader variant, scheduled events arrive with
+  empty params and the dispatcher's 10s fallback doesn't mirror behavior.
+- `String()` switch (~chaos.go:307): without an entry, logs use the
+  "Unknown Event" path.
+
+Also confirmed: there is **no typed YAML parser** — chaos events are stored
+as plain `[]string` and cast to `ChaosEvent` (`config.go:176`, `chaos.go:82`).
+
+**Fix applied:** rewrote §3 with an explicit registration-sites table
+covering all four `chaos.go` surfaces + three `main.go` switches.
+Implementation order updated to reflect the four chaos.go edits.
+
+## P1 — Gate-on CI validation requires an 8-minute dry run (accepted)
+
+Round-1 reviewer's point: a 30s authoring run isn't strong evidence for
+8m CI behavior with gate-on. The Processing Gate adds NAK retries under
+handoff; cumulative effect over 8 minutes is materially different from 30s.
+
+**Fix applied:** verification gate 4 is now an explicit 8-minute local
+dry run matching the exact CI invocation
+(`--config chaos_comprehensive.yaml --duration 8m --cooldown 90s
+--stop-on-failure=false`). Treated as a hard merge prerequisite, not a
+post-merge rollout risk.
+
+## P1 — New CI jobs need deterministic proof (accepted)
+
+Round-1 reviewer noted: a 30s focused config without cooldown is too
+probabilistic, and `chaos_network_disconnect.yaml` could "pass" without
+either event firing at all.
+
+**Fix applied:**
+- Added a unit test (`TestNetworkDisconnectLeaderEvent_ParamsAndStringer`)
+  that exercises the new event's params + stringer deterministically,
+  bypassing the chaos scheduler.
+- Extended `chaos_network_disconnect.yaml` to 90s + 15s cooldown +
+  explicit `gap_aging: 60s`. Over 90s with 5–10s interval, ~10 events
+  fire; with two configured names, leader-disconnect has high
+  probability of firing at least once.
+
+## P2 — RoundRobin job needs explicit drain/gap-aging contract (accepted)
+
+Round-1 reviewer noted: RoundRobin reassignment churn is higher than
+WeightedConsistentHash; can't blindly copy `gap_aging: 240s` or use the
+45s default.
+
+**Fix applied:** §5 now specifies explicit `duration: 90s`,
+`gap_aging: 60s`, `interval: "10s-15s"`, and `--cooldown 20s` from the CI
+job. Plan also explains why each value is chosen.
+
+## P2 — Process-mode behavior for new event (accepted)
+
+Round-1 reviewer noted: process-mode `leader_failure` doesn't do real
+leader lookup (it kills the first running worker), and the plan didn't
+specify what process-mode should do for the new variant.
+
+**Fix applied:** new "Process-mode behavior" subsection in §3 says the
+new event is **all-in-one only**; process-mode logs "process mode does
+not support leader-disconnect; skipping" and returns. All Phase 4 CI
+configs use all-in-one, so the skip is invisible in CI.

--- a/docs/plans/sim-oracle-phase5/00-plan.md
+++ b/docs/plans/sim-oracle-phase5/00-plan.md
@@ -1,0 +1,448 @@
+# Sim Oracle Phase 5 — Gate-On Ownership Violation Investigation
+
+## TL;DR
+
+Phase 3 added the `RecordReceivedFromWorker(pid, seq, workerID)` API and
+classifies same-`(pid, seq)` arrivals from a **different** workerID than the
+recorded "original" worker as `MessageOwnershipViolationError`. Phase 4 ran
+`chaos_gate.yaml` (gate-on, 2m) and observed exactly such a violation:
+partition=19 seq=153 processed by worker-5, then by worker-0 24 s later after
+a `worker_restart` and `network_disconnect_leader` event pair.
+
+This phase determines whether that violation is **(a)** a real parti gate
+gap, **(b)** an oracle false positive caused by classifying legitimate
+redelivery-after-reassignment as a violation, or **(c)** both — and lays
+the structural groundwork (current-owner discriminator, four-way
+classification) needed to make that determination soundly.
+
+**Out of scope:** H2 (heartbeat-watcher invariants), H5 (abrupt-kill
+semantics), H7 (checkpoint completeness), M2 (RecoveryStrategy), M3
+(ResolverConfig tuning), M4 (`source.NatsKV` chaos). All independent;
+none blocking gate-on CI **at chaos_gate.yaml duration**. They get their
+own phases. Phase 5 does **not** enable gate-on at chaos_comprehensive.yaml
+duration — that follow-up requires H2 first (see §6 Outcome A scope).
+
+## Why
+
+The current classifier — at `tracker.go:lookupOrigWorkerLocked` /
+`classifyKnownDuplicateLocked` — encodes this invariant:
+
+> Same `(partitionID, partitionSeq)` observed twice with different
+> `workerID` → ownership violation.
+
+That invariant is **wrong**. JetStream is at-least-once. When a partition
+is reassigned (chaos, scale, restart, leader failure), the new owner
+**necessarily** redelivers any un-acked sequences — and those sequences
+were originally processed by the previous owner. Same seq, different
+workerID, both correct.
+
+The real exclusivity property parti guarantees is:
+
+> At any time T, at most one worker is the **canonical owner** of
+> partition P, as recorded in the leader's assignment KV.
+
+A duplicate from a different worker is only a violation if **at the moment
+of receipt** that worker is not the canonical owner — or if **two workers
+are concurrently the canonical owner**, which is the real split-brain
+scenario the Processing Gate is designed to prevent.
+
+Without that discriminator, the gate-on CI signal is useless: every
+chaos-induced reassignment generates a false positive, so a real gate
+gap would be drowned out.
+
+## Phase plan
+
+### Step 1 — Publish an immutable owner-snapshot via atomic.Pointer
+
+The coordinator already maintains `workerAssignments map[string]map[int]struct{}`
+populated from the `OnAssignmentChanged` hook (coordinator.go:1171).
+**This map has no mutex.** All current writes happen in one goroutine
+(`processAssignments`), but extending reads to the receipt goroutine
+without synchronization would cause `fatal error: concurrent map
+iteration and map write`.
+
+Solution: publish an **immutable** snapshot via `atomic.Pointer`. The
+ingestion goroutine remains the sole writer (no locks); the receipt
+goroutine reads atomically.
+
+Add to `Coordinator` (coordinator.go):
+
+```go
+// ownerSnapshot is an immutable view of partition→workers at a moment in time.
+// Built and published by processAssignments; consumed by the tracker via
+// CurrentOwnersOf. The slices are sorted for deterministic test output and
+// must NOT be mutated after store; subsequent updates publish a new pointer.
+type ownerSnapshot struct {
+    perPartition map[int][]string
+    initialized  bool      // false until first AssignmentReport ingested
+    asOf         time.Time // last update
+}
+
+// In struct:
+ownerSnap atomic.Pointer[ownerSnapshot]
+```
+
+Add public method:
+
+```go
+// CurrentOwnersOf returns (workerIDs, snapshotInitialized).
+// workerIDs is a slice of workers that report partitionID in their most-recent
+// OnAssignmentChanged snapshot. The slice is immutable (do not mutate).
+// snapshotInitialized is false during cold start, before any AssignmentReport
+// has been processed.
+func (c *Coordinator) CurrentOwnersOf(partitionID int) (owners []string, snapshotInitialized bool)
+```
+
+Refactor `processAssignments` so every write to `workerAssignments` (the
+ingestion loop AND the stopped-worker prune at coordinator.go:1130) is
+followed by a rebuild + atomic store of `ownerSnap`. Initialize `ownerSnap`
+to `&ownerSnapshot{perPartition: map[int][]string{}, initialized: false}`
+in `NewCoordinator` so `Load()` never returns nil.
+
+**Scope note (pre-existing race, NOT in scope):** `startWorkerCatchUp`
+at coordinator.go:402 reads `c.workerAssignments` from the receipt
+goroutine without synchronization — that race predates Phase 5. Do not
+fix in this phase ([Rule 3 — Surgical Changes](../../AGENTS.md#rule-3--surgical-changes)).
+Add a one-line note to `tmp/sim_phase5_known_issues.md` for future
+cleanup.
+
+### Step 2 — Owner-lookup callback on tracker
+
+Refactor `MessageTracker.RecordReceivedFromWorker` to use an optional
+owner-lookup callback set via:
+
+```go
+func (t *MessageTracker) SetOwnerLookup(fn func(partitionID int) (owners []string, snapshotInitialized bool))
+```
+
+Constraints:
+- Lookup may be `nil` (unit tests, legacy callers) — in that case the
+  classifier falls back to current behavior (origWorker mismatch →
+  violation), preserving pre-Phase-5 semantics for any test or caller
+  that hasn't opted in.
+- Lookup must not block. Cost is one atomic load + one map lookup.
+- Pattern matches existing `SetLogOutOfOrder` / `SetWorkerCacheMax`.
+
+### Step 3 — Refine `classifyKnownDuplicateLocked`
+
+Refined classification table when `(pid, seq)` is a known duplicate
+(i.e., `lookupOrigWorkerLocked` returned `known=true`). Predicates
+evaluated **top-down**; first match wins.
+
+| #  | Predicate                                                | Classification               |
+|----|----------------------------------------------------------|------------------------------|
+| 1  | `origWorker == workerID`                                 | Redelivery (same worker)     |
+| 2  | `ownerLookup == nil`                                     | OwnershipViolation (legacy fallback) |
+| 3  | `len(currentOwners) > 1`                                 | **ConcurrentOwnersViolation** |
+| 4  | `len(currentOwners) == 1 && contains(workerID)`          | Redelivery (handoff)         |
+| 5  | `len(currentOwners) == 1 && contains(origWorker)`        | OwnershipViolation (stale receipt — receiver not assigned) |
+| 6  | `len(currentOwners) == 1 && !contains(either)`           | OwnershipViolation (stranger receiver) |
+| 7  | `len(currentOwners) == 0 && snapshotInitialized == true` | **OwnershipInconclusive** (mid-handoff after baseline) |
+| 8  | `len(currentOwners) == 0 && snapshotInitialized == false`| **OwnershipUnobserved** (cold start) |
+
+Returns:
+- Row 1, 4 → `ErrMessageRedelivery`
+- Row 2, 3, 5, 6 → `ErrMessageOwnershipViolation` (with new
+  `ConcurrentOwnersViolation` flag on row 3 — see §3a)
+- Row 7 → `ErrMessageOwnershipInconclusive` (new sentinel)
+- Row 8 → `ErrMessageOwnershipUnobserved` (new sentinel)
+
+#### §3a — Concurrent-owner: violation, but specially flagged
+
+When row 3 fires, the receipt is recorded as a violation **and** as a
+concurrent-owner event (P1-1 evidence). The distinction matters for
+post-hoc diagnosis: concurrent ownership is split-brain at the
+assignment layer (worse than stale-receipt); the failure report should
+make this visible.
+
+Decision rationale (countered alternative): keeping concurrent-owner as
+a third class (neither violation nor redelivery) would let Outcome A
+pass when split-brain is actively occurring. Classifying as violation
+is the right safety default.
+
+### Step 4 — Wire `Coordinator.CurrentOwnersOf` into tracker construction
+
+In `NewCoordinator` (coordinator.go:179), after constructing `c.tracker`,
+call:
+
+```go
+c.tracker.SetOwnerLookup(c.CurrentOwnersOf)
+```
+
+This makes the discriminator live for every real run; unit tests that
+construct `MessageTracker` directly remain unaffected.
+
+### Step 5 — Add unit tests for the refined classifier
+
+Verify-first per [memory](../../.claude/memory): write the failing tests
+**before** implementing §3. File: `tracker_ownership_test.go`. New cases:
+
+1. `TestClassify_NilLookupFallback` — preserves current behavior (legacy
+   fallback row 2). orig=worker-5, receipt=worker-0, lookup nil. Expect
+   `ErrMessageOwnershipViolation`.
+2. `TestClassify_HandoffRedelivery_NewOwnerOnly` — orig=worker-5,
+   receipt=worker-0, current=[worker-0], initialized=true. Expect
+   `ErrMessageRedelivery` (row 4).
+3. `TestClassify_StaleReceipt_OriginalStillOwner` — orig=worker-5,
+   receipt=worker-0, current=[worker-5], initialized=true. Expect
+   `ErrMessageOwnershipViolation` (row 5).
+4. `TestClassify_StrangerReceiver_NeitherAssigned` — orig=worker-5,
+   receipt=worker-0, current=[worker-3], initialized=true. Expect
+   `ErrMessageOwnershipViolation` (row 6).
+5. `TestClassify_ConcurrentOwners_CurrentAndThird` — orig=worker-5,
+   receipt=worker-0, current=[worker-0, worker-9], initialized=true.
+   Expect `ErrMessageOwnershipViolation` AND the
+   ConcurrentOwnersViolation flag (row 3, P0-2).
+6. `TestClassify_ConcurrentOwners_AllThree` — orig=worker-5,
+   receipt=worker-0, current=[worker-5, worker-0, worker-9],
+   initialized=true. Expect `ErrMessageOwnershipViolation` AND
+   ConcurrentOwnersViolation flag (row 3).
+7. `TestClassify_OwnershipInconclusive_SnapshotInitialized` —
+   orig=worker-5, receipt=worker-0, current=[], initialized=true.
+   Expect `ErrMessageOwnershipInconclusive` (row 7).
+8. `TestClassify_OwnershipUnobserved_SnapshotUninitialized` —
+   orig=worker-5, receipt=worker-0, current=[], initialized=false.
+   Expect `ErrMessageOwnershipUnobserved` (row 8).
+9. `TestClassify_SameWorkerRedelivery` — orig=worker-5, receipt=worker-5,
+   current=[worker-5]. Expect `ErrMessageRedelivery` (row 1).
+10. `TestClassify_PartitionScenarioFromPhase4` — reproduce the exact
+    partition=19 seq=153 chaos_gate finding with `currentOwners` mocked
+    to [worker-0] (single new owner). Expect handoff redelivery.
+
+Plus coordinator-level tests (new file `coordinator_owners_test.go`):
+
+11. `TestCurrentOwnersOf_BeforeAnyAssignment` — fresh coordinator, no
+    `AssignmentReport` consumed. Expect `owners=[], initialized=false`.
+12. `TestCurrentOwnersOf_AfterFirstAssignment` — ingest one
+    AssignmentReport for worker-0 covering partition 7. Expect
+    `owners=["worker-0"], initialized=true`.
+13. `TestCurrentOwnersOf_ConcurrentIngestion` — race-detector test
+    running `CurrentOwnersOf` concurrently with `AssignmentReport`
+    ingestion. Must pass under `-race`.
+
+### Step 6 — Re-run chaos_gate.yaml under refined classifier
+
+After §1–§5 land:
+
+```bash
+go build -o test/simulation/bin/simulation ./test/simulation/cmd/simulation
+./test/simulation/bin/simulation \
+  --config test/simulation/configs/chaos_gate.yaml \
+  --duration 5m --cooldown 30s --stop-on-failure=false \
+  --failure-report tmp/sim_phase5_gate_run1.json
+```
+
+**Outcome rules (revised post-review):**
+
+Outcome A criteria (all required):
+1. `OwnershipViolations` count == 0
+2. `ConcurrentOwnerEvents` count == 0
+3. `InconclusiveOwnerEvents` count == 0
+4. `OwnershipUnobservedPostChaosCount` == 0 (cold-start unobserved
+   arrivals are tolerated via the separate `OwnershipUnobservedPreChaos-
+   Count`; arrivals after the first ChaosEvent has fired must all be
+   classifiable). Split-counter design avoids relying on absolute
+   timestamps in the failure report.
+5. `TotalSent == TotalReceived` (existing invariant)
+
+To make criterion 4 auditable, `FailureReport` records
+`FirstChaosEventAt` (a timestamp set by the chaos dispatch loop on the
+first event) and exposes both pre- and post-chaos counters separately.
+
+Implementation (precise contract):
+
+- Coordinator gains `MarkChaosStarted()` and an internal
+  `chaosStarted atomic.Bool` (plus `firstChaosAt time.Time` guarded by
+  one-time `sync.Once` so the timestamp is captured exactly once).
+- The chaos dispatch loop calls `coord.MarkChaosStarted()` **before**
+  invoking the chaos handler for the very first event. The exact call
+  site is the chaos goroutine in `cmd/simulation/main.go` immediately
+  before the `handleChaosEvent(...)` / `handleGoroutineChaos(...)`
+  dispatch on the first iteration (gated by a local `firstEvent bool`
+  to avoid per-event overhead).
+- The classifier reads `chaosStarted.Load()` while incrementing the
+  unobserved counter. Since `MarkChaosStarted()` uses `Store(true)`
+  with release semantics and the classifier uses `Load()` with acquire
+  semantics, the ordering is well-defined: **any receipt classified
+  after `MarkChaosStarted()` returns lands in the post-chaos bucket.**
+- The classifier holds `t.mu` for the bucket-increment step; the
+  `atomic.Bool` is read without holding `t.mu` (it can't deadlock with
+  `MarkChaosStarted` because `MarkChaosStarted` is lock-free).
+- For receipts in flight at the moment `MarkChaosStarted` is called,
+  the bucket assignment is deterministic per the atomic ordering above:
+  any receipt whose classifier-side `Load()` returns `true` is
+  post-chaos, regardless of when the receipt physically arrived.
+  Acceptable: the gate is on aggregate count of unobserved post-chaos
+  events, and the "exactly-on-the-boundary" receipt is post-chaos by
+  construction.
+
+- **A. All five criteria met** → no exclusivity-violation signal
+  detectable by this classifier under this workload. This is consistent
+  with (but does not by itself prove) the hypothesis that the prior
+  Phase 4 finding was a classifier false positive. **Caveat for H2-class
+  bugs**: a heartbeat-watcher / resolver failure where the receiving
+  worker is the sole current owner per `workerAssignments` could
+  produce a row-4 redelivery classification that hides a real gate
+  admission bug (see Risk 5). Outcome A → enable gate-on CI at the
+  `chaos_gate.yaml` workload (5m duration, 3-retry budget matching the
+  existing simulation-stress pattern). Do **NOT** enable gate-on at
+  `chaos_comprehensive.yaml` — that requires H2 first (out of scope).
+- **B. Any of criteria 1–4 nonzero** → real signal. Inspect
+  `tmp/sim_phase5_gate_run1.json`:
+  - `OwnershipViolations` (rows 2, 5, 6) → potential gate gap. Capture
+    evidence; file as separate `docs/plans/parti-exclusivity-bug.md`.
+  - `ConcurrentOwnerEvents` (row 3) → assignment-layer split-brain.
+    Most likely a leader-election bug. Capture; file separately.
+  - `InconclusiveOwnerEvents` (row 7) → discriminator staleness too
+    high to gate on. Investigate snapshot publication latency; consider
+    adding KV-source-direct lookup as a fallback.
+  - `OwnershipUnobservedCount > 0` after first chaos event → cluster
+    isn't reporting assignments fast enough. Likely worker startup
+    sequence issue.
+- **C. Mixed signals** → classify each evidence record; pick A or B per
+  finding.
+
+Do not enable gate-on CI in case B or C.
+
+### Step 7 — Update chaos_gate.yaml header
+
+Replace the current "two hypotheses" section with one of:
+
+- **Outcome A**: a note that the prior finding was a classifier false
+  positive (origWorker != workerID under legitimate handoff). Reference
+  this phase's plan.
+- **Outcome B/C**: a description of the actual bug class found, with a
+  pointer to the separately filed plan.
+
+### Step 8 — Linter, unit tests, race-detector, full local 5m dry-run
+
+Required gates:
+- `make lint` — clean.
+- `make test` — passes.
+- `go test -race ./test/simulation/internal/coordinator -run 'CurrentOwners|RecordReceived|Classify'`
+  — passes (catches §1 race regressions).
+- §6 5m chaos_gate.yaml run — Outcome A criteria 1–5, or documented
+  Outcome B/C with a separately filed investigation plan.
+
+## Risk surface
+
+**Risk 1 — Worker-reported snapshot is not leader-authoritative.**
+`workerAssignments` reflects each worker's most-recent
+`OnAssignmentChanged` view, not the leader's KV state. There is an
+inherent lag. The plan handles this by treating `len(currentOwners) == 0`
+post-baseline as `OwnershipInconclusive` rather than auto-classifying
+as redelivery — so a stale-snapshot window doesn't silently hide a real
+bug. **If `InconclusiveOwnerEvents > 0` consistently**, we know the
+snapshot lag is too large to gate on, which is itself a useful signal.
+
+**Risk 2 — Atomic snapshot rebuild cost.** Every `AssignmentReport`
+triggers a full rebuild of the `perPartition` map. With ~10 workers and
+~50 partitions, that's ~500 entries; in practice assignment reports
+arrive at ChaosEvent cadence (15-25s) plus startup, so the rebuild is
+cheap. No additional concern.
+
+**Risk 3 — Outcome A still requires interpretation.** Even with the
+four-counter gate, a quiet 5m run with no chaos-driven reassignment
+events would pass trivially. Mitigation: chaos_gate.yaml has
+`min_workers=4, max_workers=8` and 20-30s chaos interval over 5m =
+10–15 events. Each event triggers reassignment, so the classifier will
+exercise the discriminator on every receipt of a redelivered message.
+
+**Risk 4 — Outcome B (real bug) extends scope.** If §6 surfaces a real
+gate bug, the work shifts to library-level investigation. Mitigation:
+Phase 5 lands the oracle improvements regardless; the bug investigation
+becomes a separately-tracked plan. Phase 5 is still mergeable on its
+own.
+
+**Risk 5 — H2-induced gate gap could land in row 4 (handoff redelivery)
+and be invisible.** The owner snapshot is worker-reported, not
+leader-authoritative. Scenario:
+
+1. H2 heartbeat-watcher bug fails to detect that worker-5 is stuck or
+   dead.
+2. Resolver/leader reassigns partition 19 to worker-0 (incorrectly,
+   because worker-5 still nominally owns it).
+3. worker-0 publishes its new `OnAssignmentChanged` snapshot covering
+   partition 19; coordinator's `workerAssignments[worker-0]` now
+   contains partition 19.
+4. worker-5 — being stuck/dead — never publishes a fresh snapshot, but
+   if it had a `WorkerStopped` event the coordinator pruned it
+   (coordinator.go:1130). If neither happens (silent stall), worker-5
+   may also still appear as an owner → row 3 ConcurrentOwners (caught).
+5. If worker-5 was pruned for any reason (stoppedWorkersCh fired),
+   `currentOwners == [worker-0]` → row 4 redelivery (false negative).
+
+This is a real blind spot. Phase 5's outcome statement is therefore
+softened (§6 Outcome A): "no exclusivity-violation signal detectable
+by this classifier under this workload" — not "no bug exists". An H2
+fix is a Phase 6+ prerequisite for a confident library-level
+exclusivity claim. The dev-only `chaos_gate.yaml` CI job is still
+useful because cases 1–3 (violation, ConcurrentOwners, Inconclusive)
+catch a large class of real bugs; the H2 blind spot is one well-defined
+class of misses.
+
+## Acceptance criteria
+
+1. `MessageTracker.SetOwnerLookup(func(int) ([]string, bool))` exists;
+   nil-safe.
+2. `Coordinator.CurrentOwnersOf(partitionID int) ([]string, bool)` exists.
+3. `NewCoordinator` wires `c.tracker.SetOwnerLookup(c.CurrentOwnersOf)`.
+4. `classifyKnownDuplicateLocked` respects the §3 table.
+5. `FailureReport` includes `OwnershipViolations`, `ConcurrentOwnerEvents`,
+   and `InconclusiveOwnerEvents` (each bounded by
+   `ownershipViolationsCap`); plus split counters
+   `OwnershipUnobservedPreChaosCount` and
+   `OwnershipUnobservedPostChaosCount` (no slices); plus
+   `FirstChaosEventAt time.Time` for auditability.
+6. All 13 new tests pass; all existing tests still pass.
+7. `make lint` clean; `go test -race` for the coordinator package passes.
+8. Re-run §6 shows Outcome A (criteria 1–5 met) or B/C with a documented
+   finding.
+9. If Outcome A: gate-on CI job added for **chaos_gate.yaml only**
+   (5m duration). chaos_comprehensive.yaml gate-on remains deferred.
+10. `chaos_gate.yaml` header updated (§7) and
+    `tmp/sim_phase5_known_issues.md` records the pre-existing
+    coordinator.go:402 race for follow-up.
+
+## Test plan
+
+- Unit: 10 classifier tests (Step 5 #1-10).
+- Unit: 3 coordinator owner-snapshot tests (Step 5 #11-13), including
+  a `-race` test for concurrent ingestion + read.
+- Local: 5m chaos_gate.yaml run as the merge gate (§6).
+- Existing: full `make test` and `make lint` pass.
+
+## Commit message (draft)
+
+The outcome paragraph (B/C vs A) is written from the actual §6 run
+results, not pre-decided.
+
+```
+feat(simulation): Phase 5 — refine ownership-violation classifier with
+current-owner discriminator
+
+The Phase 3 classifier flagged any same-(partition, seq) receipt from a
+different worker as an ownership violation. Under JetStream's
+at-least-once semantics, legitimate redelivery-after-reassignment
+necessarily produces such receipts and is NOT a violation.
+
+Refine the classifier to consult the leader-reported assignment
+snapshot (coordinator.workerAssignments, published via atomic.Pointer
+to a frozen ownerSnapshot) at the moment of receipt. The classifier
+now distinguishes five cases:
+- Redelivery (same worker or handoff to a single new owner)
+- OwnershipViolation (stale, stranger, or ownerLookup-nil fallback)
+- ConcurrentOwnersViolation (split-brain: snapshot reports >1 owner)
+- OwnershipInconclusive (mid-handoff after baseline; snapshot empty)
+- OwnershipUnobserved (cold start; snapshot uninitialized)
+
+New API:
+- MessageTracker.SetOwnerLookup(func(int) ([]string, bool))
+- Coordinator.CurrentOwnersOf(partitionID int) ([]string, bool)
+
+FailureReport gains ConcurrentOwnerEvents and InconclusiveOwnerEvents
+slices (bounded) plus OwnershipUnobservedCount; OwnershipViolations[i]
+gains CurrentOwners for post-hoc analysis.
+
+[Outcome paragraph filled in from §6 run results.]
+```

--- a/docs/plans/sim-oracle-phase5/01-review-response.md
+++ b/docs/plans/sim-oracle-phase5/01-review-response.md
@@ -1,0 +1,185 @@
+# Phase 5 — Plan Review v1 Response
+
+Codex review at `tmp/sim-oracle-phase5_review.md`. Verdict: REVISE.
+Three P0s, two P1s, one P2. All defensible and addressed below; the
+plan has been updated accordingly.
+
+## P0-1 — Unknown-owner duplicates make Outcome A unsound — **ACCEPT**
+
+Codex is right. `currentOwners == []` should not silently fall into the
+redelivery bucket, because that lets every uninitialized-snapshot cross-
+worker duplicate masquerade as legitimate.
+
+**Resolution** (plan §3, §3a, §6, §10 updated):
+
+- New classification: `MessageOwnershipInconclusiveError` /
+  `ErrMessageOwnershipInconclusive`. Returned when `currentOwners == []`
+  AND the owner snapshot has been initialized (i.e., at least one
+  `AssignmentReport` has been ingested).
+- New classification: `MessageOwnershipUnobservedError` /
+  `ErrMessageOwnershipUnobserved`. Returned when `currentOwners == []`
+  AND the snapshot is uninitialized (cold start, before any worker has
+  reported).
+- Outcome A now requires **all four** to be zero: ownership violations,
+  concurrent-owner records (see P0-2), inconclusive records, and
+  unobserved records (with snapshot initialized). Unobserved during cold
+  start is acceptable but must close out before the first ChaosEvent
+  fires — see Outcome A criterion 9.
+
+## P0-2 — Multi-owner snapshots not classified — **ACCEPT**
+
+Right. The previous table left `len(currentOwners) > 1` (without orig
+in the set) implicitly classified as handoff redelivery. That masks
+two-way split-brain where the prior owner has already dropped its
+self-report but a third worker has been concurrently assigned with
+the receiving worker.
+
+**Resolution** (plan §3 table revised):
+
+The classifier now checks `len(currentOwners) > 1` **first**, before the
+membership tests:
+
+| Owner-set predicate                                  | Classification                |
+|------------------------------------------------------|-------------------------------|
+| `len(currentOwners) > 1`                             | **ConcurrentOwnersViolation** |
+| `len == 1`, contains workerID, !contains origWorker  | Redelivery (handoff)          |
+| `len == 1`, contains workerID, contains origWorker   | (impossible — len==1)         |
+| `len == 1`, !contains workerID, contains origWorker  | OwnershipViolation (stale)    |
+| `len == 1`, !contains workerID, !contains origWorker | OwnershipViolation (stranger) |
+| `len == 0`, snapshot initialized                     | OwnershipInconclusive (P0-1)  |
+| `len == 0`, snapshot uninitialized                   | OwnershipUnobserved (P0-1)    |
+| ownerLookup == nil                                   | Legacy fallback (preserve)    |
+| origWorker == workerID                               | Redelivery (same worker)      |
+
+Note: "stranger" — receiver isn't assigned but origWorker isn't either —
+is a violation. The receiver shouldn't be processing a partition no one
+owns; if owner snapshot is fresh enough to know origWorker is gone, it's
+fresh enough to know receiver isn't authorized.
+
+## P0-3 — `workerAssignments` not safe to read cross-goroutine — **ACCEPT**
+
+Confirmed by direct read: `workerAssignments` has no mutex; `mu`
+mentioned in §1 of the old plan was hallucinated. Iterating it from the
+receipt goroutine while `processAssignments` writes it is a data race
+and will produce `fatal error: concurrent map iteration and map write`
+under chaos churn.
+
+**Resolution** (plan §1 revised):
+
+Replace `mu`-based reads with an immutable owner snapshot published via
+`atomic.Pointer`:
+
+```go
+type ownerSnapshot struct {
+    perPartition map[int][]string // partitionID -> sorted workerIDs
+    initialized  bool             // false until first ingestion
+    asOf         time.Time
+}
+
+// In Coordinator:
+ownerSnapshot atomic.Pointer[ownerSnapshot]
+```
+
+- `processAssignments` rebuilds the snapshot on **every** mutation of
+  `workerAssignments` (the ingestion loop and the stopped-worker prune)
+  and atomically stores a new pointer. Single-writer; no lock needed.
+- `CurrentOwnersOf(pid)` loads the snapshot atomically and returns the
+  pre-built `perPartition[pid]` slice. Slice is part of an immutable
+  snapshot — safe to share without copy.
+- `CurrentOwnersOf` also returns a freshness boolean so the classifier
+  can distinguish initialized vs uninitialized snapshots (P0-1).
+
+**Scope note**: a pre-existing race at coordinator.go:402 (`startWorker-
+CatchUp` reads `c.workerAssignments` from the receipt goroutine) is
+**not** in scope here. It predates Phase 5 and is independently fixable
+in a follow-up. We do not "improve adjacent code" per [Rule 3](../../AGENTS.md#rule-3--surgical-changes).
+Document as a known-issue in `tmp/sim_phase5_known_issues.md` for
+future Phase 6 cleanup.
+
+## P1-1 — Audit schema only captures violations, not downgrades — **ACCEPT**
+
+Right. Outcome A claims would be unverifiable without durable records.
+
+**Resolution** (plan §3, §6, §10 updated):
+
+`FailureReport` gains two bounded slices alongside `OwnershipViolations`:
+
+- `ConcurrentOwnerEvents []ClassificationEvidence` — for the new
+  ConcurrentOwnersViolation classification (P0-2).
+- `InconclusiveOwnerEvents []ClassificationEvidence` — for
+  OwnershipInconclusive cases (P0-1).
+- (UnobservedOwnerEvents are not retained — they happen pre-baseline
+  and are expected; the count alone is sufficient.)
+
+```go
+type ClassificationEvidence struct {
+    PartitionID    int
+    Sequence       int64
+    OriginalWorker string
+    ReceivingWorker string
+    CurrentOwners  []string
+    SnapshotAsOf   time.Time
+    Reason         string // "concurrent_owners", "inconclusive_owners", "stale_origin", ...
+}
+```
+
+Bound at `ownershipViolationsCap` (1000, existing field) for both new
+slices. Step 6 outcome rules consume these structured records, not
+just counts.
+
+## P1-2 — H2 (heartbeat-watcher) deferral lacks an interpretation rule — **ACCEPT (modified)**
+
+Codex argues that without H2 health-gating, a stale resolver could
+cause a real admission bug that the new classifier silently downgrades.
+Two responses:
+
+**(a) The classifier already won't silently downgrade.** Under P0-1
+fixes, any cross-worker duplicate that the discriminator can't explain
+lands in `OwnershipInconclusive` (if snapshot initialized) or counts
+as un-classified evidence. Outcome A requires all four counters at
+zero; H2-induced gate admission bugs will surface as inconclusive
+records, not be hidden.
+
+**(b) But Outcome A → enable CI is still risky** if H2 health is
+unobservable. The CI gate would pass on a quiet 5m run that happens to
+not hit the resolver edge case.
+
+**Resolution** (plan §6 outcome rules + §10 acceptance criterion):
+
+- Outcome A enables gate-on CI **only at the chaos_gate.yaml duration**
+  (5m), with `--stop-on-failure=false` and 3-retry budget matching the
+  existing simulation-stress job pattern.
+- Outcome A does **NOT** enable gate-on at `chaos_comprehensive.yaml`
+  duration (8m, aggressive 15-25s chaos). That decision is deferred to
+  a future phase after H2 is addressed, per the chaos_gate.yaml header
+  context.
+- The new CI job, if added, runs `chaos_gate.yaml` specifically — same
+  workload that validated the classifier, no scope creep.
+
+## P2 — Draft commit message pre-decides Outcome A — **ACCEPT**
+
+Right. Removed the pre-decided outcome paragraph from the plan's draft
+commit message. The final commit message will be written from the actual
+run results.
+
+## Plan changes applied
+
+1. §1 — replace `mu`-based reads with `atomic.Pointer` snapshot; add
+   `CurrentOwnersOf` freshness return; document scope-out of pre-existing
+   line 402 race.
+2. §3 — new classification table with cardinality-first check; four
+   classification outcomes (Violation / ConcurrentOwners /
+   Inconclusive / Unobserved / Redelivery).
+3. §3a — replaced; explicit Unobserved vs Inconclusive semantics.
+4. §5 — three additional unit tests:
+   - `TestClassify_ConcurrentOwners_CurrentAndThird`
+   - `TestClassify_OwnershipInconclusive_SnapshotInitialized`
+   - `TestClassify_OwnershipUnobserved_SnapshotUninitialized`
+   - `TestCurrentOwnersOf_ConcurrentAssignmentIngestion` (race test)
+   - `TestFailureReport_IncludesClassificationEvidence`
+5. §6 — Outcome A requires all four counters at zero; CI enablement
+   scope-limited to chaos_gate.yaml workload.
+6. §10 — acceptance criteria 5, 8, 9 revised.
+7. Commit message draft — outcome paragraph removed.
+
+The updated plan is at `docs/plans/sim-oracle-phase5/00-plan.md`.

--- a/docs/plans/sim-oracle-phase5/02-review-response.md
+++ b/docs/plans/sim-oracle-phase5/02-review-response.md
@@ -1,0 +1,56 @@
+# Phase 5 — Plan Review v2 Response
+
+Codex re-review at `tmp/sim-oracle-phase5_v2_review.md`. Verdict: REVISE.
+All three P0s closed. Two P1s remain:
+
+## P1-R1 — Outcome A cannot be verified from the planned failure report — **ACCEPT**
+
+Right. "OwnershipUnobservedCount == 0 after the first ChaosEvent fired"
+is not auditable from a single integer count.
+
+**Resolution (plan §6, §10 updated):**
+
+- Split the unobserved counter into
+  `OwnershipUnobservedPreChaosCount` and
+  `OwnershipUnobservedPostChaosCount`.
+- Outcome A criterion 4 is now `OwnershipUnobservedPostChaosCount == 0`.
+- `FailureReport.FirstChaosEventAt time.Time` is captured for
+  post-hoc inspection.
+- Implementation: coordinator gets a new method
+  `MarkChaosStarted()` invoked by the chaos dispatch loop on the first
+  event. Internal `chaosStarted bool` and `firstChaosAt time.Time`
+  fields; classifier reads `chaosStarted` (atomic.Bool) when
+  incrementing the unobserved counter, routing to the pre- or
+  post-chaos bucket.
+
+Acceptance criterion 5 updated accordingly.
+
+## P1-R2 — Risk 5 overclaims H2 cannot land in row 4 — **ACCEPT**
+
+Codex's scenario is sound: under H2 + stopped-worker prune timing, an
+H2-induced gap can present as `currentOwners == [receivingWorker]`,
+which row 4 classifies as redelivery. That's a real false-negative
+class.
+
+**Resolution (plan Risk 5 + §6 Outcome A wording updated):**
+
+- Risk 5 rewritten with the concrete H2-induced row-4 scenario.
+- Outcome A wording softened from "classifier was the root cause /
+  bug fixed" to "no exclusivity-violation signal detectable by this
+  classifier under this workload". An H2 fix remains a Phase 6+
+  prerequisite for a stronger library-level exclusivity claim.
+- Note: the CI gate-on enablement at `chaos_gate.yaml` is still
+  appropriate. It catches violations, ConcurrentOwners, and
+  Inconclusive — three useful classes — and the H2-induced row-4
+  miss is one well-defined class of false negative documented in
+  Risk 5.
+
+## Plan changes applied
+
+- §6 Outcome A criteria 4 → split counters.
+- §6 Outcome A interpretation softened.
+- Risk 5 fully rewritten with concrete row-4 scenario.
+- §10 acceptance criterion 5 → split counters + FirstChaosEventAt.
+
+The plan additions are minimal — Risk 5 explicitly documents the H2
+blind spot but does not block this phase's structural improvements.

--- a/scripts/trace_visualizer/main.go
+++ b/scripts/trace_visualizer/main.go
@@ -21,10 +21,10 @@ type FailureReport struct {
 }
 
 type MessageGapError struct {
-	PartitionID int   `json:"PartitionID"`
-	ExpectedSeq int64 `json:"ExpectedSeq"`
-	ReceivedSeq int64 `json:"ReceivedSeq"`
-	LastSent    int64 `json:"LastSent"`
+	PartitionID int   `json:"partition_id"`
+	ExpectedSeq int64 `json:"expected_seq"`
+	ReceivedSeq int64 `json:"received_seq"`
+	LastSent    int64 `json:"last_sent"`
 }
 
 type LogEvent struct {

--- a/scripts/trace_visualizer/main_test.go
+++ b/scripts/trace_visualizer/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestFailureReportSchemaMatchesCoordinator verifies that the visualizer's
+// MessageGapError JSON tags decode coordinator-produced failure_report.json
+// payloads correctly. Coordinator writes snake_case; a prior mismatch
+// (UpperCamelCase here) silently decoded every field to zero, making the
+// visualizer's partition filter always target partition 0 and producing
+// misleading timelines.
+//
+// The fixture below is a minimal, coordinator-shape failure report. If the
+// coordinator's MessageGapError JSON schema changes, this test must update
+// in lockstep.
+func TestFailureReportSchemaMatchesCoordinator(t *testing.T) {
+	raw := []byte(`{
+		"timestamp": "2026-05-18T00:00:00Z",
+		"reason": "test",
+		"detailed_gaps": [
+			{
+				"partition_id": 42,
+				"expected_seq": 7,
+				"received_seq": 9,
+				"last_sent": 12
+			}
+		]
+	}`)
+
+	var report FailureReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(report.DetailedGaps) != 1 {
+		t.Fatalf("DetailedGaps len = %d, want 1", len(report.DetailedGaps))
+	}
+
+	g := report.DetailedGaps[0]
+	if g.PartitionID != 42 {
+		t.Errorf("PartitionID = %d, want 42 (snake_case tag mismatch?)", g.PartitionID)
+	}
+	if g.ExpectedSeq != 7 {
+		t.Errorf("ExpectedSeq = %d, want 7", g.ExpectedSeq)
+	}
+	if g.ReceivedSeq != 9 {
+		t.Errorf("ReceivedSeq = %d, want 9", g.ReceivedSeq)
+	}
+	if g.LastSent != 12 {
+		t.Errorf("LastSent = %d, want 12", g.LastSent)
+	}
+}

--- a/test/simulation/cmd/simulation/main.go
+++ b/test/simulation/cmd/simulation/main.go
@@ -460,6 +460,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			GateNakDelay:                cfg.Workers.ProcessingGate.NakDelay,
 			GateNakJitter:               cfg.Workers.ProcessingGate.NakJitter,
 			GateDebug:                   cfg.Workers.ProcessingGate.Debug,
+			IsInitialCohort:             true,
 		}
 
 		w, err := worker.NewWorker(workerCfg)
@@ -485,6 +486,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 
 			newCfg := workerCfg
 			newCfg.NC = newNC
+			newCfg.IsInitialCohort = false // restart is not part of the initial cohort
 
 			// Recreate a new worker instance for clean restart
 			nw, err := worker.NewWorker(newCfg)
@@ -1400,6 +1402,7 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 		GateNakDelay:                aioCfg.Workers.ProcessingGate.NakDelay,
 		GateNakJitter:               aioCfg.Workers.ProcessingGate.NakJitter,
 		GateDebug:                   aioCfg.Workers.ProcessingGate.Debug,
+		IsInitialCohort:             false, // scale_up / restart is a takeover-cohort worker
 	}
 	w, err := worker.NewWorker(wcfg)
 	if err != nil {

--- a/test/simulation/cmd/simulation/main.go
+++ b/test/simulation/cmd/simulation/main.go
@@ -220,10 +220,14 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 	// when many workers ensure the same buckets concurrently.
 	{
 		pc := parti.DefaultConfig()
-		// Disable KV TTL for handoff claims in simulation runs. Auto-purging the
-		// handoff bucket causes ownership entries to disappear in steady state, which
-		// forces the Processing Gate into unknown-ownership NAK loops and inflates
-		// apparent gaps. We want claims to persist until superseded.
+		// LOAD-BEARING: disable JetStream KV TTL for the handoff bucket in
+		// simulation runs. This is the only path that actually controls the
+		// bucket's storage-level TTL — kvutil opens an existing bucket without
+		// reconciling config, so this pre-create value sticks. Without it,
+		// auto-purging would drop ownership entries in steady state, forcing
+		// the Processing Gate into unknown-ownership NAK loops and inflating
+		// apparent gaps. The manager's in-memory cfg.KVBuckets.HandoffTTL is
+		// purely advisory once the bucket exists.
 		pc.KVBuckets.HandoffTTL = 0
 		// Use short, independent timeouts per bucket to avoid blocking startup
 		timeBuckets := []struct {
@@ -295,6 +299,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 		TopN:            cfg.Coordinator.DupTrace.TopN,
 	}
 	coord := coordinator.NewCoordinator(cfg.Partitions.Count, metricsCollector, dupCfg, cfg.Coordinator.StopOnFailure, cfg.Coordinator.FailureReportPath)
+	coord.GetTracker().SetWorkerCacheMax(cfg.Coordinator.WorkerCacheMaxPerPartition)
 	// Configure optional SLO threshold for oldest pending hole age
 	coord.SetSLOHoleMaxAge(cfg.Coordinator.SLO.HoleMaxAge)
 	// Wire catch-up SLO (healing latency after absence)
@@ -360,6 +365,13 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			BurstEnabled:     cfg.Chaos.BurstEnabled,
 			BurstProbability: cfg.Chaos.BurstProbability,
 			EventCallback: func(event coordinator.ChaosEvent, params map[string]any) {
+				// Mark the first chaos event so the classifier can route
+				// unobserved-owner duplicates into the post-chaos bucket.
+				// Must fire BEFORE the handler runs so any receipts
+				// triggered by this event are correctly attributed.
+				if coord != nil {
+					coord.MarkChaosStarted()
+				}
 				handleChaosEvent(ctx, coord, event, params, processMgr, metricsCollector, checkpointMgr, goroutineRegistry)
 			},
 		}
@@ -438,6 +450,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			MetricsCollector:    metricsCollector,
 			ConsumerBatchSize:   cfg.Workers.ConsumerBatchSize,
 			HandlerConcurrency:  cfg.Workers.HandlerConcurrency,
+			AckWait:             cfg.Workers.AckWait,
 			MaxSubjects:         cfg.Workers.MaxSubjects,
 			// Exclusive consumption (Processing Gate)
 			EnforceExclusiveConsumption: cfg.Workers.EnforceExclusiveConsumption,
@@ -655,14 +668,19 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 				lost := metricsCollector.GetLostMessagesTotal()
 				failures := metricsCollector.GetAuditFailuresTotal()
 				initialExc, takeoverExc := coord.SlowStartExceedances()
-				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 {
+				tr := coord.GetTracker()
+				violations := tr.GetOwnershipViolationCount()
+				concurrent := tr.GetConcurrentOwnersViolationCount()
+				inconclusive := tr.GetOwnershipInconclusiveCount()
+				_, unobservedPost := tr.GetOwnershipUnobservedCounts()
+				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 || inconclusive > 0 || unobservedPost > 0 {
 					// Record error but proceed to ordered shutdown
-					invariantsErr = fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d",
-						failures, late, lost, initialExc, takeoverExc)
+					invariantsErr = fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d",
+						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost)
 				}
 				if invariantsErr == nil {
-					log.Printf("Stability invariants passed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d",
-						failures, late, lost, initialExc, takeoverExc)
+					log.Printf("Stability invariants passed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d",
+						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost)
 				} else {
 					log.Printf("Stability invariants failed: %v", invariantsErr)
 				}
@@ -703,9 +721,23 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 				lost := metricsCollector.GetLostMessagesTotal()
 				failures := metricsCollector.GetAuditFailuresTotal()
 				initialExc, takeoverExc := coord.SlowStartExceedances()
-				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 {
-					return fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d",
-						failures, late, lost, initialExc, takeoverExc)
+				tr := coord.GetTracker()
+				violations := tr.GetOwnershipViolationCount()
+				concurrent := tr.GetConcurrentOwnersViolationCount()
+				inconclusive := tr.GetOwnershipInconclusiveCount()
+				_, unobservedPost := tr.GetOwnershipUnobservedCounts()
+				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 || inconclusive > 0 || unobservedPost > 0 {
+					invariantsErr := fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d",
+						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost)
+					// Emit the structured failure_report.json so CI artifacts
+					// include InconclusiveOwnerEvents / unobserved counters /
+					// FirstChaosEventAt — auditability that the new
+					// shutdown-invariant counters demand. TriggerFailure
+					// is idempotent via failureOnce, safe to call even if
+					// an earlier critical failure already wrote the report.
+					coord.TriggerFailure("Stability invariants failed at shutdown", invariantsErr)
+
+					return invariantsErr
 				}
 			}
 
@@ -859,6 +891,7 @@ func runWorker(ctx context.Context, cfg *config.Config) error {
 		MetricsCollector:    nil, // No metrics in standalone worker mode
 		ConsumerBatchSize:   cfg.Workers.ConsumerBatchSize,
 		HandlerConcurrency:  cfg.Workers.HandlerConcurrency,
+		AckWait:             cfg.Workers.AckWait,
 		MaxSubjects:         cfg.Workers.MaxSubjects,
 	}
 
@@ -917,6 +950,8 @@ func runCoordinator(ctx context.Context, cfg *config.Config) error {
 }
 
 // handleChaosEvent handles chaos events by interacting with the process manager.
+//
+//nolint:cyclop // Branching mirrors the chaos-event matrix.
 func handleChaosEvent(
 	ctx context.Context,
 	coord *coordinator.Coordinator,
@@ -998,6 +1033,12 @@ func handleChaosEvent(
 		}
 		handleNetworkDisconnect(duration, processMgr, metricsCollector)
 
+	case coordinator.NetworkDisconnectLeaderEvent:
+		// Process-mode has no real leader lookup (handleLeaderFailure
+		// just kills the first running worker). Rather than approximate,
+		// skip — the event is all-in-one only.
+		log.Println("[Chaos] process mode does not support leader-disconnect; skipping")
+
 	case coordinator.WorkerPauseEvent:
 		// Simulate worker pause
 		duration, ok := params["duration"].(time.Duration)
@@ -1028,7 +1069,7 @@ func handleGoroutineChaos( //nolint:cyclop,gocyclo
 	// Guard: skip worker-related events when no active workers
 	activeWorkers := registry.GetActiveCount(coordinator.WorkerGoroutine)
 	switch event {
-	case coordinator.WorkerCrashEvent, coordinator.WorkerRestartEvent, coordinator.LeaderFailureEvent, coordinator.ScaleDownEvent, coordinator.NetworkDisconnectEvent, coordinator.WorkerPauseEvent, coordinator.SlowConsumerEvent:
+	case coordinator.WorkerCrashEvent, coordinator.WorkerRestartEvent, coordinator.LeaderFailureEvent, coordinator.ScaleDownEvent, coordinator.NetworkDisconnectEvent, coordinator.NetworkDisconnectLeaderEvent, coordinator.WorkerPauseEvent, coordinator.SlowConsumerEvent:
 		if activeWorkers == 0 {
 			log.Printf("[Chaos] Skipping %s: no active workers", event)
 			return
@@ -1152,6 +1193,9 @@ func handleGoroutineChaos( //nolint:cyclop,gocyclo
 		} else {
 			log.Printf("[Chaos] Worker %s missing underlying object; cannot disconnect", target.ID)
 		}
+
+	case coordinator.NetworkDisconnectLeaderEvent:
+		handleLeaderGoroutineNetworkDisconnect(registry, params)
 
 	case coordinator.SlowConsumerEvent:
 		// Slow down a random worker's processing
@@ -1347,6 +1391,7 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 		MetricsCollector:            aioMetrics,
 		ConsumerBatchSize:           aioCfg.Workers.ConsumerBatchSize,
 		HandlerConcurrency:          aioCfg.Workers.HandlerConcurrency,
+		AckWait:                     aioCfg.Workers.AckWait,
 		MaxSubjects:                 aioCfg.Workers.MaxSubjects,
 		EnforceExclusiveConsumption: aioCfg.Workers.EnforceExclusiveConsumption,
 		GateAllowedStates:           aioCfg.Workers.ProcessingGate.AllowedStates,
@@ -1672,6 +1717,47 @@ func handleWorkerPause(duration time.Duration, processMgr *coordinator.ProcessMa
 		if err := processMgr.SignalProcess(targetID, syscall.SIGCONT); err != nil {
 			log.Printf("[Chaos] Failed to resume worker %s: %v", targetID, err)
 		}
+	})
+}
+
+// handleLeaderGoroutineNetworkDisconnect implements the "Split Brain"
+// chaos variant: pick the current leader and isolate it from NATS for
+// the configured duration. Mirrors handleLeaderGoroutineFailure's
+// leader-selection pattern but uses Disconnect() instead of Cancel().
+func handleLeaderGoroutineNetworkDisconnect(
+	registry *coordinator.GoroutineRegistry,
+	params map[string]any,
+) {
+	workers := registry.GetByType(coordinator.WorkerGoroutine)
+	if len(workers) == 0 {
+		log.Println("[Chaos] No active workers to disconnect (leader variant)")
+		return
+	}
+	var leader *coordinator.GoroutineInfo
+	for _, w := range workers {
+		if wobj, ok := w.Obj.(*worker.Worker); ok && wobj.IsLeader() {
+			leader = w
+			break
+		}
+	}
+	if leader == nil {
+		log.Println("[Chaos] No leader worker found to disconnect (network_disconnect_leader)")
+		return
+	}
+	dur, ok := params["duration"].(time.Duration)
+	if !ok || dur <= 0 {
+		dur = 10 * time.Second
+	}
+	wobj, ok := leader.Obj.(*worker.Worker)
+	if !ok {
+		log.Printf("[Chaos] Leader worker %s missing underlying object; cannot disconnect", leader.ID)
+		return
+	}
+	log.Printf("[Chaos] Disconnecting LEADER worker %s for %v", leader.ID, dur)
+	wobj.Disconnect()
+	time.AfterFunc(dur, func() {
+		log.Printf("[Chaos] Reconnecting LEADER worker %s", leader.ID)
+		wobj.Reconnect()
 	})
 }
 

--- a/test/simulation/configs/chaos_comprehensive.yaml
+++ b/test/simulation/configs/chaos_comprehensive.yaml
@@ -19,6 +19,14 @@ workers:
   processing_delay:
     min: 1ms
     max: 5ms
+  # Processing Gate is deliberately OFF in this config — adding it
+  # alongside the aggressive 15-25s chaos interval, burst-enabled
+  # bursts, and 8m duration creates sustained NAK loops that prevent
+  # the cluster from draining (empirically: ~40% of messages
+  # undelivered under gate-on + comprehensive chaos in local 8m runs).
+  # The gate-on CI signal lives on chaos_gate.yaml under a lighter
+  # workload (see .github/workflows/simulation-stress.yml's
+  # gate-on-simulation job).
 
 chaos:
   enabled: true
@@ -35,7 +43,8 @@ chaos:
     - scale_down
     - scale_up
     - worker_pause
-    # - network_disconnect
+    - network_disconnect
+    - network_disconnect_leader
     - slow_consumer
 
 coordinator:

--- a/test/simulation/configs/chaos_gate.yaml
+++ b/test/simulation/configs/chaos_gate.yaml
@@ -1,0 +1,98 @@
+# Gate-on CI config. Exercises enforce_exclusive_consumption end-to-end
+# under chaos so the refined ownership-violation classifier has signal.
+#
+# OUTCOME (2026-05-18, 5m local run): clean. 24240/24240 messages
+# received, zero OwnershipViolations, zero ConcurrentOwnerEvents, zero
+# InconclusiveOwnerEvents, zero post-chaos OwnershipUnobservedCount.
+# A historical chaos finding (cross-worker observation of partition=19
+# seq=153 after worker_restart + network_disconnect_leader) was a
+# classifier false positive — under JetStream at-least-once semantics,
+# redelivery to the new partition owner after a legitimate handoff is
+# correct, not a violation. The refined classifier consults the
+# leader-reported owner snapshot and distinguishes:
+#   - Redelivery (same worker OR handoff to single new owner)
+#   - OwnershipViolation (stale / stranger / ownerLookup-nil fallback)
+#   - ConcurrentOwnersViolation (snapshot reports >1 current owner — split-brain)
+#   - OwnershipInconclusive (mid-handoff after baseline; empty snapshot)
+#   - OwnershipUnobserved (cold start; snapshot uninitialized)
+#
+# Known residual blind spot: an H2 heartbeat-watcher / resolver bug that
+# presents the receiving worker as the sole current owner per the
+# worker-reported snapshot would be classified as legitimate handoff
+# redelivery. Heartbeat-watcher hardening is deferred; gate-on is
+# enabled here at the chaos_gate workload only, not at
+# chaos_comprehensive duration.
+#
+# CI: runs from .github/workflows/simulation-stress.yml as the
+# gate-on-simulation job (5m duration, 3-retry budget).
+# Local repro:
+#   go build -o test/simulation/bin/simulation ./test/simulation/cmd/simulation
+#   ./test/simulation/bin/simulation \
+#     --config test/simulation/configs/chaos_gate.yaml \
+#     --duration 5m --cooldown 30s --stop-on-failure=false
+
+simulation:
+  duration: 5m
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 30
+  message_rate_per_partition: 3
+  distribution: uniform
+
+producers:
+  count: 2
+
+workers:
+  count: 6
+  assignment_strategy: WeightedConsistentHash
+  processing_delay:
+    min: 5ms
+    max: 20ms
+  consumer_batch_size: 8
+  handler_concurrency: 2
+  # AckWait must be < coordinator.gap_aging (60s).
+  ack_wait: 20s
+  # Exercise the Processing Gate end-to-end. This is the only CI config
+  # that turns on enforce_exclusive_consumption — without it, the
+  # OwnershipViolationCount > 0 invariant has no signal.
+  enforce_exclusive_consumption: true
+  processing_gate:
+    allowed_states: ["commit", "stable"]
+    warmup_duration: 10s
+    warmup_allowed_states: ["stable"]
+    nak_delay: 60ms
+    nak_jitter: 0.3
+
+chaos:
+  enabled: true
+  # Moderate intensity — events every 20-30s. Comprehensive's 15-25s
+  # combined with gate-on creates feedback loops that prevent draining.
+  interval: "20s-30s"
+  min_workers: 4
+  max_workers: 8
+  burst_enabled: false
+  events:
+    - worker_crash
+    - worker_restart
+    - leader_failure
+    - scale_down
+    - scale_up
+    - worker_pause
+    - network_disconnect
+    - network_disconnect_leader
+
+coordinator:
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 45s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/chaos_network_disconnect.yaml
+++ b/test/simulation/configs/chaos_network_disconnect.yaml
@@ -1,5 +1,5 @@
 simulation:
-  duration: 30s
+  duration: 90s
   mode: all-in-one
 
 nats:
@@ -24,9 +24,17 @@ chaos:
   enabled: true
   interval: "5s-10s"
   events:
+    # Both the random-target and leader-target variants fire across the
+    # 90s window; with the 5-10s interval this yields ~10 events, so
+    # each variant has high probability of firing at least once.
     - network_disconnect
+    - network_disconnect_leader
 
 coordinator:
+  # Explicit gap_aging (overrides 45s default) — chaos may briefly
+  # disconnect the leader, so give the cluster more headroom to recover
+  # before escalating holes to gaps.
+  gap_aging: 60s
   slo:
     enable_catch_up: true
     catch_up_deadline: 30s

--- a/test/simulation/configs/chaos_roundrobin.yaml
+++ b/test/simulation/configs/chaos_roundrobin.yaml
@@ -1,0 +1,61 @@
+simulation:
+  duration: 90s
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 50
+  message_rate_per_partition: 5
+  distribution: uniform
+
+producers:
+  count: 2
+
+workers:
+  count: 10
+  # RoundRobin intentionally does not preserve cache affinity on rebalance
+  # (see strategy/round_robin.go). This config exercises that strategy
+  # under the comprehensive chaos workload to surface RR-specific bugs.
+  assignment_strategy: RoundRobin
+  processing_delay:
+    min: 1ms
+    max: 5ms
+
+chaos:
+  enabled: true
+  # Roughly 6–9 events over 90s — covers all listed events with high probability.
+  interval: "10s-15s"
+  min_workers: 8
+  max_workers: 14
+  # Mirror chaos_comprehensive.yaml's event set so the RoundRobin job
+  # exercises the same chaos surface, just with a different assignment
+  # strategy. Plan §5 contract.
+  events:
+    - worker_crash
+    - worker_restart
+    - leader_failure
+    - producer_crash
+    - scale_down
+    - scale_up
+    - worker_pause
+    - network_disconnect
+    - network_disconnect_leader
+    - slow_consumer
+
+coordinator:
+  # 60s is long enough to absorb a scale-down + reassignment storm under
+  # RoundRobin's broader reassignment behavior (RR moves more partitions
+  # per scale event than WeightedConsistentHash), but short enough that
+  # the 90s run can still produce gap signal if something truly breaks.
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 30s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/stress-5m-aggressive.yaml
+++ b/test/simulation/configs/stress-5m-aggressive.yaml
@@ -32,6 +32,9 @@ workers:
   consumer_batch_size: 32
   handler_concurrency: 2
   max_subjects: 600
+  # ack_wait must be < coordinator.gap_aging (20s). 10s matches the
+  # aggressive intent: fast detection without racing JetStream redelivery.
+  ack_wait: 10s
   enforce_exclusive_consumption: true
   processing_gate:
     warmup_duration: 10s

--- a/test/simulation/configs/stress-short-aggressive.yaml
+++ b/test/simulation/configs/stress-short-aggressive.yaml
@@ -32,6 +32,8 @@ workers:
   consumer_batch_size: 16
   handler_concurrency: 2
   max_subjects: 300
+  # ack_wait must be < coordinator.gap_aging (20s). See gap_aging below.
+  ack_wait: 10s
   enforce_exclusive_consumption: true
   processing_gate:
     warmup_duration: 5s

--- a/test/simulation/configs/stress-short-quick.yaml
+++ b/test/simulation/configs/stress-short-quick.yaml
@@ -32,6 +32,9 @@ workers:
   consumer_batch_size: 16
   handler_concurrency: 4  # Increase concurrency to heal backlog faster
   max_subjects: 300
+  # ack_wait must be < coordinator.gap_aging (30s). 15s leaves a 2x headroom
+  # for JetStream redelivery without sacrificing detection speed.
+  ack_wait: 15s
   enforce_exclusive_consumption: true
   processing_gate:
     warmup_duration: 5s

--- a/test/simulation/internal/config/config.go
+++ b/test/simulation/internal/config/config.go
@@ -84,6 +84,11 @@ type WorkersConfig struct {
 	// MaxSubjects optionally overrides the WorkerConsumer subject guardrail. If unset or 0,
 	// the simulation will default this to the partition count to avoid cold-start cap errors.
 	MaxSubjects int `yaml:"max_subjects"`
+	// AckWait is the JetStream consumer AckWait for each worker. Must be strictly less than
+	// Coordinator.GapAging — otherwise JetStream's redelivery window for a crashed worker
+	// exceeds the oracle's hole-escalation window, producing false-positive gap escalations
+	// under chaos. Defaults to 30s.
+	AckWait time.Duration `yaml:"ack_wait"`
 }
 
 // ProcessingDelayConfig configures message processing delay.
@@ -124,6 +129,12 @@ type CoordinatorConfig struct {
 	// FailureReportPath defines where to write the JSON failure report.
 	// Defaults to "failure_report.json" if empty.
 	FailureReportPath string `yaml:"failure_report_path"`
+	// WorkerCacheMaxPerPartition caps the per-partition seq→worker map
+	// the tracker uses to classify ownership violations vs redeliveries.
+	// Beyond this window, duplicates fall back to the legacy duplicate
+	// counter. Default 4096 when unset; raise for very long stress runs
+	// to extend the ownership-violation detection horizon.
+	WorkerCacheMaxPerPartition int `yaml:"worker_cache_max_per_partition"`
 }
 
 // SLOConfig holds optional SLO thresholds for simulation reporting.

--- a/test/simulation/internal/config/defaults.go
+++ b/test/simulation/internal/config/defaults.go
@@ -4,7 +4,7 @@ import "time"
 
 // applyDefaults applies default values to configuration fields that are not set.
 //
-//nolint:cyclop // Complexity acceptable for comprehensive config validation
+//nolint:cyclop,gocyclo // Complexity acceptable for comprehensive config validation
 func applyDefaults(cfg *Config) {
 	// Simulation defaults
 	if cfg.Simulation.Mode == "" {
@@ -72,6 +72,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Workers.ProcessingDelay.Max == 0 {
 		cfg.Workers.ProcessingDelay.Max = 50 * time.Millisecond
 	}
+	if cfg.Workers.AckWait == 0 {
+		cfg.Workers.AckWait = 30 * time.Second
+	}
 
 	// Coordinator defaults
 	if cfg.Coordinator.ValidationWindow == 0 {
@@ -79,6 +82,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Coordinator.GapAging == 0 {
 		cfg.Coordinator.GapAging = 45 * time.Second
+	}
+	if cfg.Coordinator.WorkerCacheMaxPerPartition == 0 {
+		cfg.Coordinator.WorkerCacheMaxPerPartition = 4096
 	}
 
 	// Chaos defaults

--- a/test/simulation/internal/config/validation.go
+++ b/test/simulation/internal/config/validation.go
@@ -105,6 +105,9 @@ func validateConfig(cfg *Config) error { //nolint:cyclop,gocyclo
 	if cfg.Workers.ProcessingDelay.Min > cfg.Workers.ProcessingDelay.Max {
 		return errors.New("min processing delay must be less than or equal to max processing delay")
 	}
+	if cfg.Workers.AckWait <= 0 {
+		return errors.New("workers.ack_wait must be positive")
+	}
 
 	// Validate Processing Gate jitter range when enabled
 	if cfg.Workers.EnforceExclusiveConsumption {
@@ -119,6 +122,18 @@ func validateConfig(cfg *Config) error { //nolint:cyclop,gocyclo
 	}
 	if cfg.Coordinator.GapAging <= 0 {
 		return errors.New("gap_aging must be positive")
+	}
+	if cfg.Coordinator.WorkerCacheMaxPerPartition <= 0 {
+		return errors.New("coordinator.worker_cache_max_per_partition must be positive")
+	}
+	// AckWait must be strictly less than GapAging so JetStream redelivers a
+	// crashed worker's in-flight messages before the coordinator escalates
+	// the hole to a confirmed gap. Equal values still race under scheduler
+	// jitter.
+	if cfg.Workers.AckWait >= cfg.Coordinator.GapAging {
+		return fmt.Errorf("workers.ack_wait (%s) must be < coordinator.gap_aging (%s) "+
+			"to avoid false-positive gap escalations during JetStream redelivery",
+			cfg.Workers.AckWait, cfg.Coordinator.GapAging)
 	}
 	// Validate SLO (optional)
 	if cfg.Coordinator.SLO.HoleMaxAge < 0 {

--- a/test/simulation/internal/config/validation_test.go
+++ b/test/simulation/internal/config/validation_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// minimalValidConfig returns a Config that passes validation after
+// applyDefaults — ready for individual fields to be mutated in tests.
+func minimalValidConfig() *Config {
+	c := &Config{}
+	c.Simulation.Mode = "all-in-one"
+	c.Simulation.Duration = 1 * time.Hour
+	c.Partitions.Count = 10
+	c.Partitions.MessageRatePerPartition = 0.1
+	c.Partitions.Distribution = "uniform"
+	c.Producers.Count = 1
+	c.Workers.Count = 1
+	c.Workers.AssignmentStrategy = "ConsistentHash"
+	c.Workers.ConsumerBatchSize = 4
+	c.Workers.HandlerConcurrency = 1
+	c.Workers.ProcessingDelay.Min = 10 * time.Millisecond
+	c.Workers.ProcessingDelay.Max = 50 * time.Millisecond
+	c.Workers.AckWait = 30 * time.Second
+	c.Coordinator.ValidationWindow = 5 * time.Minute
+	c.Coordinator.GapAging = 45 * time.Second
+	c.Coordinator.WorkerCacheMaxPerPartition = 4096
+	c.NATS.Mode = "embedded"
+	c.NATS.URL = "nats://localhost:4222"
+
+	return c
+}
+
+// TestValidate_AckWaitGteGapAging_Rejects exercises B2: the simulation
+// must reject configs where JetStream's redelivery window can exceed the
+// oracle's hole-escalation window. Both equal and greater violate.
+func TestValidate_AckWaitGteGapAging_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		ackWait  time.Duration
+		gapAging time.Duration
+	}{
+		{"equal_30s", 30 * time.Second, 30 * time.Second},
+		{"ackWaitGreater", 30 * time.Second, 20 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := minimalValidConfig()
+			c.Workers.AckWait = tc.ackWait
+			c.Coordinator.GapAging = tc.gapAging
+
+			err := validateConfig(c)
+			if err == nil {
+				t.Fatalf("expected validation error for AckWait=%s GapAging=%s, got nil",
+					tc.ackWait, tc.gapAging)
+			}
+			if !strings.Contains(err.Error(), "ack_wait") || !strings.Contains(err.Error(), "gap_aging") {
+				t.Errorf("error must name both fields; got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_AckWaitLtGapAging_Passes(t *testing.T) {
+	c := minimalValidConfig()
+	c.Workers.AckWait = 10 * time.Second
+	c.Coordinator.GapAging = 30 * time.Second
+	if err := validateConfig(c); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+// TestValidate_AckWaitOmitted_AppliesDefault proves that omitting
+// workers.ack_wait does not bypass B2: after applyDefaults populates the
+// 30s default, validation must catch an aggressive gap_aging < 30s.
+func TestValidate_AckWaitOmitted_AppliesDefault(t *testing.T) {
+	c := minimalValidConfig()
+	c.Workers.AckWait = 0 // omitted in YAML
+	c.Coordinator.GapAging = 20 * time.Second
+
+	applyDefaults(c)
+	if c.Workers.AckWait != 30*time.Second {
+		t.Fatalf("applyDefaults did not set AckWait=30s; got %s", c.Workers.AckWait)
+	}
+
+	err := validateConfig(c)
+	if err == nil {
+		t.Fatal("expected validation error after defaulting; got nil")
+	}
+	if !strings.Contains(err.Error(), "ack_wait") {
+		t.Errorf("error must reference ack_wait; got: %v", err)
+	}
+}
+
+// TestAllShippedConfigsValidate loads every YAML config under
+// test/simulation/configs/ and asserts it survives load + defaults +
+// validate. Catches yaml drift introduced by the AckWait addition and
+// verifies chaos_comprehensive.yaml (the only CI config) is unaffected.
+func TestAllShippedConfigsValidate(t *testing.T) {
+	// Walk up from the package dir to test/simulation/configs/.
+	configsDir := filepath.Join("..", "..", "configs")
+	entries, err := os.ReadDir(configsDir)
+	if err != nil {
+		t.Fatalf("read configs dir %s: %v", configsDir, err)
+	}
+
+	loaded := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		path := filepath.Join(configsDir, e.Name())
+		t.Run(e.Name(), func(t *testing.T) {
+			if _, err := LoadConfig(path); err != nil {
+				t.Errorf("LoadConfig(%s): %v", path, err)
+			}
+		})
+		loaded++
+	}
+	if loaded == 0 {
+		t.Fatalf("no yaml configs found under %s (test setup wrong?)", configsDir)
+	}
+}
+
+// TestValidate_WorkerCacheMaxPerPartition_NonPositive_Rejects guards
+// the config invariant: zero or negative caps are meaningless and
+// would silently fall back to a default — better to surface as a
+// config error so operators tune it deliberately.
+func TestValidate_WorkerCacheMaxPerPartition_NonPositive_Rejects(t *testing.T) {
+	for _, n := range []int{0, -1} {
+		c := minimalValidConfig()
+		c.Coordinator.WorkerCacheMaxPerPartition = n
+		err := validateConfig(c)
+		if err == nil {
+			t.Fatalf("WorkerCacheMaxPerPartition=%d should fail validation", n)
+		}
+		if !strings.Contains(err.Error(), "worker_cache_max_per_partition") {
+			t.Errorf("error must reference worker_cache_max_per_partition; got: %v", err)
+		}
+	}
+}
+
+// TestApplyDefaults_WorkerCacheMaxPerPartition asserts the default fires.
+func TestApplyDefaults_WorkerCacheMaxPerPartition(t *testing.T) {
+	c := minimalValidConfig()
+	c.Coordinator.WorkerCacheMaxPerPartition = 0
+	applyDefaults(c)
+	if c.Coordinator.WorkerCacheMaxPerPartition != 4096 {
+		t.Errorf("default = %d, want 4096", c.Coordinator.WorkerCacheMaxPerPartition)
+	}
+	if err := validateConfig(c); err != nil {
+		t.Errorf("validation must pass after defaults; got %v", err)
+	}
+}
+
+// TestValidate_AckWaitNonPositive_Rejects keeps the field-level invariant
+// visible: explicit zero or negative ack_wait (after defaulting would not
+// kick in if user set a literal 0) is rejected.
+func TestValidate_AckWaitNonPositive_Rejects(t *testing.T) {
+	c := minimalValidConfig()
+	c.Workers.AckWait = -1 * time.Second
+	err := validateConfig(c)
+	if err == nil || !strings.Contains(err.Error(), "ack_wait") {
+		t.Fatalf("expected ack_wait validation error; got %v", err)
+	}
+}

--- a/test/simulation/internal/coordinator/chaos.go
+++ b/test/simulation/internal/coordinator/chaos.go
@@ -31,8 +31,15 @@ const (
 	// ProducerCrashEvent simulates a producer process crash.
 	ProducerCrashEvent ChaosEvent = "producer_crash"
 
-	// NetworkDisconnectEvent simulates NATS connection loss.
+	// NetworkDisconnectEvent simulates NATS connection loss on a random worker.
 	NetworkDisconnectEvent ChaosEvent = "network_disconnect"
+
+	// NetworkDisconnectLeaderEvent simulates NATS connection loss targeted
+	// at the current leader worker — the "Split Brain" scenario the audit's
+	// DESIGN_REVIEW.md called out. All-in-one mode only; process-mode
+	// dispatch logs and skips because process-mode has no real leader
+	// lookup.
+	NetworkDisconnectLeaderEvent ChaosEvent = "network_disconnect_leader"
 
 	// WorkerPauseEvent temporarily pauses a worker's processing without removing it.
 	WorkerPauseEvent ChaosEvent = "worker_pause"
@@ -196,8 +203,10 @@ func (cc *ChaosController) generateEventParams(event ChaosEvent) map[string]any 
 		params["target"] = "leader"
 		params["signal"] = "SIGKILL"
 
-	case NetworkDisconnectEvent:
-		// Disconnect for 5-30 seconds
+	case NetworkDisconnectEvent, NetworkDisconnectLeaderEvent:
+		// Disconnect for 5-30 seconds (both random and leader-target
+		// variants share the same duration range — the only difference
+		// is which worker the dispatcher selects).
 		params["duration"] = time.Duration(cc.rng.Intn(26)+5) * time.Second
 
 	case WorkerPauseEvent:
@@ -320,7 +329,9 @@ func (e ChaosEvent) String() string {
 	case ProducerCrashEvent:
 		return "Producer Crash (SIGKILL)"
 	case NetworkDisconnectEvent:
-		return "Network Disconnect"
+		return "Network Disconnect (Random)"
+	case NetworkDisconnectLeaderEvent:
+		return "Network Disconnect (Leader)"
 	case WorkerPauseEvent:
 		return "Worker Pause"
 	case SlowConsumerEvent:

--- a/test/simulation/internal/coordinator/chaos.go
+++ b/test/simulation/internal/coordinator/chaos.go
@@ -204,10 +204,14 @@ func (cc *ChaosController) generateEventParams(event ChaosEvent) map[string]any 
 		params["signal"] = "SIGKILL"
 
 	case NetworkDisconnectEvent, NetworkDisconnectLeaderEvent:
-		// Disconnect for 5-30 seconds (both random and leader-target
+		// Disconnect for 5-15 seconds (both random and leader-target
 		// variants share the same duration range — the only difference
-		// is which worker the dispatcher selects).
-		params["duration"] = time.Duration(cc.rng.Intn(26)+5) * time.Second
+		// is which worker the dispatcher selects). Upper bound is capped
+		// at 15s so a single disconnect cannot exceed the simulation's
+		// slow-start budgets when chaos fires during cold start; longer
+		// outages don't add new coverage but do produce flaky start-
+		// latency exceedances for chaos-delayed initial-cohort workers.
+		params["duration"] = time.Duration(cc.rng.Intn(11)+5) * time.Second
 
 	case WorkerPauseEvent:
 		// Pause for 5-8 seconds to build backlog

--- a/test/simulation/internal/coordinator/chaos_network_leader_test.go
+++ b/test/simulation/internal/coordinator/chaos_network_leader_test.go
@@ -27,14 +27,14 @@ func TestNetworkDisconnectLeaderEvent_ParamsAndStringer(t *testing.T) {
 	}
 	cc := NewChaosController(cfg)
 
-	// generateEventParams duration matches the random variant: 5–30s.
+	// generateEventParams duration matches the random variant: 5–15s.
 	params := cc.generateEventParams(NetworkDisconnectLeaderEvent)
 	dur, ok := params["duration"].(time.Duration)
 	if !ok {
 		t.Fatalf("params[duration] missing or wrong type: %T %+v", params["duration"], params)
 	}
-	if dur < 5*time.Second || dur > 30*time.Second {
-		t.Errorf("duration = %v, want 5s..30s", dur)
+	if dur < 5*time.Second || dur > 15*time.Second {
+		t.Errorf("duration = %v, want 5s..15s", dur)
 	}
 
 	// String() must not fall through to "Unknown Event".

--- a/test/simulation/internal/coordinator/chaos_network_leader_test.go
+++ b/test/simulation/internal/coordinator/chaos_network_leader_test.go
@@ -1,0 +1,64 @@
+package coordinator
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNetworkDisconnectLeaderEvent_ParamsAndStringer is the deterministic
+// proof that the new chaos event's registration is complete. The audit's
+// round-1 P1 was that probabilistic CI runs may not exercise the new
+// event at all; this test bypasses the scheduler entirely and asserts:
+//   - generateEventParams populates a duration in the expected range
+//   - String() returns a human-readable name (not "Unknown Event")
+//   - GetAvailableEvents would surface it if listed in config
+//
+// These three invariants guard against future refactors that miss one of
+// the typed-switch surfaces (the round-1 review found I missed
+// generateEventParams and String() in my original plan).
+func TestNetworkDisconnectLeaderEvent_ParamsAndStringer(t *testing.T) {
+	cfg := ChaosConfig{
+		Enabled:     true,
+		Events:      []string{string(NetworkDisconnectLeaderEvent)},
+		MinInterval: 1 * time.Second,
+		MaxInterval: 2 * time.Second,
+	}
+	cc := NewChaosController(cfg)
+
+	// generateEventParams duration matches the random variant: 5–30s.
+	params := cc.generateEventParams(NetworkDisconnectLeaderEvent)
+	dur, ok := params["duration"].(time.Duration)
+	if !ok {
+		t.Fatalf("params[duration] missing or wrong type: %T %+v", params["duration"], params)
+	}
+	if dur < 5*time.Second || dur > 30*time.Second {
+		t.Errorf("duration = %v, want 5s..30s", dur)
+	}
+
+	// String() must not fall through to "Unknown Event".
+	got := NetworkDisconnectLeaderEvent.String()
+	if got == "" || strings.Contains(strings.ToLower(got), "unknown") {
+		t.Errorf("String() = %q, want a recognized human-readable name", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "leader") {
+		t.Errorf("String() = %q, want a name that mentions 'leader' to distinguish from the random variant", got)
+	}
+
+	// Random variant is unaffected — guards against accidentally clobbering it.
+	if got := NetworkDisconnectEvent.String(); strings.Contains(strings.ToLower(got), "leader") {
+		t.Errorf("random NetworkDisconnect String() should NOT mention 'leader'; got %q", got)
+	}
+
+	// Constants must be distinct.
+	if NetworkDisconnectLeaderEvent == NetworkDisconnectEvent {
+		t.Error("NetworkDisconnectLeaderEvent and NetworkDisconnectEvent must be distinct constants")
+	}
+
+	// Configured event survives the parse path (string → ChaosEvent cast).
+	available := cc.GetAvailableEvents()
+	if !slices.Contains(available, NetworkDisconnectLeaderEvent) {
+		t.Errorf("NetworkDisconnectLeaderEvent not in GetAvailableEvents(); got %v", available)
+	}
+}

--- a/test/simulation/internal/coordinator/chaos_scenarios_test.go
+++ b/test/simulation/internal/coordinator/chaos_scenarios_test.go
@@ -45,6 +45,7 @@ func TestChaos_WorkerPause(t *testing.T) {
 		AssignmentStrategy:  "consistent-hash",
 		ProcessingDelayMin:  1 * time.Millisecond,
 		ProcessingDelayMax:  5 * time.Millisecond,
+		AckWait:             30 * time.Second,
 		CoordinatorReportCh: reportCh,
 		AssignmentReportCh:  assignCh,
 	}
@@ -156,6 +157,7 @@ func TestChaos_NetworkDisconnect(t *testing.T) {
 		AssignmentStrategy:  "consistent-hash",
 		ProcessingDelayMin:  1 * time.Millisecond,
 		ProcessingDelayMax:  5 * time.Millisecond,
+		AckWait:             30 * time.Second,
 		CoordinatorReportCh: reportCh,
 		AssignmentReportCh:  assignCh,
 	}

--- a/test/simulation/internal/coordinator/coordinator.go
+++ b/test/simulation/internal/coordinator/coordinator.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"maps"
 	"os"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/arloliu/parti/v2/test/simulation/internal/metrics"
@@ -34,6 +36,24 @@ type Coordinator struct {
 	prevPartitionOwners map[int]string // partitionID -> workerID for previous snapshot
 	activeOwners        map[int]string // partitionID -> workerID based on actual processing reports
 	ownersMu            sync.RWMutex   // guards activeOwners
+
+	// ownership-violation evidence: bounded slice of cross-worker same-seq
+	// observations. Surfaced verbatim in FailureReport.OwnershipViolations.
+	// Bounded to ownershipViolationsCap entries to keep failure reports
+	// from ballooning under chaos cascades.
+	//
+	// concurrentOwnerEvents indexes the subset of ownershipViolations
+	// where the owner snapshot reported >1 current owner (
+	// split-brain signal); same backing data, separately enumerable.
+	//
+	// inconclusiveOwnerEvents records cross-worker duplicates where the
+	// owner snapshot was initialized but reported no current owner —
+	// classifications that are non-fatal but still block Outcome A.
+	ownershipViolationsMu   sync.Mutex
+	ownershipViolations     []MessageOwnershipViolationError
+	concurrentOwnerEvents   []MessageOwnershipViolationError
+	inconclusiveOwnerEvents []ClassificationEvidence
+	ownershipViolationsCap  int
 
 	// start-latency tracking: time from Worker.Start() to first OnAssignmentChanged with
 	// a non-empty partition set. Surfaces regressions of the leader-takeover hang fix
@@ -93,6 +113,34 @@ type Coordinator struct {
 	stopOnFailure     bool
 	failureReportPath string
 	failureOnce       sync.Once
+	stopOnce          sync.Once // guards close(stopCh) — both Start(ctx) and TriggerFailure can race to close on shutdown.
+
+	// ownerSnap is an immutable per-partition owner snapshot published
+	// by processAssignments. The receipt path reads it via
+	// CurrentOwnersOf without locks. See docs/plans/sim-oracle-phase5/00-plan.md §1.
+	ownerSnap atomic.Pointer[ownerSnapshot]
+
+	// chaosOnce ensures firstChaosEventAt is captured exactly once when
+	// MarkChaosStarted is called. The chaosStarted flag is on the
+	// tracker (atomic.Bool) so the classifier can read it lock-free.
+	//
+	// firstChaosEventAt is published via atomic.Pointer because it is
+	// read from goroutines other than the chaos-dispatch one (failure
+	// report writer, external observers via FirstChaosEventAt).
+	chaosOnce         sync.Once
+	firstChaosEventAt atomic.Pointer[time.Time]
+}
+
+// ownerSnapshot is an immutable view of partition→workers at a moment
+// in time. Built and atomically published by processAssignments;
+// consumed by the tracker via the owner-lookup callback. Slices in
+// perPartition are sorted (deterministic test output) and MUST NOT be
+// mutated after the snapshot pointer is stored — subsequent updates
+// build and publish a new snapshot.
+type ownerSnapshot struct {
+	perPartition map[int][]string
+	initialized  bool
+	asOf         time.Time
 }
 
 // workerRecoveryContext tracks a single worker's backlog healing progress.
@@ -194,12 +242,86 @@ func NewCoordinator(totalPartitions int, metricsCollector *metrics.Collector, du
 		workerRecovery:          make(map[string]*workerRecoveryContext),
 		stopOnFailure:           stopOnFailure,
 		failureReportPath:       failureReportPath,
+		ownershipViolationsCap:  1000,
 	}
 	c.dup = NewDupTracer(dupCfg)
 	// Suppress verbose out-of-order logs by default; metrics capture disorder depth.
 	c.tracker.SetLogOutOfOrder(false)
+	// Initialize the owner-snapshot to a non-nil zero so CurrentOwnersOf
+	// never sees a nil pointer. processAssignments will publish updated
+	// snapshots as AssignmentReports arrive.
+	c.ownerSnap.Store(&ownerSnapshot{perPartition: map[int][]string{}, initialized: false})
+	// Install the discriminator on the tracker.
+	c.tracker.SetOwnerLookup(c.CurrentOwnersOf)
 
 	return c
+}
+
+// CurrentOwnersOf returns the workerIDs currently reporting partitionID
+// in their most-recent OnAssignmentChanged snapshot, plus a flag
+// indicating whether the snapshot has been initialized.
+//
+// snapshotInitialized is false during cold start, before any
+// AssignmentReport has been processed.
+//
+// The returned slice is part of an immutable snapshot. Callers MUST
+// NOT mutate it. Concurrency-safe: backed by atomic.Pointer load.
+func (c *Coordinator) CurrentOwnersOf(partitionID int) (owners []string, snapshotInitialized bool) {
+	snap := c.ownerSnap.Load()
+	if snap == nil {
+		return nil, false
+	}
+	return snap.perPartition[partitionID], snap.initialized
+}
+
+// MarkChaosStarted notifies the coordinator that the first ChaosEvent
+// has fired. Must be called by the chaos dispatch loop BEFORE invoking
+// the chaos handler for the first event. Idempotent — subsequent calls
+// are no-ops. Safe to call concurrently.
+func (c *Coordinator) MarkChaosStarted() {
+	c.chaosOnce.Do(func() {
+		now := time.Now()
+		c.firstChaosEventAt.Store(&now)
+	})
+	c.tracker.MarkChaosStarted()
+}
+
+// FirstChaosEventAt returns the timestamp captured when MarkChaosStarted
+// was first invoked. Zero value if chaos has not yet started.
+func (c *Coordinator) FirstChaosEventAt() time.Time {
+	t := c.firstChaosEventAt.Load()
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// rebuildOwnerSnapshotLocked rebuilds and publishes an immutable owner
+// snapshot from c.workerAssignments. Caller must be on the
+// processAssignments goroutine (sole writer of workerAssignments).
+//
+// Always sets initialized=true: this function is only invoked from
+// inside processAssignments after consuming an AssignmentReport or
+// stopped-worker event, so reaching this point means at least one
+// report has been processed. The empty-snapshot case (no workers
+// currently own any partition) is a known state, not unknown — the
+// spec's snapshotInitialized==false regime applies strictly to the
+// cold-start window before any report has been ingested.
+func (c *Coordinator) rebuildOwnerSnapshotLocked() {
+	perPartition := make(map[int][]string)
+	for wid, pset := range c.workerAssignments {
+		for pid := range pset {
+			perPartition[pid] = append(perPartition[pid], wid)
+		}
+	}
+	for pid := range perPartition {
+		slices.Sort(perPartition[pid])
+	}
+	c.ownerSnap.Store(&ownerSnapshot{
+		perPartition: perPartition,
+		initialized:  true,
+		asOf:         time.Now(),
+	})
 }
 
 // SetExpectedWorkers sets an optional expected worker count hint for baseline observations.
@@ -316,7 +438,18 @@ func (c *Coordinator) Start(ctx context.Context) {
 
 	<-ctx.Done()
 	log.Println("[Coordinator] Stopping")
-	close(c.stopCh)
+	c.closeStopCh()
+}
+
+// closeStopCh safely closes c.stopCh exactly once. Both the normal
+// Start(ctx) shutdown path and TriggerFailure can fire under shutdown
+// (the shutdown-invariant TriggerFailure runs alongside ctx.Done),
+// and a Go channel double-close panics. The sync.Once guard makes the
+// close idempotent across all paths.
+func (c *Coordinator) closeStopCh() {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+	})
 }
 
 // GetStats returns current statistics.
@@ -856,23 +989,118 @@ func (c *Coordinator) processSentMessages(ctx context.Context) {
 	}
 }
 
+// ClassificationEvidence is a bounded record of a cross-worker
+// known-duplicate classification . Used for InconclusiveOwner-
+// Events (and would extend to other downgrade classes if added later).
+// ConcurrentOwners and stale-receipt records are still captured via the
+// extended MessageOwnershipViolationError; this struct exists for the
+// non-violation classifications that still need post-hoc inspection.
+type ClassificationEvidence struct {
+	PartitionID     int       `json:"partition_id"`
+	Sequence        int64     `json:"sequence"`
+	OriginalWorker  string    `json:"original_worker"`
+	ReceivingWorker string    `json:"receiving_worker"`
+	Reason          string    `json:"reason"`
+	ObservedAt      time.Time `json:"observed_at"`
+}
+
 // FailureReport represents the structured failure output.
 type FailureReport struct {
-	Timestamp    time.Time         `json:"timestamp"`
-	Reason       string            `json:"reason"`
-	Stats        TrackerStats      `json:"stats"`
-	GapErrors    []string          `json:"gap_errors,omitempty"`
-	DetailedGaps []MessageGapError `json:"detailed_gaps,omitempty"`
-	ActiveGaps   int               `json:"active_gaps"`
-	PendingHoles int64             `json:"pending_holes"`
+	Timestamp                         time.Time                        `json:"timestamp"`
+	Reason                            string                           `json:"reason"`
+	Stats                             TrackerStats                     `json:"stats"`
+	GapErrors                         []string                         `json:"gap_errors,omitempty"`
+	DetailedGaps                      []MessageGapError                `json:"detailed_gaps,omitempty"`
+	ActiveGaps                        int                              `json:"active_gaps"`
+	PendingHoles                      int64                            `json:"pending_holes"`
+	OwnershipViolations               []MessageOwnershipViolationError `json:"ownership_violations,omitempty"`
+	ConcurrentOwnerEvents             []MessageOwnershipViolationError `json:"concurrent_owner_events,omitempty"`
+	InconclusiveOwnerEvents           []ClassificationEvidence         `json:"inconclusive_owner_events,omitempty"`
+	OwnershipUnobservedPreChaosCount  int64                            `json:"ownership_unobserved_pre_chaos_count"`
+	OwnershipUnobservedPostChaosCount int64                            `json:"ownership_unobserved_post_chaos_count"`
+	FirstChaosEventAt                 time.Time                        `json:"first_chaos_event_at,omitzero"`
+}
+
+// appendOwnershipViolation appends a violation to the bounded list. Caller
+// must not hold any other coordinator locks (this takes its own).
+// ConcurrentOwner-flagged violations are also indexed separately for
+// failure-report visibility — same backing list, just an additional
+// pointer-equivalent slice.
+func (c *Coordinator) appendOwnershipViolation(ove MessageOwnershipViolationError) {
+	c.ownershipViolationsMu.Lock()
+	defer c.ownershipViolationsMu.Unlock()
+	if len(c.ownershipViolations) >= c.ownershipViolationsCap {
+		return
+	}
+	c.ownershipViolations = append(c.ownershipViolations, ove)
+	if ove.ConcurrentOwners {
+		if len(c.concurrentOwnerEvents) < c.ownershipViolationsCap {
+			c.concurrentOwnerEvents = append(c.concurrentOwnerEvents, ove)
+		}
+	}
+}
+
+// appendInconclusiveOwnerEvent appends an inconclusive-owner
+// classification record to its bounded list. Capped at
+// ownershipViolationsCap entries to keep failure reports compact.
+func (c *Coordinator) appendInconclusiveOwnerEvent(ev ClassificationEvidence) {
+	c.ownershipViolationsMu.Lock()
+	defer c.ownershipViolationsMu.Unlock()
+	if len(c.inconclusiveOwnerEvents) >= c.ownershipViolationsCap {
+		return
+	}
+	c.inconclusiveOwnerEvents = append(c.inconclusiveOwnerEvents, ev)
+}
+
+// snapshotOwnershipViolations returns a copy of the current violation list.
+func (c *Coordinator) snapshotOwnershipViolations() []MessageOwnershipViolationError {
+	c.ownershipViolationsMu.Lock()
+	defer c.ownershipViolationsMu.Unlock()
+	if len(c.ownershipViolations) == 0 {
+		return nil
+	}
+	out := make([]MessageOwnershipViolationError, len(c.ownershipViolations))
+	copy(out, c.ownershipViolations)
+
+	return out
+}
+
+// snapshotConcurrentOwnerEvents returns a copy of the concurrent-owner
+// subset of violations.
+func (c *Coordinator) snapshotConcurrentOwnerEvents() []MessageOwnershipViolationError {
+	c.ownershipViolationsMu.Lock()
+	defer c.ownershipViolationsMu.Unlock()
+	if len(c.concurrentOwnerEvents) == 0 {
+		return nil
+	}
+	out := make([]MessageOwnershipViolationError, len(c.concurrentOwnerEvents))
+	copy(out, c.concurrentOwnerEvents)
+
+	return out
+}
+
+// snapshotInconclusiveOwnerEvents returns a copy of the inconclusive-owner
+// classifications.
+func (c *Coordinator) snapshotInconclusiveOwnerEvents() []ClassificationEvidence {
+	c.ownershipViolationsMu.Lock()
+	defer c.ownershipViolationsMu.Unlock()
+	if len(c.inconclusiveOwnerEvents) == 0 {
+		return nil
+	}
+	out := make([]ClassificationEvidence, len(c.inconclusiveOwnerEvents))
+	copy(out, c.inconclusiveOwnerEvents)
+
+	return out
 }
 
 // TriggerFailure triggers a failure report and stops the simulation.
+// Idempotent via failureOnce. The stopCh close goes through closeStopCh
+// (sync.Once) so it cannot panic on a race with Start(ctx)'s shutdown.
 func (c *Coordinator) TriggerFailure(reason string, err error) {
 	c.failureOnce.Do(func() {
 		log.Printf("[Coordinator] CRITICAL FAILURE: %s (%v). Stopping simulation.", reason, err)
 		c.writeFailureReport(reason, err)
-		close(c.stopCh) // Signal global stop
+		c.closeStopCh() // Signal global stop
 	})
 }
 
@@ -886,12 +1114,19 @@ func (c *Coordinator) writeFailureReport(reason string, err error) {
 		path = "failure_report.json"
 	}
 
+	stats := c.tracker.GetStats()
 	report := FailureReport{
-		Timestamp:    time.Now(),
-		Reason:       fmt.Sprintf("%s: %v", reason, err),
-		Stats:        c.tracker.GetStats(),
-		ActiveGaps:   c.tracker.GetStats().GapCount,
-		PendingHoles: c.tracker.GetPendingHoles(),
+		Timestamp:                         time.Now(),
+		Reason:                            fmt.Sprintf("%s: %v", reason, err),
+		Stats:                             stats,
+		ActiveGaps:                        stats.GapCount,
+		PendingHoles:                      c.tracker.GetPendingHoles(),
+		OwnershipViolations:               c.snapshotOwnershipViolations(),
+		ConcurrentOwnerEvents:             c.snapshotConcurrentOwnerEvents(),
+		InconclusiveOwnerEvents:           c.snapshotInconclusiveOwnerEvents(),
+		OwnershipUnobservedPreChaosCount:  stats.OwnershipUnobservedPreChaosCount,
+		OwnershipUnobservedPostChaosCount: stats.OwnershipUnobservedPostChaosCount,
+		FirstChaosEventAt:                 c.FirstChaosEventAt(),
 	}
 
 	// Include specific error details if available
@@ -925,7 +1160,7 @@ func (c *Coordinator) processReceivedMessages(ctx context.Context) {
 			return
 		case msg := <-c.receivedCh:
 			// Record received and handle potential catch-up lifecycle transitions.
-			healed, err := c.tracker.RecordReceived(msg.PartitionID, msg.PartitionSequence)
+			healed, err := c.tracker.RecordReceivedFromWorker(msg.PartitionID, msg.PartitionSequence, msg.WorkerID)
 			if c.catchUpEnabled {
 				c.processCatchUpActivity(msg.WorkerID)
 			}
@@ -933,38 +1168,8 @@ func (c *Coordinator) processReceivedMessages(ctx context.Context) {
 			c.ownersMu.Lock()
 			c.activeOwners[msg.PartitionID] = msg.WorkerID
 			c.ownersMu.Unlock()
-			if err != nil {
-				// Include worker ID for debugging attribution
-				var extra string
-				var ge *MessageGapError
-				if errors.As(err, &ge) {
-					extra = fmt.Sprintf(" worker=%s last_sent=%d", msg.WorkerID, ge.LastSent)
-				}
-				_ = extra
-				// log.Printf("[Coordinator] ERROR: %v%s", err, extra)
-
-				// Record gap/duplicate metrics using proper error type checking
-				if c.metricsCollector != nil {
-					if errors.Is(err, ErrMessageGap) {
-						c.metricsCollector.RecordGap()
-					}
-
-					if errors.Is(err, ErrMessageDuplicate) {
-						c.metricsCollector.RecordDuplicate()
-						c.metricsCollector.RecordDuplicatePartition(msg.PartitionID)
-					}
-				}
-
-				// Trace duplicates into sliding window for analysis
-				if errors.Is(err, ErrMessageDuplicate) {
-					c.dup.RecordDuplicate(msg.PartitionID, msg.WorkerID, msg.PartitionSequence, time.Now())
-				}
-
-				// Trigger stop-on-failure if enabled and it's a gap
-				if c.stopOnFailure && errors.Is(err, ErrMessageGap) {
-					c.internalTriggerFailure("Gap detected", err)
-					return
-				}
+			if err != nil && c.dispatchReceiveError(msg, err) {
+				return
 			}
 
 			// Record metrics
@@ -984,6 +1189,89 @@ func (c *Coordinator) processReceivedMessages(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// dispatchReceiveError routes a tracker error to its appropriate handler
+// (metric, log, failure-report append, stop-on-failure trigger). Returns
+// true if the caller should stop the receive loop (e.g., stop-on-failure
+// triggered).
+func (c *Coordinator) dispatchReceiveError(msg ReceivedMessage, err error) bool {
+	// Redelivery is informational — record metric and continue. Must
+	// dispatch BEFORE the generic error branches so it doesn't fall
+	// through to DupTracer or stop-on-failure.
+	if errors.Is(err, ErrMessageRedelivery) {
+		if c.metricsCollector != nil {
+			c.metricsCollector.RecordRedelivery()
+		}
+
+		return false
+	}
+	if errors.Is(err, ErrMessageOwnershipViolation) {
+		return c.handleOwnershipViolation(err)
+	}
+	//  inconclusive/unobserved owner classifications are
+	// non-fatal but still recorded so Outcome A can be audited.
+	if errors.Is(err, ErrMessageOwnershipInconclusive) {
+		var ie *MessageOwnershipInconclusiveError
+		if errors.As(err, &ie) {
+			c.appendInconclusiveOwnerEvent(ClassificationEvidence{
+				PartitionID:     ie.PartitionID,
+				Sequence:        ie.Sequence,
+				OriginalWorker:  ie.OriginalWorker,
+				ReceivingWorker: ie.CurrentWorker,
+				Reason:          "inconclusive_owner_snapshot_empty",
+				ObservedAt:      time.Now(),
+			})
+		}
+
+		return false
+	}
+	if errors.Is(err, ErrMessageOwnershipUnobserved) {
+		// Count tracking happens in the tracker (pre/post chaos buckets);
+		// no failure-report record per occurrence — only aggregate counts.
+		return false
+	}
+
+	// Generic gap/duplicate path.
+	if c.metricsCollector != nil {
+		if errors.Is(err, ErrMessageGap) {
+			c.metricsCollector.RecordGap()
+		}
+		if errors.Is(err, ErrMessageDuplicate) {
+			c.metricsCollector.RecordDuplicate()
+			c.metricsCollector.RecordDuplicatePartition(msg.PartitionID)
+		}
+	}
+	if errors.Is(err, ErrMessageDuplicate) {
+		c.dup.RecordDuplicate(msg.PartitionID, msg.WorkerID, msg.PartitionSequence, time.Now())
+	}
+	if c.stopOnFailure && errors.Is(err, ErrMessageGap) {
+		c.internalTriggerFailure("Gap detected", err)
+
+		return true
+	}
+
+	return false
+}
+
+func (c *Coordinator) handleOwnershipViolation(err error) bool {
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		return false
+	}
+	if c.metricsCollector != nil {
+		c.metricsCollector.RecordOwnershipViolation()
+	}
+	c.appendOwnershipViolation(*ove)
+	log.Printf("[Coordinator] OWNERSHIP VIOLATION: partition=%d seq=%d original=%s current=%s",
+		ove.PartitionID, ove.Sequence, ove.OriginalWorker, ove.CurrentWorker)
+	if c.stopOnFailure {
+		c.internalTriggerFailure("Ownership violation detected", err)
+
+		return true
+	}
+
+	return false
 }
 
 func (c *Coordinator) runMetricsTicker(ctx context.Context) {
@@ -1062,6 +1350,7 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 				continue
 			}
 			delete(c.workerAssignments, wid)
+			c.rebuildOwnerSnapshotLocked()
 			if c.baselineLocked && c.totalPartitions > 0 {
 				fresh := make(map[int]string, c.totalPartitions)
 				for id, wset := range c.workerAssignments {
@@ -1103,6 +1392,7 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 				}
 			}
 			c.workerAssignments[ar.WorkerID] = set
+			c.rebuildOwnerSnapshotLocked()
 
 			// Build global set.
 			global := make(map[int]struct{})

--- a/test/simulation/internal/coordinator/coordinator.go
+++ b/test/simulation/internal/coordinator/coordinator.go
@@ -200,9 +200,18 @@ type AssignmentReport struct {
 // StartLatencyReport reports the latency from Worker.Start() to the first
 // OnAssignmentChanged hook firing with a non-empty partition set. It is
 // emitted exactly once per worker instance.
+//
+// IsInitialCohort is set by the caller at worker construction: true for
+// workers spawned during simulation bootstrap, false for workers created
+// via scale_up or restart. The coordinator uses this flag (not the
+// receive-time view of baselineLocked) to decide which budget applies,
+// closing a race where a chaos-delayed initial-cohort worker's report
+// arrives after baselineLocked has already flipped and is misbucketed
+// as takeover.
 type StartLatencyReport struct {
-	WorkerID string
-	Latency  time.Duration
+	WorkerID        string
+	Latency         time.Duration
+	IsInitialCohort bool
 }
 
 // NewCoordinator creates a new coordinator.
@@ -1363,15 +1372,18 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 				c.prevPartitionOwners = fresh
 			}
 		case sl := <-c.startLatenciesCh:
-			// Classify using this goroutine's live view of baselineLocked so the
-			// distinction between "initial fleet coming up" and "late joiner /
-			// takeover replacement" is decided at the moment the worker's first
-			// assignment landed, without cross-goroutine locking.
+			// Classify by the caller-provided cohort flag. Earlier versions
+			// used baselineLocked at receive time, but that races: when the
+			// worker's assignment report and startLatency report sit in
+			// separate channels, the select can drain the assignment first,
+			// flip baselineLocked, then misbucket the trailing startLatency
+			// of an initial-cohort worker as takeover. The flag is stamped
+			// at worker construction, so the decision is timing-invariant.
 			c.startLatencyMu.Lock()
-			if c.baselineLocked {
-				c.takeoverStartLatencies[sl.WorkerID] = sl.Latency
-			} else {
+			if sl.IsInitialCohort {
 				c.initialStartLatencies[sl.WorkerID] = sl.Latency
+			} else {
+				c.takeoverStartLatencies[sl.WorkerID] = sl.Latency
 			}
 			c.startLatencyMu.Unlock()
 		case ar := <-c.assignmentsCh:

--- a/test/simulation/internal/coordinator/coordinator_test.go
+++ b/test/simulation/internal/coordinator/coordinator_test.go
@@ -3,7 +3,61 @@ package coordinator
 import (
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/arloliu/parti/v2/test/simulation/internal/metrics"
 )
+
+// TestStartLatencyClassifier_HonorsCohortFlag verifies the classifier
+// buckets samples by the report's IsInitialCohort stamp instead of the
+// coordinator's receive-time view of baselineLocked. Without this
+// invariant, a chaos-delayed initial-cohort worker whose assignment
+// report drains before its startLatency report (flipping baselineLocked
+// before the trailing sample is classified) gets misbucketed as a
+// takeover — a flaky path observed under network_disconnect_leader chaos.
+func TestStartLatencyClassifier_HonorsCohortFlag(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	mc := metrics.NewCollectorWithRegistry(reg)
+	coord := NewCoordinator(1, mc, DupTraceSettings{}, false, "")
+	coord.ConfigureSlowStartBudgets(5*time.Second, 5*time.Second)
+
+	go coord.Start(t.Context())
+
+	ch := coord.GetStartLatencyChannel()
+	ch <- StartLatencyReport{WorkerID: "w-initial-slow", Latency: 100 * time.Millisecond, IsInitialCohort: true}
+	ch <- StartLatencyReport{WorkerID: "w-takeover-fast", Latency: 100 * time.Millisecond, IsInitialCohort: false}
+
+	// Poll the bucketed maps; processing is async via the assignments goroutine.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		coord.startLatencyMu.Lock()
+		gotInitial := coord.initialStartLatencies["w-initial-slow"]
+		gotTakeover := coord.takeoverStartLatencies["w-takeover-fast"]
+		coord.startLatencyMu.Unlock()
+		if gotInitial > 0 && gotTakeover > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	coord.startLatencyMu.Lock()
+	defer coord.startLatencyMu.Unlock()
+	if _, ok := coord.initialStartLatencies["w-initial-slow"]; !ok {
+		t.Errorf("initialStartLatencies missing w-initial-slow (got %+v)", coord.initialStartLatencies)
+	}
+	if _, ok := coord.takeoverStartLatencies["w-takeover-fast"]; !ok {
+		t.Errorf("takeoverStartLatencies missing w-takeover-fast (got %+v)", coord.takeoverStartLatencies)
+	}
+	if _, wrong := coord.takeoverStartLatencies["w-initial-slow"]; wrong {
+		t.Error("w-initial-slow incorrectly bucketed as takeover")
+	}
+	if _, wrong := coord.initialStartLatencies["w-takeover-fast"]; wrong {
+		t.Error("w-takeover-fast incorrectly bucketed as initial")
+	}
+}
 
 // TestPruneStaleRecoveries verifies that stale recovery contexts are pruned.
 func TestPruneStaleRecoveries(t *testing.T) {

--- a/test/simulation/internal/coordinator/tracker.go
+++ b/test/simulation/internal/coordinator/tracker.go
@@ -5,13 +5,21 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// Sentinel errors for gap and duplicate detection.
+// Sentinel errors for gap, duplicate, redelivery, and ownership-violation
+// detection. Note that ErrMessageRedelivery is informational — not a
+// failure — but is surfaced via the error channel for consistent
+// errors.Is-based dispatch in the coordinator.
 var (
-	ErrMessageGap       = errors.New("message gap detected")
-	ErrMessageDuplicate = errors.New("duplicate message detected")
+	ErrMessageGap                   = errors.New("message gap detected")
+	ErrMessageDuplicate             = errors.New("duplicate message detected")
+	ErrMessageRedelivery            = errors.New("at-least-once redelivery")
+	ErrMessageOwnershipViolation    = errors.New("ownership violation: same sequence processed by different workers")
+	ErrMessageOwnershipInconclusive = errors.New("ownership inconclusive: cross-worker duplicate with no current owner reported")
+	ErrMessageOwnershipUnobserved   = errors.New("ownership unobserved: cross-worker duplicate before any owner snapshot was ingested")
 )
 
 // MessageGapError wraps message gap details.
@@ -45,6 +53,121 @@ func (e *MessageDuplicateError) Error() string {
 func (e *MessageDuplicateError) Unwrap() error {
 	return ErrMessageDuplicate
 }
+
+// MessageRedeliveryEvent is returned as the error value when the same
+// worker reprocesses a sequence (legitimate JetStream at-least-once
+// redelivery — not a failure). The coordinator dispatches it via
+// errors.Is(err, ErrMessageRedelivery) to record an informational metric
+// and explicitly does NOT propagate it to the stop-on-failure path,
+// DupTracer, or the failure report. The "Event" suffix signals "not a
+// failure"; the type implements error solely for unified dispatch.
+//
+//nolint:errname // see docstring above; Event suffix is intentional
+type MessageRedeliveryEvent struct {
+	PartitionID int    `json:"partition_id"`
+	Sequence    int64  `json:"sequence"`
+	WorkerID    string `json:"worker_id"`
+}
+
+func (e *MessageRedeliveryEvent) Error() string {
+	return fmt.Sprintf("redelivery: partition=%d seq=%d worker=%s",
+		e.PartitionID, e.Sequence, e.WorkerID)
+}
+
+func (e *MessageRedeliveryEvent) Unwrap() error {
+	return ErrMessageRedelivery
+}
+
+// MessageOwnershipViolationError signals that the same (partition, seq)
+// was processed by two different workers — a parti exclusivity contract
+// violation (Processing Gate or handoff regression). The coordinator
+// records it into FailureReport.OwnershipViolations and treats it as a
+// hard stability-invariant failure.
+//
+// Reason is populated when an owner-lookup callback is installed, to
+// record which row of the classification table fired. Empty for legacy
+// (nil-lookup) violations.
+//
+// ConcurrentOwners is true when the snapshot reported >1 current owner
+// for the partition at the moment of the duplicate receipt — the most
+// severe form of violation (assignment-layer split-brain).
+type MessageOwnershipViolationError struct {
+	PartitionID      int      `json:"partition_id"`
+	Sequence         int64    `json:"sequence"`
+	OriginalWorker   string   `json:"original_worker"`
+	CurrentWorker    string   `json:"current_worker"`
+	CurrentOwners    []string `json:"current_owners,omitempty"`
+	Reason           string   `json:"reason,omitempty"`
+	ConcurrentOwners bool     `json:"concurrent_owners,omitempty"`
+}
+
+func (e *MessageOwnershipViolationError) Error() string {
+	return fmt.Sprintf("ownership violation: partition=%d seq=%d original=%s current=%s reason=%s concurrent=%t",
+		e.PartitionID, e.Sequence, e.OriginalWorker, e.CurrentWorker, e.Reason, e.ConcurrentOwners)
+}
+
+func (e *MessageOwnershipViolationError) Unwrap() error {
+	return ErrMessageOwnershipViolation
+}
+
+// MessageOwnershipInconclusiveError signals a cross-worker duplicate
+// where the owner snapshot has been initialized but reports no current
+// owner for the partition (mid-handoff window after baseline). Not a
+// hard failure on its own; counts against Outcome A — a non-zero count
+// means the discriminator lacked sufficient signal to classify safely.
+//
+//nolint:errname // matches MessageOwnershipViolationError naming for consistency
+type MessageOwnershipInconclusiveError struct {
+	PartitionID    int    `json:"partition_id"`
+	Sequence       int64  `json:"sequence"`
+	OriginalWorker string `json:"original_worker"`
+	CurrentWorker  string `json:"current_worker"`
+}
+
+func (e *MessageOwnershipInconclusiveError) Error() string {
+	return fmt.Sprintf("ownership inconclusive: partition=%d seq=%d original=%s current=%s",
+		e.PartitionID, e.Sequence, e.OriginalWorker, e.CurrentWorker)
+}
+
+func (e *MessageOwnershipInconclusiveError) Unwrap() error {
+	return ErrMessageOwnershipInconclusive
+}
+
+// MessageOwnershipUnobservedError signals a cross-worker duplicate
+// during the cold-start window before any owner snapshot was ingested.
+// Tolerated pre-first-ChaosEvent; counted against Outcome A
+// post-first-ChaosEvent. Two distinct counters track these regimes.
+//
+//nolint:errname // matches MessageOwnershipViolationError naming for consistency
+type MessageOwnershipUnobservedError struct {
+	PartitionID    int    `json:"partition_id"`
+	Sequence       int64  `json:"sequence"`
+	OriginalWorker string `json:"original_worker"`
+	CurrentWorker  string `json:"current_worker"`
+}
+
+func (e *MessageOwnershipUnobservedError) Error() string {
+	return fmt.Sprintf("ownership unobserved: partition=%d seq=%d original=%s current=%s",
+		e.PartitionID, e.Sequence, e.OriginalWorker, e.CurrentWorker)
+}
+
+func (e *MessageOwnershipUnobservedError) Unwrap() error {
+	return ErrMessageOwnershipUnobserved
+}
+
+// OwnerLookupFunc returns the current owners (worker IDs) of a
+// partition per the leader-reported assignment snapshot, plus a flag
+// indicating whether the snapshot has been initialized. Returning
+// (nil, false) means no AssignmentReport has been ingested yet
+// (cold start). Returning (nil, true) or ([], true) means an empty
+// owner set after the snapshot has been initialized (mid-handoff).
+type OwnerLookupFunc func(partitionID int) (owners []string, snapshotInitialized bool)
+
+// DefaultWorkerCacheMaxPerPartition bounds the per-partition seq→worker
+// map. Beyond this window, ownership-violation detection falls back to
+// the legacy duplicate counter (a "detection horizon", not full-history
+// proof). Configurable via Coordinator.WorkerCacheMaxPerPartition.
+const DefaultWorkerCacheMaxPerPartition = 4096
 
 // MessageTracker tracks sent and received message sequences.
 type MessageTracker struct {
@@ -86,6 +209,44 @@ type MessageTracker struct {
 	// can classify their eventual arrival as a gap heal rather than a duplicate.
 	// Maps sequence -> escalation time for pruning.
 	gapEscalated map[int]map[int64]time.Time
+	// lastWorkerPerSeq stores the workerID that first physically processed
+	// each (partition, seq). Used to distinguish legitimate JetStream
+	// redelivery (same worker) from a true ownership violation (different
+	// worker). Per-partition map is bounded at workerCacheMax — when the
+	// cap is reached, the lowest-seq entry is evicted.
+	lastWorkerPerSeq map[int]map[int64]string
+	// workerCacheMax caps each partition's lastWorkerPerSeq map. Zero
+	// means "use DefaultWorkerCacheMaxPerPartition".
+	workerCacheMax int
+	// redeliveryCount counts partSeq<=lastReceived observations where the
+	// reporting worker matches the original; informational.
+	redeliveryCount int64
+	// ownershipViolationCount counts partSeq<=lastReceived observations
+	// where the reporting worker differs from the original; a hard failure.
+	ownershipViolationCount int64
+	// concurrentOwnersViolationCount counts violations where the owner
+	// snapshot reported >1 current owner (split-brain) at the moment of
+	// the duplicate receipt. Subset of ownershipViolationCount.
+	concurrentOwnersViolationCount int64
+	// ownershipInconclusiveCount counts cross-worker duplicates where the
+	// owner snapshot was initialized but reported no current owner
+	// (mid-handoff). Blocks Outcome A — see docs/plans/sim-oracle-phase5.
+	ownershipInconclusiveCount int64
+	// ownershipUnobservedPreChaosCount counts cross-worker duplicates
+	// during cold start, before the first ChaosEvent has fired. Tolerated.
+	ownershipUnobservedPreChaosCount int64
+	// ownershipUnobservedPostChaosCount counts cross-worker duplicates
+	// observed before any owner snapshot was ingested, but after the
+	// first ChaosEvent. Always a real signal — blocks Outcome A.
+	ownershipUnobservedPostChaosCount int64
+	// ownerLookup is the optional owner-snapshot discriminator
+	// . When nil, classifier falls back to legacy
+	// origWorker-mismatch-only logic.
+	ownerLookup OwnerLookupFunc
+	// chaosStarted flips to true after MarkChaosStarted is called once.
+	// Read by the classifier to route unobserved-owner duplicates to the
+	// pre- or post-chaos bucket. atomic.Bool — no t.mu needed for reads.
+	chaosStarted atomic.Bool
 	// logOutOfOrder toggles verbose logging of out-of-order observations.
 	// Disabled by default to avoid noisy logs when holes heal quickly.
 	logOutOfOrder bool
@@ -96,6 +257,15 @@ type MessageTracker struct {
 // Returns:
 //   - *MessageTracker: Initialized tracker
 func NewMessageTracker() *MessageTracker {
+	return NewMessageTrackerWithCap(DefaultWorkerCacheMaxPerPartition)
+}
+
+// NewMessageTrackerWithCap is NewMessageTracker with an explicit
+// per-partition worker-cache cap. Pass 0 to use the default.
+func NewMessageTrackerWithCap(workerCacheMax int) *MessageTracker {
+	if workerCacheMax <= 0 {
+		workerCacheMax = DefaultWorkerCacheMaxPerPartition
+	}
 	return &MessageTracker{
 		lastSentPerPartition:      make(map[int]int64),
 		lastReceivedPerPartition:  make(map[int]int64),
@@ -107,6 +277,8 @@ func NewMessageTracker() *MessageTracker {
 		logOutOfOrder:             false,
 		suppressedMarked:          make(map[int]map[int64]struct{}),
 		gapEscalated:              make(map[int]map[int64]time.Time),
+		lastWorkerPerSeq:          make(map[int]map[int64]string),
+		workerCacheMax:            workerCacheMax,
 	}
 }
 
@@ -117,6 +289,28 @@ func (t *MessageTracker) SetLogOutOfOrder(enabled bool) {
 	t.mu.Lock()
 	t.logOutOfOrder = enabled
 	t.mu.Unlock()
+}
+
+// SetOwnerLookup installs the owner-snapshot discriminator .
+// When non-nil, cross-worker duplicates are classified per the refined
+// table in docs/plans/sim-oracle-phase5/00-plan.md §3; when nil, the
+// classifier falls back to legacy origWorker-mismatch-only logic.
+//
+// Pass nil to disable (default).
+func (t *MessageTracker) SetOwnerLookup(fn OwnerLookupFunc) {
+	t.mu.Lock()
+	t.ownerLookup = fn
+	t.mu.Unlock()
+}
+
+// MarkChaosStarted signals that the first ChaosEvent has fired. Must be
+// called by the chaos dispatch loop BEFORE invoking the chaos handler
+// for the first event. Subsequent calls are no-ops. After this returns,
+// any subsequent classification of an unobserved-owner duplicate counts
+// toward the post-chaos bucket; before it returns, toward the pre-chaos
+// bucket. Safe to call concurrently with classification.
+func (t *MessageTracker) MarkChaosStarted() {
+	t.chaosStarted.Store(true)
 }
 
 // RecordSent records that a message was sent.
@@ -134,26 +328,38 @@ func (t *MessageTracker) RecordSent(partitionID int, producerID string, partitio
 	t.lastSentPerProducer[producerID] = producerSeq
 }
 
-// RecordReceived records that a message was received and validates sequence.
+// RecordReceived is the workerID-less variant of RecordReceivedFromWorker,
+// equivalent to passing workerID="". Same-worker redelivery vs ownership
+// violation classification is disabled — any partSeq<=lastReceived
+// observation that isn't a gap heal counts as a plain duplicate. Kept
+// for tests and the checkpoint-restore replay path that have no worker
+// attribution.
+func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]time.Duration, error) {
+	return t.RecordReceivedFromWorker(partitionID, partitionSeq, "")
+}
+
+// RecordReceivedFromWorker records that a message was received and
+// validates the sequence. When workerID is non-empty, late-arrival
+// duplicates are classified as either redelivery (same worker) or
+// ownership violation (different worker). When workerID is empty,
+// classification falls back to the legacy duplicate counter.
 //
 // Parameters:
 //   - partitionID: Partition ID
 //   - partitionSeq: Partition sequence number
-//
-// Returns:
-//   - error: Error if gap or duplicate detected
-//
-// RecordReceived records that a message was received and validates sequence.
-// It returns a slice of durations representing healed holes lifetimes (time from firstSeen to arrival).
-//
-// Parameters:
-//   - partitionID: Partition ID
-//   - partitionSeq: Partition sequence number
+//   - workerID: Reporting worker ID; empty disables ownership classification.
 //
 // Returns:
 //   - []time.Duration: Lifetimes for healed holes consumed while advancing the contiguous window
-//   - error: Error if gap or duplicate detected
-func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]time.Duration, error) {
+//   - error: One of:
+//     *MessageGapError on confirmed gap (via AgeOut path; not from this call)
+//     *MessageDuplicateError on pruned-fallback / empty-workerID duplicate
+//     *MessageRedeliveryEvent on same-worker reprocess (informational)
+//     *MessageOwnershipViolationError on different-worker reprocess (failure)
+//     nil on normal arrival, contiguous advance, or gap heal
+//
+//nolint:cyclop // Branching mirrors the receive-classification matrix.
+func (t *MessageTracker) RecordReceivedFromWorker(partitionID int, partitionSeq int64, workerID string) ([]time.Duration, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -163,23 +369,39 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 
 	lastReceived, exists := t.lastReceivedPerPartition[partitionID]
 	if !exists {
-		// Initialize structures for this partition
-		t.lastReceivedPerPartition[partitionID] = partitionSeq
+		// Anchor lastReceived at 0 and fall through to the regular gap /
+		// duplicate detection path. The producer's first sequence is 1
+		// (see producer.go), so partitionSeq==1 hits the contiguous-advance
+		// branch and partitionSeq>1 enters the out-of-order branch which
+		// registers [1, partitionSeq-1] as missing. Pre-fix this branch
+		// seeded lastReceived=partitionSeq, which silently swallowed
+		// pre-seq losses (false negative) and misclassified a later seq=1
+		// arrival as a duplicate (false positive).
+		lastReceived = 0
+		t.lastReceivedPerPartition[partitionID] = 0
 		if _, ok := t.missingPerPartition[partitionID]; !ok {
 			t.missingPerPartition[partitionID] = make(map[int64]time.Time)
 		}
-		if partitionSeq > t.highWatermarkPerPartition[partitionID] {
-			t.highWatermarkPerPartition[partitionID] = partitionSeq
-		}
-		// First physical arrival for this partition
-		t.physicalReceivedCount++
-
-		return healedDurations, nil
 	}
 
 	// Ensure maps are initialized
 	if _, ok := t.missingPerPartition[partitionID]; !ok {
 		t.missingPerPartition[partitionID] = make(map[int64]time.Time)
+	}
+
+	// Early classification of duplicate-of-known-seq. The invariant is:
+	// if partitionSeq is already in lastWorkerPerSeq, it was physically
+	// observed (the only places that record into lastWorkerPerSeq are
+	// the three physical-receipt paths below: out-of-order, contiguous
+	// advance, gap-heal). A new receipt of the same seq is therefore a
+	// duplicate, regardless of whether it would otherwise route through
+	// the out-of-order branch (partitionSeq > expectedSeq, when the
+	// missing window hasn't closed yet) or the post-advance branch
+	// (partitionSeq <= lastReceived). Catching both paths here ensures
+	// a same-seq cross-worker observation can never bypass classification
+	// by being "still out-of-order".
+	if origWorker, known := t.lookupOrigWorkerLocked(partitionID, partitionSeq); known {
+		return healedDurations, t.classifyKnownDuplicateLocked(partitionID, partitionSeq, workerID, origWorker)
 	}
 
 	expectedSeq := lastReceived + 1
@@ -193,13 +415,22 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 		// Safety check for massive gaps to prevent OOM
 		gapSize := partitionSeq - expectedSeq
 		if gapSize <= 10000 {
-			// Track missing range [expectedSeq, partitionSeq-1] without counting as an error yet
+			// Track missing range [expectedSeq, partitionSeq-1] without counting as an error yet.
+			// Sequences <= prior high watermark that aren't already in `miss` were physically
+			// observed earlier out-of-order (window-advance invariant); skip them or they
+			// become phantom holes that block the window-advance loop and can be escalated
+			// to false gaps by AgeOut.
 			miss := t.missingPerPartition[partitionID]
 			now := time.Now()
+			hwm := t.highWatermarkPerPartition[partitionID]
 			for s := expectedSeq; s < partitionSeq; s++ {
-				if _, exists := miss[s]; !exists {
-					miss[s] = now
+				if _, present := miss[s]; present {
+					continue
 				}
+				if s <= hwm {
+					continue
+				}
+				miss[s] = now
 			}
 			// Update high watermark
 			if partitionSeq > t.highWatermarkPerPartition[partitionID] {
@@ -207,6 +438,9 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 			}
 			// Physically received this out-of-order sequence
 			t.physicalReceivedCount++
+			// Record worker for this out-of-order seq; future duplicates
+			// of this same seq from a different worker → ownership violation.
+			t.recordWorkerForSeqLocked(partitionID, partitionSeq, workerID)
 			// Do not count as a gap immediately; treat as out-of-order and let holes fill
 			return healedDurations, nil
 		}
@@ -219,7 +453,9 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 		// Fall through to normal processing as if we are now in sync
 	}
 
-	// Duplicate, or gap-healed (late arrival of previously escalated gap)
+	// Duplicate (origin not in lastWorkerPerSeq — pruned, empty-workerID
+	// replay, or unrecorded), or gap-healed (late arrival of previously
+	// escalated gap).
 	if partitionSeq <= lastReceived {
 		if escalatedSet, ok := t.gapEscalated[partitionID]; ok {
 			if _, wasGap := escalatedSet[partitionSeq]; wasGap {
@@ -228,11 +464,20 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 				t.gapsHealedCount++
 				// Count physical receipt (this sequence not previously physically observed)
 				t.physicalReceivedCount++
+				// Record the worker that healed; future duplicates can be
+				// classified as redelivery vs violation against this id
+				// (via the early-classification check at the top).
+				t.recordWorkerForSeqLocked(partitionID, partitionSeq, workerID)
 				log.Printf("[Tracker] GAP_HEALED partition=%d seq=%d last_received=%d high_watermark=%d", partitionID, partitionSeq, lastReceived, t.highWatermarkPerPartition[partitionID])
+
 				return healedDurations, nil
 			}
 		}
-		// True duplicate (already in contiguous window and not a gap heal)
+
+		// Reaching here means partitionSeq was not in lastWorkerPerSeq AND
+		// not in gapEscalated. This is the "unclassifiable duplicate"
+		// fallback (origin pruned, or replayed from checkpoint with empty
+		// workerID and so never recorded). Increment the legacy counter.
 		log.Printf("[Tracker] DUPLICATE partition=%d seq=%d last_received=%d high_watermark=%d", partitionID, partitionSeq, lastReceived, t.highWatermarkPerPartition[partitionID])
 		t.duplicateCount++
 
@@ -261,6 +506,8 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 	}
 	// Count physical receipt of this sequence (unique arrival)
 	t.physicalReceivedCount++
+	// Record worker for this contiguous-advance seq.
+	t.recordWorkerForSeqLocked(partitionID, partitionSeq, workerID)
 
 	// Advance window over any subsequent messages that were already received out-of-order
 	for {
@@ -276,6 +523,194 @@ func (t *MessageTracker) RecordReceived(partitionID int, partitionSeq int64) ([]
 	}
 
 	return healedDurations, nil
+}
+
+// lookupOrigWorkerLocked returns the worker that first physically processed
+// (partitionID, partitionSeq), and whether the entry is known. Caller must
+// hold t.mu. The empty-string and not-found cases are both reported as
+// "known=false" intentionally — both route to the legacy duplicate fallback
+// in classifyKnownDuplicateLocked.
+func (t *MessageTracker) lookupOrigWorkerLocked(partitionID int, partitionSeq int64) (string, bool) {
+	pmap, ok := t.lastWorkerPerSeq[partitionID]
+	if !ok {
+		return "", false
+	}
+	w, found := pmap[partitionSeq]
+	if !found || w == "" {
+		return "", false
+	}
+
+	return w, true
+}
+
+// classifyKnownDuplicateLocked is the unified classification path for a
+// duplicate where the original worker is already recorded. Used by the
+// early-detection branch at the top of RecordReceivedFromWorker so that
+// out-of-order duplicates and post-advance duplicates are classified
+// identically. Caller must hold t.mu.
+//
+// When ownerLookup is set , the table from
+// docs/plans/sim-oracle-phase5/00-plan.md §3 is evaluated top-down to
+// distinguish handoff redelivery, stale receipt, stranger receiver,
+// split-brain, and the two empty-owner regimes. When ownerLookup is
+// nil, the legacy origWorker-mismatch-only behavior is preserved.
+//
+//nolint:cyclop,gocyclo // mirrors the classification table; collapsing arms loses readability of the §3 mapping.
+func (t *MessageTracker) classifyKnownDuplicateLocked(partitionID int, partitionSeq int64, workerID, origWorker string) error {
+	if workerID == "" {
+		// Caller doesn't know its own worker (e.g., checkpoint restore).
+		// Cannot classify; fall back to legacy duplicate counter.
+		log.Printf("[Tracker] DUPLICATE partition=%d seq=%d (current workerID empty; cannot classify)", partitionID, partitionSeq)
+		t.duplicateCount++
+
+		return &MessageDuplicateError{PartitionID: partitionID, Sequence: partitionSeq}
+	}
+	// Row 1: same worker → legitimate redelivery (caught before owner
+	// lookup since this doesn't depend on the snapshot).
+	if origWorker == workerID {
+		t.redeliveryCount++
+
+		return &MessageRedeliveryEvent{
+			PartitionID: partitionID,
+			Sequence:    partitionSeq,
+			WorkerID:    workerID,
+		}
+	}
+	// Row 2: legacy fallback when no discriminator is installed.
+	if t.ownerLookup == nil {
+		log.Printf("[Tracker] OWNERSHIP_VIOLATION partition=%d seq=%d original=%s current=%s (legacy)", partitionID, partitionSeq, origWorker, workerID)
+		t.ownershipViolationCount++
+
+		return &MessageOwnershipViolationError{
+			PartitionID:    partitionID,
+			Sequence:       partitionSeq,
+			OriginalWorker: origWorker,
+			CurrentWorker:  workerID,
+			Reason:         "legacy_no_lookup",
+		}
+	}
+	owners, initialized := t.ownerLookup(partitionID)
+	ownersCopy := make([]string, len(owners))
+	copy(ownersCopy, owners)
+	// Row 3: concurrent ownership — most severe.
+	if len(owners) > 1 {
+		log.Printf("[Tracker] CONCURRENT_OWNERS partition=%d seq=%d original=%s current=%s owners=%v", partitionID, partitionSeq, origWorker, workerID, owners)
+		t.ownershipViolationCount++
+		t.concurrentOwnersViolationCount++
+
+		return &MessageOwnershipViolationError{
+			PartitionID:      partitionID,
+			Sequence:         partitionSeq,
+			OriginalWorker:   origWorker,
+			CurrentWorker:    workerID,
+			CurrentOwners:    ownersCopy,
+			Reason:           "concurrent_owners",
+			ConcurrentOwners: true,
+		}
+	}
+	// Row 7/8: empty owner set — distinguish initialized (mid-handoff)
+	// vs uninitialized (cold start).
+	if len(owners) == 0 {
+		if initialized {
+			log.Printf("[Tracker] OWNERSHIP_INCONCLUSIVE partition=%d seq=%d original=%s current=%s", partitionID, partitionSeq, origWorker, workerID)
+			t.ownershipInconclusiveCount++
+
+			return &MessageOwnershipInconclusiveError{
+				PartitionID:    partitionID,
+				Sequence:       partitionSeq,
+				OriginalWorker: origWorker,
+				CurrentWorker:  workerID,
+			}
+		}
+		if t.chaosStarted.Load() {
+			t.ownershipUnobservedPostChaosCount++
+		} else {
+			t.ownershipUnobservedPreChaosCount++
+		}
+		log.Printf("[Tracker] OWNERSHIP_UNOBSERVED partition=%d seq=%d original=%s current=%s chaosStarted=%v", partitionID, partitionSeq, origWorker, workerID, t.chaosStarted.Load())
+
+		return &MessageOwnershipUnobservedError{
+			PartitionID:    partitionID,
+			Sequence:       partitionSeq,
+			OriginalWorker: origWorker,
+			CurrentWorker:  workerID,
+		}
+	}
+	// Rows 4-6: len(owners) == 1.
+	only := owners[0]
+	switch only {
+	case workerID:
+		// Row 4: handoff redelivery — new owner reports the partition.
+		t.redeliveryCount++
+
+		return &MessageRedeliveryEvent{
+			PartitionID: partitionID,
+			Sequence:    partitionSeq,
+			WorkerID:    workerID,
+		}
+	case origWorker:
+		// Row 5: stale receipt — original worker still assigned, but
+		// receiver is not. Real violation.
+		log.Printf("[Tracker] OWNERSHIP_VIOLATION_STALE partition=%d seq=%d original=%s current=%s owner=%s", partitionID, partitionSeq, origWorker, workerID, only)
+		t.ownershipViolationCount++
+
+		return &MessageOwnershipViolationError{
+			PartitionID:    partitionID,
+			Sequence:       partitionSeq,
+			OriginalWorker: origWorker,
+			CurrentWorker:  workerID,
+			CurrentOwners:  ownersCopy,
+			Reason:         "stale_receipt",
+		}
+	default:
+		// Row 6: stranger receiver — neither worker is currently
+		// assigned. Real violation.
+		log.Printf("[Tracker] OWNERSHIP_VIOLATION_STRANGER partition=%d seq=%d original=%s current=%s owner=%s", partitionID, partitionSeq, origWorker, workerID, only)
+		t.ownershipViolationCount++
+
+		return &MessageOwnershipViolationError{
+			PartitionID:    partitionID,
+			Sequence:       partitionSeq,
+			OriginalWorker: origWorker,
+			CurrentWorker:  workerID,
+			CurrentOwners:  ownersCopy,
+			Reason:         "stranger_receiver",
+		}
+	}
+}
+
+// recordWorkerForSeqLocked stores the workerID that physically processed
+// (partitionID, partitionSeq). Caller must hold t.mu. Empty workerID is a
+// no-op (preserves the "unclassifiable" fallback semantic). When the
+// per-partition map exceeds t.workerCacheMax, the smallest-seq entry is
+// evicted (O(N) walk; amortized cheap since the cache only grows on unique
+// physical receipts).
+func (t *MessageTracker) recordWorkerForSeqLocked(partitionID int, partitionSeq int64, workerID string) {
+	if workerID == "" {
+		return
+	}
+	pmap, ok := t.lastWorkerPerSeq[partitionID]
+	if !ok {
+		pmap = make(map[int64]string)
+		t.lastWorkerPerSeq[partitionID] = pmap
+	}
+	pmap[partitionSeq] = workerID
+	limit := t.workerCacheMax
+	if limit <= 0 {
+		limit = DefaultWorkerCacheMaxPerPartition
+	}
+	if len(pmap) > limit {
+		// Evict the smallest-seq entry.
+		var minSeq int64
+		first := true
+		for s := range pmap {
+			if first || s < minSeq {
+				minSeq = s
+				first = false
+			}
+		}
+		delete(pmap, minSeq)
+	}
 }
 
 // AgeOut escalates aged missing sequences to gaps up to the cutoff time.
@@ -438,23 +873,91 @@ func (t *MessageTracker) GetStats() TrackerStats {
 	}
 
 	return TrackerStats{
-		TotalPartitions: len(t.lastSentPerPartition),
-		TotalSent:       totalSent,
-		TotalReceived:   totalReceived,
-		InFlight:        inFlight,
-		GapCount:        t.gapCount,
-		DuplicateCount:  t.duplicateCount,
+		TotalPartitions:                   len(t.lastSentPerPartition),
+		TotalSent:                         totalSent,
+		TotalReceived:                     totalReceived,
+		InFlight:                          inFlight,
+		GapCount:                          t.gapCount,
+		DuplicateCount:                    t.duplicateCount,
+		RedeliveryCount:                   t.redeliveryCount,
+		OwnershipViolationCount:           t.ownershipViolationCount,
+		ConcurrentOwnersViolationCount:    t.concurrentOwnersViolationCount,
+		OwnershipInconclusiveCount:        t.ownershipInconclusiveCount,
+		OwnershipUnobservedPreChaosCount:  t.ownershipUnobservedPreChaosCount,
+		OwnershipUnobservedPostChaosCount: t.ownershipUnobservedPostChaosCount,
 	}
+}
+
+// SetWorkerCacheMax updates the per-partition seq→worker cache cap.
+// Intended to be called once after NewMessageTracker, before the tracker
+// has seen significant traffic. Pass 0 to reset to the default.
+func (t *MessageTracker) SetWorkerCacheMax(n int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if n <= 0 {
+		n = DefaultWorkerCacheMaxPerPartition
+	}
+	t.workerCacheMax = n
+}
+
+// GetOwnershipViolationCount returns the number of detected ownership
+// violations (same-seq processed by different workers). A non-zero count
+// is a hard stability-invariant failure for the simulation.
+func (t *MessageTracker) GetOwnershipViolationCount() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ownershipViolationCount
+}
+
+// GetRedeliveryCount returns the number of detected same-worker
+// redeliveries. Informational; expected to be > 0 under chaos.
+func (t *MessageTracker) GetRedeliveryCount() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.redeliveryCount
+}
+
+// GetConcurrentOwnersViolationCount returns the subset of ownership
+// violations where the owner snapshot reported >1 current owner —
+// assignment-layer split-brain.
+func (t *MessageTracker) GetConcurrentOwnersViolationCount() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.concurrentOwnersViolationCount
+}
+
+// GetOwnershipInconclusiveCount returns the number of cross-worker
+// duplicates classified as inconclusive (initialized snapshot reported
+// no current owner). Non-zero blocks Outcome A.
+func (t *MessageTracker) GetOwnershipInconclusiveCount() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ownershipInconclusiveCount
+}
+
+// GetOwnershipUnobservedCounts returns the (pre, post) split counters
+// for cross-worker duplicates observed before any owner snapshot was
+// ingested. Pre-chaos is tolerated; post-chaos blocks Outcome A.
+func (t *MessageTracker) GetOwnershipUnobservedCounts() (preChaos, postChaos int64) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.ownershipUnobservedPreChaosCount, t.ownershipUnobservedPostChaosCount
 }
 
 // TrackerStats represents tracker statistics.
 type TrackerStats struct {
-	TotalPartitions int   `json:"total_partitions"`
-	TotalSent       int64 `json:"total_sent"`
-	TotalReceived   int64 `json:"total_received"`
-	InFlight        int64 `json:"in_flight"` // Messages sent but not yet received
-	GapCount        int   `json:"gap_count"`
-	DuplicateCount  int   `json:"duplicate_count"`
+	TotalPartitions                   int   `json:"total_partitions"`
+	TotalSent                         int64 `json:"total_sent"`
+	TotalReceived                     int64 `json:"total_received"`
+	InFlight                          int64 `json:"in_flight"` // Messages sent but not yet received
+	GapCount                          int   `json:"gap_count"`
+	DuplicateCount                    int   `json:"duplicate_count"`
+	RedeliveryCount                   int64 `json:"redelivery_count"`
+	OwnershipViolationCount           int64 `json:"ownership_violation_count"`
+	ConcurrentOwnersViolationCount    int64 `json:"concurrent_owners_violation_count"`
+	OwnershipInconclusiveCount        int64 `json:"ownership_inconclusive_count"`
+	OwnershipUnobservedPreChaosCount  int64 `json:"ownership_unobserved_pre_chaos_count"`
+	OwnershipUnobservedPostChaosCount int64 `json:"ownership_unobserved_post_chaos_count"`
 }
 
 // GetPendingHoles returns the total number of currently missing sequences across all partitions.

--- a/test/simulation/internal/coordinator/tracker_firstobs_test.go
+++ b/test/simulation/internal/coordinator/tracker_firstobs_test.go
@@ -1,0 +1,151 @@
+package coordinator
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRecordReceived_FirstSeqIsOne is a regression test: the steady-state
+// happy path (first observation is seq=1) must continue to work.
+func TestRecordReceived_FirstSeqIsOne(t *testing.T) {
+	tr := NewMessageTracker()
+	if _, err := tr.RecordReceived(7, 1); err != nil {
+		t.Fatalf("RecordReceived(7, 1): %v", err)
+	}
+	_, last := tr.GetPartitionState(7)
+	if last != 1 {
+		t.Errorf("lastReceived = %d, want 1", last)
+	}
+	if got := tr.GetPhysicalReceivedCount(); got != 1 {
+		t.Errorf("physicalReceivedCount = %d, want 1", got)
+	}
+}
+
+// TestRecordReceived_FirstSeqOutOfOrder covers B1's false-positive case:
+// seq=2 arrives before seq=1 at startup. Pre-fix this seeded
+// lastReceived=2 and the subsequent seq=1 was misclassified as a
+// duplicate. Post-fix the seed is 0, and seq=1 heals the missing entry
+// the seq=2 receipt created.
+func TestRecordReceived_FirstSeqOutOfOrder(t *testing.T) {
+	tr := NewMessageTracker()
+
+	if _, err := tr.RecordReceived(0, 2); err != nil {
+		t.Fatalf("RecordReceived(0, 2): %v", err)
+	}
+
+	healed, err := tr.RecordReceived(0, 1)
+	if err != nil {
+		t.Fatalf("RecordReceived(0, 1) must not return error (pre-fix returned duplicate); got %v", err)
+	}
+	if len(healed) != 1 {
+		t.Errorf("healed durations = %d, want 1", len(healed))
+	}
+
+	_, last := tr.GetPartitionState(0)
+	if last != 2 {
+		t.Errorf("lastReceived = %d, want 2", last)
+	}
+	if got := tr.GetHolesHealedCount(); got != 1 {
+		t.Errorf("holesHealedCount = %d, want 1", got)
+	}
+	st := tr.GetStats()
+	if st.DuplicateCount != 0 {
+		t.Errorf("DuplicateCount = %d, want 0 (seq=1 must not be classified as duplicate)", st.DuplicateCount)
+	}
+}
+
+// TestRecordReceived_FirstObservationIsGap covers B1's false-negative
+// case plus the round-1 reviewer's phantom-hole regression. Receiving
+// seq=3, 4, 5 in order (without 1, 2 yet) must record exactly {1, 2} as
+// missing — NOT {1, 2, 3} or {1, 2, 3, 4}. Then receiving 1 and 2 must
+// drive lastReceived all the way to 5 via the window-advance loop.
+func TestRecordReceived_FirstObservationIsGap(t *testing.T) {
+	tr := NewMessageTracker()
+
+	for _, s := range []int64{3, 4, 5} {
+		if _, err := tr.RecordReceived(11, s); err != nil {
+			t.Fatalf("RecordReceived(11, %d): %v", s, err)
+		}
+	}
+
+	// After 3, 4, 5: missing set must be exactly {1, 2}. Verify via
+	// GetPendingHoles which counts entries in missingPerPartition.
+	if got := tr.GetPendingHoles(); got != 2 {
+		t.Fatalf("pendingHoles = %d, want 2 (phantom hole bug: range-fill re-added already-seen seqs)", got)
+	}
+	if got := tr.GetPhysicalReceivedCount(); got != 3 {
+		t.Errorf("physicalReceivedCount = %d, want 3", got)
+	}
+
+	// Now heal: 1 then 2. Window must advance to 5 because 3, 4, 5 were
+	// already observed (high watermark = 5, missing set = empty).
+	if _, err := tr.RecordReceived(11, 1); err != nil {
+		t.Fatalf("RecordReceived(11, 1): %v", err)
+	}
+	if _, err := tr.RecordReceived(11, 2); err != nil {
+		t.Fatalf("RecordReceived(11, 2): %v", err)
+	}
+
+	_, last := tr.GetPartitionState(11)
+	if last != 5 {
+		t.Errorf("lastReceived = %d, want 5 (window-advance must consume 3,4,5)", last)
+	}
+	if got := tr.GetHolesHealedCount(); got != 2 {
+		t.Errorf("holesHealedCount = %d, want 2", got)
+	}
+	st := tr.GetStats()
+	if st.GapCount != 0 {
+		t.Errorf("GapCount = %d, want 0", st.GapCount)
+	}
+	if st.DuplicateCount != 0 {
+		t.Errorf("DuplicateCount = %d, want 0", st.DuplicateCount)
+	}
+}
+
+// TestRecordReceived_FirstObsGap_AgedOut exercises the phantom-hole
+// failure case end-to-end through AgeOut: if seq=3 is wrongly added to
+// missing (the reviewer's P0), AgeOut would escalate seqs 1, 2, AND 3 to
+// gaps. The fix ensures only the genuinely-missing {1, 2} are escalated.
+func TestRecordReceived_FirstObsGap_AgedOut(t *testing.T) {
+	tr := NewMessageTracker()
+
+	// First, three out-of-order receipts to set up the phantom-hole risk.
+	for _, s := range []int64{3, 4, 5} {
+		if _, err := tr.RecordReceived(11, s); err != nil {
+			t.Fatalf("RecordReceived(11, %d): %v", s, err)
+		}
+	}
+
+	// Age everything: cutoff in the future relative to firstSeen timestamps.
+	cutoff := time.Now().Add(1 * time.Hour)
+	escalations := tr.AgeOut(cutoff)
+
+	// Exactly 2 gap escalations (seqs 1 and 2). If the phantom-hole bug
+	// is present, this is 3 (also includes seq 3).
+	if len(escalations) != 2 {
+		t.Fatalf("AgeOut escalations = %d, want 2 (phantom-hole regression?); details: %v",
+			len(escalations), escalations)
+	}
+
+	seen := map[int64]bool{}
+	for _, e := range escalations {
+		var gerr *MessageGapError
+		if !errors.As(e, &gerr) {
+			t.Fatalf("escalation %v: not a *MessageGapError", e)
+		}
+		seen[gerr.ExpectedSeq] = true
+	}
+	if !seen[1] || !seen[2] {
+		t.Errorf("expected seqs {1, 2} escalated; got %v", seen)
+	}
+	if seen[3] {
+		t.Error("seq 3 must NOT be escalated (was physically observed)")
+	}
+
+	// After AgeOut consumes seqs 1, 2 the window must advance to 5.
+	_, last := tr.GetPartitionState(11)
+	if last != 5 {
+		t.Errorf("after AgeOut: lastReceived = %d, want 5", last)
+	}
+}

--- a/test/simulation/internal/coordinator/tracker_owner_lookup_test.go
+++ b/test/simulation/internal/coordinator/tracker_owner_lookup_test.go
@@ -1,0 +1,449 @@
+package coordinator
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// Refined cross-worker duplicate classifier with an owner-snapshot
+// discriminator. The classifier consults the leader-reported assignment
+// at the moment of receipt to distinguish legitimate handoff redelivery
+// from a real exclusive-consumption violation. The §3 classification
+// table is documented in the source for classifyKnownDuplicateLocked.
+// Each row in that table maps to one test below; the tests document
+// intent (what classification means under which snapshot state) rather
+// than just exercising code paths.
+
+// stubLookup returns a deterministic owner-set + initialized flag for
+// the partition under test. Other partitions return empty/uninitialized.
+func stubLookup(partition int, owners []string, initialized bool) OwnerLookupFunc {
+	return func(pid int) ([]string, bool) {
+		if pid != partition {
+			return nil, false
+		}
+		return owners, initialized
+	}
+}
+
+// Row 1: origWorker == workerID — legitimate redelivery, no snapshot
+// consulted. Covered by the existing tracker_ownership_test.go suite
+// (TestRecordReceived_SameWorkerDuplicate_IsRedelivery); restated here
+// against the new ownerLookup path to confirm row 1 still wins when
+// owner lookup IS installed.
+func TestClassify_SameWorkerRedelivery_WithOwnerLookup(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-A")
+	if !errors.Is(err, ErrMessageRedelivery) {
+		t.Fatalf("expected redelivery; got %v", err)
+	}
+}
+
+// Row 2: nil ownerLookup — legacy fallback preserves prior behavior.
+// Any cross-worker duplicate is a violation regardless of snapshot.
+func TestClassify_NilLookup_LegacyViolation(t *testing.T) {
+	tr := NewMessageTracker()
+	// No SetOwnerLookup — explicit nil.
+
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("expected violation; got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		t.Fatalf("err should unwrap to violation; got %T", err)
+	}
+	if ove.Reason != "legacy_no_lookup" {
+		t.Errorf("Reason = %q, want legacy_no_lookup", ove.Reason)
+	}
+}
+
+// Row 3: ConcurrentOwners — owner snapshot reports >1 worker. The most
+// severe class. Hits regardless of orig/receiving membership.
+func TestClassify_ConcurrentOwners_CurrentAndThird(t *testing.T) {
+	tr := NewMessageTracker()
+	// First record from worker-A with snapshot=[worker-A] (single owner).
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	// Now flip the snapshot to two concurrent owners not including orig.
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-B", "worker-C"}, true))
+
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("expected violation (concurrent owners); got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		t.Fatalf("err type: %T", err)
+	}
+	if !ove.ConcurrentOwners {
+		t.Errorf("ConcurrentOwners flag should be true; got %+v", ove)
+	}
+	if ove.Reason != "concurrent_owners" {
+		t.Errorf("Reason = %q, want concurrent_owners", ove.Reason)
+	}
+	if got := tr.GetConcurrentOwnersViolationCount(); got != 1 {
+		t.Errorf("ConcurrentOwnersViolationCount = %d, want 1", got)
+	}
+}
+
+// Row 3 cardinality-3 variant — both orig and receiver are in the
+// snapshot along with a third worker. Still violation, still concurrent.
+func TestClassify_ConcurrentOwners_AllThree(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A", "worker-B", "worker-C"}, true))
+
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		t.Fatalf("err type: %T", err)
+	}
+	if !ove.ConcurrentOwners {
+		t.Errorf("ConcurrentOwners should be true with 3-way snapshot; got %+v", ove)
+	}
+}
+
+// Row 4: handoff redelivery — snapshot reports the new owner only.
+// This is the scenario the prior classifier flagged as a false positive.
+func TestClassify_HandoffRedelivery_NewOwnerOnly(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	// Reassignment: partition handed off to worker-B; worker-B is now sole owner.
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-B"}, true))
+
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageRedelivery) {
+		t.Fatalf("expected redelivery (handoff); got %v", err)
+	}
+	if got := tr.GetOwnershipViolationCount(); got != 0 {
+		t.Errorf("ViolationCount = %d, want 0 (handoff should not be a violation)", got)
+	}
+}
+
+// Row 5: stale receipt — original worker is still listed as sole owner;
+// the receiving worker is processing a partition it shouldn't be.
+func TestClassify_StaleReceipt_OriginalStillOwner(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	// Snapshot still says worker-A owns it; worker-B has no business
+	// processing this seq.
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("expected violation (stale receipt); got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		t.Fatalf("err type: %T", err)
+	}
+	if ove.Reason != "stale_receipt" {
+		t.Errorf("Reason = %q, want stale_receipt", ove.Reason)
+	}
+	if ove.ConcurrentOwners {
+		t.Error("ConcurrentOwners should be false on stale-receipt; got true")
+	}
+}
+
+// Row 6: stranger receiver — neither worker is in the snapshot. Some
+// third worker owns the partition; both orig and receiver are wrong.
+// Real violation.
+func TestClassify_StrangerReceiver_NeitherAssigned(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	// Snapshot now says worker-C owns partition 7; worker-A is gone and
+	// worker-B has no business processing.
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-C"}, true))
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("expected violation (stranger); got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		t.Fatalf("err type: %T", err)
+	}
+	if ove.Reason != "stranger_receiver" {
+		t.Errorf("Reason = %q, want stranger_receiver", ove.Reason)
+	}
+}
+
+// Row 7: OwnershipInconclusive — snapshot initialized but empty for
+// this partition (mid-handoff window). Blocks Outcome A but isn't a
+// hard violation.
+func TestClassify_OwnershipInconclusive_SnapshotInitialized(t *testing.T) {
+	tr := NewMessageTracker()
+	// First seed an initialized snapshot via a real receipt.
+	tr.SetOwnerLookup(stubLookup(7, []string{"worker-A"}, true))
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	// Now flip to an empty-but-initialized snapshot (chaos churn, prior
+	// owner pruned, new owner not yet reported).
+	tr.SetOwnerLookup(stubLookup(7, []string{}, true))
+
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipInconclusive) {
+		t.Fatalf("expected inconclusive; got %v (kind %T)", err, err)
+	}
+	if got := tr.GetOwnershipInconclusiveCount(); got != 1 {
+		t.Errorf("InconclusiveCount = %d, want 1", got)
+	}
+	if got := tr.GetOwnershipViolationCount(); got != 0 {
+		t.Errorf("ViolationCount = %d, want 0 (inconclusive should not count as violation)", got)
+	}
+}
+
+// Row 8 (pre-chaos): OwnershipUnobserved — snapshot has never been
+// initialized. Pre-chaos bucket.
+func TestClassify_OwnershipUnobserved_PreChaos(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, nil, false)) // uninitialized
+
+	// Record first receipt with snapshot uninitialized — recorded normally.
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipUnobserved) {
+		t.Fatalf("expected unobserved; got %v", err)
+	}
+	pre, post := tr.GetOwnershipUnobservedCounts()
+	if pre != 1 || post != 0 {
+		t.Errorf("counts = (pre=%d, post=%d), want (1, 0) — chaos not started", pre, post)
+	}
+}
+
+// Row 8 (post-chaos): OwnershipUnobserved after MarkChaosStarted.
+// Must route to the post-chaos counter, which blocks Outcome A.
+func TestClassify_OwnershipUnobserved_PostChaos(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(7, nil, false))
+
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	tr.MarkChaosStarted()
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-B")
+	if !errors.Is(err, ErrMessageOwnershipUnobserved) {
+		t.Fatalf("expected unobserved; got %v", err)
+	}
+	pre, post := tr.GetOwnershipUnobservedCounts()
+	if pre != 0 || post != 1 {
+		t.Errorf("counts = (pre=%d, post=%d), want (0, 1) — chaos started", pre, post)
+	}
+}
+
+// Reproduce a historical chaos finding (partition=19 seq=153 from
+// worker-5, then worker-0) with a mocked snapshot showing worker-0 as
+// the new sole owner. Under the refined classifier this is legitimate
+// handoff redelivery, not a violation — JetStream's at-least-once
+// semantics guarantee a new partition owner will see un-acked
+// sequences from the prior owner after reassignment.
+func TestClassify_HistoricalHandoffScenario_IsRedelivery(t *testing.T) {
+	tr := NewMessageTracker()
+	tr.SetOwnerLookup(stubLookup(19, []string{"worker-5"}, true))
+	if _, err := tr.RecordReceivedFromWorker(19, 153, "worker-5"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	// Handoff to worker-0 after worker_restart + network_disconnect_leader.
+	tr.SetOwnerLookup(stubLookup(19, []string{"worker-0"}, true))
+
+	_, err := tr.RecordReceivedFromWorker(19, 153, "worker-0")
+	if !errors.Is(err, ErrMessageRedelivery) {
+		t.Fatalf("expected handoff redelivery; got %v", err)
+	}
+	if got := tr.GetOwnershipViolationCount(); got != 0 {
+		t.Fatalf("ViolationCount = %d, want 0 — partition=19 seq=153 was a classifier false positive", got)
+	}
+}
+
+// CurrentOwnersOf returns ([], false) when no AssignmentReport has been
+// consumed. The classifier must route empty-uninitialized to row 8
+// (Unobserved), not row 4 (Redelivery).
+func TestCurrentOwnersOf_BeforeAnyAssignment(t *testing.T) {
+	c := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+	defer c.closeStopCh()
+	owners, init := c.CurrentOwnersOf(7)
+	if init {
+		t.Error("snapshotInitialized should be false before any AssignmentReport")
+	}
+	if len(owners) != 0 {
+		t.Errorf("owners = %v, want empty", owners)
+	}
+}
+
+// After an AssignmentReport is processed, CurrentOwnersOf must reflect
+// the published snapshot. This verifies rebuildOwnerSnapshotLocked
+// publishes to the atomic.Pointer on the assignment path.
+func TestCurrentOwnersOf_AfterFirstAssignment(t *testing.T) {
+	c := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+	defer c.closeStopCh()
+
+	// Simulate ingestion by directly writing workerAssignments and
+	// invoking rebuild — equivalent to processAssignments' inner work.
+	c.workerAssignments["worker-0"] = map[int]struct{}{7: {}, 8: {}}
+	c.rebuildOwnerSnapshotLocked()
+
+	owners, init := c.CurrentOwnersOf(7)
+	if !init {
+		t.Error("snapshotInitialized should be true after rebuild")
+	}
+	if len(owners) != 1 || owners[0] != "worker-0" {
+		t.Errorf("owners = %v, want [worker-0]", owners)
+	}
+	// Partition with no owner returns empty + initialized=true.
+	owners2, init2 := c.CurrentOwnersOf(99)
+	if !init2 {
+		t.Error("snapshotInitialized should remain true for other partitions")
+	}
+	if len(owners2) != 0 {
+		t.Errorf("partition 99 owners = %v, want empty", owners2)
+	}
+}
+
+// Race-detector regression test: confirms the atomic.Pointer design
+// closes the data race that codex P0-3 flagged. Concurrent rebuilds
+// (publisher) and CurrentOwnersOf reads (consumer) under -race must
+// not trip Go's race detector or cause "concurrent map iteration".
+func TestCurrentOwnersOf_ConcurrentIngestion(t *testing.T) {
+	c := NewCoordinator(50, nil, DupTraceSettings{}, false, "")
+	defer c.closeStopCh()
+
+	var wg sync.WaitGroup
+	const iterations = 500
+
+	// Writer: simulate AssignmentReport ingestion (single goroutine,
+	// matching the real processAssignments contract).
+	wg.Go(func() {
+		for i := range iterations {
+			c.workerAssignments["worker-A"] = map[int]struct{}{i % 50: {}}
+			c.rebuildOwnerSnapshotLocked()
+		}
+	})
+
+	// Reader: simulate the receipt path repeatedly calling the lookup.
+	wg.Go(func() {
+		for i := range iterations {
+			_, _ = c.CurrentOwnersOf(i % 50)
+		}
+	})
+
+	wg.Wait()
+}
+
+// MarkChaosStarted must be idempotent and capture the timestamp only
+// once. Concurrent calls must not double-set.
+func TestMarkChaosStarted_IdempotentAndAtomic(t *testing.T) {
+	c := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+	defer c.closeStopCh()
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			c.MarkChaosStarted()
+		})
+	}
+	wg.Wait()
+
+	first := c.FirstChaosEventAt()
+	if first.IsZero() {
+		t.Fatal("FirstChaosEventAt should be set after MarkChaosStarted")
+	}
+	c.MarkChaosStarted()
+	second := c.FirstChaosEventAt()
+	if !first.Equal(second) {
+		t.Errorf("FirstChaosEventAt changed across calls: first=%v second=%v", first, second)
+	}
+}
+
+// The shutdown-invariant path calls coord.TriggerFailure during
+// ctx.Done shutdown, which closes stopCh; Coordinator.Start(ctx) also
+// closes stopCh on its own ctx.Done branch. Without the stopOnce
+// guard, the second close panics with "close of closed channel".
+// This test exercises both close paths against the same coordinator
+// instance — must not panic.
+func TestCoordinator_StopChDoubleClose_IsIdempotent(t *testing.T) {
+	c := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+
+	// First close (e.g., normal Start(ctx) shutdown).
+	c.closeStopCh()
+	// Second close from the TriggerFailure path — must not panic.
+	c.TriggerFailure("Stability invariants failed at shutdown", errors.New("test"))
+	// Third direct close attempt — must not panic.
+	c.closeStopCh()
+
+	// Channel must be closed (receive returns immediately).
+	select {
+	case <-c.stopCh:
+	default:
+		t.Fatal("stopCh should be closed after closeStopCh")
+	}
+}
+
+// Codex post-impl review P1: an empty AssignmentReport (worker reports
+// zero partitions, e.g., immediately after a graceful drain) must flip
+// snapshotInitialized to true. Pre-fix this branch returned
+// initialized=false because rebuild only flipped on non-empty
+// assignments, masking real inconclusive duplicates as "unobserved".
+func TestCurrentOwnersOf_EmptyAssignmentInitializesSnapshot(t *testing.T) {
+	c := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+	defer c.closeStopCh()
+
+	// Worker reports an empty partition set — equivalent to processing
+	// an AssignmentReport{WorkerID: "worker-X", Partitions: nil}.
+	c.workerAssignments["worker-A"] = map[int]struct{}{}
+	c.rebuildOwnerSnapshotLocked()
+
+	owners, init := c.CurrentOwnersOf(7)
+	if !init {
+		t.Error("snapshotInitialized should be true after any AssignmentReport, even empty")
+	}
+	if len(owners) != 0 {
+		t.Errorf("owners = %v, want empty", owners)
+	}
+}
+
+// CurrentOwnersOf returned slices are immutable shares of the snapshot.
+// Verify the documented contract: callers who mutate the returned
+// slice would corrupt the snapshot — so callers must not mutate. The
+// test asserts the returned slice is what the snapshot stored, not a
+// per-call copy (this is a deliberate design choice for cheapness).
+func TestCurrentOwnersOf_ReturnedSliceIsSnapshotShare(t *testing.T) {
+	c := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+	defer c.closeStopCh()
+
+	c.workerAssignments["worker-A"] = map[int]struct{}{7: {}}
+	c.workerAssignments["worker-B"] = map[int]struct{}{7: {}}
+	c.rebuildOwnerSnapshotLocked()
+
+	owners1, _ := c.CurrentOwnersOf(7)
+	owners2, _ := c.CurrentOwnersOf(7)
+	if len(owners1) != 2 || len(owners2) != 2 {
+		t.Fatalf("expected 2 owners; got %v / %v", owners1, owners2)
+	}
+	// Both reads should return the same slice header (no per-call copy).
+	if &owners1[0] != &owners2[0] {
+		t.Error("expected reads of the same snapshot to share storage")
+	}
+}

--- a/test/simulation/internal/coordinator/tracker_ownership_test.go
+++ b/test/simulation/internal/coordinator/tracker_ownership_test.go
@@ -1,0 +1,352 @@
+package coordinator
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRecordReceived_SameWorkerDuplicate_IsRedelivery covers the
+// "legitimate JetStream redelivery" classification: the same worker
+// reprocesses a sequence (e.g., NAK then redelivery). Must return a
+// *MessageRedeliveryEvent satisfying errors.Is(ErrMessageRedelivery)
+// — informational, not a failure.
+func TestRecordReceived_SameWorkerDuplicate_IsRedelivery(t *testing.T) {
+	tr := NewMessageTracker()
+
+	if _, err := tr.RecordReceivedFromWorker(7, 1, "worker-A"); err != nil {
+		t.Fatalf("RecordReceived(7, 1, worker-A): %v", err)
+	}
+
+	_, err := tr.RecordReceivedFromWorker(7, 1, "worker-A")
+	if err == nil {
+		t.Fatal("expected redelivery event on same-worker reprocess; got nil")
+	}
+	if !errors.Is(err, ErrMessageRedelivery) {
+		t.Errorf("err should satisfy errors.Is(ErrMessageRedelivery); got %v", err)
+	}
+	var rev *MessageRedeliveryEvent
+	if !errors.As(err, &rev) {
+		t.Fatalf("err should unwrap to *MessageRedeliveryEvent; got %T", err)
+	}
+	if rev.WorkerID != "worker-A" || rev.Sequence != 1 || rev.PartitionID != 7 {
+		t.Errorf("event fields wrong: %+v", rev)
+	}
+
+	if got := tr.GetRedeliveryCount(); got != 1 {
+		t.Errorf("RedeliveryCount = %d, want 1", got)
+	}
+	if got := tr.GetOwnershipViolationCount(); got != 0 {
+		t.Errorf("OwnershipViolationCount = %d, want 0", got)
+	}
+	st := tr.GetStats()
+	if st.DuplicateCount != 0 {
+		t.Errorf("legacy DuplicateCount = %d, want 0 (should classify as redelivery, not duplicate)", st.DuplicateCount)
+	}
+}
+
+// TestRecordReceived_DifferentWorkerDuplicate_IsOwnershipViolation is the
+// CRITICAL detection path: a Processing-Gate or handoff regression that
+// briefly lets two workers process the same (partition, seq). Pre-fix
+// this surfaced only as a generic DuplicateCount++; post-fix it returns
+// *MessageOwnershipViolationError with both worker IDs.
+func TestRecordReceived_DifferentWorkerDuplicate_IsOwnershipViolation(t *testing.T) {
+	tr := NewMessageTracker()
+
+	if _, err := tr.RecordReceivedFromWorker(8, 1, "worker-A"); err != nil {
+		t.Fatalf("RecordReceived(8, 1, worker-A): %v", err)
+	}
+
+	_, err := tr.RecordReceivedFromWorker(8, 1, "worker-B")
+	if err == nil {
+		t.Fatal("expected ownership violation on different-worker reprocess; got nil")
+	}
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Errorf("err should satisfy errors.Is(ErrMessageOwnershipViolation); got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if !errors.As(err, &ove) {
+		t.Fatalf("err should unwrap to *MessageOwnershipViolationError; got %T", err)
+	}
+	if ove.OriginalWorker != "worker-A" || ove.CurrentWorker != "worker-B" {
+		t.Errorf("worker fields wrong: orig=%q cur=%q", ove.OriginalWorker, ove.CurrentWorker)
+	}
+	if ove.PartitionID != 8 || ove.Sequence != 1 {
+		t.Errorf("partition/seq fields wrong: %+v", ove)
+	}
+	if got := tr.GetOwnershipViolationCount(); got != 1 {
+		t.Errorf("OwnershipViolationCount = %d, want 1", got)
+	}
+	if got := tr.GetRedeliveryCount(); got != 0 {
+		t.Errorf("RedeliveryCount = %d, want 0", got)
+	}
+}
+
+// TestRecordReceived_PrunedWorker_FallsBackToLegacyDuplicate exercises the
+// detection-horizon trade-off: when the cache window evicts the original
+// worker for an old seq, a later duplicate falls back to the legacy
+// DuplicateCount counter (no false ownership-violation).
+func TestRecordReceived_PrunedWorker_FallsBackToLegacyDuplicate(t *testing.T) {
+	tr := NewMessageTrackerWithCap(2)
+
+	// Receive seqs 1, 2, 3 from worker-A. After seq=3 the cache (cap=2)
+	// has evicted seq=1.
+	for _, s := range []int64{1, 2, 3} {
+		if _, err := tr.RecordReceivedFromWorker(9, s, "worker-A"); err != nil {
+			t.Fatalf("RecordReceived(9, %d, worker-A): %v", s, err)
+		}
+	}
+
+	_, err := tr.RecordReceivedFromWorker(9, 1, "worker-B")
+	if err == nil {
+		t.Fatal("expected duplicate error on pruned-fallback path; got nil")
+	}
+	if errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("must NOT classify as ownership violation when origin is pruned; got %v", err)
+	}
+	if !errors.Is(err, ErrMessageDuplicate) {
+		t.Errorf("err should satisfy errors.Is(ErrMessageDuplicate); got %v", err)
+	}
+	st := tr.GetStats()
+	if st.DuplicateCount != 1 {
+		t.Errorf("DuplicateCount = %d, want 1", st.DuplicateCount)
+	}
+	if st.OwnershipViolationCount != 0 {
+		t.Errorf("OwnershipViolationCount = %d, want 0", st.OwnershipViolationCount)
+	}
+}
+
+// TestRecordReceived_GapHealRecordsWorker covers the gap-heal path: a
+// previously-escalated gap is healed by worker-A; a later duplicate from
+// worker-B must be classified as a violation.
+func TestRecordReceived_GapHealRecordsWorker(t *testing.T) {
+	tr := NewMessageTracker()
+
+	// Build gap: receive seq=1 then seq=3 (missing 2), age out → 2 becomes a gap.
+	if _, err := tr.RecordReceivedFromWorker(10, 1, "worker-A"); err != nil {
+		t.Fatalf("seq=1: %v", err)
+	}
+	if _, err := tr.RecordReceivedFromWorker(10, 3, "worker-A"); err != nil {
+		t.Fatalf("seq=3: %v", err)
+	}
+	if esc := tr.AgeOut(time.Now()); len(esc) != 1 {
+		t.Fatalf("AgeOut escalations = %d, want 1", len(esc))
+	}
+
+	// Heal the gap from worker-A.
+	if _, err := tr.RecordReceivedFromWorker(10, 2, "worker-A"); err != nil {
+		t.Fatalf("heal seq=2 from worker-A: %v", err)
+	}
+
+	// Now duplicate of seq=2 from worker-B → must classify as violation.
+	_, err := tr.RecordReceivedFromWorker(10, 2, "worker-B")
+	if err == nil {
+		t.Fatal("expected ownership violation on cross-worker dup of healed gap; got nil")
+	}
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Errorf("err should satisfy errors.Is(ErrMessageOwnershipViolation); got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if errors.As(err, &ove) && ove.OriginalWorker != "worker-A" {
+		t.Errorf("OriginalWorker = %q, want worker-A (gap-heal should have recorded it)", ove.OriginalWorker)
+	}
+}
+
+// TestRecordReceived_OutOfOrderRecordsWorker is the targeted regression
+// guard for the out-of-order branch: the worker that first physically
+// processes a seq via the out-of-order path MUST be recorded, so a later
+// duplicate from a different worker triggers a violation. If the
+// out-of-order branch silently skips worker recording, the duplicate falls
+// back to plain MessageDuplicateError and this test fails.
+func TestRecordReceived_OutOfOrderRecordsWorker(t *testing.T) {
+	tr := NewMessageTracker()
+
+	// Out-of-order: receive seq=2 from worker-A before seq=1.
+	if _, err := tr.RecordReceivedFromWorker(12, 2, "worker-A"); err != nil {
+		t.Fatalf("out-of-order seq=2: %v", err)
+	}
+	// Close the window: receive seq=1 from worker-B; contiguous-advance
+	// pulls seq=2 from the out-of-order buffer.
+	if _, err := tr.RecordReceivedFromWorker(12, 1, "worker-B"); err != nil {
+		t.Fatalf("contiguous seq=1: %v", err)
+	}
+
+	// Duplicate seq=2 from worker-C. origWorker for seq=2 was set by the
+	// out-of-order branch (worker-A). If that branch failed to record,
+	// origWorker would be "" and this would fall back to legacy duplicate.
+	_, err := tr.RecordReceivedFromWorker(12, 2, "worker-C")
+	if err == nil {
+		t.Fatal("expected ownership violation; got nil")
+	}
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("err should be ownership violation (proves out-of-order branch records workers); got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if errors.As(err, &ove) && ove.OriginalWorker != "worker-A" {
+		t.Errorf("OriginalWorker = %q, want worker-A (recorded by out-of-order branch)", ove.OriginalWorker)
+	}
+}
+
+// TestRecordReceived_OutOfOrderDuplicateBeforeWindowAdvance is the
+// regression guard for the round-1 post-impl-review P1: a same-seq
+// reprocess while the seq is still out-of-order (lastReceived hasn't
+// advanced past it yet) must NOT silently overwrite first-worker
+// attribution. Pre-fix the out-of-order branch unconditionally recorded
+// the worker, so a cross-worker collision in this window vanished
+// (no violation counted, original attribution lost). Post-fix the
+// early-classification path at the top of RecordReceivedFromWorker
+// catches it.
+func TestRecordReceived_OutOfOrderDuplicateBeforeWindowAdvance(t *testing.T) {
+	tr := NewMessageTracker()
+
+	// Receive seq=2 from worker-A out-of-order (seq=1 still missing).
+	if _, err := tr.RecordReceivedFromWorker(20, 2, "worker-A"); err != nil {
+		t.Fatalf("first out-of-order seq=2 from worker-A: %v", err)
+	}
+	// Now another worker reprocesses seq=2 while seq=1 is STILL missing.
+	// Pre-fix: this took the out-of-order branch again, overwrote
+	// lastWorkerPerSeq[20][2] = worker-B, and returned nil.
+	_, err := tr.RecordReceivedFromWorker(20, 2, "worker-B")
+	if err == nil {
+		t.Fatal("expected ownership violation on cross-worker out-of-order duplicate; got nil")
+	}
+	if !errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("err should be ownership violation; got %v", err)
+	}
+	var ove *MessageOwnershipViolationError
+	if errors.As(err, &ove) {
+		if ove.OriginalWorker != "worker-A" {
+			t.Errorf("OriginalWorker = %q, want worker-A (must NOT be overwritten by the second receipt)", ove.OriginalWorker)
+		}
+		if ove.CurrentWorker != "worker-B" {
+			t.Errorf("CurrentWorker = %q, want worker-B", ove.CurrentWorker)
+		}
+	}
+
+	// Counter check.
+	if got := tr.GetOwnershipViolationCount(); got != 1 {
+		t.Errorf("OwnershipViolationCount = %d, want 1", got)
+	}
+
+	// Also verify lastWorkerPerSeq still attributes to worker-A — the
+	// in-place classifier must not overwrite the original record.
+	if w, ok := tr.lookupOrigWorkerLocked(20, 2); !ok || w != "worker-A" {
+		t.Errorf("original worker overwritten: got (%q, %v); want (worker-A, true)", w, ok)
+	}
+}
+
+// TestRecordReceived_OutOfOrderSameWorkerRedelivery covers the redelivery
+// twin of the regression above: worker-A re-receives its own out-of-order
+// seq=2 (e.g., JetStream redelivered before window advance).
+func TestRecordReceived_OutOfOrderSameWorkerRedelivery(t *testing.T) {
+	tr := NewMessageTracker()
+	if _, err := tr.RecordReceivedFromWorker(21, 2, "worker-A"); err != nil {
+		t.Fatalf("first seq=2: %v", err)
+	}
+	_, err := tr.RecordReceivedFromWorker(21, 2, "worker-A")
+	if err == nil || !errors.Is(err, ErrMessageRedelivery) {
+		t.Fatalf("expected redelivery event; got %v", err)
+	}
+	if got := tr.GetRedeliveryCount(); got != 1 {
+		t.Errorf("RedeliveryCount = %d, want 1", got)
+	}
+	if got := tr.GetOwnershipViolationCount(); got != 0 {
+		t.Errorf("OwnershipViolationCount = %d, want 0", got)
+	}
+}
+
+// TestCoordinator_OwnershipViolation_FlowsToFailureReport covers the
+// coordinator-side wiring: appendOwnershipViolation populates the bounded
+// slice, snapshotOwnershipViolations returns a stable copy, and the
+// resulting FailureReport includes the violation entries with both
+// worker IDs intact. The receive-loop dispatch path that calls
+// appendOwnershipViolation is short (a few lines) and exercised by code
+// review — this test focuses on the data-flow contract end-users see in
+// the JSON report.
+func TestCoordinator_OwnershipViolation_FlowsToFailureReport(t *testing.T) {
+	coord := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+
+	coord.appendOwnershipViolation(MessageOwnershipViolationError{
+		PartitionID: 42, Sequence: 7, OriginalWorker: "worker-A", CurrentWorker: "worker-B",
+	})
+	coord.appendOwnershipViolation(MessageOwnershipViolationError{
+		PartitionID: 99, Sequence: 1, OriginalWorker: "worker-X", CurrentWorker: "worker-Y",
+	})
+
+	snap := coord.snapshotOwnershipViolations()
+	if len(snap) != 2 {
+		t.Fatalf("snapshot length = %d, want 2", len(snap))
+	}
+	if snap[0].OriginalWorker != "worker-A" || snap[0].CurrentWorker != "worker-B" {
+		t.Errorf("snap[0] = %+v", snap[0])
+	}
+	if snap[1].OriginalWorker != "worker-X" || snap[1].CurrentWorker != "worker-Y" {
+		t.Errorf("snap[1] = %+v", snap[1])
+	}
+
+	// Snapshot must be a copy — mutating the returned slice must not
+	// affect the coordinator's internal list.
+	snap[0].CurrentWorker = "tampered"
+	snap2 := coord.snapshotOwnershipViolations()
+	if snap2[0].CurrentWorker == "tampered" {
+		t.Error("snapshot must be a copy; coordinator state was mutated")
+	}
+}
+
+// TestCoordinator_OwnershipViolations_BoundedByCap proves the bounded
+// slice never grows past the cap, even under cascading violations.
+func TestCoordinator_OwnershipViolations_BoundedByCap(t *testing.T) {
+	coord := NewCoordinator(10, nil, DupTraceSettings{}, false, "")
+	coord.ownershipViolationsCap = 3 // tight cap for the test
+
+	for i := range 10 {
+		coord.appendOwnershipViolation(MessageOwnershipViolationError{
+			PartitionID: i, Sequence: int64(i),
+			OriginalWorker: "A", CurrentWorker: "B",
+		})
+	}
+
+	snap := coord.snapshotOwnershipViolations()
+	if len(snap) != 3 {
+		t.Errorf("snapshot length = %d, want 3 (cap)", len(snap))
+	}
+}
+
+// TestCheckpointRestore_EmptyWorkerID_FallsBackToLegacyDuplicate guards
+// the round-1 reviewer's P0: an empty workerID (as passed by the
+// checkpoint-restore replay) must not manufacture false-positive
+// ownership violations. The recordWorkerForSeqLocked no-op for "" + the
+// classification arm's "either side empty → legacy duplicate" guarantees
+// this.
+func TestCheckpointRestore_EmptyWorkerID_FallsBackToLegacyDuplicate(t *testing.T) {
+	tr := NewMessageTracker()
+
+	// Restore replay style: pass "" workerID.
+	if _, err := tr.RecordReceived(13, 1); err != nil {
+		t.Fatalf("restore replay seq=1: %v", err)
+	}
+
+	// Real worker later sees a duplicate of seq=1 — must NOT be a violation.
+	_, err := tr.RecordReceivedFromWorker(13, 1, "worker-A")
+	if err == nil {
+		t.Fatal("expected error on duplicate; got nil")
+	}
+	if errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Fatalf("must NOT classify as violation when origin is restore-replay (empty); got %v", err)
+	}
+	if !errors.Is(err, ErrMessageDuplicate) {
+		t.Errorf("err should be legacy duplicate; got %v", err)
+	}
+
+	// And the reverse direction: real worker first, then empty replay
+	// (impossible in practice but the symmetric guard catches the
+	// "workerID == \"\"" arm).
+	tr2 := NewMessageTracker()
+	if _, err := tr2.RecordReceivedFromWorker(14, 1, "worker-X"); err != nil {
+		t.Fatalf("first receipt: %v", err)
+	}
+	_, err = tr2.RecordReceived(14, 1)
+	if errors.Is(err, ErrMessageOwnershipViolation) {
+		t.Errorf("empty current workerID must not produce violation; got %v", err)
+	}
+}

--- a/test/simulation/internal/coordinator/tracker_test.go
+++ b/test/simulation/internal/coordinator/tracker_test.go
@@ -11,28 +11,28 @@ import (
 func TestMessageTrackerHoleHealing(t *testing.T) {
 	tracker := NewMessageTracker()
 
-	// Establish initial contiguous sequence 0
-	healed, err := tracker.RecordReceived(0, 0)
+	// Establish initial contiguous sequence 1 (producer sequences start at 1)
+	healed, err := tracker.RecordReceived(0, 1)
 	if err != nil || len(healed) != 0 {
 		t.Fatalf("initial RecordReceived unexpected err=%v healed=%v", err, healed)
 	}
 
-	// Jump ahead to sequence 2 creating hole for sequence 1
-	healed, err = tracker.RecordReceived(0, 2)
+	// Jump ahead to sequence 3 creating hole for sequence 2
+	healed, err = tracker.RecordReceived(0, 3)
 	if err != nil {
-		t.Fatalf("unexpected error recording out-of-order sequence 2: %v", err)
+		t.Fatalf("unexpected error recording out-of-order sequence 3: %v", err)
 	}
 	if len(healed) != 0 {
 		t.Fatalf("expected no healed durations yet after out-of-order, got %d", len(healed))
 	}
 
-	// Small delay to produce measurable lifetime for hole 1
+	// Small delay to produce measurable lifetime for hole 2
 	time.Sleep(10 * time.Millisecond)
 
-	// Now receive missing sequence 1 healing hole
-	healed, err = tracker.RecordReceived(0, 1)
+	// Now receive missing sequence 2 healing hole
+	healed, err = tracker.RecordReceived(0, 2)
 	if err != nil {
-		t.Fatalf("unexpected error recording missing sequence 1: %v", err)
+		t.Fatalf("unexpected error recording missing sequence 2: %v", err)
 	}
 	if len(healed) != 1 {
 		t.Fatalf("expected 1 healed duration, got %d", len(healed))
@@ -50,29 +50,29 @@ func TestMessageTrackerHoleHealing(t *testing.T) {
 func TestMessageTrackerPhysicalAndGapHealing(t *testing.T) {
 	tracker := NewMessageTracker()
 
-	// Receive initial sequence 0
-	_, err := tracker.RecordReceived(1, 0)
+	// Receive initial sequence 1 (producer sequences start at 1)
+	_, err := tracker.RecordReceived(1, 1)
 	if err != nil {
 		t.Fatalf("unexpected error receiving initial seq: %v", err)
 	}
 
-	// Jump ahead to 3 creating holes 1,2
-	_, err = tracker.RecordReceived(1, 3)
+	// Jump ahead to 4 creating holes 2,3
+	_, err = tracker.RecordReceived(1, 4)
 	if err != nil {
-		t.Fatalf("unexpected error receiving out-of-order seq 3: %v", err)
+		t.Fatalf("unexpected error receiving out-of-order seq 4: %v", err)
 	}
 
-	// At this point physicalReceived should be 2 (seq 0 and 3)
+	// At this point physicalReceived should be 2 (seq 1 and 4)
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 2 {
 		t.Fatalf("expected physical received = 2, got %d", pr)
 	}
 
 	// Age out holes immediately by using cutoff=now
 	escalations := tracker.AgeOut(time.Now())
-	if len(escalations) != 2 { // holes 1 and 2 promoted
+	if len(escalations) != 2 { // holes 2 and 3 promoted
 		t.Fatalf("expected 2 escalations (gaps), got %d", len(escalations))
 	}
-	// Contiguous window advanced virtually to 2, but physical count unchanged
+	// Contiguous window advanced virtually past the holes; physical count unchanged
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 2 {
 		t.Fatalf("physical received should remain 2 after virtual advancement, got %d", pr)
 	}
@@ -85,28 +85,28 @@ func TestMessageTrackerPhysicalAndGapHealing(t *testing.T) {
 		t.Fatalf("gaps healed should be 0, got %d", gh)
 	}
 
-	// Late arrival of sequence 1 (previously escalated gap)
-	_, err = tracker.RecordReceived(1, 1)
+	// Late arrival of sequence 2 (previously escalated gap)
+	_, err = tracker.RecordReceived(1, 2)
 	if err != nil { // treat gap heal as non-error
-		t.Fatalf("unexpected error on gap-healed arrival seq 1: %v", err)
+		t.Fatalf("unexpected error on gap-healed arrival seq 2: %v", err)
 	}
 	if gh := tracker.GetGapsHealedCount(); gh != 1 {
 		t.Fatalf("expected gaps healed count = 1, got %d", gh)
 	}
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 3 {
-		t.Fatalf("expected physical received = 3 after healing seq 1, got %d", pr)
+		t.Fatalf("expected physical received = 3 after healing seq 2, got %d", pr)
 	}
 
-	// Late arrival of sequence 2
-	_, err = tracker.RecordReceived(1, 2)
+	// Late arrival of sequence 3
+	_, err = tracker.RecordReceived(1, 3)
 	if err != nil {
-		t.Fatalf("unexpected error on gap-healed arrival seq 2: %v", err)
+		t.Fatalf("unexpected error on gap-healed arrival seq 3: %v", err)
 	}
 	if gh := tracker.GetGapsHealedCount(); gh != 2 {
 		t.Fatalf("expected gaps healed count = 2, got %d", gh)
 	}
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 4 {
-		t.Fatalf("expected physical received = 4 after healing seq 2, got %d", pr)
+		t.Fatalf("expected physical received = 4 after healing seq 3, got %d", pr)
 	}
 
 	// Ensure holesHealed remains 0 (we did not physically heal holes before escalation)
@@ -122,15 +122,15 @@ func TestMessageTrackerDuplicateDoesNotIncrementPhysical(t *testing.T) {
 	tracker := NewMessageTracker()
 
 	// First receipt increments physical count
-	if _, err := tracker.RecordReceived(2, 0); err != nil {
+	if _, err := tracker.RecordReceived(2, 1); err != nil {
 		t.Fatalf("unexpected error on first receipt: %v", err)
 	}
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 1 {
 		t.Fatalf("expected physical received = 1 after first receipt, got %d", pr)
 	}
 
-	// Duplicate of seq 0 should return duplicate error and not change physical count
-	if _, err := tracker.RecordReceived(2, 0); !errors.Is(err, ErrMessageDuplicate) {
+	// Duplicate of seq 1 should return duplicate error and not change physical count
+	if _, err := tracker.RecordReceived(2, 1); !errors.Is(err, ErrMessageDuplicate) {
 		t.Fatalf("expected ErrMessageDuplicate, got %v", err)
 	}
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 1 {
@@ -147,25 +147,26 @@ func TestSuppressionMarksHeadOnlyAndIdempotent(t *testing.T) {
 	t.Parallel()
 	tracker := NewMessageTracker()
 
-	// Build missing set {1,3} by receiving 0,2,4 on partition 3
-	if _, err := tracker.RecordReceived(3, 0); err != nil {
-		t.Fatalf("unexpected error on seq 0: %v", err)
+	// Build a partition with three consecutive head-of-line holes plus one
+	// gap-separated hole, by receiving seq=5 alone then seq=7. This yields
+	// missing = {1,2,3,4,6}; head-of-line consecutive holes = {1,2,3,4}.
+	if _, err := tracker.RecordReceived(3, 5); err != nil {
+		t.Fatalf("unexpected error on seq 5: %v", err)
 	}
-	if _, err := tracker.RecordReceived(3, 2); err != nil {
-		t.Fatalf("unexpected error on seq 2: %v", err)
-	}
-	if _, err := tracker.RecordReceived(3, 4); err != nil {
-		t.Fatalf("unexpected error on seq 4: %v", err)
+	if _, err := tracker.RecordReceived(3, 7); err != nil {
+		t.Fatalf("unexpected error on seq 7: %v", err)
 	}
 
 	// Age the holes a bit
 	time.Sleep(5 * time.Millisecond)
 	cutoff := time.Now()
 
-	// Head-of-line consecutive holes are {1,2,3}; all should be marked in one pass
+	// Only the four consecutive head holes (1..4) should be marked; seq 6 is
+	// gap-separated by the already-observed seq 5 and must be skipped — that
+	// is the "head only" invariant this test guards.
 	newly := tracker.MarkHeadOfLineAgedHolesSuppressed(cutoff)
-	if newly != 3 {
-		t.Fatalf("expected 3 newly suppressed head-of-line holes, got %d", newly)
+	if newly != 4 {
+		t.Fatalf("expected 4 newly suppressed head-of-line holes, got %d", newly)
 	}
 	// Idempotent on subsequent calls with same state
 	if again := tracker.MarkHeadOfLineAgedHolesSuppressed(cutoff); again != 0 {
@@ -184,12 +185,12 @@ func TestAgeOutSkipsNotYetAged(t *testing.T) {
 	t.Parallel()
 	tracker := NewMessageTracker()
 
-	// Create hole: receive 0, then jump to 2 (missing 1)
-	if _, err := tracker.RecordReceived(4, 0); err != nil {
-		t.Fatalf("unexpected error on seq 0: %v", err)
+	// Create hole: receive 1, then jump to 3 (missing 2)
+	if _, err := tracker.RecordReceived(4, 1); err != nil {
+		t.Fatalf("unexpected error on seq 1: %v", err)
 	}
-	if _, err := tracker.RecordReceived(4, 2); err != nil {
-		t.Fatalf("unexpected error on seq 2: %v", err)
+	if _, err := tracker.RecordReceived(4, 3); err != nil {
+		t.Fatalf("unexpected error on seq 3: %v", err)
 	}
 
 	// Cutoff far in the past: firstSeen will be after this cutoff, so not aged
@@ -197,9 +198,8 @@ func TestAgeOutSkipsNotYetAged(t *testing.T) {
 	if escalations := tracker.AgeOut(past); len(escalations) != 0 {
 		t.Fatalf("expected 0 escalations for not-yet-aged holes, got %d", len(escalations))
 	}
-	// lastReceived should remain at 0
 	if pr := tracker.GetPhysicalReceivedCount(); pr != 2 {
-		t.Fatalf("physical received should be 2 (seq 0 and 2), got %d", pr)
+		t.Fatalf("physical received should be 2 (seq 1 and 3), got %d", pr)
 	}
 
 	// Now with current cutoff, the hole should escalate
@@ -214,22 +214,22 @@ func TestGapHealThenDuplicate(t *testing.T) {
 	tracker := NewMessageTracker()
 
 	// Create two holes and escalate
-	if _, err := tracker.RecordReceived(5, 0); err != nil {
-		t.Fatalf("unexpected error on seq 0: %v", err)
+	if _, err := tracker.RecordReceived(5, 1); err != nil {
+		t.Fatalf("unexpected error on seq 1: %v", err)
 	}
-	if _, err := tracker.RecordReceived(5, 3); err != nil {
-		t.Fatalf("unexpected error on seq 3: %v", err)
+	if _, err := tracker.RecordReceived(5, 4); err != nil {
+		t.Fatalf("unexpected error on seq 4: %v", err)
 	}
 	if escalations := tracker.AgeOut(time.Now()); len(escalations) != 2 {
 		t.Fatalf("expected 2 escalations, got %d", len(escalations))
 	}
 
-	// Heal gap for seq 1
-	if _, err := tracker.RecordReceived(5, 1); err != nil {
-		t.Fatalf("unexpected error healing gap seq 1: %v", err)
+	// Heal gap for seq 2
+	if _, err := tracker.RecordReceived(5, 2); err != nil {
+		t.Fatalf("unexpected error healing gap seq 2: %v", err)
 	}
-	// Sending seq 1 again should be a duplicate
-	if _, err := tracker.RecordReceived(5, 1); !errors.Is(err, ErrMessageDuplicate) {
+	// Sending seq 2 again should be a duplicate
+	if _, err := tracker.RecordReceived(5, 2); !errors.Is(err, ErrMessageDuplicate) {
 		t.Fatalf("expected ErrMessageDuplicate after heal, got %v", err)
 	}
 }
@@ -239,12 +239,12 @@ func TestDisorderDepthAndPendingAges(t *testing.T) {
 	t.Parallel()
 	tracker := NewMessageTracker()
 
-	// Receive 0 then 4 -> holes {1,2,3}; depth = 4 - 0 = 4
-	if _, err := tracker.RecordReceived(6, 0); err != nil {
-		t.Fatalf("unexpected error on seq 0: %v", err)
+	// Receive 1 then 5 -> holes {2,3,4}; depth = highWatermark - lastReceived = 5 - 1 = 4
+	if _, err := tracker.RecordReceived(6, 1); err != nil {
+		t.Fatalf("unexpected error on seq 1: %v", err)
 	}
-	if _, err := tracker.RecordReceived(6, 4); err != nil {
-		t.Fatalf("unexpected error on seq 4: %v", err)
+	if _, err := tracker.RecordReceived(6, 5); err != nil {
+		t.Fatalf("unexpected error on seq 5: %v", err)
 	}
 	if depth := tracker.GetDisorderDepth(); depth != 4 {
 		t.Fatalf("expected disorder depth 4, got %d", depth)
@@ -261,12 +261,12 @@ func TestDisorderDepthAndPendingAges(t *testing.T) {
 		}
 	}
 
-	// Heal head-of-line hole 1 -> depth becomes 3; ages now for {2,3}
-	if _, err := tracker.RecordReceived(6, 1); err != nil {
-		t.Fatalf("unexpected error healing seq 1: %v", err)
+	// Heal head-of-line hole 2 -> depth becomes 3; ages now for {3,4}
+	if _, err := tracker.RecordReceived(6, 2); err != nil {
+		t.Fatalf("unexpected error healing seq 2: %v", err)
 	}
 	if depth := tracker.GetDisorderDepth(); depth != 3 {
-		t.Fatalf("expected disorder depth 3 after healing 1, got %d", depth)
+		t.Fatalf("expected disorder depth 3 after healing 2, got %d", depth)
 	}
 	ages = tracker.GetPendingHoleAges()
 	if len(ages) != 2 {
@@ -280,8 +280,8 @@ func TestMassiveGap(t *testing.T) {
 	tracker := NewMessageTracker()
 
 	// 1. Receive initial sequence
-	if _, err := tracker.RecordReceived(1, 0); err != nil {
-		t.Fatalf("unexpected error on seq 0: %v", err)
+	if _, err := tracker.RecordReceived(1, 1); err != nil {
+		t.Fatalf("unexpected error on seq 1: %v", err)
 	}
 
 	// 2. Receive sequence with massive gap (> 10000)

--- a/test/simulation/internal/metrics/collector.go
+++ b/test/simulation/internal/metrics/collector.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/consumer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promclient "github.com/prometheus/client_model/go"
@@ -16,10 +16,12 @@ type Collector struct {
 	// Protects cached assignment metrics reads/writes
 	assignMu sync.RWMutex
 	// Message counters (per-partition)
-	messagesSentTotal      *prometheus.CounterVec
-	messagesReceivedTotal  *prometheus.CounterVec
-	messageGapsTotal       prometheus.Counter
-	messageDuplicatesTotal prometheus.Counter
+	messagesSentTotal        *prometheus.CounterVec
+	messagesReceivedTotal    *prometheus.CounterVec
+	messageGapsTotal         prometheus.Counter
+	messageDuplicatesTotal   prometheus.Counter
+	redeliveriesTotal        prometheus.Counter
+	ownershipViolationsTotal prometheus.Counter
 	// Per-partition duplicates
 	messageDuplicatesByPartition *prometheus.CounterVec
 
@@ -190,7 +192,19 @@ func NewCollectorWithRegistry(reg prometheus.Registerer) *Collector {
 		messageDuplicatesTotal: factory.NewCounter(
 			prometheus.CounterOpts{
 				Name: "simulation_message_duplicates_total",
-				Help: "Total number of duplicate messages detected",
+				Help: "Total number of duplicate messages detected (legacy fallback — origin pruned or unknown)",
+			},
+		),
+		redeliveriesTotal: factory.NewCounter(
+			prometheus.CounterOpts{
+				Name: "simulation_redeliveries_total",
+				Help: "Total number of same-worker redeliveries (informational; not a failure)",
+			},
+		),
+		ownershipViolationsTotal: factory.NewCounter(
+			prometheus.CounterOpts{
+				Name: "simulation_ownership_violations_total",
+				Help: "Total number of cross-worker same-seq observations (parti exclusivity contract violation)",
 			},
 		),
 		messageDuplicatesByPartition: factory.NewCounterVec(
@@ -590,6 +604,17 @@ func (c *Collector) RecordDuplicate() {
 	c.messageDuplicatesTotal.Inc()
 }
 
+// RecordRedelivery records a same-worker redelivery (informational).
+func (c *Collector) RecordRedelivery() {
+	c.redeliveriesTotal.Inc()
+}
+
+// RecordOwnershipViolation records a cross-worker same-seq detection
+// (parti exclusivity contract violation — a failure signal).
+func (c *Collector) RecordOwnershipViolation() {
+	c.ownershipViolationsTotal.Inc()
+}
+
 // RecordDuplicatePartition records a duplicate event for a specific partition.
 // Parameters:
 //   - partitionID: Partition ID
@@ -853,50 +878,6 @@ func (c *Collector) RecoveryDurationSummary() (uint64, float64) {
 	return 0, 0
 }
 
-// RecordDrainAudit records aggregated drain audit results from a worker's tracker.
-// Parameters:
-//   - results: Slice of audit results per partition
-//   - workerID: ID of the worker performing the audit (for future labeling; currently unused)
-func (c *Collector) RecordDrainAudit(results []durable.AuditResult, workerID string) {
-	var totalLate, totalLost, totalHoles int
-	var maxDuration time.Duration
-	timedOut := false
-	for _, r := range results {
-		if r.LateMessages > 0 {
-			totalLate += r.LateMessages
-		}
-		if r.LostMessages > 0 {
-			totalLost += r.LostMessages
-		}
-		if r.UnresolvedHoles > 0 {
-			totalHoles += r.UnresolvedHoles
-		}
-		if r.Duration > maxDuration {
-			maxDuration = r.Duration
-		}
-		if r.TimedOut {
-			timedOut = true
-		}
-	}
-	if totalLate > 0 {
-		for i := 0; i < totalLate; i++ { // counter has no Add pre v1.19
-			c.lateMessagesTotal.Inc()
-		}
-	}
-	if totalLost > 0 {
-		for i := 0; i < totalLost; i++ {
-			c.lostMessagesTotal.Inc()
-		}
-	}
-	c.holesOpen.Set(float64(totalHoles))
-	if maxDuration > 0 {
-		c.auditDurationSeconds.Observe(maxDuration.Seconds())
-	}
-	if timedOut || totalLate > 0 || totalLost > 0 {
-		c.auditFailuresTotal.Inc()
-	}
-}
-
 // GetLateMessagesTotal returns the total late messages counter value.
 func (c *Collector) GetLateMessagesTotal() uint64 {
 	m := &promclient.Metric{}
@@ -936,13 +917,13 @@ func (c *Collector) ColdStartConvergenceSummary() (uint64, float64) {
 	return 0, 0
 }
 
-// GateMetricsAdapter returns an adapter that implements durable.GateMetrics.
-func (c *Collector) GateMetricsAdapter() durable.GateMetrics {
+// GateMetricsAdapter returns an adapter that implements consumer.GateMetrics.
+func (c *Collector) GateMetricsAdapter() consumer.GateMetrics {
 	return gateMetricsAdapter{c: c}
 }
 
-// ResolverMetricsAdapter returns an adapter that implements durable.ResolverMetrics.
-func (c *Collector) ResolverMetricsAdapter() durable.ResolverMetrics {
+// ResolverMetricsAdapter returns an adapter that implements consumer.ResolverMetrics.
+func (c *Collector) ResolverMetricsAdapter() consumer.ResolverMetrics {
 	return resolverMetricsAdapter{c: c}
 }
 

--- a/test/simulation/internal/worker/worker.go
+++ b/test/simulation/internal/worker/worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -16,7 +17,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/arloliu/parti/v2"
-	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/consumer"
 	"github.com/arloliu/parti/v2/source"
 	"github.com/arloliu/parti/v2/strategy"
 	"github.com/arloliu/parti/v2/test/simulation/internal/coordinator"
@@ -40,8 +41,11 @@ type Worker struct {
 	js      jetstream.JetStream
 	cfg     *parti.Config
 	manager *parti.Manager
-	// updater is the manager-driven consumer updater)
-	updater             parti.WorkerConsumerUpdater
+	// updater is the manager-driven consumer updater. Holds the same instance
+	// as `dynamic` but typed as the parti interface for WithWorkerConsumerUpdater.
+	updater parti.WorkerConsumerUpdater
+	// dynamic is the typed concrete consumer used for Stop on shutdown.
+	dynamic             *consumer.Dynamic
 	processingDelayMin  time.Duration
 	processingDelayMax  time.Duration
 	coordinatorReportCh chan<- coordinator.ReceivedMessage
@@ -131,6 +135,8 @@ type Config struct {
 	// Throughput knobs
 	ConsumerBatchSize  int
 	HandlerConcurrency int
+	// AckWait is the JetStream consumer AckWait. Must be < Coordinator.GapAging.
+	AckWait time.Duration
 	// MaxSubjects optionally overrides subject guardrail. If 0, defaults to partition count.
 	MaxSubjects int
 	// Exclusive consumption (Processing Gate)
@@ -153,6 +159,16 @@ type Config struct {
 //   - *Worker: Initialized worker
 //   - error: Error if initialization fails
 func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop
+	// Safety net: AckWait must be supplied by the caller. The
+	// config.validateConfig pass enforces AckWait < Coordinator.GapAging,
+	// but a forgetful caller of NewWorker (e.g., a missing field in a
+	// worker.Config literal) would silently fall back to the durable
+	// helper's 30s default, reintroducing the false-positive gap-escalation
+	// window that the simulation config validation exists to prevent.
+	if cfg.AckWait <= 0 {
+		return nil, errors.New("worker.Config.AckWait must be > 0 (caller forgot to plumb cfg.Workers.AckWait?)")
+	}
+
 	// Use nop logger by default; switch to std logger when gate debug is enabled
 	logger := logging.NewNop()
 	if cfg.GateDebug || os.Getenv("PARTI_SIM_LOG") == "1" {
@@ -195,15 +211,9 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop
 	// Enable two-phase handoff only when exclusive consumption is requested.
 	// This publishes ownership claims to KV so the Processing Gate can enforce exclusivity.
 	partiCfg.EnableTwoPhaseHandoff = cfg.EnforceExclusiveConsumption
-	// Shorten handoff TTL for simulation so stale claims expire quickly if any linger
-	// and to speed up steady-state convergence under churn.
-	// NOTE: Claims are the source of truth for exclusivity. Using a non-zero KV TTL
-	// will purge stable claims and cause the Processing Gate to see unknown ownership,
-	// leading to prolonged NAK loops and artificial gaps under sustained load.
-	// For simulation correctness and long runs, disable KV TTL (persist claims until superseded).
-	if cfg.EnforceExclusiveConsumption {
-		partiCfg.KVBuckets.HandoffTTL = 0
-	}
+	// The handoff bucket's effective KV TTL is set by the all-in-one pre-create
+	// path in cmd/simulation/main.go; manager-level overrides here are no-ops
+	// because parti.SetDefaults restores the struct-tag default before Validate.
 
 	// Use a generous startup timeout to avoid cancellations during
 	// concurrent KV bucket creation, hygiene passes, and ID claiming across many workers.
@@ -235,37 +245,43 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop
 	perSubMaxAckPending := max(worker.consumerBatchSize*2,
 		// preserve a small minimum
 		8)
-	// Create durable helper early so manager can drive updates via option.
-	helperConfig := durable.WorkerConsumerConfig{
-		ConsumerPrefix:  "simulation",
-		SubjectTemplate: "simulation.partition.{{.PartitionID}}",
-		StreamName:      "SIMULATION",
-		Logger:          logger,
-		// Enable manual ack so the handler controls when to ack (after reporting to coordinator).
-		// This avoids double-acking and ensures our reporting order is consistent.
-		ManualAck: true,
-		BatchSize: worker.consumerBatchSize,
-		// Short fetch timeout so goroutines blocked in Next() exit rapidly after cancellation,
-		// reducing apparent goroutine leak in simulation leak tests.
-		FetchTimeout: 1 * time.Second,
-		// Drain per-subject on removal to reduce NAK churn during chaos scale-down.
-		DrainOnRemove: true,
-		// Under exclusivity gating and chaos, messages can be NAKed multiple times.
-		// Increase MaxDeliver to avoid premature drop and false gap escalations.
-		MaxDeliver: 50,
-		// AckWait must be shorter than Coordinator.GapAging (default 45s) to avoid false positives
-		// during worker crashes where messages are held by the dead consumer.
-		AckWait: 30 * time.Second,
+
+	// Build the consumer options. Plumbed verbatim from the prior
+	// durable.WorkerConsumerConfig literal — see
+	// docs/plans/sim-oracle-phase2/00-plan.md for the field-by-field mapping.
+	consumerOpts := []consumer.DynamicOption{
+		consumer.WithLogger(logger),
+		// Enable manual ack so the handler controls when to ack (after
+		// reporting to coordinator). This avoids double-acking and ensures
+		// our reporting order is consistent.
+		consumer.WithManualAck(true),
+		consumer.WithBatchSize(worker.consumerBatchSize),
+		// Short fetch timeout so goroutines blocked in Next() exit rapidly
+		// after cancellation, reducing apparent goroutine leak in simulation
+		// leak tests.
+		consumer.WithFetchTimeout(1 * time.Second),
+		// Drain per-subject on removal to reduce NAK churn during chaos
+		// scale-down. Timeout=0 → use the durable default (10s).
+		consumer.WithDrainOnRemove(true, 0),
+		// Under exclusivity gating and chaos, messages can be NAKed multiple
+		// times. Increase MaxDeliver to avoid premature drop and false gap
+		// escalations.
+		consumer.WithMaxDeliver(50),
+		// AckWait must be < Coordinator.GapAging; cross-validated in
+		// config.validateConfig so this can never reintroduce false-positive
+		// gap escalations during chaos.
+		consumer.WithAckWait(cfg.AckWait),
 		// Caps to bound per-subject concurrency and reduce disorder.
-		MaxWaiting:    2,
-		MaxAckPending: perSubMaxAckPending,
-		// Suppress pulls when not owner or not in commit/stable to reduce NAK storms.
-		PullGatingEnabled: true,
+		consumer.WithMaxWaiting(2),
+		consumer.WithMaxAckPending(perSubMaxAckPending),
+		// Suppress pulls when not owner or not in commit/stable to reduce
+		// NAK storms.
+		consumer.WithPullGating(true),
 	}
 
-	// Enable Processing Gate for exclusive consumption when configured
+	// Enable Processing Gate for exclusive consumption when configured.
 	if cfg.EnforceExclusiveConsumption {
-		pg := &durable.ProcessingGateConfig{
+		pg := &consumer.ProcessingGateConfig{
 			Enabled:   true,
 			NakDelay:  cfg.GateNakDelay,
 			NakJitter: cfg.GateNakJitter,
@@ -308,22 +324,30 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop
 			}
 			pg.AllowedStates = states
 		}
-		helperConfig.ProcessingGate = pg
-		// Use defaults for HandoffBucketName/Prefix; WorkerConsumer will auto-init resolver
+		consumerOpts = append(consumerOpts, consumer.WithProcessingGate(pg))
 	}
+
 	js, err := jetstream.New(cfg.NC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init JetStream: %w", err)
 	}
 
-	updater, err := durable.NewWorkerConsumer(js, helperConfig, worker.processMessage)
+	dynamic, err := consumer.NewDynamic(
+		js,
+		"SIMULATION",
+		"simulation",
+		"simulation.partition.{{.PartitionID}}",
+		consumer.MessageHandlerFunc(worker.processMessage),
+		consumerOpts...,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create worker consumer updater: %w", err)
+		return nil, fmt.Errorf("failed to create consumer.Dynamic: %w", err)
 	}
-	worker.updater = updater
+	worker.dynamic = dynamic
+	worker.updater = dynamic
 
 	if cfg.MetricsCollector != nil {
-		updater.SetResolverMetrics(cfg.MetricsCollector.ResolverMetricsAdapter())
+		dynamic.SetResolverMetrics(cfg.MetricsCollector.ResolverMetricsAdapter())
 	}
 
 	// Set up hooks to record metrics only (consumer updates handled by manager option)
@@ -426,10 +450,12 @@ func (w *Worker) handleAssignmentChanged(ctx context.Context, oldSet, newSet []t
 	if len(newSet) > 0 && w.firstAssignmentOK.CompareAndSwap(false, true) {
 		if w.startLatencyCh != nil && !w.startCalledAt.IsZero() {
 			latency := time.Since(w.startCalledAt)
+			// Block on send so the SlowStartExceedances invariant the
+			// coordinator gates pass/fail on can never lose samples under
+			// chaos bursts. Symmetric with the assignmentReportCh send below.
 			select {
+			case <-ctx.Done():
 			case w.startLatencyCh <- coordinator.StartLatencyReport{WorkerID: w.id, Latency: latency}:
-			default:
-				log.Printf("[%s] startLatencyCh full, dropping first-assignment latency=%s", w.id, latency)
 			}
 		}
 	}
@@ -664,10 +690,12 @@ func (w *Worker) Stop() {
 		_ = w.manager.Stop(ctx)
 	}
 
-	// Proactively close the updater if it exposes a Close(ctx) API to prevent
-	// subject loop goroutine leaks (WorkerConsumer spawns one per partition).
-	if c, ok := w.updater.(interface{ Close(context.Context) error }); ok {
-		_ = c.Close(context.Background())
+	// Proactively stop the consumer.Dynamic to prevent subject-loop goroutine
+	// leaks (one per partition). consumer.Dynamic.Stop delegates to the
+	// underlying durable WorkerConsumer.Close. Pass the bounded shutdown
+	// ctx (5s timeout above) so the stop is time-bounded.
+	if w.dynamic != nil {
+		_ = w.dynamic.Stop(ctx)
 	}
 
 	w.started.Store(false)

--- a/test/simulation/internal/worker/worker.go
+++ b/test/simulation/internal/worker/worker.go
@@ -65,6 +65,11 @@ type Worker struct {
 	// past its caller's deadline.
 	startCalledAt     time.Time
 	firstAssignmentOK atomic.Bool
+	// isInitialCohort stamps the start-latency report so the coordinator's
+	// classifier can bucket the sample without depending on receive-time
+	// ordering of channels. True for workers constructed during simulation
+	// bootstrap; false for restart / scale_up replacements.
+	isInitialCohort bool
 	// throughput controls
 	handlerConcurrency int
 	consumerBatchSize  int
@@ -148,6 +153,11 @@ type Config struct {
 	GateNakJitter               float64
 	// Gate debug logging
 	GateDebug bool
+	// IsInitialCohort tags this worker as part of the simulation's initial
+	// cluster (true) or as a later joiner via scale_up / restart (false).
+	// Carried through to StartLatencyReport so the coordinator's classifier
+	// can pick the right budget without depending on channel-receive timing.
+	IsInitialCohort bool
 }
 
 // NewWorker creates a new worker.
@@ -240,6 +250,7 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop
 		currentPartitions:   0,
 		handlerConcurrency:  cfg.HandlerConcurrency,
 		consumerBatchSize:   cfg.ConsumerBatchSize,
+		isInitialCohort:     cfg.IsInitialCohort,
 	}
 
 	perSubMaxAckPending := max(worker.consumerBatchSize*2,
@@ -455,7 +466,7 @@ func (w *Worker) handleAssignmentChanged(ctx context.Context, oldSet, newSet []t
 			// chaos bursts. Symmetric with the assignmentReportCh send below.
 			select {
 			case <-ctx.Done():
-			case w.startLatencyCh <- coordinator.StartLatencyReport{WorkerID: w.id, Latency: latency}:
+			case w.startLatencyCh <- coordinator.StartLatencyReport{WorkerID: w.id, Latency: latency, IsInitialCohort: w.isInitialCohort}:
 			}
 		}
 	}

--- a/test/simulation/internal/worker/worker_assignment_hook_test.go
+++ b/test/simulation/internal/worker/worker_assignment_hook_test.go
@@ -1,0 +1,150 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/test/simulation/internal/coordinator"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestNewWorker_RejectsZeroAckWait guards the C2 safety net: any worker.Config
+// call site that omits AckWait must fail loudly at NewWorker time, not
+// silently fall back to the durable helper's 30s default (which would
+// reintroduce the false-positive gap-escalation window that C2 exists
+// to eliminate).
+func TestNewWorker_RejectsZeroAckWait(t *testing.T) {
+	_, err := NewWorker(Config{
+		ID:                 "test-worker",
+		PartitionCount:     1,
+		AssignmentStrategy: "ConsistentHash",
+		HandlerConcurrency: 1,
+		ConsumerBatchSize:  1,
+		// AckWait deliberately omitted.
+	})
+	if err == nil {
+		t.Fatal("expected NewWorker to reject Config with AckWait=0; got nil")
+	}
+	if !strings.Contains(err.Error(), "AckWait") {
+		t.Errorf("error must reference AckWait; got: %v", err)
+	}
+}
+
+// TestHandleAssignmentChanged_BlockingSendDelivers proves that the
+// first-assignment latency sample is delivered (not dropped) when the
+// coordinator's drain goroutine is slow. The pre-fix behavior used a
+// non-blocking send with a `default:` branch that silently dropped
+// samples — blinding the SlowStartExceedances invariant the channel
+// exists to enforce.
+//
+// Test pattern (verify-first on the "hook does not exit while buffer
+// is full" property, NOT on delivery order, which was inherently racy):
+//  1. Pre-fill a size-1 channel so any send blocks under the fix.
+//  2. Start the hook in a goroutine; record completion via hookDone.
+//  3. Sleep generously (200ms) so the goroutine has certainly reached
+//     the select.
+//  4. Pre-fix: `default:` already fired; hookDone is closed. FAIL.
+//     Post-fix: goroutine is parked; hookDone is open.
+//  5. Drain sentinel; assert the hook's sample is then delivered.
+func TestHandleAssignmentChanged_BlockingSendDelivers(t *testing.T) {
+	startLatencyCh := make(chan coordinator.StartLatencyReport, 1)
+	startLatencyCh <- coordinator.StartLatencyReport{WorkerID: "sentinel"}
+
+	w := &Worker{
+		id:                  "test-worker",
+		ctx:                 context.Background(),
+		startLatencyCh:      startLatencyCh,
+		startCalledAt:       time.Now().Add(-100 * time.Millisecond),
+		assignmentReportCh:  nil, // not under test
+		coordinatorReportCh: nil,
+		firstAssignmentOK:   atomic.Bool{},
+	}
+
+	hookDone := make(chan struct{})
+	go func() {
+		_ = w.handleAssignmentChanged(context.Background(), nil, []types.Partition{
+			{Keys: []string{"0"}, Weight: 1},
+		})
+		close(hookDone)
+	}()
+
+	// Give the goroutine enough time to reach the select. After this
+	// point, pre-fix code has already exited via `default:`.
+	time.Sleep(200 * time.Millisecond)
+
+	select {
+	case <-hookDone:
+		t.Fatal("hook returned without delivering sample — buggy default: branch fired (pre-fix code path)")
+	default:
+		// Expected: goroutine parked on the blocking send.
+	}
+
+	// Drain the sentinel; this releases the parked send.
+	select {
+	case rep := <-startLatencyCh:
+		if rep.WorkerID != "sentinel" {
+			t.Fatalf("expected sentinel first, got %q (test setup wrong)", rep.WorkerID)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("could not drain sentinel; channel state unexpected")
+	}
+
+	select {
+	case rep := <-startLatencyCh:
+		if rep.WorkerID != "test-worker" {
+			t.Errorf("WorkerID = %q, want %q", rep.WorkerID, "test-worker")
+		}
+		if rep.Latency <= 0 {
+			t.Errorf("Latency = %v, want positive", rep.Latency)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("did not receive StartLatencyReport within 1s after draining sentinel")
+	}
+
+	select {
+	case <-hookDone:
+	case <-time.After(1 * time.Second):
+		t.Fatal("handleAssignmentChanged did not return after receive")
+	}
+}
+
+// TestHandleAssignmentChanged_CancellationDoesNotWedge proves that the
+// blocking send respects ctx.Done() and does not hang on shutdown when
+// the coordinator has stopped draining.
+//
+// Setup: zero-buffer channel, no receiver, cancel the worker's ctx
+// before invoking the hook. Assert the hook returns promptly.
+func TestHandleAssignmentChanged_CancellationDoesNotWedge(t *testing.T) {
+	startLatencyCh := make(chan coordinator.StartLatencyReport) // unbuffered, no receiver
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	w := &Worker{
+		id:                  "test-worker",
+		ctx:                 ctx,
+		startLatencyCh:      startLatencyCh,
+		startCalledAt:       time.Now().Add(-100 * time.Millisecond),
+		assignmentReportCh:  nil,
+		coordinatorReportCh: nil,
+		firstAssignmentOK:   atomic.Bool{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = w.handleAssignmentChanged(ctx, nil, []types.Partition{
+			{Keys: []string{"0"}, Weight: 1},
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Pass — handler returned without wedging.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleAssignmentChanged wedged after ctx cancellation")
+	}
+}

--- a/test/simulation/internal/worker/worker_assignment_hook_test.go
+++ b/test/simulation/internal/worker/worker_assignment_hook_test.go
@@ -111,6 +111,45 @@ func TestHandleAssignmentChanged_BlockingSendDelivers(t *testing.T) {
 	}
 }
 
+// TestHandleAssignmentChanged_StampsInitialCohortFlag proves that the
+// per-worker IsInitialCohort flag is carried into the StartLatencyReport.
+// The coordinator's classifier depends on this stamp to bucket samples
+// without racing against baselineLocked flips — a slow chaos-delayed
+// initial-cohort worker must still land in the initial bucket regardless
+// of channel-receive timing.
+func TestHandleAssignmentChanged_StampsInitialCohortFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cohort bool
+	}{
+		{"initial", true},
+		{"takeover", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := make(chan coordinator.StartLatencyReport, 1)
+			w := &Worker{
+				id:                "test-worker",
+				ctx:               context.Background(),
+				startLatencyCh:    ch,
+				startCalledAt:     time.Now().Add(-50 * time.Millisecond),
+				firstAssignmentOK: atomic.Bool{},
+				isInitialCohort:   tc.cohort,
+			}
+			_ = w.handleAssignmentChanged(context.Background(), nil, []types.Partition{
+				{Keys: []string{"0"}, Weight: 1},
+			})
+			select {
+			case rep := <-ch:
+				if rep.IsInitialCohort != tc.cohort {
+					t.Errorf("IsInitialCohort = %v, want %v", rep.IsInitialCohort, tc.cohort)
+				}
+			case <-time.After(1 * time.Second):
+				t.Fatal("no StartLatencyReport received")
+			}
+		})
+	}
+}
+
 // TestHandleAssignmentChanged_CancellationDoesNotWedge proves that the
 // blocking send respects ctx.Done() and does not hang on shutdown when
 // the coordinator has stopped draining.

--- a/test/simulation/internal/worker/worker_leak_test.go
+++ b/test/simulation/internal/worker/worker_leak_test.go
@@ -63,6 +63,7 @@ func TestWorker_GoroutineLeak(t *testing.T) {
 		AssignmentStrategy:  "consistent-hash",
 		ProcessingDelayMin:  1 * time.Millisecond,
 		ProcessingDelayMax:  5 * time.Millisecond,
+		AckWait:             30 * time.Second,
 		CoordinatorReportCh: make(chan coordinator.ReceivedMessage, 100),
 		MetricsCollector:    nil, // Don't use metrics to avoid registration conflicts
 	}
@@ -135,6 +136,7 @@ func TestWorker_MultipleStarts(t *testing.T) {
 		AssignmentStrategy:  "consistent-hash",
 		ProcessingDelayMin:  1 * time.Millisecond,
 		ProcessingDelayMax:  5 * time.Millisecond,
+		AckWait:             30 * time.Second,
 		CoordinatorReportCh: make(chan coordinator.ReceivedMessage, 100),
 		MetricsCollector:    nil, // Don't use metrics to avoid registration conflicts
 	}


### PR DESCRIPTION
## Summary

Multi-pillar hardening of the simulation harness:

- **Oracle correctness** — anchor `lastReceived=0` on first observation so pre-seq losses aren't silently swallowed; make `startLatency` send blocking against `ctx.Done` so latency samples aren't dropped under chaos bursts; configurable `workerCacheMaxPerPartition`; tighter `AckWait` validation.
- **Public consumer API migration** — worker and metrics build on `consumer.Dynamic` / `consumer.{Gate,Resolver}Metrics` instead of `internal/durable`. Simulation no longer reaches into `internal/*`.
- **Refined duplicate classification** — `RecordReceivedFromWorker(partition, seq, workerID)` plus an owner-snapshot discriminator (`Coordinator.CurrentOwnersOf`, published via `atomic.Pointer`) distinguishes 5 outcomes: Redelivery, OwnershipViolation, ConcurrentOwnersViolation, OwnershipInconclusive, OwnershipUnobserved (split pre/post-chaos). `FailureReport` gains `ConcurrentOwnerEvents`, `InconclusiveOwnerEvents`, and `FirstChaosEventAt`. Stop-channel close is idempotent via `sync.Once`.
- **CI coverage** — leader-targeted network-disconnect chaos; new focused network-disconnect job, RoundRobin strategy job, and gate-on (`enforce_exclusive_consumption`) job against a 5m chaos workload. All use the 3-retry pattern.

5m gate-on dry run: 24240/24240 messages received with zero entries in all four ownership counter classes. A prior cross-worker "violation" observed under the older classifier was a false positive caused by classifying legitimate handoff redelivery as exclusive-consumption breach.

## Test plan

- [x] `make lint` clean
- [x] `make test` passes
- [x] 5m gate-on chaos run clean (zero ownership-violation counters)
- [ ] CI: chaos-simulation job passes
- [ ] CI: network-disconnect-simulation job passes
- [ ] CI: roundrobin-simulation job passes
- [ ] CI: gate-on-simulation job passes