### PR TITLE
Add provision SDK and partictl CLI (v1)

### DIFF
--- a/.agents/rules/500-validation-and-workflow.md
+++ b/.agents/rules/500-validation-and-workflow.md
@@ -9,11 +9,8 @@ Apply these rules before validation, commits, or PR work.
 - Verify docs are updated when exported API changes.
 
 ## Git Conventions
-- **Branches:** `feat/`, `fix/`, `docs/`, `chore/`, `test/`.
-- **Commits:** Conventional format. Present tense. First line < 50 chars.
-    - `feat: add weighted consistent hash strategy`
-    - `fix: handle nil partition source`
-- **Attribution:** Never add `Co-Authored-By` or any other attribution trailers.
+See [550-git-conventions.md](550-git-conventions.md) for branch
+naming, commit message format and body guidelines, and PR conventions.
 
 ## Code Review Checklist
 - [ ] Correctness

--- a/.agents/rules/550-git-conventions.md
+++ b/.agents/rules/550-git-conventions.md
@@ -1,0 +1,52 @@
+# 550 - Git Conventions
+
+Apply these rules when crafting commits, branches, or pull-request titles and descriptions.
+
+## Branches
+- Prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `test/`, `refactor/`, `perf/`.
+
+## Commit Messages
+
+### Format
+- Follow [Conventional Commits](https://www.conventionalcommits.org/).
+  A type prefix is required: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `perf`, etc.
+  An optional scope goes in parentheses: `fix(assignment): ...`. Present tense.
+- First line ≤ 50 characters when possible; hard cap 100.
+
+### Body — short and clear
+The body explains WHY the change is needed and WHAT its PURPOSE is,
+then summarises the MAIN CHANGES at a high level. Aim for 3–8 short
+paragraphs — readable in under a minute.
+
+Skip low-level details that belong in the code, the PR description, or the spec:
+- Per-function or per-file diffs (the code already shows them).
+- Line-by-line walk-throughs.
+- Review-iteration counts and rationale (e.g. how many rounds of reviewer feedback shaped the design).
+- Exhaustive test enumerations.
+
+Bias toward the reader who finds this commit via `git log` or `git blame` months later
+and wants to understand the change quickly.
+
+### No plan / review jargon
+Future readers of `git log` and `git blame` have no access to in-progress plan documents or review reports.
+Do NOT reference:
+- Sequencing labels: `PR-1`, `PR-2`, `Phase 4`, ...
+- Work-item IDs: `W12`, `W15`, `W19`, `H2.C`, ...
+- Review-iteration jargon: `plan-review v2 P0-B`, `post-impl v3.1`, `Codex xhigh`, ...
+- References to specific `tmp/*_review.md` reports.
+
+Bad: `fix(assignment): close W15+W16 per PR-2 spec`.
+
+Good: `fix(assignment): serialize apply pipeline with stale gate`.
+
+Citing the spec FILE PATH is fine (e.g. `See docs/plans/worker-state-hardening/02-pr2-spec.md`) —
+the path is discoverable; the section IDs inside it are not.
+
+### Attribution
+Never add `Co-Authored-By` or any other attribution trailers.
+
+## Pull Requests
+- Title follows the same Conventional Commits format as the commit's first line.
+- Body restates the WHY and PURPOSE for reviewers.
+  Linking the spec and prior review history is acceptable here when it is useful context,
+  but lead with domain language so a reviewer who hasn't read the plan can still understand the change.

--- a/.agents/rules/850-review-loop-workflow.md
+++ b/.agents/rules/850-review-loop-workflow.md
@@ -1,0 +1,96 @@
+# 850 - Review Loop Workflow
+
+Apply when running a plan-track or implementation-track loop in this repo —
+specifically, when deciding which reviewer skill to dispatch, when to stop,
+and how to handle findings between rounds. This rule documents the canonical
+sequence so it does not have to be re-described every task.
+
+For design discipline that applies inside each round (state the invariant,
+grep don't claim, atomicity is designed in), see
+[`800-design-and-review-loops.md`](800-design-and-review-loops.md). 800 is the
+*how to think during a round*; 850 is *how to sequence the rounds*.
+
+## Canonical Sequence
+
+### Plan track
+
+```
+draft plan
+  → /plan-review (architectural pass, effort=xhigh)
+  → revise plan per findings
+  → /plan-review again until no P0/P1 architecture findings
+  → /final-plan-review (precision pass, effort=high)
+  → revise per findings
+  → hand off to implementation
+```
+
+### Implementation track
+
+```
+implement (or /simplify a draft)
+  → /post-impl-review v1 (effort=xhigh)
+  → fix findings
+  → /post-impl-review v2 (effort=xhigh)
+  → fix findings
+  → /post-impl-review v3+ (effort=high; step down per skill cost note)
+  → merge when verdict=merge and zero P0/P1
+```
+
+### Lightweight alternatives
+
+Skip the full structured review when you only want a fresh outside-model pass
+over a diff — use `/codex:review --wait` or `/codex:adversarial-review --wait`
+directly. These do not write a versioned report; they are not substitutes for
+`/post-impl-review` when the spec-vs-impl audit is the point.
+
+### Stopping conditions
+
+- **Plan-track:** stop when `/final-plan-review` returns no P0 and no P1
+  findings, or returns a verdict equivalent to "ready to implement."
+- **Impl-track:** stop when `/post-impl-review` returns verdict=`merge` with
+  zero P0 and zero P1. P2 polish items are not merge-blockers.
+
+## Between-Round Discipline
+
+1. **Read the full report, then triage.** Each P0/P1 gets one of:
+   *accept* (apply the fix), *argue back* (the reviewer was wrong — record
+   why with `file:line`), or *defer* (legitimate but out of this round's
+   scope — file a follow-up). Silent drops are not allowed.
+2. **Edits land in the plan or code, not in chat.** The next round's reviewer
+   must see the change in the file, not in a conversation summary.
+3. **Do not auto-apply reviewer suggestions.** Even when the fix looks
+   obvious, the report is *input to your edit*, not a patch. Reviewers are
+   wrong often enough that blind application creates new findings.
+4. **Argue-back must cite source.** "I disagree, see `file:line` showing X"
+   is acceptable; "I think this is fine" is not.
+5. **Surface the next dispatch as a cost gate.** Each external reviewer
+   round costs real tokens and 2–8 minutes wall time. Propose the next round
+   to the user before dispatching; do not chain rounds silently.
+
+## Re-Dispatch Guard
+
+Before dispatching v2+ of any reviewer, confirm material change since the
+last report. The reviewer skills enforce this at dispatch time; the rule
+here is the *intent*: re-reviewing unchanged input wastes the budget and
+typically reproduces the prior verdict. If nothing changed but the loop has
+not converged, the next step is a human judgment call — not another dispatch.
+
+## Stage Escalation
+
+- Precision pass surfaces a P0/P1 with architectural shape →
+  reopen `/plan-review`. `/final-plan-review` cannot redesign.
+- `/post-impl-review` surfaces a finding that requires re-architecture (not
+  just code fixes) → stop the impl loop, reopen `/plan-review` on the
+  affected pillar, then return to impl.
+- More than 2–3 rounds at the same stage with new findings each time →
+  the underlying approach is wrong (see
+  [`800-design-and-review-loops.md`](800-design-and-review-loops.md) §8,
+  "Patching past 2-3 rounds means the design is wrong"). Reset, do not
+  patch further.
+
+## Cross-References
+
+- [`800-design-and-review-loops.md`](800-design-and-review-loops.md) —
+  design discipline that applies *within* each round.
+- [`AGENTS.md` — Skills](../../AGENTS.md#skills) — invocation details for
+  `/plan-review`, `/final-plan-review`, `/post-impl-review`.

--- a/.agents/rules/AGENTS.md
+++ b/.agents/rules/AGENTS.md
@@ -7,6 +7,7 @@ every task, then read the files whose triggers match the work.
 - For most Go implementation tasks, read `000`, `100`, `200`, `500`, and `600`.
 - Add `300` when adding or changing tests.
 - Add `400` when editing docs, examples, README content, or exported API.
+- Add `550` when crafting commits, branches, or PR titles/descriptions.
 - Add `700` only for hot paths, external input, credentials, auth, or network-facing code.
 - Add `800` only for non-trivial design, plan, or review-loop work.
 - For tiny documentation-only edits, `000` plus the relevant docs or workflow rule is enough.
@@ -25,7 +26,10 @@ every task, then read the files whose triggers match the work.
 - **[400-docs.md](400-docs.md)** — Exported symbol docs, README/docs sync, Godoc examples.
 
 ## Before Validation, Commit, or PR Work
-- **[500-validation-and-workflow.md](500-validation-and-workflow.md)** — Git conventions, validation gates, Make targets.
+- **[500-validation-and-workflow.md](500-validation-and-workflow.md)** — Validation gates, code review checklist, Make targets.
+
+## Before Crafting Commits or PRs
+- **[550-git-conventions.md](550-git-conventions.md)** — Branch naming, Conventional Commits, commit body guidelines, plan/review jargon prohibition, attribution.
 
 ## After Modifying Go Files
 - **[600-go-after-write.md](600-go-after-write.md)** — `go fix` scope, lint workflow, stale linter cache handling.

--- a/.agents/rules/AGENTS.md
+++ b/.agents/rules/AGENTS.md
@@ -10,6 +10,7 @@ every task, then read the files whose triggers match the work.
 - Add `550` when crafting commits, branches, or PR titles/descriptions.
 - Add `700` only for hot paths, external input, credentials, auth, or network-facing code.
 - Add `800` only for non-trivial design, plan, or review-loop work.
+- Add `850` when sequencing a plan or implementation review loop (which reviewer to dispatch, when to stop, how to handle findings).
 - For tiny documentation-only edits, `000` plus the relevant docs or workflow rule is enough.
 
 ## Always
@@ -38,6 +39,7 @@ every task, then read the files whose triggers match the work.
 - **[700-performance-security.md](700-performance-security.md)** — Hot-path performance, allocation discipline, input validation, secrets, NATS auth.
 
 ## Before Plan, Design, or Review-Loop Work
-- **[800-design-and-review-loops.md](800-design-and-review-loops.md)** — Invariants, path enumeration, atomicity, review-loop discipline.
+- **[800-design-and-review-loops.md](800-design-and-review-loops.md)** — Invariants, path enumeration, atomicity, review-loop discipline (how to think during a round).
+- **[850-review-loop-workflow.md](850-review-loop-workflow.md)** — Canonical reviewer sequence, stopping conditions, between-round triage, stage escalation (how to sequence the rounds).
 
 For broad or ambiguous tasks, read all rule files before editing.

--- a/.agents/skills/final-plan-review/SKILL.md
+++ b/.agents/skills/final-plan-review/SKILL.md
@@ -45,6 +45,8 @@ If present, use the Codex path. If absent (plugin uninstalled) or the codex run 
 
 Dispatch via the `Agent` tool using the codex rescue subagent. Pass `--wait`, `--effort high`, and `--write` as routing flags in the prompt prefix. `--write` must be explicit — the rescue subagent's default is read-only for "review" tasks, but this skill needs Codex to write the report file.
 
+The codex-rescue subagent parses these as routing controls and strips them from the task text before invoking `codex-companion.mjs` (see its agent definition: "Preserve the user's task text as-is apart from stripping routing flags"). They are intent signals to the subagent, not literal CLI args appended to the prompt.
+
 ```
 Agent({
   subagent_type: "codex:codex-rescue",
@@ -112,6 +114,9 @@ Replace `<PLAN_PATH>`, `<STRATEGY_DOC_PATH>`, `<CODE_REFS>`, and `<REPORT_PATH>`
 >
 > **Produce a review report** at `<REPORT_PATH>`.
 >
+> Write ONLY to `<REPORT_PATH>`. Do not create, modify, or delete any other
+> file.
+>
 > Format same as a standard plan review (Summary / Findings by severity /
 > Verdict), but bias toward P1 and P2 severity. A P0 here would be a
 > serious surprise; if you find one, flag it prominently in the Summary.
@@ -134,6 +139,8 @@ Replace `<PLAN_PATH>`, `<STRATEGY_DOC_PATH>`, `<CODE_REFS>`, and `<REPORT_PATH>`
 3. If P0 or P1 findings exist, propose plan edits to address them. Do not auto-apply edits to the plan without user confirmation — precision-pass findings sometimes reveal genuine architectural ambiguities the user wants to discuss.
 
 ## Loop guidance
+
+Before dispatching, confirm the plan has materially changed since the most recent `tmp/<plan-stem>_*precision*_review.md` or `tmp/<plan-stem>_*final*_review.md`. If no prior precision pass exists, proceed. If a prior pass exists and the plan looks unchanged at a glance, surface that to the user and ask whether to dispatch anyway — re-running a precision pass on an unchanged plan typically reproduces the previous findings and wastes the budget called out in "Cost notes".
 
 Typically one pass of `final-plan-review` is enough. If the plan still has open P0/P1 findings after fixes, that suggests reopening `plan-review` to address architecture, not running another precision pass.
 

--- a/.agents/skills/plan-review/SKILL.md
+++ b/.agents/skills/plan-review/SKILL.md
@@ -45,6 +45,8 @@ If present, use the Codex path. If absent (plugin uninstalled) or the codex run 
 
 Dispatch via the `Agent` tool using the codex rescue subagent. The subagent is a thin forwarder that runs the Codex CLI with your prompt; pass `--wait`, `--effort xhigh`, and `--write` as routing flags in the prompt prefix. `--write` must be explicit — the rescue subagent's default is read-only for "review" tasks, but this skill needs Codex to write the report file.
 
+The codex-rescue subagent parses these as routing controls and strips them from the task text before invoking `codex-companion.mjs` (see its agent definition: "Preserve the user's task text as-is apart from stripping routing flags"). They are intent signals to the subagent, not literal CLI args appended to the prompt.
+
 ```
 Agent({
   subagent_type: "codex:codex-rescue",
@@ -114,6 +116,9 @@ Replace `<PLAN_PATH>`, `<SHORT_NAME>`, `<COMPANION_DOCS>`, `<CODE_REFS>`, and `<
 >
 > **Produce a review report** at `<REPORT_PATH>`.
 >
+> Write ONLY to `<REPORT_PATH>`. Do not create, modify, or delete any other
+> file.
+>
 > **Report format:**
 >
 > ```markdown
@@ -166,6 +171,13 @@ Replace `<PLAN_PATH>`, `<SHORT_NAME>`, `<COMPANION_DOCS>`, `<CODE_REFS>`, and `<
 ## Loop guidance
 
 If the caller asks to "loop until clean":
+- Step 0: before dispatching, confirm the plan has materially changed since the
+  last `tmp/<plan-stem>_*_review.md` for this plan. If no prior review exists,
+  proceed. If a prior review exists and the plan looks unchanged at a glance
+  (no new sections, no rewritten pillars), surface that to the user and ask
+  whether to dispatch anyway — a re-review on an unchanged plan typically
+  reproduces the previous findings and wastes the budget called out in
+  "Cost notes".
 - Pass 1: dispatch this skill, then summarize.
 - If verdict is "fix-then-merge" or equivalent and findings are addressable in the plan (not in code), edit the plan to address each finding, then dispatch again.
 - Stop when the verdict is "ready" / "merge" / no P0 or P1 findings remain.

--- a/.agents/skills/post-impl-review/SKILL.md
+++ b/.agents/skills/post-impl-review/SKILL.md
@@ -47,6 +47,8 @@ If present, use the Codex path. If absent (plugin uninstalled) or the codex run 
 
 Dispatch via the `Agent` tool using the codex rescue subagent. Pass `--wait`, `--effort xhigh`, and `--write` as routing flags in the prompt prefix. `--write` must be explicit — the rescue subagent's default is read-only for "review" tasks, but this skill needs Codex to write the versioned report file.
 
+The codex-rescue subagent parses these as routing controls and strips them from the task text before invoking `codex-companion.mjs` (see its agent definition: "Preserve the user's task text as-is apart from stripping routing flags"). They are intent signals to the subagent, not literal CLI args appended to the prompt.
+
 ```
 Agent({
   subagent_type: "codex:codex-rescue",
@@ -161,6 +163,11 @@ Replace `<PHASE>`, `<VERSION>`, `<PLAN_PATH>`, `<SPEC_SECTIONS>`, `<IN_SCOPE_FIL
 >
 > Path: `<REPORT_PATH>`.
 >
+> Do not modify source files, tests, or any tracked file in the repository.
+> `<REPORT_PATH>` is your only deliverable. Running the validation commands
+> above is expected — the build/test toolchain managing its own caches under
+> `~/.cache/go-build`, `vendor/`, etc. does not count as a modification.
+>
 > Format:
 >
 > ```markdown
@@ -233,6 +240,8 @@ The post-implementation review is designed to run multiple times within one phas
 ```
 implement → post-impl-review v1 → fix findings → post-impl-review v2 → … → merge
 ```
+
+**Step 0 before dispatching v2+:** confirm the working tree actually changed since the prior review. Spot-check with `git diff --stat` and verify the diff touches the files cited in the prior round's P0/P1 findings. If the diff is empty or doesn't address the prior findings, do not dispatch — re-reviewing unchanged code reproduces the previous verdict and wastes the budget called out in "Cost notes". Surface the gap to the user instead.
 
 Each version's report should reference the prior version's findings explicitly. Use a versioned filename so the history is preserved on disk: `tmp/<plan-stem>_<phase>_post_implementation_review_v1.md`, `..._v2.md`, etc.
 

--- a/cmd/partictl/cmd_apply.go
+++ b/cmd/partictl/cmd_apply.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// applyFlags holds flags specific to the apply command.
+type applyFlags struct {
+	common      commonFlags
+	file        string
+	dryRun      bool
+	jsonOut     bool
+	failOnDrift bool
+}
+
+func cmdApply(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("apply", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var f applyFlags
+	fs.StringVar(&f.file, "f", "", "YAML config path (required)")
+	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
+	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
+	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
+	fs.StringVar(&f.common.token, "token", "", "NATS token")
+	fs.StringVar(&f.common.timeout, "timeout", "30s", "operation timeout (e.g. 30s, 1m)")
+	fs.BoolVar(&f.dryRun, "dry-run", false, "plan only — emit the same output as partictl plan")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit JSON output (PlanResult for -dry-run, Report otherwise)")
+	fs.BoolVar(&f.failOnDrift, "fail-on-drift", false, "exit 2 if non-informational drift is detected (dry-run only)")
+
+	if err := fs.Parse(args); err != nil {
+		return ExitValidation
+	}
+
+	// Validate -timeout before any NATS connect so invalid values exit 3.
+	timeoutDur, err := parseTimeout(f.common.timeout)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	if f.file == "" {
+		fmt.Fprintln(stderr, "partictl apply: -f is required")
+		fs.Usage()
+
+		return ExitValidation
+	}
+
+	cfg, err := loadConfig(f.file)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	// Static validation before any NATS connect.
+	if err := provision.Validate(cfg); err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	ctx, stop, exitIfTimeout := makeContext(timeoutDur, stderr)
+	defer stop()
+
+	conn, code, err := connectNATS(ctx, f.common)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+
+		return code
+	}
+	defer conn.close()
+
+	// -dry-run: runs the same planning path as cmdPlan and emits identical output.
+	if f.dryRun {
+		planResult, err := provision.Plan(ctx, conn.js, cfg)
+		if err != nil {
+			if exitIfTimeout(ctx) {
+				return ExitNATS
+			}
+			fmt.Fprintln(stderr, "partictl apply -dry-run:", err)
+
+			return classifyError(err)
+		}
+
+		if f.jsonOut {
+			_ = jsonOutput(stdout, planResult)
+		} else {
+			renderPlanText(stdout, planResult)
+		}
+
+		if f.failOnDrift && hasDrift(planResult.Drift) {
+			return ExitDrift
+		}
+
+		return ExitOK
+	}
+
+	// Live apply.
+	report, err := provision.Apply(ctx, conn.js, cfg)
+	if err != nil {
+		if exitIfTimeout(ctx) {
+			if f.jsonOut {
+				_ = jsonOutput(stdout, report)
+			} else {
+				renderReportText(stdout, report)
+			}
+
+			return ExitNATS
+		}
+		if f.jsonOut {
+			_ = jsonOutput(stdout, report)
+		} else {
+			renderReportText(stdout, report)
+		}
+
+		return classifyError(err)
+	}
+
+	if f.jsonOut {
+		_ = jsonOutput(stdout, report)
+	} else {
+		renderReportText(stdout, report)
+	}
+
+	return ExitOK
+}

--- a/cmd/partictl/cmd_plan.go
+++ b/cmd/partictl/cmd_plan.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// planFlags holds flags specific to the plan command.
+type planFlags struct {
+	common      commonFlags
+	file        string
+	jsonOut     bool
+	failOnDrift bool
+}
+
+func cmdPlan(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("plan", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var f planFlags
+	fs.StringVar(&f.file, "f", "", "YAML config path (required)")
+	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
+	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
+	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
+	fs.StringVar(&f.common.token, "token", "", "NATS token")
+	fs.StringVar(&f.common.timeout, "timeout", "30s", "operation timeout (e.g. 30s, 1m)")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit JSON output (PlanResult)")
+	fs.BoolVar(&f.failOnDrift, "fail-on-drift", false, "exit 2 if non-informational drift is detected")
+
+	if err := fs.Parse(args); err != nil {
+		return ExitValidation
+	}
+
+	// Validate -timeout before any NATS connect so invalid values exit 3.
+	timeoutDur, err := parseTimeout(f.common.timeout)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	if f.file == "" {
+		fmt.Fprintln(stderr, "partictl plan: -f is required")
+		fs.Usage()
+
+		return ExitValidation
+	}
+
+	cfg, err := loadConfig(f.file)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	// Static validation first (no I/O). provision.Plan also validates, but
+	// we want the parse-error → exit 3 short-circuit before any NATS connect.
+	if err := provision.Validate(cfg); err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	ctx, stop, exitIfTimeout := makeContext(timeoutDur, stderr)
+	defer stop()
+
+	conn, code, err := connectNATS(ctx, f.common)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+
+		return code
+	}
+	defer conn.close()
+
+	planResult, err := provision.Plan(ctx, conn.js, cfg)
+	if err != nil {
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+		fmt.Fprintln(stderr, "partictl plan:", err)
+
+		return classifyError(err)
+	}
+
+	if f.jsonOut {
+		_ = jsonOutput(stdout, planResult)
+	} else {
+		renderPlanText(stdout, planResult)
+	}
+
+	if f.failOnDrift && hasDrift(planResult.Drift) {
+		return ExitDrift
+	}
+
+	return ExitOK
+}

--- a/cmd/partictl/cmd_validate.go
+++ b/cmd/partictl/cmd_validate.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// validateFlags holds flags specific to the validate command.
+type validateFlags struct {
+	common  commonFlags
+	file    string
+	live    bool
+	jsonOut bool
+	// instance is accepted for CLI flag consistency with view but not used:
+	// validate is config-scoped, not live-resource-scoped.
+	instance string
+}
+
+func cmdValidate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var f validateFlags
+	fs.StringVar(&f.file, "f", "", "YAML config path (required)")
+	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
+	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
+	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
+	fs.StringVar(&f.common.token, "token", "", "NATS token")
+	fs.StringVar(&f.common.timeout, "timeout", "30s", "operation timeout (e.g. 30s, 1m)")
+	fs.BoolVar(&f.live, "live", false, "perform live validation (requires NATS connectivity)")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit JSON output (Report-shaped envelope)")
+	fs.StringVar(&f.instance, "instance", "", "restrict results to resources with matching parti.io/instance")
+
+	if err := fs.Parse(args); err != nil {
+		// flag.ContinueOnError already wrote the error message to stderr.
+		return ExitValidation
+	}
+
+	// Validate -timeout before any NATS connect so invalid values exit 3 even
+	// on the static (non-live) path.
+	timeoutDur, err := parseTimeout(f.common.timeout)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	// Warn when -instance is set alongside -f: validate is config-scoped and
+	// -instance has no effect.
+	if f.instance != "" && f.file != "" {
+		fmt.Fprintln(stderr, "partictl: -instance ignored because -f scopes resources from the config file")
+	}
+
+	if f.file == "" {
+		fmt.Fprintln(stderr, "partictl validate: -f is required")
+		fs.Usage()
+
+		return ExitValidation
+	}
+
+	// Load YAML config.
+	cfg, err := loadConfig(f.file)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	// Static validation (no I/O).
+	if err := provision.Validate(cfg); err != nil {
+		if f.jsonOut {
+			_ = jsonOutput(stdout, validateResultJSON(false, []string{err.Error()}))
+		} else {
+			renderValidateText(stdout, false, []string{err.Error()})
+		}
+
+		return ExitValidation
+	}
+
+	// Non-live path: report OK and return.
+	if !f.live {
+		if f.jsonOut {
+			_ = jsonOutput(stdout, validateResultJSON(true, nil))
+		} else {
+			renderValidateText(stdout, true, nil)
+		}
+
+		return ExitOK
+	}
+
+	// Live validation path.
+	ctx, stop, exitIfTimeout := makeContext(timeoutDur, stderr)
+	defer stop()
+
+	conn, code, err := connectNATS(ctx, f.common)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+
+		return code
+	}
+	defer conn.close()
+
+	report, err := provision.ValidateLive(ctx, conn.js, cfg)
+	if err != nil {
+		if exitIfTimeout(ctx) {
+			if f.jsonOut {
+				_ = jsonOutput(stdout, report)
+			}
+
+			return ExitNATS
+		}
+		if f.jsonOut {
+			_ = jsonOutput(stdout, report)
+		} else {
+			errs := make([]string, 0, len(report.Errors)+1)
+			for _, re := range report.Errors {
+				errs = append(errs, re.Error)
+			}
+			if len(errs) == 0 {
+				errs = append(errs, err.Error())
+			}
+			renderValidateText(stdout, false, errs)
+		}
+
+		return classifyError(err)
+	}
+
+	if f.jsonOut {
+		_ = jsonOutput(stdout, report)
+	} else {
+		renderValidateText(stdout, true, nil)
+	}
+
+	return ExitOK
+}

--- a/cmd/partictl/cmd_view.go
+++ b/cmd/partictl/cmd_view.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// viewFlags holds flags specific to the view command.
+type viewFlags struct {
+	common   commonFlags
+	file     string
+	jsonOut  bool
+	instance string
+}
+
+func cmdView(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("view", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var f viewFlags
+	fs.StringVar(&f.file, "f", "", "YAML config path (optional; scopes view to config resources)")
+	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
+	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
+	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
+	fs.StringVar(&f.common.token, "token", "", "NATS token")
+	fs.StringVar(&f.common.timeout, "timeout", "30s", "operation timeout (e.g. 30s, 1m)")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit JSON output (Snapshot)")
+	fs.StringVar(&f.instance, "instance", "", "restrict results to resources with matching parti.io/instance")
+
+	if err := fs.Parse(args); err != nil {
+		return ExitValidation
+	}
+
+	// Validate -timeout before any NATS connect so invalid values exit 3.
+	timeoutDur, err := parseTimeout(f.common.timeout)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	ctx, stop, exitIfTimeout := makeContext(timeoutDur, stderr)
+	defer stop()
+
+	// Determine scope: config-scoped (with -f) or inventory (without -f).
+	var scope provision.Scope
+	if f.file != "" {
+		// Warn when -instance is also set: -f scopes resources from the config
+		// and the -instance flag is silently ignored.
+		if f.instance != "" {
+			fmt.Fprintln(stderr, "partictl: -instance ignored because -f scopes resources from the config file")
+		}
+		cfg, err := loadConfig(f.file)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+
+			return ExitValidation
+		}
+		// Static validate to catch obviously bad configs early; view still
+		// functions with a partial config, but we want the user to fix it.
+		if err := provision.Validate(cfg); err != nil {
+			fmt.Fprintln(stderr, err)
+
+			return ExitValidation
+		}
+		scope = provision.ScopeFromConfig(cfg)
+		// When -f is set the config's Instance wins; -instance flag is ignored.
+	} else {
+		scope = provision.ScopeAll()
+		scope.Instance = f.instance
+	}
+
+	conn, code, err := connectNATS(ctx, f.common)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+
+		return code
+	}
+	defer conn.close()
+
+	snap, err := provision.View(ctx, conn.js, scope)
+	if err != nil {
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+		fmt.Fprintln(stderr, "partictl view:", err)
+
+		return classifyError(err)
+	}
+
+	if f.jsonOut {
+		_ = jsonOutput(stdout, snap)
+	} else {
+		renderSnapshotText(stdout, snap)
+	}
+
+	return ExitOK
+}

--- a/cmd/partictl/config.go
+++ b/cmd/partictl/config.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/arloliu/parti/v2/provision"
+	"gopkg.in/yaml.v3"
+)
+
+// loadConfig reads the YAML file at path and unmarshals it into a
+// provision.Config. Returns an error wrapping the underlying file or parse
+// error; errors are classification-ready (callers map to exit 3).
+func loadConfig(path string) (provision.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return provision.Config{}, fmt.Errorf("partictl: read config %q: %w", path, err)
+	}
+
+	var cfg provision.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return provision.Config{}, fmt.Errorf("partictl: parse config %q: %w", path, err)
+	}
+
+	return cfg, nil
+}

--- a/cmd/partictl/doc.go
+++ b/cmd/partictl/doc.go
@@ -1,0 +1,5 @@
+// Package main is the cmd/partictl CLI for Parti environment provisioning.
+//
+// Commands: view, validate, plan, apply.
+// See partictl -help for full usage.
+package main

--- a/cmd/partictl/exitcodes.go
+++ b/cmd/partictl/exitcodes.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Exit code constants. These are stable across releases — new codes only
+// appear above 4 to avoid CI breakage.
+const (
+	// ExitOK is success.
+	ExitOK = 0
+	// ExitRuntime is a runtime/generic error (operation failed after preflight).
+	ExitRuntime = 1
+	// ExitDrift is drift detected and not resolved (only with -fail-on-drift).
+	ExitDrift = 2
+	// ExitValidation is a static or live validation error, or a flag-parse error.
+	ExitValidation = 3
+	// ExitNATS is a NATS connect, auth, or context timeout/cancel failure.
+	ExitNATS = 4
+)
+
+// classifyError maps err to the appropriate CLI exit code per the plan's
+// Exit code precedence table:
+//
+//  1. ErrInvalidConfig (static) → 3
+//  2. context.Canceled / context.DeadlineExceeded → 4
+//  3. ErrLiveValidation (live) → 3
+//  4. NATS permission errors (after connect) → 3
+//  5. Anything else → 1
+//
+// NATS connect errors are not wrapped in a sentinel; callers that produce a
+// NATS connect error (natsconn.go) should return ExitNATS directly rather
+// than routing through this helper.
+//
+// Note: context-error precedence over permission errors is intentional — a
+// cancelled context can surface as ErrNoResponders from nats.go.
+func classifyError(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	// Static validation (highest priority of error sentinels).
+	if errors.Is(err, provision.ErrInvalidConfig) {
+		return ExitValidation
+	}
+	// Context cancellation / timeout → NATS/infra failure code.
+	// Must come before permission checks: a cancelled context can surface
+	// as ErrNoResponders.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ExitNATS
+	}
+	// Live validation.
+	if errors.Is(err, provision.ErrLiveValidation) {
+		return ExitValidation
+	}
+	// NATS permission errors after a successful connect (e.g., from
+	// provision.Plan / provision.View) map to validation class (exit 3).
+	// These differ from connect-time auth failures, which are handled by
+	// natsconn.go and never reach classifyError.
+	if errors.Is(err, nats.ErrPermissionViolation) ||
+		errors.Is(err, jetstream.ErrJetStreamNotEnabled) ||
+		errors.Is(err, jetstream.ErrJetStreamNotEnabledForAccount) ||
+		errors.Is(err, nats.ErrNoResponders) {
+		return ExitValidation
+	}
+	// Everything else is a runtime error.
+	return ExitRuntime
+}
+
+// hasDrift reports whether a PlanResult contains any non-informational drift
+// (adopted, drift-mutable, or drift-immutable severity).
+func hasDrift(drift []provision.DriftFinding) bool {
+	for _, d := range drift {
+		switch d.Severity {
+		case provision.SeverityAdopted,
+			provision.SeverityDriftMutable,
+			provision.SeverityDriftImmutable:
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/partictl/exitcodes_test.go
+++ b/cmd/partictl/exitcodes_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		{"nil", nil, ExitOK},
+		{"ErrInvalidConfig", provision.ErrInvalidConfig, ExitValidation},
+		{"ErrInvalidConfig wrapped", fmt.Errorf("wrap: %w", provision.ErrInvalidConfig), ExitValidation},
+		{"context.Canceled", context.Canceled, ExitNATS},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, ExitNATS},
+		{"ErrLiveValidation", provision.ErrLiveValidation, ExitValidation},
+		{"ErrLiveValidation wrapped", fmt.Errorf("wrap: %w", provision.ErrLiveValidation), ExitValidation},
+		{"generic error", errors.New("some runtime error"), ExitRuntime},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyError(tc.err)
+			if got != tc.wantCode {
+				t.Errorf("classifyError(%v) = %d, want %d", tc.err, got, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestClassifyError_NATSPermissionDenied verifies that NATS permission errors
+// returned after a successful connect (e.g., from provision.Plan) map to
+// ExitValidation (exit 3), not ExitRuntime (exit 1).
+func TestClassifyError_NATSPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"ErrPermissionViolation direct", nats.ErrPermissionViolation},
+		{"ErrPermissionViolation wrapped", fmt.Errorf("provision: lookup KV_foo: %w", nats.ErrPermissionViolation)},
+		{"ErrJetStreamNotEnabled", jetstream.ErrJetStreamNotEnabled},
+		{"ErrJetStreamNotEnabled wrapped", fmt.Errorf("provision: info KV_bar: %w", jetstream.ErrJetStreamNotEnabled)},
+		{"ErrJetStreamNotEnabledForAccount", jetstream.ErrJetStreamNotEnabledForAccount},
+		{"ErrNoResponders", nats.ErrNoResponders},
+		{"ErrNoResponders wrapped", fmt.Errorf("provision: lookup KV_baz: %w", nats.ErrNoResponders)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyError(tc.err)
+			if got != ExitValidation {
+				t.Errorf("classifyError(%v) = %d, want %d (ExitValidation)", tc.err, got, ExitValidation)
+			}
+		})
+	}
+}
+
+func TestHasDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		drift []provision.DriftFinding
+		want  bool
+	}{
+		{"empty", nil, false},
+		{"informational only", []provision.DriftFinding{{Severity: provision.SeverityInformational}}, false},
+		{"adopted", []provision.DriftFinding{{Severity: provision.SeverityAdopted}}, true},
+		{"drift-mutable", []provision.DriftFinding{{Severity: provision.SeverityDriftMutable}}, true},
+		{"drift-immutable", []provision.DriftFinding{{Severity: provision.SeverityDriftImmutable}}, true},
+		{"mixed informational + drift", []provision.DriftFinding{
+			{Severity: provision.SeverityInformational},
+			{Severity: provision.SeverityDriftMutable},
+		}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasDrift(tc.drift)
+			if got != tc.want {
+				t.Errorf("hasDrift() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/partictl/main.go
+++ b/cmd/partictl/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/cmd/partictl/nats_test.go
+++ b/cmd/partictl/nats_test.go
@@ -1,0 +1,554 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// startTestNATS starts an embedded NATS server and returns the client URL
+// for use with the CLI flags.
+func startTestNATS(t *testing.T) string {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	return nc.ConnectedUrl()
+}
+
+// startTestNATSWithJS starts an embedded NATS server and returns both the URL
+// and a JetStream context for direct provisioning in tests.
+func startTestNATSWithJS(t *testing.T) (string, jetstream.JetStream) {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("create jetstream: %v", err)
+	}
+	return nc.ConnectedUrl(), js
+}
+
+// runWithNATS calls run() injecting the -server flag pointing to the
+// embedded NATS server. It returns stdout and the exit code; stderr is
+// discarded (callers that need stderr should call run() directly).
+func runWithNATS(t *testing.T, url string, args ...string) (stdout string, code int) {
+	t.Helper()
+	// Splice -server after the subcommand name.
+	if len(args) == 0 {
+		var outBuf, errBuf bytes.Buffer
+		code = run(args, &outBuf, &errBuf)
+
+		return outBuf.String(), code
+	}
+	subcmd := args[0]
+	rest := args[1:]
+	full := append([]string{subcmd, "-server", url}, rest...)
+	var outBuf, errBuf bytes.Buffer
+	code = run(full, &outBuf, &errBuf)
+
+	return outBuf.String(), code
+}
+
+// runWithNATSBytes is like runWithNATS but returns stdout as []byte.
+// Used for byte-identity assertions (bytes.Equal).
+func runWithNATSBytes(t *testing.T, url string, args ...string) (stdout []byte, code int) {
+	t.Helper()
+	if len(args) == 0 {
+		var outBuf, errBuf bytes.Buffer
+		code = run(args, &outBuf, &errBuf)
+
+		return outBuf.Bytes(), code
+	}
+	subcmd := args[0]
+	rest := args[1:]
+	full := append([]string{subcmd, "-server", url}, rest...)
+	var outBuf, errBuf bytes.Buffer
+	code = run(full, &outBuf, &errBuf)
+
+	return outBuf.Bytes(), code
+}
+
+// --- view tests ---
+
+func TestView_EmptyServer(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+	stdout, code := runWithNATS(t, url, "view")
+	if code != ExitOK {
+		t.Errorf("view empty server = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "no Parti-managed resources found") {
+		t.Errorf("expected 'no Parti-managed resources found': %q", stdout)
+	}
+}
+
+func TestView_EmptyServer_JSON(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+	stdout, code := runWithNATS(t, url, "view", "-json")
+	if code != ExitOK {
+		t.Errorf("view empty server -json = %d, want 0", code)
+	}
+	// Must have apiVersion and kind.
+	if !strings.Contains(stdout, `"apiVersion"`) {
+		t.Errorf("missing apiVersion: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"parti.io/provision/v1"`) {
+		t.Errorf("missing provision/v1: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"kind"`) {
+		t.Errorf("missing kind: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"Snapshot"`) {
+		t.Errorf("missing Snapshot kind: %q", stdout)
+	}
+
+	// Unmarshal and verify shape.
+	var snap provision.Snapshot
+	if err := json.Unmarshal([]byte(stdout), &snap); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+	if snap.APIVersion != provision.APIVersionProvisionV1 {
+		t.Errorf("apiVersion = %q, want %q", snap.APIVersion, provision.APIVersionProvisionV1)
+	}
+	if snap.Kind != provision.KindSnapshot {
+		t.Errorf("kind = %q, want %q", snap.Kind, provision.KindSnapshot)
+	}
+	if snap.ObservedAt.IsZero() {
+		t.Error("observedAt should be non-zero in JSON output")
+	}
+}
+
+func TestView_WithMarkedBuckets(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+
+	ctx := context.Background()
+
+	// Create a marked bucket (control-plane:id).
+	marker := provision.BuildMarker(provision.ComponentControlPlaneID, "test-instance")
+	_, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   "test-stableid",
+		Storage:  jetstream.FileStorage,
+		History:  1,
+		Metadata: marker,
+	})
+	if err != nil {
+		t.Fatalf("create KV: %v", err)
+	}
+
+	// Create an unmarked bucket (should not appear in view).
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  "unrelated-bucket",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+	})
+	if err != nil {
+		t.Fatalf("create unmarked KV: %v", err)
+	}
+
+	stdout, code := runWithNATS(t, url, "view")
+	if code != ExitOK {
+		t.Errorf("view with marked buckets = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "test-stableid") {
+		t.Errorf("expected test-stableid in output: %q", stdout)
+	}
+	if strings.Contains(stdout, "unrelated-bucket") {
+		t.Errorf("unmarked bucket should not appear in output: %q", stdout)
+	}
+}
+
+func TestView_InstanceFilter(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+	ctx := context.Background()
+
+	// Create a bucket stamped with instance "prod".
+	prodMarker := provision.BuildMarker(provision.ComponentControlPlaneID, "prod")
+	_, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   "prod-stableid",
+		Storage:  jetstream.FileStorage,
+		History:  1,
+		Metadata: prodMarker,
+	})
+	if err != nil {
+		t.Fatalf("create prod KV: %v", err)
+	}
+
+	// Create a bucket stamped with instance "staging".
+	stagingMarker := provision.BuildMarker(provision.ComponentControlPlaneID, "staging")
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   "staging-stableid",
+		Storage:  jetstream.FileStorage,
+		History:  1,
+		Metadata: stagingMarker,
+	})
+	if err != nil {
+		t.Fatalf("create staging KV: %v", err)
+	}
+
+	// view -instance=prod should only return prod bucket.
+	stdout, code := runWithNATS(t, url, "view", "-instance", "prod")
+	if code != ExitOK {
+		t.Errorf("view -instance=prod = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "prod-stableid") {
+		t.Errorf("expected prod-stableid: %q", stdout)
+	}
+	if strings.Contains(stdout, "staging-stableid") {
+		t.Errorf("staging-stableid should not appear: %q", stdout)
+	}
+}
+
+// --- plan tests ---
+
+func TestPlan_EmptyServer_JSON(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+	stdout, code := runWithNATS(t, url, "plan", "-f", "testdata/minimal.yaml", "-json")
+	if code != ExitOK {
+		t.Errorf("plan empty server = %d, want 0", code)
+	}
+
+	var plan provision.PlanResult
+	if err := json.Unmarshal([]byte(stdout), &plan); err != nil {
+		t.Fatalf("unmarshal plan: %v", err)
+	}
+	if plan.APIVersion != provision.APIVersionProvisionV1 {
+		t.Errorf("apiVersion = %q, want %q", plan.APIVersion, provision.APIVersionProvisionV1)
+	}
+	if plan.Kind != provision.KindPlan {
+		t.Errorf("kind = %q, want %q", plan.Kind, provision.KindPlan)
+	}
+	// Against an empty server, minimal.yaml should produce 4 create-kv actions.
+	if len(plan.Actions) != 4 {
+		t.Errorf("expected 4 actions, got %d: %+v", len(plan.Actions), plan.Actions)
+	}
+	for _, a := range plan.Actions {
+		if a.Kind != provision.ActionCreateKV {
+			t.Errorf("expected all actions to be create-kv, got %q", a.Kind)
+		}
+	}
+}
+
+func TestPlan_FailOnDrift_NoDrift(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+	ctx := context.Background()
+
+	// Pre-create the bucket properly with the Parti marker so there's no drift.
+	cfg, err := loadConfig("testdata/minimal.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	_, err = provision.Apply(ctx, js, cfg)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// plan -fail-on-drift with no drift should exit 0.
+	_, code := runWithNATS(t, url, "plan",
+		"-f", "testdata/minimal.yaml",
+		"-fail-on-drift",
+	)
+	if code != ExitOK {
+		t.Errorf("plan -fail-on-drift no drift = %d, want 0", code)
+	}
+}
+
+func TestPlan_FailOnDrift_WithDrift(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+	ctx := context.Background()
+
+	// Create an unmarked bucket with the same name as what the config expects
+	// → adopted drift.
+	cfg, err := loadConfig("testdata/minimal.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfgN, err := provision.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("apply defaults: %v", err)
+	}
+	// Create without marker.
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  cfgN.ControlPlane.StableIDBucket,
+		Storage: jetstream.FileStorage,
+		History: 1,
+	})
+	if err != nil {
+		t.Fatalf("create unmarked bucket: %v", err)
+	}
+
+	// plan -fail-on-drift should exit 2.
+	_, code := runWithNATS(t, url, "plan",
+		"-f", "testdata/minimal.yaml",
+		"-fail-on-drift",
+	)
+	if code != ExitDrift {
+		t.Errorf("plan -fail-on-drift with drift = %d, want %d (ExitDrift)", code, ExitDrift)
+	}
+}
+
+func TestPlan_FailOnDrift_WithoutFlag(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+	ctx := context.Background()
+
+	// Same adopted-drift setup as above.
+	cfg, err := loadConfig("testdata/minimal.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfgN, err := provision.ApplyDefaults(cfg)
+	if err != nil {
+		t.Fatalf("apply defaults: %v", err)
+	}
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  cfgN.ControlPlane.StableIDBucket,
+		Storage: jetstream.FileStorage,
+		History: 1,
+	})
+	if err != nil {
+		t.Fatalf("create unmarked bucket: %v", err)
+	}
+
+	// Without -fail-on-drift, should exit 0 even with drift.
+	_, code := runWithNATS(t, url, "plan", "-f", "testdata/minimal.yaml")
+	if code != ExitOK {
+		t.Errorf("plan without -fail-on-drift = %d, want 0", code)
+	}
+}
+
+// --- apply tests ---
+
+func TestApply_DryRun_ByteIdenticalToPlan(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+
+	// plan -json and apply -dry-run -json must produce byte-identical output.
+	// This is the literal byte-identity check from the spec (bytes.Equal, not string comparison).
+	planOut, planCode := runWithNATSBytes(t, url, "plan", "-f", "testdata/minimal.yaml", "-json")
+	if planCode != ExitOK {
+		t.Fatalf("plan -json = %d", planCode)
+	}
+
+	applyOut, applyCode := runWithNATSBytes(t, url, "apply",
+		"-f", "testdata/minimal.yaml", "-json", "-dry-run")
+	if applyCode != ExitOK {
+		t.Fatalf("apply -dry-run -json = %d", applyCode)
+	}
+
+	// Literal byte-identity check from the spec: plan -json and apply -dry-run -json
+	// must produce the exact same bytes, not just equal strings.
+	if !bytes.Equal(planOut, applyOut) {
+		t.Errorf("plan -json and apply -dry-run -json are not byte-identical\nplan:\n%s\napply:\n%s",
+			planOut, applyOut)
+	}
+}
+
+func TestApply_DryRun_ByteIdentical_MultipleRuns(t *testing.T) {
+	// Verify byte-identity holds across two separate plan runs (deterministic).
+	t.Parallel()
+	url := startTestNATS(t)
+
+	planOut1, code1 := runWithNATS(t, url, "plan", "-f", "testdata/minimal.yaml", "-json")
+	planOut2, code2 := runWithNATS(t, url, "plan", "-f", "testdata/minimal.yaml", "-json")
+	if code1 != ExitOK || code2 != ExitOK {
+		t.Fatalf("plan runs failed: %d %d", code1, code2)
+	}
+	if planOut1 != planOut2 {
+		t.Errorf("plan output is not deterministic:\nrun1:\n%s\nrun2:\n%s", planOut1, planOut2)
+	}
+}
+
+func TestApply_CreatesResources(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+
+	stdout, code := runWithNATS(t, url, "apply",
+		"-f", "testdata/minimal.yaml", "-json")
+	if code != ExitOK {
+		t.Errorf("apply = %d, want 0", code)
+	}
+
+	var report provision.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if report.APIVersion != provision.APIVersionProvisionV1 {
+		t.Errorf("apiVersion = %q, want %q", report.APIVersion, provision.APIVersionProvisionV1)
+	}
+	if report.Kind != provision.KindReport {
+		t.Errorf("kind = %q, want %q", report.Kind, provision.KindReport)
+	}
+	if len(report.Executed) == 0 {
+		t.Error("expected executed actions, got none")
+	}
+	if report.Aborted {
+		t.Error("report.Aborted should be false")
+	}
+
+	// Re-run plan: should show no actions (everything was created).
+	planOut, planCode := runWithNATS(t, url, "plan",
+		"-f", "testdata/minimal.yaml", "-json")
+	if planCode != ExitOK {
+		t.Errorf("second plan = %d, want 0", planCode)
+	}
+	var planResult provision.PlanResult
+	if err := json.Unmarshal([]byte(planOut), &planResult); err != nil {
+		t.Fatalf("unmarshal plan: %v", err)
+	}
+	if len(planResult.Actions) != 0 {
+		t.Errorf("expected no actions after apply, got %d", len(planResult.Actions))
+	}
+}
+
+func TestApply_Idempotent(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+
+	// First apply.
+	_, code := runWithNATS(t, url, "apply", "-f", "testdata/minimal.yaml")
+	if code != ExitOK {
+		t.Fatalf("first apply = %d", code)
+	}
+
+	// Second apply should be a no-op (no errors).
+	stdout, code := runWithNATS(t, url, "apply", "-f", "testdata/minimal.yaml", "-json")
+	if code != ExitOK {
+		t.Errorf("second apply = %d, want 0", code)
+	}
+	var report provision.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if len(report.Errors) != 0 {
+		t.Errorf("second apply had errors: %+v", report.Errors)
+	}
+}
+
+// --- golden JSON output tests ---
+// These tests validate the JSON envelope structure (apiVersion/kind) by
+// parsing the output rather than byte-comparing against a file, because
+// Snapshot.ObservedAt varies per run. For PlanResult (no timestamp), we
+// assert structural determinism.
+
+func TestGolden_ViewJSON_SnapshotEnvelope(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+	ctx := context.Background()
+
+	// Pre-create a stamped bucket.
+	marker := provision.BuildMarker(provision.ComponentControlPlaneID, "golden")
+	_, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   "golden-stableid",
+		Storage:  jetstream.FileStorage,
+		History:  1,
+		Metadata: marker,
+	})
+	if err != nil {
+		t.Fatalf("create KV: %v", err)
+	}
+
+	stdout, code := runWithNATS(t, url, "view", "-json")
+	if code != ExitOK {
+		t.Fatalf("view -json = %d", code)
+	}
+
+	var snap provision.Snapshot
+	if err := json.Unmarshal([]byte(stdout), &snap); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+	if snap.APIVersion != provision.APIVersionProvisionV1 {
+		t.Errorf("apiVersion = %q, want %q", snap.APIVersion, provision.APIVersionProvisionV1)
+	}
+	if snap.Kind != provision.KindSnapshot {
+		t.Errorf("kind = %q, want %q", snap.Kind, provision.KindSnapshot)
+	}
+
+	// ObservedAt should be set and recent.
+	if snap.ObservedAt.IsZero() {
+		t.Error("observedAt should not be zero")
+	}
+	if time.Since(snap.ObservedAt) > 30*time.Second {
+		t.Errorf("observedAt looks stale: %v", snap.ObservedAt)
+	}
+
+	found := false
+	for _, b := range snap.ControlPlane {
+		if b.Bucket == "golden-stableid" {
+			found = true
+			if b.Instance != "golden" {
+				t.Errorf("instance = %q, want %q", b.Instance, "golden")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("golden-stableid not found in ControlPlane: %+v", snap.ControlPlane)
+	}
+}
+
+func TestGolden_PlanJSON_Deterministic(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+
+	// Run plan twice; both runs must produce identical JSON bytes.
+	out1, code1 := runWithNATS(t, url, "plan", "-f", "testdata/minimal.yaml", "-json")
+	out2, code2 := runWithNATS(t, url, "plan", "-f", "testdata/minimal.yaml", "-json")
+
+	if code1 != ExitOK || code2 != ExitOK {
+		t.Fatalf("plan failed: code1=%d code2=%d", code1, code2)
+	}
+	if out1 != out2 {
+		t.Errorf("plan is not deterministic\nrun1:\n%s\nrun2:\n%s", out1, out2)
+	}
+}
+
+// --- validate -live tests ---
+
+func TestValidateLive_OK(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+	stdout, code := runWithNATS(t, url, "validate",
+		"-f", "testdata/minimal.yaml", "-live")
+	if code != ExitOK {
+		t.Errorf("validate -live = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "ok") {
+		t.Errorf("expected 'ok': %q", stdout)
+	}
+}
+
+func TestValidateLive_Unreachable(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("validate",
+		"-f", "testdata/minimal.yaml",
+		"-live",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("validate -live unreachable = %d, want %d (ExitNATS)", code, ExitNATS)
+	}
+}
+
+// --- NATS connect with nats.Connect error → exit 4 ---
+
+func TestNATSConnect_ErrorExitCode(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("view",
+		"-server", "nats://127.0.0.1:1", // guaranteed refused
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("NATS connect failure = %d, want %d (ExitNATS)", code, ExitNATS)
+	}
+}

--- a/cmd/partictl/natsconn.go
+++ b/cmd/partictl/natsconn.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// commonFlags holds the NATS connection flags shared by all commands.
+type commonFlags struct {
+	server  string
+	creds   string
+	nkey    string
+	token   string
+	timeout string // parsed separately; stored as flag string
+}
+
+// natsConn bundles a connected NATS client with its JetStream context.
+// Callers must call nc.Close() when done.
+type natsConn struct {
+	nc *nats.Conn
+	js jetstream.JetStream
+}
+
+// close closes the underlying NATS connection.
+func (n *natsConn) close() {
+	n.nc.Close()
+}
+
+// defaultServer returns the NATS server URL to use when -server is not set.
+// Priority: $NATS_URL env > nats.DefaultURL.
+func defaultServer() string {
+	if v := os.Getenv("NATS_URL"); v != "" {
+		return v
+	}
+
+	return nats.DefaultURL
+}
+
+// connectNATS opens a NATS connection using the options from commonFlags.
+// On failure it returns ExitNATS (4) as the exit code, along with the error.
+// On success callers must call conn.close() when done.
+func connectNATS(ctx context.Context, cf commonFlags) (*natsConn, int, error) {
+	opts := []nats.Option{
+		nats.Name("partictl"),
+	}
+
+	if cf.creds != "" {
+		opts = append(opts, nats.UserCredentials(cf.creds))
+	}
+	if cf.nkey != "" {
+		nkeyOpt, err := nats.NkeyOptionFromSeed(cf.nkey)
+		if err != nil {
+			return nil, ExitNATS, fmt.Errorf("partictl: load nkey %q: %w", cf.nkey, err)
+		}
+		opts = append(opts, nkeyOpt)
+	}
+	if cf.token != "" {
+		opts = append(opts, nats.Token(cf.token))
+	}
+
+	nc, err := nats.Connect(cf.server, opts...)
+	if err != nil {
+		return nil, ExitNATS, fmt.Errorf("partictl: connect to %s: %w", cf.server, err)
+	}
+
+	// Honour ctx cancellation. nats.Connect does not accept a context; check after.
+	if ctx.Err() != nil {
+		nc.Close()
+		return nil, ExitNATS, ctx.Err()
+	}
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return nil, ExitNATS, fmt.Errorf("partictl: create jetstream: %w", err)
+	}
+
+	return &natsConn{nc: nc, js: js}, ExitOK, nil
+}

--- a/cmd/partictl/output.go
+++ b/cmd/partictl/output.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// jsonOutput marshals v to JSON and writes it to w, followed by a newline.
+// Returns an error only when the marshal fails (should never happen for
+// well-formed provision types).
+func jsonOutput(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// --- Snapshot renderer ---
+
+// renderSnapshotText writes a human-readable table of the snapshot to w.
+// Wall-clock timestamps are excluded per the plan's output rules.
+func renderSnapshotText(w io.Writer, snap provision.Snapshot) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	allEmpty := len(snap.ControlPlane) == 0 &&
+		len(snap.PartitionSource) == 0 &&
+		len(snap.DynamicConsumers) == 0
+	if allEmpty {
+		fmt.Fprintln(w, "no Parti-managed resources found")
+		return
+	}
+
+	if len(snap.ControlPlane) > 0 {
+		fmt.Fprintln(tw, "CONTROL PLANE")
+		fmt.Fprintln(tw, "  BUCKET\tCOMPONENT\tSTORAGE\tHISTORY\tTTL\tINSTANCE")
+		for _, b := range snap.ControlPlane {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%d\t%s\t%s\n",
+				b.Bucket, b.Component, b.Storage, b.History,
+				fmtTTL(b.TTL), b.Instance)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	if len(snap.PartitionSource) > 0 {
+		fmt.Fprintln(tw, "PARTITION SOURCE")
+		fmt.Fprintln(tw, "  BUCKET\tCOMPONENT\tSTORAGE\tHISTORY\tTTL\tINSTANCE")
+		for _, b := range snap.PartitionSource {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%d\t%s\t%s\n",
+				b.Bucket, b.Component, b.Storage, b.History,
+				fmtTTL(b.TTL), b.Instance)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	if len(snap.DynamicConsumers) > 0 {
+		fmt.Fprintln(tw, "DYNAMIC CONSUMERS")
+		fmt.Fprintln(tw, "  STREAM\tDURABLE\tCOMPONENT\tINSTANCE")
+		for _, c := range snap.DynamicConsumers {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				c.StreamName, c.Durable, c.Component, c.Instance)
+		}
+		fmt.Fprintln(tw)
+	}
+}
+
+func fmtTTL(d time.Duration) string {
+	if d == 0 {
+		return "none"
+	}
+	return d.String()
+}
+
+// --- PlanResult renderer ---
+
+// renderPlanText writes a human-readable plan output to w.
+func renderPlanText(w io.Writer, plan provision.PlanResult) {
+	if len(plan.Actions) == 0 && len(plan.Drift) == 0 {
+		fmt.Fprintln(w, "plan: no changes required")
+		return
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	if len(plan.Actions) > 0 {
+		fmt.Fprintln(tw, "ACTIONS")
+		fmt.Fprintln(tw, "  KIND\tNAME")
+		for _, a := range plan.Actions {
+			fmt.Fprintf(tw, "  %s\t%s\n", a.Kind, a.Name)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	if len(plan.Drift) > 0 {
+		fmt.Fprintln(tw, "DRIFT")
+		fmt.Fprintln(tw, "  SEVERITY\tKIND\tNAME\tDETAIL")
+		for _, d := range plan.Drift {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+				d.Severity, d.Kind, d.Name, fmtDriftDetail(d.Detail))
+		}
+		fmt.Fprintln(tw)
+	}
+}
+
+func fmtDriftDetail(detail map[string]any) string {
+	if len(detail) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(detail))
+	for k, v := range detail {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+	}
+	// Sort for deterministic output.
+	sortStrings(parts)
+
+	return strings.Join(parts, " ")
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+// --- Report renderer ---
+
+// renderReportText writes a human-readable apply report to w.
+func renderReportText(w io.Writer, report provision.Report) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	if report.Aborted {
+		fmt.Fprintln(w, "apply: aborted (context cancelled)")
+	}
+
+	if len(report.Executed) == 0 && len(report.Skipped) == 0 && len(report.Errors) == 0 {
+		if !report.Aborted {
+			fmt.Fprintln(w, "apply: no changes applied")
+		}
+		return
+	}
+
+	if len(report.Executed) > 0 {
+		fmt.Fprintln(tw, "EXECUTED")
+		fmt.Fprintln(tw, "  KIND\tNAME\tRACED")
+		for _, a := range report.Executed {
+			raced := ""
+			if a.Raced {
+				raced = "yes"
+			}
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n", a.Kind, a.Name, raced)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	if len(report.Skipped) > 0 {
+		fmt.Fprintln(tw, "SKIPPED")
+		fmt.Fprintln(tw, "  KIND\tNAME\tREASON")
+		for _, a := range report.Skipped {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n", a.Kind, a.Name, a.Reason)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	if len(report.Errors) > 0 {
+		fmt.Fprintln(tw, "ERRORS")
+		fmt.Fprintln(tw, "  KIND\tNAME\tERROR")
+		for _, e := range report.Errors {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n", e.Kind, e.Name, e.Error)
+		}
+		fmt.Fprintln(tw)
+	}
+}
+
+// renderValidateText writes a human-readable validate result to w.
+// ok is true when validation passed; errs contains the validation error strings.
+func renderValidateText(w io.Writer, ok bool, errs []string) {
+	if ok {
+		fmt.Fprintln(w, "ok")
+		return
+	}
+	for _, e := range errs {
+		fmt.Fprintln(w, "validation error:", e)
+	}
+}
+
+// validateResultJSON is the JSON envelope for the validate command.
+// We reuse the Report shape as directed by the plan ("Prefer reusing Report").
+// On success, Executed/Skipped/Errors are all nil/empty.
+// On failure, Errors contains one entry per validation error.
+func validateResultJSON(ok bool, errs []string) provision.Report {
+	r := provision.Report{
+		APIVersion: provision.APIVersionProvisionV1,
+		Kind:       provision.KindReport,
+		Executed:   []provision.ExecutedAction{},
+		Skipped:    []provision.SkippedAction{},
+		Errors:     []provision.ResourceError{},
+	}
+	if !ok {
+		for _, e := range errs {
+			r.Errors = append(r.Errors, provision.ResourceError{
+				Kind:  "config",
+				Name:  "validate",
+				Error: e,
+			})
+		}
+	}
+
+	return r
+}

--- a/cmd/partictl/run.go
+++ b/cmd/partictl/run.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// run is the testable entrypoint for partictl. args should be the command-line
+// arguments (excluding the program name), stdout and stderr are the output
+// writers. Returns an exit code.
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return ExitValidation
+	}
+
+	subCmd := args[0]
+	rest := args[1:]
+
+	switch subCmd {
+	case "view":
+		return cmdView(rest, stdout, stderr)
+	case "validate":
+		return cmdValidate(rest, stdout, stderr)
+	case "plan":
+		return cmdPlan(rest, stdout, stderr)
+	case "apply":
+		return cmdApply(rest, stdout, stderr)
+	case "help", "-help", "--help", "-h":
+		printUsage(stdout)
+		return ExitOK
+	default:
+		fmt.Fprintf(stderr, "partictl: unknown command %q\n\n", subCmd)
+		printUsage(stderr)
+		return ExitValidation
+	}
+}
+
+// printUsage writes the top-level usage text.
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, `partictl — Parti environment provisioning CLI
+
+Usage:
+  partictl <command> [flags]
+
+Commands:
+  view      Show live Parti-managed resources (Snapshot)
+  validate  Validate a config file (static; -live adds NATS preflight)
+  plan      Compute desired-vs-live drift and proposed actions (PlanResult)
+  apply     Create missing resources; -dry-run emits the same output as plan
+
+Common flags (accepted by all commands):
+  -server   <url>       NATS server URL (default: $NATS_URL or nats://127.0.0.1:4222)
+  -creds    <path>      Path to NATS credentials file
+  -nkey     <path>      Path to NATS nkey seed file
+  -token    <string>    NATS token
+  -timeout  <duration>  Operation timeout (default: 30s)
+  -f        <path>      YAML config file (required for validate/plan/apply; optional for view)
+  -json                 Emit machine-readable JSON output
+  -instance <name>      Filter by parti.io/instance (view without -f; validate)
+
+Deferred commands (not yet available in v1):
+  partitions plan/apply, adopt, stream view/plan/apply, init, emit
+
+Exit codes:
+  0  success
+  1  runtime / generic error
+  2  drift detected (-fail-on-drift)
+  3  config parse or validation error
+  4  NATS connect / auth / timeout failure
+
+Run 'partictl <command> -help' for per-command flags.
+`)
+}
+
+// parseTimeout parses a duration string supplied via -timeout. Returns an
+// error if the string is empty, syntactically invalid, or non-positive.
+// Callers should treat any error as a flag-parse error (ExitValidation).
+func parseTimeout(s string) (time.Duration, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("partictl: invalid -timeout value %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("partictl: -timeout must be positive, got %q", s)
+	}
+
+	return d, nil
+}
+
+// makeContext creates a context with the signal-cancel wrapper on top of a
+// timeout. The returned stop function must be deferred by the caller.
+// exitIfTimeout returns true when ctx expired due to timeout or signal, used
+// by commands to map the error to ExitNATS.
+func makeContext(d time.Duration, _ io.Writer) (context.Context, context.CancelFunc, func(ctx context.Context) bool) {
+	// Signal-cancellable root context.
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+
+	ctx, cancel := context.WithTimeout(sigCtx, d)
+
+	combinedStop := func() {
+		cancel()
+		stop()
+	}
+
+	exitIfTimeout := func(ctx context.Context) bool {
+		return ctx.Err() != nil
+	}
+
+	return ctx, combinedStop, exitIfTimeout
+}

--- a/cmd/partictl/run_test.go
+++ b/cmd/partictl/run_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// runArgs is a helper to call run() and capture stdout/stderr.
+func runArgs(args ...string) (stdout, stderr string, code int) {
+	var outBuf, errBuf bytes.Buffer
+	code = run(args, &outBuf, &errBuf)
+	return outBuf.String(), errBuf.String(), code
+}
+
+// --- Top-level dispatch tests ---
+
+func TestRunNoArgs(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs()
+	if code != ExitValidation {
+		t.Errorf("run() with no args = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runArgs("--help")
+	if code != ExitOK {
+		t.Errorf("run(--help) = %d, want %d (ExitOK)", code, ExitOK)
+	}
+	if !strings.Contains(stdout, "partictl") {
+		t.Errorf("help output missing 'partictl': %q", stdout)
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("bogus-command")
+	if code != ExitValidation {
+		t.Errorf("run(bogus-command) = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "unknown command") {
+		t.Errorf("expected 'unknown command' in stderr: %q", stderr)
+	}
+}
+
+// --- validate command (static, no NATS) ---
+
+func TestValidateNoFlag(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("validate")
+	if code != ExitValidation {
+		t.Errorf("validate (no -f) = %d, want %d", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "-f is required") {
+		t.Errorf("expected -f required message in stderr: %q", stderr)
+	}
+}
+
+func TestValidateFlagParseError(t *testing.T) {
+	t.Parallel()
+	// Unknown flag → flag.ContinueOnError returns error → ExitValidation.
+	_, _, code := runArgs("validate", "-unknown-flag")
+	if code != ExitValidation {
+		t.Errorf("validate -unknown-flag = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+func TestValidateStaticOK(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runArgs("validate", "-f", "testdata/minimal.yaml")
+	if code != ExitOK {
+		t.Errorf("validate minimal.yaml = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "ok") {
+		t.Errorf("expected 'ok' in stdout: %q", stdout)
+	}
+}
+
+func TestValidateStaticBadVersion(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("validate", "-f", "testdata/bad_version.yaml")
+	if code != ExitValidation {
+		t.Errorf("validate bad_version.yaml = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+func TestValidateStaticFullYAML(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runArgs("validate", "-f", "testdata/full.yaml")
+	if code != ExitOK {
+		t.Errorf("validate full.yaml = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "ok") {
+		t.Errorf("expected 'ok' in stdout: %q", stdout)
+	}
+}
+
+func TestValidateStaticJSONEnvelope(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runArgs("validate", "-f", "testdata/minimal.yaml", "-json")
+	if code != ExitOK {
+		t.Errorf("validate -json = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, `"apiVersion"`) {
+		t.Errorf("expected apiVersion in JSON output: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"parti.io/provision/v1"`) {
+		t.Errorf("expected parti.io/provision/v1 in JSON output: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"kind"`) {
+		t.Errorf("expected kind in JSON output: %q", stdout)
+	}
+}
+
+func TestValidateStaticBadVersionJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runArgs("validate", "-f", "testdata/bad_version.yaml", "-json")
+	if code != ExitValidation {
+		t.Errorf("validate bad_version.yaml -json = %d, want %d", code, ExitValidation)
+	}
+	// JSON output should be a Report-shaped envelope with at least one error.
+	var report provision.Report
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("JSON unmarshal failed: %v\noutput: %q", err, stdout)
+	}
+	if len(report.Errors) == 0 {
+		t.Errorf("expected at least one error in report, got none; output: %q", stdout)
+	}
+}
+
+// --- plan command (no NATS, static validation) ---
+
+func TestPlanNoFlag(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("plan")
+	if code != ExitValidation {
+		t.Errorf("plan (no -f) = %d, want %d", code, ExitValidation)
+	}
+	_ = stderr
+}
+
+func TestPlanBadVersion(t *testing.T) {
+	// Bad apiVersion → static validation fails (exit 3) before NATS connect.
+	t.Parallel()
+	_, _, code := runArgs("plan", "-f", "testdata/bad_version.yaml")
+	if code != ExitValidation {
+		t.Errorf("plan bad_version.yaml = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+func TestPlanNATSUnreachable(t *testing.T) {
+	// Valid config but NATS unreachable → exit 4.
+	t.Parallel()
+	_, _, code := runArgs("plan",
+		"-f", "testdata/minimal.yaml",
+		"-server", "nats://127.0.0.1:1", // unreachable port
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("plan with unreachable NATS = %d, want %d (ExitNATS)", code, ExitNATS)
+	}
+}
+
+func TestPlanContextTimeout(t *testing.T) {
+	// Extremely short timeout → context deadline exceeded → exit 4.
+	t.Parallel()
+	_, _, code := runArgs("plan",
+		"-f", "testdata/minimal.yaml",
+		"-server", "nats://127.0.0.1:1", // unreachable
+		"-timeout", "1ns",
+	)
+	if code != ExitNATS {
+		t.Errorf("plan with 1ns timeout = %d, want %d (ExitNATS)", code, ExitNATS)
+	}
+}
+
+// --- apply command (static validation) ---
+
+func TestApplyNoFlag(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("apply")
+	if code != ExitValidation {
+		t.Errorf("apply (no -f) = %d, want %d", code, ExitValidation)
+	}
+	_ = stderr
+}
+
+func TestApplyBadVersion(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("apply", "-f", "testdata/bad_version.yaml")
+	if code != ExitValidation {
+		t.Errorf("apply bad_version.yaml = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+func TestApplyDryRunNATSUnreachable(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("apply",
+		"-f", "testdata/minimal.yaml",
+		"-dry-run",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("apply -dry-run with unreachable NATS = %d, want %d (ExitNATS)", code, ExitNATS)
+	}
+}
+
+// --- view command ---
+
+func TestViewNATSUnreachable(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("view",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("view with unreachable NATS = %d, want %d (ExitNATS)", code, ExitNATS)
+	}
+}
+
+// --- config YAML loading ---
+
+func TestConfigLoad_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("validate", "-f", "testdata/nonexistent.yaml")
+	if code != ExitValidation {
+		t.Errorf("validate missing file = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+func TestConfigLoad_FullYAML(t *testing.T) {
+	t.Parallel()
+	// Full YAML round-trips and passes static validation.
+	stdout, _, code := runArgs("validate", "-f", "testdata/full.yaml")
+	if code != ExitOK {
+		t.Errorf("validate full.yaml = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "ok") {
+		t.Errorf("expected 'ok': %q", stdout)
+	}
+}
+
+// --- exit-code precedence tests ---
+
+// TestPrecedence_ParseErrorBeforeNATS: a flag parse error → exit 3, even though
+// NATS is unreachable (the NATS connect never happens).
+func TestPrecedence_ParseErrorBeforeNATS(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("validate", "-bad-flag-should-not-exist")
+	if code != ExitValidation {
+		t.Errorf("parse error precedence = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+// TestPrecedence_StaticValidationBeforeNATS: bad apiVersion → exit 3 (no NATS
+// connect attempted).
+func TestPrecedence_StaticValidationBeforeNATS(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("plan",
+		"-f", "testdata/bad_version.yaml",
+		"-server", "nats://127.0.0.1:1",
+	)
+	if code != ExitValidation {
+		t.Errorf("static validation before NATS = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+// TestPrecedence_StaticValidationBeforeDrift: bad apiVersion with -fail-on-drift →
+// exit 3 (static validation error takes precedence over drift check).
+func TestPrecedence_StaticValidationBeforeDrift(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("plan",
+		"-f", "testdata/bad_version.yaml",
+		"-fail-on-drift",
+		"-server", "nats://127.0.0.1:1",
+	)
+	if code != ExitValidation {
+		t.Errorf("static validation + -fail-on-drift = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+// --- P0-2: invalid -timeout exits 3 ---
+
+// TestValidate_InvalidTimeout_ExitsParseError: -timeout with garbage value →
+// exit 3 (flag-parse error), even on the static path (no -live, no NATS).
+func TestValidate_InvalidTimeout_ExitsParseError(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("validate",
+		"-f", "testdata/minimal.yaml",
+		"-timeout", "garbage",
+	)
+	if code != ExitValidation {
+		t.Errorf("validate -timeout garbage = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "invalid") {
+		t.Errorf("expected 'invalid' in stderr: %q", stderr)
+	}
+}
+
+// TestPlan_InvalidTimeout_ExitsParseError: -timeout with garbage value →
+// exit 3 even before any NATS connect.
+func TestPlan_InvalidTimeout_ExitsParseError(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("plan",
+		"-f", "testdata/minimal.yaml",
+		"-timeout", "garbage",
+	)
+	if code != ExitValidation {
+		t.Errorf("plan -timeout garbage = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "invalid") {
+		t.Errorf("expected 'invalid' in stderr: %q", stderr)
+	}
+}
+
+// --- P1-2: precedence tests for malformed YAML and permission-denied ---
+
+// TestPrecedence_MalformedYAMLWinsOverUnreachableNATS: a YAML parse error →
+// exit 3, even though NATS is unreachable (parse error wins before NATS connect).
+func TestPrecedence_MalformedYAMLWinsOverUnreachableNATS(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("plan",
+		"-f", "testdata/malformed.yaml",
+		"-server", "nats://127.0.0.1:1", // unreachable
+	)
+	if code != ExitValidation {
+		t.Errorf("malformed YAML + unreachable NATS = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+// TestPrecedence_PermissionDenied_PlanExits3 verifies via classifyError that a
+// NATS permission error returned from provision.Plan maps to exit 3 (not exit 1).
+// Full NATS-server-with-auth test not required; classifyError is the load-bearing path.
+// (nats.ErrPermissionViolation coverage is in TestClassifyError_NATSPermissionDenied.)
+func TestPrecedence_PermissionDenied_PlanExits3(t *testing.T) {
+	t.Parallel()
+	// ErrLiveValidation wraps permission errors from provision.ValidateLive, so
+	// a wrapped ErrLiveValidation must also map to ExitValidation.
+	permWrap := fmt.Errorf("provision: validatelive: permission denied: %w", provision.ErrLiveValidation)
+	code := classifyError(permWrap)
+	if code != ExitValidation {
+		t.Errorf("ErrLiveValidation-wrapped permission error → %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+}
+
+// --- P2-2: -instance ignored warning ---
+
+// TestView_InstanceIgnoredWithFile: view -f ... -instance ... → stderr warning.
+func TestView_InstanceIgnoredWithFile(t *testing.T) {
+	t.Parallel()
+	// -f set and -instance set → warning, then fails with unreachable NATS (exit 4).
+	_, stderr, _ := runArgs("view",
+		"-f", "testdata/minimal.yaml",
+		"-instance", "prod",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "100ms",
+	)
+	if !strings.Contains(stderr, "-instance ignored") {
+		t.Errorf("expected '-instance ignored' warning in stderr: %q", stderr)
+	}
+}
+
+// TestValidate_InstanceIgnoredWithFile: validate -f ... -instance ... → stderr warning.
+func TestValidate_InstanceIgnoredWithFile(t *testing.T) {
+	t.Parallel()
+	// -f and -instance both set; validate is always config-scoped → warning.
+	_, stderr, code := runArgs("validate",
+		"-f", "testdata/minimal.yaml",
+		"-instance", "prod",
+	)
+	if code != ExitOK {
+		t.Errorf("validate with -instance = %d, want 0 (ExitOK)", code)
+	}
+	if !strings.Contains(stderr, "-instance ignored") {
+		t.Errorf("expected '-instance ignored' warning in stderr: %q", stderr)
+	}
+}

--- a/cmd/partictl/testdata/bad_version.yaml
+++ b/cmd/partictl/testdata/bad_version.yaml
@@ -1,0 +1,5 @@
+apiVersion: parti.io/v99
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s

--- a/cmd/partictl/testdata/full.yaml
+++ b/cmd/partictl/testdata/full.yaml
@@ -1,0 +1,35 @@
+# Canonical "Full" provision config matching the example in
+# docs/plans/provision-sdk-cli. Each field uses a distinct value so the
+# YAML-unmarshal test can verify every nested field is populated via its
+# declared yaml tag (a missing tag would surface as a zero-value comparison).
+apiVersion: parti.io/v1
+instance: prod-us-east
+policy: warn
+
+controlPlane:
+  stableIdBucket: parti-stableid
+  electionBucket: parti-election
+  heartbeatBucket: parti-heartbeat
+  assignmentBucket: parti-assignment
+  handoffBucket: parti-handoff
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s
+  assignmentTtl: 1m30s
+  handoffTtl: 2m
+  enableTwoPhaseHandoff: true
+
+partitionSource:
+  bucket: parti-partitions
+  key: partitions/v1
+  replicas: 3
+  storage: file
+  history: 1
+  maxValueSize: 1048576
+  ttl: 7m
+
+dynamicConsumers:
+  - streamName: orders
+    consumerPrefix: ord-worker
+    subjectTemplate: "orders.{partition_id}.>"
+    partitionsRef: ./partitions.yaml

--- a/cmd/partictl/testdata/malformed.yaml
+++ b/cmd/partictl/testdata/malformed.yaml
@@ -1,0 +1,4 @@
+apiVersion: parti.io/provision/v1
+kind: Provision
+controlPlane:
+  stableIDBucket: "unclosed string

--- a/cmd/partictl/testdata/minimal.yaml
+++ b/cmd/partictl/testdata/minimal.yaml
@@ -1,0 +1,7 @@
+# Minimal provision config — control-plane block with only the three
+# required TTLs. Bucket names default to runtime defaults during Validate.
+apiVersion: parti.io/v1
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s

--- a/consumer/common.go
+++ b/consumer/common.go
@@ -168,15 +168,23 @@ func (c *CommonConfig) Validate() error {
 	return fuda.Validate(c)
 }
 
-// checkWorkQueueRecoveryCompat returns ErrInvalidConfig when the stream uses
+// CheckWorkQueueRecoveryCompat returns ErrInvalidConfig when the stream uses
 // WorkQueuePolicy and the recovery strategy requires a non-DeliverAllPolicy.
 // NATS only permits DeliverAllPolicy on work-queue streams; RecoverFromNew
 // (DeliverNewPolicy) and RecoverFromLastProcessed (DeliverByStartSequencePolicy)
 // would silently fail during every recovery attempt.
 //
 // The check is best-effort: failures to fetch stream info are silently ignored
-// so callers are not blocked by transient connectivity issues.
-func checkWorkQueueRecoveryCompat(ctx context.Context, js jetstream.JetStream, streamName string, strategy RecoveryStrategy) error {
+// so callers are not blocked by transient connectivity issues. This means
+// transient JetStream API failures during the pre-flight do not block consumer
+// updates; the runtime continues as if the check passed.
+//
+// This function is exported so the provision SDK can reuse the exact same
+// implementation in its dynamic-consumer alignment check
+// (see provision.ValidateLiveDynamicConsumers). Reusing rather than
+// duplicating guarantees byte-equivalent error semantics with the runtime
+// Dynamic.Update path.
+func CheckWorkQueueRecoveryCompat(ctx context.Context, js jetstream.JetStream, streamName string, strategy RecoveryStrategy) error {
 	var strategyName string
 	switch strategy {
 	case RecoverFromNew:

--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -308,7 +308,7 @@ func NewDynamic(
 //     exceeds MaxConcurrentSubjects.
 func (d *Dynamic) Update(ctx context.Context, workerID string, partitions []types.Partition) error {
 	d.workQueueOnce.Do(func() {
-		d.workQueueErr = checkWorkQueueRecoveryCompat(ctx, d.js, d.streamName, d.recoveryStrategy)
+		d.workQueueErr = CheckWorkQueueRecoveryCompat(ctx, d.js, d.streamName, d.recoveryStrategy)
 	})
 	if d.workQueueErr != nil {
 		return d.workQueueErr

--- a/consumer/queue.go
+++ b/consumer/queue.go
@@ -277,7 +277,7 @@ func (q *Queue) Start(ctx context.Context) error {
 	}
 	q.consumer = cons
 
-	if err := checkWorkQueueRecoveryCompat(ctx, q.js, q.config.StreamName, q.config.RecoveryStrategy); err != nil {
+	if err := CheckWorkQueueRecoveryCompat(ctx, q.js, q.config.StreamName, q.config.RecoveryStrategy); err != nil {
 		return err
 	}
 

--- a/consumer/static.go
+++ b/consumer/static.go
@@ -233,7 +233,7 @@ func NewStatic(
 //   - error: Non-nil if the consumer is already started or if JetStream
 //     consumer creation fails.
 func (s *Static) Start(ctx context.Context) error {
-	if err := checkWorkQueueRecoveryCompat(ctx, s.js, s.streamName, s.recoveryStrategy); err != nil {
+	if err := CheckWorkQueueRecoveryCompat(ctx, s.js, s.streamName, s.recoveryStrategy); err != nil {
 		return err
 	}
 	return s.inner.Start(ctx)

--- a/docs/plans/partition-fencing/00-design-proposal.md
+++ b/docs/plans/partition-fencing/00-design-proposal.md
@@ -1,0 +1,611 @@
+# Partition Fencing Design Proposal
+
+## Status
+
+**Not started — deferred to the next minor version.**
+
+Design is settled and has cleared two informal review rounds plus one
+precision-pass review (`reviews/01-precision-pass-review.md`, verdict
+READY WITH P1 FIXES, P0=0, P1=7, P2=0). The seven P1s are text/API-contract
+tightenings, not architectural reopenings; they must be folded in before
+implementation begins. The architecture itself is locked.
+
+This revision narrows v1 to **token propagation + correct ack/error semantics**
+and explicitly defers the validator, test harness, and non-Stable-state token
+minting. The lean surface is small enough to land safely; richer helpers can be
+added later under real user demand.
+
+See `README.md` for the deferral rationale and the open P1 list.
+
+## Assumptions
+
+- Parti should preserve the current `Dynamic` architecture: leader-calculated
+  partition ownership, direct worker consumption, and JetStream-owned delivery /
+  ack / redelivery.
+- Weighted assignment remains partition-based. A partition must stay the unit of
+  affinity, load balancing, and handoff.
+- The existing two-phase handoff and `ProcessingGate` are useful, but they do
+  not fully prove that old in-flight handler work cannot finish after ownership
+  has moved.
+- The first version should be opt-in and should not require users to replace
+  their storage system, cache, or handler framework.
+
+## Problem
+
+Parti can prevent many new non-owner pulls and handler entries, but it cannot
+currently prove that an old owner has stopped producing accepted side effects
+after a partition has been reassigned.
+
+Example race:
+
+1. Worker `A` owns partition `P`.
+2. `A` pulls message `m1` and enters a slow handler.
+3. A rebalance assigns `P` to worker `B`.
+4. The handoff claim eventually says `B` owns `P`.
+5. `B` starts processing new work for `P`.
+6. `A`'s old handler finishes late and writes stale state.
+
+The processing gate helps before a handler starts. It does not automatically
+protect every side effect after the handler has already started.
+
+The safety invariant we want is:
+
+> Once partition `P` has moved to a newer ownership epoch, no side effect from an
+> older owner / older epoch can be accepted.
+
+## Why This Matters
+
+Partition affinity exists because workers cache partition-local state and often
+hold partition-local resources. That improves throughput, but it also makes
+handoff correctness more important:
+
+- A stale handler can overwrite newer state after a rebalance.
+- Two workers can briefly act on the same partition even when new pulls are
+  gated correctly, because one worker may already be inside the handler.
+- JetStream ack/redelivery correctness is not enough; application side effects
+  may happen before ack and outside JetStream.
+- A stronger old-owner drain protocol is possible, but it makes rebalances wait
+  on old workers and still needs a timeout story for slow or dead workers.
+
+Fencing gives a cleaner correctness boundary: old work may still finish, but it
+cannot commit accepted side effects after ownership has advanced.
+
+### Idempotency Is Necessary But Not Sufficient
+
+Workers should still be responsible for idempotency. Parti uses JetStream's
+at-least-once delivery model, so the same message can be delivered more than
+once after retries, redelivery, crashes, or consumer recreation. Handler code
+must tolerate duplicate input.
+
+Idempotency answers:
+
+> If I process the same input twice, do I avoid duplicating the same effect?
+
+Fencing answers a different question:
+
+> If an old owner finishes stale work after ownership moved, can it overwrite or
+> conflict with newer owner work?
+
+Example where idempotency is enough:
+
+1. Message `m1` says "set order 123 status = paid".
+2. Worker `A` processes `m1`.
+3. `m1` is redelivered.
+4. Worker `B` processes `m1`.
+5. The same state is written again; no duplicate external effect occurs.
+
+Example where idempotency is not enough:
+
+1. Worker `A` owns partition `P` and starts slow processing for `m1`.
+2. Ownership moves to worker `B`.
+3. `B` processes newer `m2` and writes state version `20`.
+4. `A` finishes old `m1` and writes state version `19`.
+
+`A` did not process `m1` twice, so idempotency did not help. The problem is that
+an old owner committed a stale side effect after a newer owner had advanced the
+partition. That is the gap fencing closes.
+
+Responsibility split:
+
+- Parti provides at-least-once delivery integration, partition affinity,
+  ownership metadata, and fence tokens for handlers that need strict side-effect
+  safety.
+- Worker/application code makes handlers idempotent and decides which side
+  effects need fencing.
+- The storage or external side-effect target must provide the atomic compare /
+  conditional write needed for strict fencing. **Parti does not provide a
+  general validator helper in v1** — atomic CAS at the side-effect target is
+  the only mechanism that actually closes the race.
+
+## What
+
+Introduce an explicit partition ownership fence token and expose it to handlers.
+
+The fence token identifies the authority under which a handler is allowed to
+produce side effects:
+
+```go
+type FenceToken struct {
+    PartitionID string
+    Owner       string
+    Epoch       int64
+    ClaimRev    uint64 // JetStream KV revision of the claim at admission time
+}
+```
+
+The token is derived from the handoff claim:
+
+- `PartitionID` comes from the message subject / assignment partition.
+- `Owner` is the worker ID currently allowed to process.
+- `Epoch` is the claim epoch observed when the handler is admitted.
+- `ClaimRev` is the KV revision of the claim record observed at admission.
+
+### Why ClaimRev is required
+
+`Epoch` alone does not satisfy the monotonicity invariant. The claims KV bucket
+has a TTL (`HandoffTTL`, default `2m`); when a claim record expires it is
+deleted, and any subsequent prepare for that partition starts from
+`NewInitialClaim` with `Epoch: 1`. An old in-flight handler holding
+`{owner=A, epoch=1}` could see its token become "valid again" against a freshly
+recreated `{owner=A, epoch=1}` claim. That violates invariant 4 below.
+
+`ClaimRev` is the per-key, monotonically increasing JetStream KV revision. A
+deleted-then-recreated key gets a fresh, strictly greater revision. Comparing
+`(Owner, Epoch, ClaimRev)` — or even just `ClaimRev` — eliminates the reuse
+hole.
+
+### Two-layer model
+
+1. **Admission fence:** `ProcessingGate` admits the handler only when the worker
+   is the owner in an allowed state (Stable in v1; see below).
+2. **Commit fence:** side-effect code uses the token in an atomic conditional
+   write against the user's storage system. The commit fence is the real
+   correctness boundary; the admission token's job is to give the commit fence
+   something to assert against.
+
+### Admission is best-effort, the commit fence is authoritative
+
+The admission token is captured from the resolver cache, which can lag the KV
+truth by up to one watcher round-trip (and longer during a watcher freeze — see
+the `claim_resolver_watcher_freeze` tests). A token attached at admission may
+therefore already describe a no-longer-current claim by the time the handler
+runs. This is acceptable: the commit fence rejects such writes at the storage
+layer. Documentation should make this explicit so users do not treat token
+presence as proof of currency.
+
+## How
+
+### 1. Capture The Fence At Handler Admission
+
+When the processing gate admits a message, it already resolves:
+
+- partition ID
+- owner
+- handoff state
+- claim epoch
+- (new) claim revision — must be exposed by the ownership resolver
+
+Extend the wrapper to attach a `FenceToken` to the handler context when all of
+these are true:
+
+- ownership is known
+- owner equals the local worker ID
+- **state is `Stable`** (v1 restriction; see Required Semantics)
+- epoch is non-zero
+- claim revision is non-zero
+
+The token is immutable once attached to the context.
+
+### 2. Stable-only minting in v1
+
+`processingGate` may be configured with `AllowedStates` broader than
+`{Stable}` to keep handlers running during handoff transitions. However,
+`NextCommit` and `NextStable` both increment the claim epoch (see
+`internal/assignment/handoff/claims.go`). A token captured during `Commit` would
+go stale at the very next normal `Commit → Stable` transition with no ownership
+change, leading to spurious `ErrFenceStale` and redelivery churn.
+
+For v1, fence tokens are minted **only when admitted in `Stable`**. Handlers
+admitted in transitional states do not receive a token; `RequireFence(ctx)`
+returns `ErrFenceMissing` for them. Documenting this as a hard rule keeps the
+contract clear: *"if you got a token, you were admitted at a quiescent ownership
+boundary."* Lifting this restriction can come later if a concrete workload needs
+it.
+
+### 3. Strict-admission mode
+
+`ProcessingGate` currently fails open on subject-template parse failure (admits
+the handler with no ownership decision). For fenced workloads that is
+incorrect: a handler with no token would still run.
+
+Add `ProcessingGateConfig.RequireFenceToken bool`. When true:
+
+- Subject parse failure → NAK with the gate's standard delay (no handler call).
+  Metric reason: `fence_required_parse_failure`.
+- Admission in a non-token-minting state (anything other than Stable in v1) →
+  NAK with the gate's standard delay.
+  Metric reason: `fence_required_non_stable`.
+- Resolver returns an ownership snapshot without a non-zero `ClaimRev` (e.g.
+  the configured resolver does not implement `OwnershipSnapshotResolver`) →
+  NAK at admission.
+  Metric reason: `fence_required_missing_revision`.
+
+NAK accounting reuses the existing `GateMetrics.IncGateNAK(reason)` interface;
+no new metric symbol is added in v1. A dedicated counter can come later if
+operators need dashboards that distinguish "ownership NAKs" from "fence
+strictness NAKs" at the metric-name level.
+
+Additionally, `RequireFenceToken=true` must be validated at startup: if the
+configured `OwnershipResolver` does not also implement
+`OwnershipSnapshotResolver` (see API Sketch), the gate constructor returns a
+configuration error rather than failing per-message. Fail-at-setup is preferred
+over fail-per-message when the misconfiguration is detectable statically.
+
+Handlers should also defensively call `consumer.RequireFence(ctx)` and return
+`ErrFenceMissing` if absent. The gate setting is defense in depth; the handler
+check is the contract.
+
+### 4. Ack/error semantics — sentinel + wrapper NAK
+
+The handler must NOT call `msg.Nak()` and return `nil`. The default consumer
+auto-ack path (`consumer/queue.go` and equivalent for Dynamic) treats `nil` as
+success and calls `msg.Ack()`, producing a double / contradictory disposition.
+
+The contract is:
+
+- Handler signals fence failure by returning `consumer.ErrFenceStale` (or any
+  error wrapping it).
+- The consumer wrapper recognizes the sentinel and translates it to
+  `msg.NakWithDelay(...)` using the same delay/jitter machinery the processing
+  gate already uses for non-owner NAKs.
+- The wrapper takes precedence over the default auto-ack path for this error.
+- Other errors continue to use the existing auto-ack-error behavior.
+
+This keeps handler code uniform regardless of `ManualAck` and avoids fighting
+the auto-ack path.
+
+### 5. Handler guidance
+
+Handlers that mutate external state should follow this shape:
+
+```go
+func Handle(ctx context.Context, msg jetstream.Msg) error {
+    token, err := consumer.RequireFence(ctx) // returns ErrFenceMissing if absent
+    if err != nil {
+        return err
+    }
+
+    next := compute(msg)
+
+    // Atomic conditional write against the side-effect target.
+    // ErrFenceStale is the sentinel the wrapper will translate to NAK.
+    return store.WriteWithFence(ctx, token, next)
+}
+```
+
+The user-side `WriteWithFence` is the commit fence. It is the user's
+responsibility (against their own storage) to make the write atomic on
+`(Owner, Epoch, ClaimRev)` — or on whichever subset their backend supports.
+Examples (illustrative only; not provided by Parti):
+
+```sql
+-- SQL: single-statement conditional update.
+UPDATE partition_state
+SET value = ?, updated_at = ?
+WHERE partition_id = ?
+  AND claim_rev <= ?         -- monotonic; reject older or equal-from-stale-owner
+  AND (claim_rev < ? OR owner = ?);
+```
+
+```go
+// JetStream KV CAS: read with revision, write with Update(rev).
+cur, err := kv.Get(ctx, key)
+if err != nil { return err }
+if cur.ClaimRev() != token.ClaimRev { return consumer.ErrFenceStale }
+_, err = kv.Update(ctx, key, encode(next), cur.Revision())
+```
+
+```text
+// Cache: version the key with the token, write unconditionally.
+cache:{partition}:{claim_rev}
+```
+
+Important: a stale fence must not be acknowledged as successful work. The
+sentinel/NAK path is the default and only supported behavior.
+
+### 6. Keep Two-Phase Handoff As An Admission Optimizer
+
+Do not make fencing depend on a stronger old-owner drain barrier in v1.
+
+The existing pieces should be interpreted as:
+
+- two-phase handoff: coordinates claim state transitions
+- pull gating: avoids unnecessary pulls for non-owners
+- processing gate: avoids starting new handler work under stale ownership
+- fence token: lets the side-effect target reject stale in-flight commits
+
+This is more robust than relying on drain alone, because it handles slow,
+blocked, or wedged handlers that started before ownership moved.
+
+## Required Semantics
+
+### Invariants
+
+1. A handler admitted by the processing gate receives the exact
+   owner / epoch / claim revision used for the admission decision.
+2. A token for revision `R` becomes stale once the claim for that partition
+   advances to any different revision (including delete-then-recreate, which
+   produces a strictly greater revision).
+3. A stale token must be distinguishable from a missing token:
+   - **stale** means "ownership/revision has advanced"
+   - **missing** means "no token was attached" (gate disabled, non-Stable
+     admission, subject parse failure)
+4. Fencing must be monotonic: a stale token cannot become valid again. Using
+   `ClaimRev` makes this provable; epoch alone does not.
+5. The token must not depend on wall-clock time.
+
+### Failure Behavior
+
+- Owner changed: side-effect target rejects → handler returns `ErrFenceStale`
+  → wrapper NAKs.
+- Epoch changed with same owner: same handling.
+- Claim revision changed (covers post-TTL recreate): same handling.
+- Missing token in a strict handler: handler returns `ErrFenceMissing` via
+  `RequireFence`. With `RequireFenceToken=true`, the gate also NAKs at admission.
+- Resolver cache stale / NATS unavailable: admission token may be absent or
+  describe a slightly stale claim. The commit-fence atomic write catches the
+  divergence. Parti does not ship a separate "validate fence" helper in v1
+  (see Deferred Work).
+
+## API Sketch
+
+Package placement is no longer an open question. The core type lives in
+`types/` so that `internal/durable` can construct it without importing
+`consumer/` (which would be an import cycle — `consumer` already imports
+`internal/durable`). Handler-facing helpers live in `consumer/` as aliases /
+thin wrappers.
+
+```go
+// types/fence.go
+package types
+
+type FenceToken struct {
+    PartitionID string
+    Owner       string
+    Epoch       int64
+    ClaimRev    uint64
+}
+```
+
+```go
+// consumer/fence.go
+package consumer
+
+import "github.com/arloliu/parti/v2/types"
+
+type FenceToken = types.FenceToken
+
+var (
+    ErrFenceMissing = errors.New("partition fence token missing")
+    ErrFenceStale   = errors.New("partition fence token stale")
+)
+
+// FenceTokenFromContext returns the token attached by the processing gate.
+// Returns ok=false if no token is present.
+func FenceTokenFromContext(ctx context.Context) (FenceToken, bool)
+
+// RequireFence returns ErrFenceMissing when no token is attached.
+// Use this in handlers that must always run under a fence.
+func RequireFence(ctx context.Context) (FenceToken, error)
+```
+
+The existing `types.OwnershipResolver` interface is **not modified**. Adding a
+method or changing a return signature would break every external implementation.
+Instead, a parallel snapshot interface is added alongside it:
+
+```go
+// types/ownership.go (additions; existing OwnershipResolver unchanged)
+
+type OwnershipSnapshot struct {
+    PartitionID string
+    Owner       string
+    State       HandoffState
+    Epoch       int64
+    ClaimRev    uint64
+}
+
+// OwnershipSnapshotResolver is an optional capability that ownership
+// resolvers may implement to support partition fencing. The built-in
+// claim-based resolver implements both this interface and OwnershipResolver.
+type OwnershipSnapshotResolver interface {
+    GetOwnership(partitionID string) (OwnershipSnapshot, bool)
+    ForceRefreshPartition(ctx context.Context, partitionID string) error
+}
+```
+
+Behavior:
+
+- The built-in `internal/durable.ClaimBasedResolver` implements both
+  `OwnershipResolver` and `OwnershipSnapshotResolver`.
+- `ProcessingGate` continues to use `OwnershipResolver.GetOwner` for normal
+  admission decisions — no behavior change for non-fenced configurations.
+- Fence-token minting requires the resolver to also implement
+  `OwnershipSnapshotResolver`. The gate type-asserts once at construction;
+  if `RequireFenceToken=true` and the assertion fails, construction returns
+  an error. If `RequireFenceToken=false` and the assertion fails, the gate
+  simply never mints tokens (handlers see `RequireFence(ctx) == ErrFenceMissing`).
+- `OwnershipResolver` is **not** deprecated. A future API break (v3 or
+  later) can revisit the question; for v2 the two interfaces coexist.
+
+### What is intentionally NOT in v1
+
+These were in earlier drafts and have been deferred — see Deferred Work for
+rationale:
+
+- `FenceValidator` interface and resolver-backed implementation.
+- In-memory `FencedStore` test helper.
+- Token minting in non-Stable admission states.
+- Any storage adapter / write helper.
+
+## Implementation Plan
+
+### Phase 1: Resolver surface
+
+- Add `types.OwnershipSnapshot` struct and `types.OwnershipSnapshotResolver`
+  interface alongside the existing `OwnershipResolver`. Do not modify the
+  existing interface.
+- Make `internal/durable.ClaimBasedResolver` implement
+  `OwnershipSnapshotResolver` (populating `ClaimRev` from
+  `KeyValueEntry.Revision()` in the watcher). The existing `GetOwner`
+  implementation is untouched, so all current callers — `processingGate`,
+  `worker_consumer`, and external implementations of `OwnershipResolver` —
+  keep working without changes.
+- Add resolver tests covering snapshot revision monotonicity across
+  prepare/commit/stable transitions and across delete-then-recreate
+  (TTL expiry path).
+
+### Phase 2: Token plumbing
+
+- Add `types.FenceToken` and `consumer.{FenceToken alias,
+  FenceTokenFromContext, RequireFence, ErrFenceMissing, ErrFenceStale}`.
+- Extend `processingGate.Wrap` to attach the token to the handler context
+  when admitted in `Stable` with a non-zero epoch and revision.
+- Tests:
+  - admitted owner in Stable receives a token with matching owner/epoch/rev
+  - admitted owner in any non-Stable state receives no token
+  - non-owner receives no handler call (existing behavior)
+  - disallowed state receives no handler call (existing behavior)
+  - unknown ownership receives no handler call after refresh attempt
+  - subject parse failure with `RequireFenceToken=false` behaves as today
+    (handler runs, no token)
+  - subject parse failure with `RequireFenceToken=true` NAKs
+
+### Phase 3: Wrapper sentinel handling
+
+- Teach the consumer wrappers (Queue, Dynamic) to recognize `ErrFenceStale`
+  (via `errors.Is`) and translate it into `NakWithDelay` using the gate's
+  delay/jitter config. The sentinel handling takes precedence over default
+  auto-ack-on-error.
+- Tests for both `ManualAck=false` and `ManualAck=true` paths.
+
+### Phase 4: Strict-admission mode
+
+- Add `ProcessingGateConfig.RequireFenceToken bool`. Wire it into:
+  - the subject-parse fail-open path (NAK, reason
+    `fence_required_parse_failure`),
+  - the non-Stable admission path (NAK, reason `fence_required_non_stable`),
+  - the missing-`ClaimRev` path (NAK, reason
+    `fence_required_missing_revision`).
+- Gate constructor returns an error when `RequireFenceToken=true` and the
+  configured resolver does not implement `OwnershipSnapshotResolver`.
+- Tests covering each NAK reason and the construction-time error.
+
+### Phase 5: Documentation
+
+- Update consumer docs and Godoc with:
+  - when fencing is required (handlers writing partition-keyed state)
+  - the admission-token vs commit-fence model and the cache-lag caveat
+  - sentinel/NAK contract
+  - SQL / JetStream-KV / cache example shapes (illustrative only)
+  - why `ProcessingGate` alone is an admission guard, not a side-effect fence
+  - explicit note that Parti does not provide a validator helper
+
+## Deferred Work (not v1)
+
+Each item below was considered for v1 and intentionally cut, with rationale.
+
+- **`FenceValidator` interface and resolver-backed implementation.** Check-then-act
+  semantics encourage users to substitute the validator for an atomic CAS, which
+  reintroduces the race the design is meant to close. Atomic conditional writes
+  at the side-effect target are the only mechanism that actually fences, and
+  v1 should not ship an API that suggests otherwise. Revisit only with a
+  concrete internal need (for example, a Parti-provided JetStream-KV state
+  helper).
+- **In-memory `FencedStore` test helper.** Useful for downstream users, but it
+  is non-trivial public surface to commit to. Defer until at least one real
+  user reports needing it.
+- **Token minting in non-Stable states.** Requires either a separate
+  "ownership-only" revision counter that does not bump on commit/stable
+  transitions, or explicit user opt-in with documented churn behavior. Out of
+  scope until requested.
+- **Optional integration test harness demonstrating the stale-in-flight race.**
+  Worth building, but only after Phase 1–4 land; it requires the
+  `ClaimRev`-bearing token to exercise the post-TTL-recreate case
+  meaningfully.
+
+## Non-Goals
+
+- Do not build a generic database adapter layer.
+- Do not require every handler to use fencing.
+- Do not make leader dispatch part of this design.
+- Do not require a global old-owner drain barrier for v1.
+- Do not promise exactly-once processing. This remains at-least-once delivery
+  with stale side effects rejected at the side-effect target.
+
+## Side Effects And Costs
+
+- **Public API expansion.** Once exposed, `FenceToken` shape is hard to change.
+  The lean v1 minimises this surface: one struct (in `types`), three function
+  symbols, two sentinel errors. `OwnershipResolver` changes are technically
+  also public, but moving to a struct return makes future extension non-breaking.
+- **Redelivery churn during rebalances.** `ErrFenceStale` defaults to NAK, so
+  in-flight work that started under an old owner re-enters until ownership and
+  delivery align. This is correct for safety; the gate's existing
+  `NakDelay`/`NakJitter` controls the churn rate.
+- **Operational and conceptual burden on users.** Users must now reason about
+  idempotency, fencing, atomic CAS, and where their storage falls on that
+  spectrum. The docs explicitly walk through this.
+- **Runtime overhead.** Token plumbing itself is one context value plus already-
+  read fields; negligible. The cost lives at the user's side-effect target
+  (their atomic CAS). Because v1 does not ship a validator, Parti does not add
+  per-message resolver/NATS work for the fencing path.
+- **False sense of safety risk.** Mitigated by (a) shipping no validator in
+  v1, and (b) explicit documentation that admission tokens are best-effort and
+  the commit fence is authoritative.
+
+## Open Questions
+
+None remaining for v1 scope. All prior questions have been resolved (see below).
+New questions may surface during implementation; record them in the relevant
+phase's PR rather than re-opening this design doc.
+
+## Closed Questions (resolved)
+
+- **Package placement:** `types.FenceToken` with `consumer` alias.
+- **Token identity:** include `ClaimRev` to satisfy monotonicity under
+  TTL/recreate.
+- **Ack handling for `ErrFenceStale`:** sentinel + wrapper NAK; handlers never
+  call `msg.Nak()` directly.
+- **Validator:** not shipped in v1.
+- **Test harness:** not shipped in v1.
+- **Token minting outside `Stable`:** not shipped in v1.
+- **Strict-mode NAK metrics:** reuse `GateMetrics.IncGateNAK(reason)` with new
+  reason labels (`fence_required_parse_failure`, `fence_required_non_stable`,
+  `fence_required_missing_revision`). No new metric symbol in v1.
+- **`RequireFence` return shape:** `(FenceToken, error)`. Keeps both APIs —
+  `FenceTokenFromContext(ctx) (FenceToken, bool)` for optional/introspective
+  use, `RequireFence(ctx) (FenceToken, error)` for strict handlers. Error form
+  composes with `errors.Is(err, consumer.ErrFenceMissing)` and matches the
+  fail-loud intent; bool would invite silent fallback.
+- **`OwnershipResolver` evolution:** add a parallel
+  `types.OwnershipSnapshotResolver` interface; do **not** modify or deprecate
+  the existing `OwnershipResolver`. The built-in claim-based resolver
+  implements both. Fence-token minting type-asserts to the snapshot interface
+  at gate construction. Revisit deprecation only with a future v3/API-break
+  plan.
+
+## Recommendation
+
+Implement fencing as a lean, opt-in handler contract layered on top of the
+existing `Dynamic` + `ProcessingGate` model.
+
+v1 ships: claim-revision in the resolver, `FenceToken` propagation in `Stable`
+admissions, `RequireFence`, `ErrFenceStale` wrapper handling, and a strict
+admission mode. Everything else is deferred until real usage justifies the
+public-API weight.
+
+Do not try to make two-phase handoff alone prove no stale side effects. Handoff
+and gating reduce the overlap window; fencing closes the correctness gap that
+remains when old in-flight work finishes late — but only if the commit fence is
+an atomic CAS at the user's storage, and only if the token identity is strong
+enough to survive claim-record recreation.

--- a/docs/plans/partition-fencing/README.md
+++ b/docs/plans/partition-fencing/README.md
@@ -1,0 +1,89 @@
+# Partition Fencing
+
+Design and implementation plan for partition ownership fence tokens — a
+correctness boundary that lets the side-effect target reject stale writes from
+old in-flight handlers after a partition has been reassigned.
+
+## Why this exists
+
+`ProcessingGate` admits handlers only when the local worker is the current
+owner, but it cannot protect side effects that happen *after* a handler has
+already started running. If ownership moves while a slow handler is in flight,
+the old handler can finish late and overwrite newer state with stale data.
+Idempotency does not close this gap because the old and new handlers are
+processing different inputs.
+
+Fencing adds an explicit token to admitted handlers. The token identifies the
+ownership authority under which the handler is allowed to commit. The
+side-effect target uses the token in an atomic conditional write; stale tokens
+fail the write and the handler returns a sentinel that the consumer wrapper
+translates into a NAK.
+
+## Status
+
+| Phase | State |
+|---|---|
+| Initial draft | Done |
+| Review round 1 (six structural concerns) | Done — addressed inline |
+| Review round 2 (over-engineering / scope) | Done — narrowed v1 surface |
+| Open-questions resolution (metrics / API shape / resolver evolution) | Done |
+| Precision-pass review | Done — `reviews/01-precision-pass-review.md`, READY WITH P1 FIXES (P0=0, P1=7, P2=0) |
+| Fold P1 fixes into proposal | **Pending** |
+| Phase 1 — Resolver surface (`OwnershipSnapshotResolver`) | **Not started** |
+| Phase 2 — Token plumbing (`FenceToken`, gate attaches in Stable) | **Not started** |
+| Phase 3 — Wrapper sentinel handling (`ErrFenceStale` → NAK) | **Not started** |
+| Phase 4 — Strict-admission mode (`RequireFenceToken`) | **Not started** |
+| Phase 5 — Documentation | **Not started** |
+
+**Deferred to the next minor version.** This work is not part of the current
+release cycle. The design is locked and ready to pick up; no further
+architectural review is needed before implementation, only the P1 fold-in
+below.
+
+## Open P1 findings to fold in before implementation
+
+From `reviews/01-precision-pass-review.md`:
+
+1. **Single authoritative resolver read at admission.** Specify that when the
+   snapshot resolver is available, *one* `GetOwnership` read serves as both
+   the admission decision and the token source. Forbid the two-read pattern
+   that would race against cache updates.
+2. **Queue sentinel delay source.** Queue carries no `ProcessingGateConfig`,
+   so it has no gate delay/jitter to reuse. Spec should say Queue uses
+   immediate `msg.Nak()` for `ErrFenceStale` (Queue isn't partition-aware;
+   fence semantics rarely apply).
+3. **Static and Broadcast scope.** Explicitly mark Static and Broadcast as
+   out-of-scope for v1 sentinel handling; their existing generic
+   error-to-NAK behavior already handles `ErrFenceStale` reasonably without
+   honoring gate delay/jitter.
+4. **`ErrFenceMissing` disposition.** State that `ErrFenceMissing` is not
+   wrapper-translated; it surfaces as a normal error (auto-NAK in
+   `ManualAck=false`, manual disposition in `ManualAck=true`). Add a
+   construction-time validation: `RequireFenceToken=true` with a disabled
+   gate must fail at construction.
+5. **Where strict-mode validation lives.** The snapshot-interface assertion
+   must run at `NewDynamic` / `NewWorkerConsumer`, not inside the per-subject
+   `newProcessingGate` call (which would surface the error mid-`Update`
+   after a partial durable setup).
+6. **SQL example bug.** The `SET` clause in the handler-guidance SQL example
+   must also advance `owner`, `epoch`, and `claim_rev`; the current example
+   updates only `value` and `updated_at`, so a copied implementation would
+   leave stale row metadata that future stale tokens could still match.
+7. **Stale "struct return" sentence.** The "Side Effects And Costs" section
+   still mentions changing `OwnershipResolver` to a struct return — a
+   leftover from the pre-parallel-interface draft. Rewrite to describe the
+   parallel-interface non-breaking change.
+
+## Layout
+
+```
+docs/plans/partition-fencing/
+├── README.md                          # This file: status + open P1 fold-in list
+├── 00-design-proposal.md              # Authoritative spec (locked architecture, pending P1 fold-in)
+└── reviews/
+    └── 01-precision-pass-review.md    # Codex final-plan-review, verdict READY WITH P1 FIXES
+```
+
+When implementation starts, add per-phase spec files
+(`01-phase1-resolver-surface.md`, etc.) following the convention used by
+`docs/plans/assignment-correctness-fixes/`.

--- a/docs/plans/partition-fencing/reviews/01-precision-pass-review.md
+++ b/docs/plans/partition-fencing/reviews/01-precision-pass-review.md
@@ -1,0 +1,77 @@
+## Summary
+
+Verdict: READY WITH P1 FIXES.
+
+No P0 correctness redesign issue surfaced in this precision pass. The main risk is stale or under-specified implementation text: the proposal is internally settled on stable-only token minting, a parallel snapshot resolver, and sentinel-based NAKs, but several sections still leave enough ambiguity for an implementer to change the wrong API, mint a token from a different cache revision than the admission decision, or wire inconsistent ack behavior across consumer types.
+
+## Findings by severity
+
+### P0
+
+None.
+
+### P1
+
+1. Token minting can race the admission decision unless the plan says which resolver read is authoritative.
+
+   Plan claim: `Required Semantics / Invariants` says a handler receives the exact owner / epoch / claim revision used for the admission decision, while `API Sketch / Behavior` says `ProcessingGate` continues to use `OwnershipResolver.GetOwner` for normal admission and separately requires `OwnershipSnapshotResolver` for token minting.
+
+   Source evidence: current `OwnershipResolver.GetOwner` returns owner/state/epoch/ok, but no revision (`types/ownership.go:31`, `types/ownership.go:42`). The built-in resolver's `GetOwner` reads the atomic cache pointer in that call (`internal/durable/claim_resolver.go:385`, `internal/durable/claim_resolver.go:386`) and returns the cached owner/state/epoch (`internal/durable/claim_resolver.go:391`, `internal/durable/claim_resolver.go:396`). The same cache pointer is replaced on force refresh (`internal/durable/claim_resolver.go:441`, `internal/durable/claim_resolver.go:447`) and watcher batches (`internal/durable/claim_resolver.go:686`, `internal/durable/claim_resolver.go:732`).
+
+   Precision problem: if implementation admits with `GetOwner(pid)` and then calls `GetOwnership(pid)` for the token, a cache update between the two reads can attach a token that was not the basis for admission. Tighten the plan to require one authoritative snapshot read for both admission and token construction when the snapshot resolver is available, or explicitly require comparing the snapshot back to the `GetOwner` tuple and skipping/NAKing on mismatch.
+
+2. Queue cannot currently use "the gate's delay/jitter" for `ErrFenceStale`.
+
+   Plan claim: `Ack/error semantics - sentinel + wrapper NAK` and `Implementation Plan / Phase 3` require Queue and Dynamic wrappers to translate `ErrFenceStale` into `NakWithDelay` using the processing gate's delay/jitter config.
+
+   Source evidence: Queue has its own `QueueConfig` and no processing gate field (`consumer/queue.go:64`, `consumer/queue.go:108`). The gate delay knobs live on `ProcessingGateConfig` (`consumer/gate_config.go:39`, `consumer/gate_config.go:46`), and Dynamic carries that config (`consumer/dynamic.go:71`, `consumer/dynamic.go:76`). Queue's current auto-disposition path only switches between `msg.Nak()` and `msg.Ack()` when `ManualAck` is false (`consumer/queue.go:469`, `consumer/queue.go:475`).
+
+   Precision problem: the Queue part of Phase 3 has no defined delay source. Specify whether Queue should use immediate `msg.Nak()`, a new Queue-level delay config, a package default, or whether Queue is out of scope for delayed sentinel handling.
+
+3. Static and Broadcast sentinel scope is not explicit.
+
+   Plan claim: `Implementation Plan / Phase 3` names only Queue and Dynamic, while `Ack/error semantics - sentinel + wrapper NAK` describes handler behavior in general terms and says the contract is uniform regardless of `ManualAck`.
+
+   Source evidence: Static is a public consumer that delegates to `ipartition.NewJSConsumer` (`consumer/static.go:109`, `consumer/static.go:208`). The static sequential path uses recovery dispatch (`internal/ipartition/consumer.go:346`, `internal/ipartition/consumer.go:347`), and static key dispatch has its own error-to-`Nak` / nil-to-`Ack` logic (`internal/ipartition/key_dispatcher.go:252`, `internal/ipartition/key_dispatcher.go:255`). Broadcast also dispatches handler results through recovery dispatch (`internal/durable/broadcast_consumer.go:392`, `internal/durable/broadcast_consumer.go:398`). Recovery dispatch ignores handler errors in `ManualAck=true`, and in auto-ack mode maps any non-nil error to immediate `msg.Nak()` (`internal/recovery/controller.go:185`, `internal/recovery/controller.go:193`).
+
+   Precision problem: an implementer can reasonably either update only Queue/Dynamic, or update every public consumer that can observe `consumer.ErrFenceStale`. The plan should explicitly say Static and Broadcast remain existing generic error behavior, or add them to Phase 3 and its tests.
+
+4. `ErrFenceMissing` disposition is unspecified for `ManualAck=true` and gate-disabled strict handlers.
+
+   Plan claim: `Required Semantics / Invariants` defines "missing" to include gate disabled, non-Stable admission, and subject parse failure; `Failure Behavior` says a strict handler returns `ErrFenceMissing` via `RequireFence`; `Ack/error semantics - sentinel + wrapper NAK` defines special wrapper handling only for `ErrFenceStale`.
+
+   Source evidence: shared consumer docs state that with `ManualAck=true`, handlers must explicitly call `Ack`, `Nak`, or `Term`, and returning an error does not trigger an action (`consumer/common.go:35`, `consumer/common.go:38`). Queue's auto-disposition block is skipped entirely when `ManualAck` is true (`consumer/queue.go:469`, `consumer/queue.go:479`). Recovery dispatch also returns immediately after the handler in manual-ack mode (`internal/recovery/controller.go:185`, `internal/recovery/controller.go:188`).
+
+   Precision problem: if a strict fenced handler runs with gate disabled and `ManualAck=true`, `RequireFence` returns `ErrFenceMissing`, but no wrapper disposition is specified. State whether `ErrFenceMissing` intentionally times out under manual ack, should be translated like `ErrFenceStale`, or should be made unreachable by config validation.
+
+5. Strict-mode setup validation is underspecified relative to the current Dynamic call path.
+
+   Plan claim: `Strict-admission mode` says `RequireFenceToken=true` is validated at startup and the gate constructor returns a configuration error if the resolver does not implement `OwnershipSnapshotResolver`; `Implementation Plan / Phase 4` repeats that the gate constructor returns an error.
+
+   Source evidence: `Dynamic.NewDynamic` builds a `durable.WorkerConsumer` before any subject loop exists (`consumer/dynamic.go:233`, `consumer/dynamic.go:272`). `NewWorkerConsumer` only initializes the resolver at construction time (`internal/durable/worker_consumer.go:120`, `internal/durable/worker_consumer.go:123`). The current processing gate constructor is called later inside `addSubjectLoop`, after the per-subject durable has already been created or bound (`internal/durable/worker_consumer.go:376`, `internal/durable/worker_consumer.go:390`).
+
+   Precision problem: if the implementer only puts the snapshot-interface check in `newProcessingGate`, the error occurs during `Dynamic.Update` per subject and after durable setup, not cleanly at public construction/startup. Specify the exact validation site and whether a partially-created per-subject durable is acceptable on this configuration error.
+
+6. The SQL fencing example does not advance the stored fence columns.
+
+   Plan claim: `Handler guidance` presents an illustrative SQL conditional update that filters on `claim_rev <= ?` and `(claim_rev < ? OR owner = ?)`, but the `SET` clause only updates `value` and `updated_at`.
+
+   Precision problem: as written, a copied implementation can accept a newer token without recording the newer `owner` / `claim_rev` in the row, so a later stale token may still satisfy the predicate against the old row metadata. The placeholders are also ambiguous: the two `claim_rev` parameters should be named as token/current values, and the example should show whether the write sets `owner`, `epoch`, and `claim_rev` to the token values. This is documentation pseudocode, not a source-code mismatch, but it is exactly the kind of example that users and implementers copy.
+
+7. The public API cost section still contains stale "struct return" text for `OwnershipResolver`.
+
+   Plan claim: `API Sketch` says the existing `types.OwnershipResolver` is not modified and a parallel `OwnershipSnapshotResolver` is added. `Side Effects And Costs` later says "`OwnershipResolver` changes are technically also public, but moving to a struct return makes future extension non-breaking."
+
+   Source evidence: the current public interface is `GetOwner(partitionID string) (string, HandoffState, int64, bool)` (`types/ownership.go:31`, `types/ownership.go:42`).
+
+   Precision problem: the side-effects paragraph is stale from the earlier "change GetOwner to struct return" design and contradicts the settled parallel-interface plan. Remove or rewrite it so implementers do not touch the existing interface.
+
+### P2
+
+None.
+
+## Verdict
+
+READY WITH P1 FIXES.
+
+Fix the seven P1 precision issues before handing this to implementation. They are text/API-contract problems, not evidence that the core fencing architecture needs to be reopened.

--- a/docs/plans/provision-sdk-cli/00-implementation-plan.md
+++ b/docs/plans/provision-sdk-cli/00-implementation-plan.md
@@ -1,0 +1,1179 @@
+# Parti Provision SDK and CLI Plan
+
+## Problem Statement
+
+Parti users who run dynamic partitioning with a NATS KV partition source must
+currently prepare several NATS resources by hand: Parti manager KV buckets, the
+two-phase handoff bucket when handoff is enabled, and the NATS KV bucket/key
+that stores partition definitions. Some deployments also want Parti-aware
+checks for application streams or dynamic per-partition consumers, but the
+Parti-specific control plane is the first problem to solve.
+
+That setup is operationally fragile because creation and update behavior is
+split across runtime startup, application bootstrap code, and manual NATS CLI
+commands. The current manager startup path creates or opens control-plane KV
+buckets, but it is not a full provisioning workflow: it does not expose a
+read-only view of current settings, does not manage the partition-source
+bucket/key as a first-class environment object, and intentionally opens
+pre-existing KV buckets without reconciling their config.
+
+Operators need a repeatable way to view, validate, plan, apply, and audit the
+Parti environment from config before workers start. The workflow must make
+missing resources easy to create, make drift visible, and avoid silently
+destroying or rewriting runtime state such as consumer ack cursors.
+
+Before this tool, a human operator must read Parti runtime config, infer the
+required NATS buckets, create resources manually, and then debug startup-time
+failures when permissions or resource settings are wrong. After this tool, the
+operator can run a read-only `view`/`plan` in CI or during a change window,
+review exactly what Parti expects, and apply only the safe missing-resource
+changes that were planned.
+
+## End-State Vision
+
+In the mature state, `provision/` and `partictl` are the canonical operator
+surface for Parti environments. They cover the full lifecycle of every NATS
+resource Parti runtime depends on, with reconcile policies that scale from
+"observe-only" to "fully repair from declarative config":
+
+- **Full resource coverage**: control-plane KV buckets, partition-source
+  bucket **and its records**, application JetStream streams, dynamic
+  per-partition consumers.
+- **Three reconcile policies**:
+  - `warn` (this plan): create missing, never mutate existing.
+  - `safe-update`: live-edit fields that NATS can reconcile in place
+    (`Description`, `Metadata`, `MaxBytes`, `MaxValueSize`, `TTL`) with
+    explicit per-field test coverage. Non-live-editable fields remain
+    `drift-immutable` and require explicit destructive intent.
+  - `force` with per-resource `allowDeleteRecreate`: destructive repair for
+    immutable drift (`History`, `Storage`, replica downgrades). Gated on
+    cursor-loss test discipline.
+- **Adoption**: `partictl adopt` stamps the Parti ownership marker on
+  resources created outside the tool, transitioning `adopted` drift into the
+  managed set without touching data.
+- **Generators**: emit a starter `parti-env.yaml` from an existing runtime
+  `parti.Config`; emit a snapshot YAML from live NATS state for review,
+  diffing, and onboarding.
+- **Optional Kubernetes integration**: a controller built on top of the SDK
+  reconciles a `ProvisionedPartiEnv`-style CRD to the same `Plan`/`Apply`
+  paths the CLI uses; no logic duplication.
+- **Templating story**: thin overlays for dev/stage/prod evaluated SDK-side
+  on top of the same `Config` struct, once a real demand profile justifies
+  the design cost.
+
+The SDK and CLI remain the canonical surface even after the K8s layer lands —
+the controller is a consumer of the SDK, not a replacement.
+
+## Phased Roadmap
+
+This plan specifies **Phase 1 (POC)** in implementation detail. Each later
+phase will get its own design plan, dispatched through the same codex-review
+loop documented under [Implementation Workflow](#implementation-workflow).
+Phases are designed to be shippable independently in the order shown;
+sequencing respects safety (mutation comes after reporting; destructive
+repair comes last) but does not require strict serial release.
+
+| Phase | Codename            | Adds                                                                                                              | Status        |
+|-------|---------------------|-------------------------------------------------------------------------------------------------------------------|---------------|
+| v1    | POC                 | `warn` policy; control-plane + partition-source bucket provisioning; dynamic-consumer alignment; `partictl` CLI   | **This plan** |
+| v2    | Safe Update + Adopt | `safe-update` policy with per-field mutability tests; `partictl adopt`; `controlPlane.replicas`                   | TBD           |
+| v3    | Partition Records   | `partictl partitions plan/apply` for partition-source key contents; record-level diff/dry-run                     | TBD           |
+| v4    | Streams             | `streams:` block on `Config`; `partictl stream view/plan/apply`; stream ownership and adoption                    | TBD           |
+| v5    | Dynamic Precreate   | Optional dynamic-consumer precreation, gated on alignment having proven byte-equivalent to runtime in v1          | TBD           |
+| v6    | Force + Repair      | `force` policy; per-resource `allowDeleteRecreate`; cursor-loss test discipline for consumer delete/recreate      | TBD           |
+| v7    | K8s Controller      | CRD types; controller built on the SDK; reconcile loop reuses `Plan`/`Apply`                                      | TBD           |
+
+Cross-cutting follow-ups (not gated on the phase order):
+
+- **Templating / overlays** — thin SDK-evaluated overlay for env-specific
+  values. Can land any time after v1 once a real demand profile is known.
+- **Config generators** — `partictl init` (from runtime `parti.Config`) and
+  `partictl emit` (from a live `Snapshot`). Either side of the round-trip
+  can ship independently.
+
+### Invariants inherited by every phase
+
+Later phases extend the v1 contract but **never break it**:
+
+- Ownership marker shape (`parti.io/managed`, `parti.io/component`,
+  `parti.io/instance`) stays in `Metadata` and remains informational.
+- JSON envelope schema stays at `apiVersion: parti.io/provision/v1` until a
+  v2 schema is explicitly designed; new fields are additive within v1.
+- Input config `apiVersion: parti.io/v1` accepts additive fields; a breaking
+  schema change bumps to `parti.io/v2` and v1-loaders continue to work.
+- CLI exit codes and their precedence (see [Exit codes](#exit-codes)) are
+  stable; new codes only appear above code 4 to avoid CI breakage.
+- `Plan` action ordering remains deterministic `(Kind, Name)`.
+- Provisioned control-plane `KeyValueConfig` remains byte-equivalent to
+  `manager_setup.go:ensureKVBucket` (the W0 shared builder is the contract).
+- Resource lookup is always by exact NATS name first; the marker never
+  authorizes mutation.
+
+## Goals
+
+- Add a public `provision/` SDK for Parti/NATS environment viewing, planning,
+  validation, application, and reporting.
+- Add a `cmd/partictl` CLI using the standard library `flag.FlagSet`; do not
+  add a CLI framework dependency in v1.
+- Support desired-state config as Go structs with both `yaml` and `json` tags.
+  The CLI officially loads YAML in v1; SDK callers can construct structs
+  directly or unmarshal from their own format.
+- Require a top-level `apiVersion: parti.io/v1` field on every YAML config so
+  future schema changes can migrate cleanly.
+- Make the v1 pillars explicitly Parti-specific:
+  - Control-plane KV bucket provisioning and drift reporting.
+  - NATS KV partition-source bucket provisioning. Partition-record management
+    lands in **Phase 3 (Partition Records)**.
+  - Dynamic-consumer alignment checks through a shared pure planning helper
+    plus a live-validation companion, without duplicating private durable
+    naming rules.
+- Support read-only operational workflows:
+  - `view`: inspect live NATS/Parti resource settings filtered by the Parti
+    ownership marker (see [Resource Ownership Marker](#resource-ownership-marker)).
+  - `validate`: validate config statically and, with `-live`, pre-flight live
+    reachability and permissions.
+  - `plan`: compute desired-vs-live drift and proposed actions.
+  - `apply --dry-run`: convenience alias for validation plus plan; emits the
+    same `Plan` JSON as `plan`.
+- Ship v1 with a single `ReconcilePolicy` value: `warn` (create missing
+  resources, report drift, never mutate existing resources). `safe-update`
+  lands in **Phase 2** and `force` lands in **Phase 6**, each with explicit
+  field/test coverage.
+
+## Non-Goals (Phase 1)
+
+Items below are out of scope for Phase 1. Where applicable, the target phase
+from the [Phased Roadmap](#phased-roadmap) is cited so deferred work has a
+clear home rather than an unbounded "follow-up plan" promise.
+
+- Do not auto-delete or recreate existing streams, buckets, or consumers by
+  default. **Phase 6 (Force + Repair)** introduces the gated destructive path.
+- Do not silently migrate any existing resource's config. v1 only creates
+  missing resources and reports drift. **Phase 2 (Safe Update + Adopt)**
+  introduces in-place mutation for live-editable fields.
+- Do not write partition contents. v1 provisions the partition-source bucket
+  only. **Phase 3 (Partition Records)** adds `partictl partitions plan/apply`.
+- Do not replace `Manager.Start` runtime ensure behavior. The provision tool
+  is a human-controlled provisioning and drift-audit layer that complements
+  runtime startup. This non-goal is permanent across all phases.
+- Do not pre-create dynamic consumers by copying private durable naming logic
+  into `provision`. This non-goal is permanent; the v4/`internal/durable`
+  extraction seam (W4) is the authorized path.
+- Do not pre-create dynamic consumers at all in Phase 1. v1 does
+  alignment-check only. **Phase 5 (Dynamic Precreate)** adds optional
+  precreation after the W4 builder is proven byte-equivalent to runtime.
+- Do not solve Kubernetes CRD/operator-controller integration. **Phase 7
+  (K8s Controller)** adds it as a layer on top of the SDK, not a replacement.
+- Do not provide a templating or overlays system. Dev/stage/prod differences
+  are handled by separate rendered YAML files in Phase 1; first-class
+  overlays are a cross-cutting follow-up.
+- Do not provision or audit application JetStream streams. v1 exposes no
+  stream-related public API, action kind, permission, scope, or CLI output.
+  **Phase 4 (Streams)** adds the full stream surface.
+- Do not expose `safe-update` or `force` reconcile policies. v1 statically
+  rejects them. **Phase 2** adds `safe-update`; **Phase 6** adds `force`.
+
+## Config Relationship
+
+`parti.Config` remains the runtime manager configuration used by application
+workers. The provision config must not become an unrelated duplicate source of
+truth.
+
+Recommended pattern:
+
+- The provision config embeds the manager-facing `parti.Config` control-plane
+  fields needed to derive bucket names, TTLs, and handoff enablement (see
+  [Control-Plane Config Mapping](#control-plane-config-mapping)).
+- Applications should keep one canonical config source and load the relevant
+  sections into both runtime `parti.Config` and `provision.Config`.
+- `partictl validate -f parti-env.yaml` checks that the provisioned
+  control-plane settings are internally valid before workers use them.
+- A future generator can emit a starter `parti-env.yaml` from an existing
+  runtime config, but v1 does not require a generator to land.
+
+## Control-Plane Config Mapping
+
+`ControlPlaneConfig` mirrors the runtime manager fields that govern
+control-plane KV bucket derivation. Each runtime bucket is derived from
+`parti.Config` as shown below; v1 `plan`/`apply` must produce a
+`jetstream.KeyValueConfig` literal that matches runtime's
+`manager_setup.go:ensureKVBucket` exactly (Bucket, History=1, Storage, optional
+TTL), plus the Parti ownership marker in `Metadata` (the only intentional
+divergence from runtime).
+
+Runtime evidence:
+- Stable ID: `m.cfg.KVBuckets.StableIDBucket`, `m.cfg.WorkerIDTTL`,
+  `FileStorage` (`manager_setup.go:35`).
+- Election: `m.cfg.KVBuckets.ElectionBucket`, `m.cfg.ElectionTimeout`,
+  `MemoryStorage` (`manager_setup.go:76`).
+- Heartbeat: `m.cfg.KVBuckets.HeartbeatBucket`, `m.cfg.HeartbeatTTL`,
+  `MemoryStorage` (`manager_setup.go:80`).
+- Assignment: `m.cfg.KVBuckets.AssignmentBucket`,
+  `m.cfg.KVBuckets.AssignmentTTL`, `FileStorage` (`manager_setup.go:84`).
+- Handoff: `m.cfg.KVBuckets.HandoffBucket`, `m.cfg.KVBuckets.HandoffTTL`,
+  `FileStorage` (`manager_setup.go:96`), gated by
+  `m.cfg.EnableTwoPhaseHandoff` (`manager.go:407`).
+- `KeyValueConfig` literal sets `Bucket`, `History: 1`, `Storage`, and
+  conditionally `TTL` (`manager_setup.go:148-156`). Replicas is **not** set.
+
+| Runtime bucket | Source fields on `ControlPlaneConfig` | NATS KV config produced |
+|----------------|----------------------------------------|--------------------------|
+| Stable ID      | `StableIDBucket`, `WorkerIDTTL`        | `Bucket: <StableIDBucket>`, `Storage: FileStorage`, `History: 1`, `TTL: WorkerIDTTL` (if > 0) |
+| Election       | `ElectionBucket`, `ElectionTimeout`    | `Bucket: <ElectionBucket>`, `Storage: MemoryStorage`, `History: 1`, `TTL: ElectionTimeout` (if > 0) |
+| Heartbeat      | `HeartbeatBucket`, `HeartbeatTTL`      | `Bucket: <HeartbeatBucket>`, `Storage: MemoryStorage`, `History: 1`, `TTL: HeartbeatTTL` (if > 0) |
+| Assignment     | `AssignmentBucket`, `AssignmentTTL`    | `Bucket: <AssignmentBucket>`, `Storage: FileStorage`, `History: 1`, `TTL: AssignmentTTL` (if > 0) |
+| Handoff (opt)  | `HandoffBucket`, `HandoffTTL`, gated by `EnableTwoPhaseHandoff` | `Bucket: <HandoffBucket>`, `Storage: FileStorage`, `History: 1`, `TTL: HandoffTTL` (if > 0) |
+
+Notes:
+
+- Bucket name fields default to the same values as the runtime
+  `KVBucketConfig` (`config.go:15,18,21,24,37`): `parti-stableid`,
+  `parti-election`, `parti-heartbeat`, `parti-assignment`, `parti-handoff`.
+  **Defaulting order:** `Validate` first applies these defaults to any
+  bucket-name field whose unmarshalled value is the empty string (the YAML
+  zero value), then rejects any bucket name that is still empty after
+  defaulting. A field omitted from YAML and a field written as `""` are
+  treated identically: both default. Operators who need to assert "no
+  bucket" cannot do so via empty string in v1; the field would simply be
+  re-populated with the runtime default.
+- TTL field names match `parti.Config` exactly: `WorkerIDTTL`,
+  `ElectionTimeout`, `HeartbeatTTL`, `AssignmentTTL`, `HandoffTTL`. Note
+  `ElectionTimeout` (not `ElectionTTL`) and `EnableTwoPhaseHandoff` (not
+  `EnableHandoff`); using runtime names eliminates any mapping ambiguity.
+- TTL is omitted from `KeyValueConfig` when its value is zero, exactly as
+  runtime does (`manager_setup.go:154-156`). `AssignmentTTL=0` is the runtime
+  default and means "no expiration" — provision must produce a
+  `KeyValueConfig` without a `TTL` field in that case.
+- `EnableTwoPhaseHandoff=false` means the handoff bucket is omitted from
+  `Plan`. v1 never deletes an existing handoff bucket even if the gate is
+  toggled off later; that drift is reported but not actioned.
+- **Replicas:** `ControlPlaneConfig` has no `Replicas` field in v1, mirroring
+  the runtime `KeyValueConfig` literal which leaves `Replicas` unset (nats.go
+  normalizes zero replicas to 1 server-side). If operators require
+  multi-replica control-plane KV, they must pre-create those buckets manually
+  in v1; provision will report them as `adopted` drift. A `Replicas` field
+  lands in **Phase 2 (Safe Update + Adopt)** alongside the safe-update
+  contract for live-replica changes.
+- The Parti ownership marker is added to `KeyValueConfig.Metadata` (see
+  [Resource Ownership Marker](#resource-ownership-marker)). The marker is the
+  only intentional divergence from runtime's literal `KeyValueConfig`.
+
+## Resource Ownership Marker
+
+Every resource created by `partictl apply` is stamped with a Parti-managed
+marker so `view`, `plan`, and `validate` can distinguish Parti-owned resources
+from unrelated NATS objects that happen to share a name.
+
+**Storage location:** the marker lives in the resource's `Metadata` map, not
+`Description`. NATS KV `Metadata` (`jetstream.KeyValueConfig.Metadata`) is
+designed for structured key-value annotation; `Description` is reserved for
+human-readable text and may be set by operators for unrelated reasons.
+
+**Marker keys** (all under the `parti.io/` prefix):
+
+- `parti.io/managed`: schema version, e.g. `v1`.
+- `parti.io/component`: one of `control-plane:id`, `control-plane:election`,
+  `control-plane:heartbeat`, `control-plane:assignment`,
+  `control-plane:handoff`, `partition-source`, or `dynamic-consumer`.
+- `parti.io/instance`: optional logical environment identifier (e.g.
+  `prod-us-east`); set from `Config.Instance` when provided. The marker is an
+  **annotation, not a namespace** — NATS bucket names are globally unique in
+  an account, so the marker cannot make two environments share the same
+  bucket name. Operators who want true multi-environment isolation must give
+  each environment unique bucket names (e.g., `parti-prod-stableid` vs
+  `parti-staging-stableid`); the instance marker lets `view`/`plan` filter
+  inventory by environment after that.
+
+**Parsing rules:**
+
+- Default `view` filter: a resource is "Parti-managed" iff `Metadata` contains
+  the key `parti.io/managed` with any non-empty value.
+- Component classification: the `parti.io/component` value selects the
+  resource category in `view`/`plan` output. Unknown component values are
+  surfaced as `component: unknown` but otherwise treated as Parti-managed.
+- Unknown `parti.io/*` keys are ignored (forward compatibility).
+- Malformed metadata (missing `parti.io/managed`) is treated as **unmarked**;
+  no error is raised.
+
+**Authority boundary:**
+
+- The marker is informational. It never authorizes mutation. Specifically: an
+  `apply` operation **never** uses marker presence to decide whether to
+  create, update, or skip a resource. Resource lookup is always by exact NATS
+  name.
+- Config-scoped `plan`/`apply` must always resolve every desired resource by
+  exact NATS name first. The marker is read only after the resource is found
+  and can only affect the **drift classification** of an existing resource,
+  never its existence determination. An implementation that filters by marker
+  before name-resolution is a bug.
+
+**Drift classification using the marker:**
+
+- Resource missing entirely → `create-kv` action (Plan emits this in v1).
+- Resource present and marked → `informational` (matches) or `drift-mutable` /
+  `drift-immutable` based on field comparison.
+- Resource present and **unmarked** but named by config → `adopted` drift,
+  severity reported; v1 emits no action for this case.
+
+## Proposed SDK
+
+Add a public `provision` package with these core concepts:
+
+```go
+// APIVersionV1 is the only config schema accepted by v1.
+const APIVersionV1 = "parti.io/v1"
+
+// ReconcilePolicy controls how Apply handles drift. v1 only supports Warn.
+type ReconcilePolicy string
+
+const (
+    PolicyWarn ReconcilePolicy = "warn"
+    // PolicySafeUpdate lands in Phase 2; PolicyForce lands in Phase 6.
+    // Each adds explicit field/test coverage. v1 rejects them at Validate().
+)
+
+// Config is the desired environment state. APIVersion is required.
+type Config struct {
+    APIVersion       string                 `yaml:"apiVersion" json:"apiVersion"`
+    Instance         string                 `yaml:"instance,omitempty" json:"instance,omitempty"`
+    Policy           ReconcilePolicy        `yaml:"policy,omitempty" json:"policy,omitempty"` // default "warn"
+    ControlPlane     *ControlPlaneConfig    `yaml:"controlPlane,omitempty" json:"controlPlane,omitempty"`
+    PartitionSource  *PartitionSourceConfig `yaml:"partitionSource,omitempty" json:"partitionSource,omitempty"`
+    DynamicConsumers []DynamicConsumerCfg   `yaml:"dynamicConsumers,omitempty" json:"dynamicConsumers,omitempty"`
+    // Streams is intentionally absent in v1. See Non-Goals.
+}
+
+// ControlPlaneConfig mirrors the runtime fields that drive control-plane KV
+// bucket creation. Field names and YAML tags match runtime parti.Config and
+// parti.KVBucketConfig exactly (some fields live under KVBuckets in runtime;
+// see the mapping note below) so callers can copy values without renaming.
+type ControlPlaneConfig struct {
+    // Bucket names (runtime origin: parti.KVBucketConfig).
+    StableIDBucket   string `yaml:"stableIdBucket"   json:"stableIdBucket"`
+    ElectionBucket   string `yaml:"electionBucket"   json:"electionBucket"`
+    HeartbeatBucket  string `yaml:"heartbeatBucket"  json:"heartbeatBucket"`
+    AssignmentBucket string `yaml:"assignmentBucket" json:"assignmentBucket"`
+    HandoffBucket    string `yaml:"handoffBucket"    json:"handoffBucket"`
+
+    // TTLs. WorkerIDTTL/HeartbeatTTL/ElectionTimeout live on parti.Config;
+    // AssignmentTTL and HandoffTTL live on parti.KVBucketConfig.
+    WorkerIDTTL     time.Duration `yaml:"workerIdTtl"     json:"workerIdTtl"`
+    ElectionTimeout time.Duration `yaml:"electionTimeout" json:"electionTimeout"`
+    HeartbeatTTL    time.Duration `yaml:"heartbeatTtl"    json:"heartbeatTtl"`
+    AssignmentTTL   time.Duration `yaml:"assignmentTtl"   json:"assignmentTtl"`   // 0 = no expiration
+    HandoffTTL      time.Duration `yaml:"handoffTtl"      json:"handoffTtl"`
+
+    // Gate for the optional handoff bucket. Name matches parti.Config.
+    EnableTwoPhaseHandoff bool `yaml:"enableTwoPhaseHandoff" json:"enableTwoPhaseHandoff"`
+}
+
+type PartitionSourceConfig struct {
+    Bucket       string        `yaml:"bucket"       json:"bucket"`
+    Key          string        `yaml:"key"          json:"key"`           // v1 provisions the bucket only; key is metadata
+    Replicas     int           `yaml:"replicas,omitempty"     json:"replicas,omitempty"`
+    Storage      string        `yaml:"storage,omitempty"      json:"storage,omitempty"`     // "file" | "memory"; default "file"
+    History      uint8         `yaml:"history,omitempty"      json:"history,omitempty"`     // default 1
+    MaxValueSize int32         `yaml:"maxValueSize,omitempty" json:"maxValueSize,omitempty"`
+    TTL          time.Duration `yaml:"ttl,omitempty"          json:"ttl,omitempty"`
+}
+
+type DynamicConsumerCfg struct {
+    StreamName      string `yaml:"streamName"               json:"streamName"`
+    ConsumerPrefix  string `yaml:"consumerPrefix"           json:"consumerPrefix"`
+    SubjectTemplate string `yaml:"subjectTemplate"          json:"subjectTemplate"`
+    PartitionsRef   string `yaml:"partitionsRef,omitempty"  json:"partitionsRef,omitempty"` // path or inline reference; load is caller-owned
+    // v1 intentionally exposes no further options. The pure builder runs
+    // against runtime defaults (see PlanDynamicConsumers comment below).
+    // Broader option surface (storage/replicas, ackWait, maxDeliver, retry,
+    // recovery strategy, etc.) lands in Phase 5 when consumer precreation
+    // ships. Operators with non-default runtime consumer.Dynamic options
+    // must continue to rely on the runtime to create those consumers;
+    // v1 alignment-check only asserts the byte-equivalent subset listed
+    // under PlanDynamicConsumers.
+}
+
+// Scope selects which resource kinds and optionally which Parti instance View
+// considers.
+type Scope struct {
+    ControlPlane     bool
+    PartitionSource  bool
+    DynamicConsumers bool
+    // Instance optionally restricts results to resources whose
+    // parti.io/instance metadata equals this value. Empty means
+    // "all instances, including unstamped" (inventory mode).
+    Instance string
+}
+
+func ScopeAll() Scope                  // every kind v1 understands; Instance=""
+func ScopeFromConfig(cfg Config) Scope // every kind set in cfg; Instance=cfg.Instance
+
+// Snapshot is the read-only live state returned by View. All resource slices
+// are plural to allow multiple Parti environments in one NATS account
+// (distinguished by parti.io/instance marker).
+type Snapshot struct {
+    APIVersion       string           `json:"apiVersion"` // always "parti.io/provision/v1"
+    Kind             string           `json:"kind"`       // always "Snapshot"
+    ObservedAt       time.Time        `json:"observedAt"` // included in JSON only; omitted from text
+    ControlPlane     []KVBucketState  `json:"controlPlane"`
+    PartitionSource  []KVBucketState  `json:"partitionSource"`
+    DynamicConsumers []ConsumerState  `json:"dynamicConsumers"`
+}
+
+// Plan is the deterministic list of actions Apply would take. Actions are
+// sorted by (Kind, Name) so diffs are stable across runs.
+type Plan struct {
+    APIVersion string           `json:"apiVersion"` // always "parti.io/provision/v1"
+    Kind       string           `json:"kind"`       // always "Plan"
+    Actions    []PlannedAction  `json:"actions"`
+    Drift      []DriftFinding   `json:"drift"`
+}
+
+// PlannedAction.Kind in v1 is always "create-kv". Stream action kinds land
+// in Phase 4 (Streams); consumer-create lands in Phase 5 (Dynamic Precreate);
+// update-* lands in Phase 2 (Safe Update); delete-* lands in Phase 6 (Force).
+// None are emitted by v1.
+type PlannedAction struct {
+    Kind     string `json:"kind"` // v1: "create-kv"
+    Name     string `json:"name"`
+    Resource any    `json:"resource"` // the would-be jetstream.KeyValueConfig
+}
+
+// DriftFinding.Severity:
+//   - "informational": resource exists and matches; no action needed
+//   - "drift-mutable":   fields differ but live-edit is safe (reserved; v1 never emits)
+//   - "drift-immutable": fields differ and require delete/recreate (reported only)
+//   - "adopted":         resource exists without the Parti marker (reported only)
+type DriftFinding struct {
+    Severity string         `json:"severity"`
+    Kind     string         `json:"kind"`
+    Name     string         `json:"name"`
+    Detail   map[string]any `json:"detail,omitempty"`
+}
+
+// Report is what Apply returns: what ran, what was skipped, what failed.
+type Report struct {
+    APIVersion string           `json:"apiVersion"` // always "parti.io/provision/v1"
+    Kind       string           `json:"kind"`       // always "Report"
+    Executed   []ExecutedAction `json:"executed"`
+    Skipped    []SkippedAction  `json:"skipped"`
+    Errors     []ResourceError  `json:"errors"`
+    Aborted    bool             `json:"aborted"` // true if ctx was cancelled mid-apply
+}
+```
+
+**Output schema versioning.** Every JSON-emitting struct (`Snapshot`, `Plan`,
+`Report`) carries `APIVersion: "parti.io/provision/v1"` and a `Kind` field.
+Operator CI keys on these fields; future versions add fields under the same
+APIVersion or bump to v2.
+
+Top-level entry points:
+
+```go
+func View(ctx context.Context, js jetstream.JetStream, scope Scope) (Snapshot, error)
+func Validate(cfg Config) error
+func ValidateLive(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, error)
+func Plan(ctx context.Context, js jetstream.JetStream, cfg Config) (Plan, error)
+func Apply(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, error)
+```
+
+### `Validate` / `ValidateLive` / `Plan` / `Apply` boundary
+
+These are distinct phases and must not overlap:
+
+- **`Validate(cfg)`** — pure static validation: required `APIVersion` match,
+  required fields, name patterns, policy is `warn`, mutually exclusive
+  options. No I/O.
+- **`ValidateLive(ctx, js, cfg)`** — pre-flight: JetStream reachability,
+  account info access, and the minimum set of permissions listed in the
+  [Permissions](#permissions) table for the resource kinds in `cfg`. Does
+  **not** compare config to live resources.
+- **`Plan(ctx, js, cfg)`** — assumes pre-flight passed; queries each named
+  resource by exact name and computes drift. Reads bucket/stream info only;
+  does **not** probe the partition-source configured-key read permission
+  (that probe is `ValidateLive`-only). Surfaces permission errors only if
+  they prevent the resource read.
+- **`Apply`** — v1 **always** calls `Validate(cfg)` and `ValidateLive(ctx, js,
+  cfg)` internally before mutation. There is no skip flag in v1. A future
+  `ApplyValidated` fast path can be added in a later phase if a real
+  performance need surfaces; v1 deliberately omits it.
+
+### Cancellation contract
+
+For all entry points, `ctx` cancellation maps to the standard Go contract:
+
+- `View`, `Validate`, `ValidateLive`, `Plan`: return zero-value result and
+  `ctx.Err()` on cancellation. These operations are read-only and do not
+  produce partial state.
+- `Apply`: if cancellation is observed **before** any mutation, returns
+  `(Report{Aborted: true}, ctx.Err())` with empty `Executed`. If cancellation
+  is observed **after** at least one mutation attempt, returns `(partial,
+  ctx.Err())` where `partial.Aborted = true`, `partial.Executed` lists
+  completed actions, and remaining planned actions are added to
+  `partial.Skipped` with reason `context-cancelled`. Cancellation is not added
+  to `partial.Errors`; only resource-level errors live there.
+- CLI maps `ctx.Err()` to exit code 4 when caused by `-timeout`, or to the
+  operating-system signal default for `SIGINT`/`SIGTERM`.
+
+### Apply failure semantics (non-cancellation)
+
+When an `Apply` action fails for an ordinary resource reason (NATS error,
+server-side validation rejection, permission denied at create time, etc.),
+`Apply` is **fail-fast**:
+
+- Actions completed before the failure remain in `Report.Executed`.
+- The failed action is recorded once in `Report.Errors` as a
+  `ResourceError` whose `Name`/`Kind` identify the resource and whose
+  error message is the underlying NATS error string.
+- All remaining planned actions are added to `Report.Skipped` with
+  reason `prior-error`.
+- `Report.Aborted` stays **false**. `Aborted` is reserved for context
+  cancellation only — it is the marker that distinguishes "the caller
+  pulled the plug" from "a resource operation failed."
+- `Apply` returns the underlying NATS error wrapped with the resource
+  name; the partial `Report` is still returned alongside.
+- CLI exit code maps to `1` (runtime/generic error) per the
+  [Exit code precedence](#exit-code-precedence) table.
+
+This rule applies to every mutation phase in v1 (control-plane bucket
+create, partition-source bucket create). Later phases that add multi-step
+actions (e.g., update-then-stamp) inherit the same fail-fast contract:
+any sub-step failure stops the run with the partial `Report` as above.
+
+### Permissions
+
+The permission table is API-call-accurate. Operators who grant exactly these
+will have `validate -live` pass and `apply` succeed for the corresponding
+resources.
+
+| Entry point  | Required NATS API subjects |
+|--------------|----------------------------|
+| `View` (no `-f`)         | `$JS.API.STREAM.LIST` (preferred; returns configs + metadata in one call) or `$JS.API.STREAM.NAMES` + `$JS.API.STREAM.INFO.*` (two-step fallback) |
+| `View` (`-f` scoped)     | `$JS.API.STREAM.INFO.KV_<bucket>` for each named bucket |
+| `Validate`               | none (pure) |
+| `ValidateLive`           | `$JS.API.INFO`; `$JS.API.STREAM.INFO.KV_<bucket>` for each named bucket; for `partitionSource`, additionally the configured-key read permission (see below) |
+| `Plan`                   | `$JS.API.INFO`; `$JS.API.STREAM.INFO.KV_<bucket>` for each named bucket. **Does not** probe the partition-source configured-key read permission — that probe is `ValidateLive`-only. |
+| `Apply` (v1, create-kv)  | `ValidateLive` permissions plus `$JS.API.STREAM.CREATE.KV_<bucket>` for each missing bucket |
+| Dynamic consumer alignment (live check) | `$JS.API.STREAM.INFO.<stream>` for each named stream; `$JS.API.CONSUMER.INFO.<stream>.<consumer>` (per-durable; preferred) or `$JS.API.CONSUMER.LIST.<stream>` (broader; only when comparing the full consumer set) |
+
+Partition-source key read permissions:
+
+- nats.go `kv.Get` calls `stream.GetLastMsgForSubject` under the hood. The API
+  subject used depends on whether the underlying stream has `AllowDirect`.
+- **Primary (direct path, `AllowDirect=true`):**
+  `$JS.API.DIRECT.GET.KV_<bucket>.$KV.<bucket>.<key>`. nats.go-created KV
+  streams always set `AllowDirect=true`
+  (`github.com/nats-io/nats.go v1.50.0`, `jetstream/kv.go:669-690`; see
+  `go.mod` for the pinned version).
+- **Fallback (non-direct path, `AllowDirect=false`):**
+  `$JS.API.STREAM.MSG.GET.KV_<bucket>`. This matters because Parti opens
+  pre-existing KV buckets without reconciling config
+  (`kvutil/bucket.go:12-20`); operators who created their partition-source
+  bucket outside nats.go may not have `AllowDirect` enabled.
+- `ValidateLive` should attempt the appropriate subject based on the live
+  bucket's `AllowDirect` setting (read once via `STREAM.INFO`). To avoid a
+  TOCTOU race when an operator toggles `AllowDirect` between the info read
+  and the probe, on permission failure `ValidateLive` re-reads `STREAM.INFO`
+  once and retries with the path implied by the refreshed value. Operators
+  who want fully race-free validation while reconfiguring streams should
+  grant both `$JS.API.DIRECT.GET.KV_<bucket>.$KV.<bucket>.<key>` and
+  `$JS.API.STREAM.MSG.GET.KV_<bucket>`.
+
+Notes:
+
+- nats.go supports custom JetStream API prefixes (`<prefix>.STREAM.INFO.<stream>`)
+  and domains (`$JS.<domain>.API.STREAM.INFO.<stream>`); substitute the
+  configured prefix/domain when documenting deployment-specific grants.
+- For the `partitionSource` bucket, `ValidateLive` probes the configured key
+  with a get; **key non-existence is not an error** in v1 (partition records
+  are managed by Phase 3). The probe only verifies the operator can read the
+  key when records exist.
+- `ValidateLive` never subscribes a watch (a transient subscription has no
+  good failure signal); the closest read permission is verified instead.
+- `ValidateLive` never writes the partition-source key.
+- `$KV.<bucket>.<key>` is the stored message subject, **not** an API
+  permission subject. It must not be granted as a JetStream API permission.
+
+## Dynamic Consumer Planning
+
+Two helpers, separated by purity:
+
+```go
+// PlanDynamicConsumers is a pure builder. It validates input and constructs
+// PlannedConsumer entries using the same subject generation, durable naming,
+// and ConsumerConfig logic as runtime consumer.Dynamic, scoped to the v1
+// alignment-check surface. It performs no I/O.
+//
+// v1 surface and equality scope:
+//   - The builder accepts only stream/prefix/template/partitions; it has no
+//     option variadic. Runtime equality is asserted against runtime defaults
+//     for every other field on durable.WorkerConsumerConfig.
+//   - The PlannedConsumer.Config the test compares against runtime is the
+//     subset deterministically produced from those inputs at runtime
+//     defaults: Durable, FilterSubject(s), AckPolicy=AckExplicit,
+//     DeliverPolicy=DeliverAll, and any other field that internal/durable
+//     unconditionally sets at runtime defaults (see W4 sub-spec for the
+//     exact, enumerated list and the corresponding source lines).
+//   - All other fields are explicitly out of v1 equality scope and the W4
+//     test must not assert them. The list lives in the W4 sub-spec, not
+//     in this plan, so it can be refined as the durable extraction lands.
+type PlannedConsumer struct {
+    StreamName string
+    Subject    string
+    Durable    string
+    Config     jetstream.ConsumerConfig
+}
+
+func PlanDynamicConsumers(
+    streamName, consumerPrefix, subjectTemplate string,
+    partitions []types.Partition,
+) ([]PlannedConsumer, error)
+
+// ValidateLiveDynamicConsumers performs the live compatibility checks that
+// runtime Dynamic.Update performs, including the WorkQueuePolicy recovery
+// strategy compatibility check. v1 ValidateLive calls this for each
+// DynamicConsumerCfg entry.
+func ValidateLiveDynamicConsumers(
+    ctx context.Context,
+    js jetstream.JetStream,
+    cfgs []DynamicConsumerCfg,
+) error
+```
+
+**Extraction strategy.** Extract the pure builder from the
+`internal/durable.WorkerConsumer` methods that already construct subjects,
+durable names, and consumer configs (e.g., `buildSubjects` / `generateSubject`,
+`perSubjectDurableName`, `ensurePerSubjectConsumer` config construction). The
+`provision` package consumes the exported builder; runtime `consumer.Dynamic`
+continues to call the same shared logic. No private durable-naming code is
+duplicated in `provision`.
+
+**Live coupling.** `ValidateLiveDynamicConsumers` calls the same
+`checkWorkQueueRecoveryCompat` path used by `Dynamic.Update`. This is required
+because pure planning cannot detect that a WorkQueuePolicy stream rejects
+`RecoverFromNew` / `RecoverFromLastProcessed` — that decision depends on live
+stream config. Tests must cover both:
+
+1. **Scoped** pure config equality: for the enumerated subset of
+   `ConsumerConfig` fields produced deterministically from `(stream, prefix,
+   subjectTemplate, partitions)` at runtime defaults (Durable, FilterSubject,
+   AckPolicy=AckExplicit, DeliverPolicy=DeliverAll, plus any other field the
+   extracted builder unconditionally sets — the exact list is fixed in the
+   W4 sub-spec), the planned `ConsumerConfig` matches what runtime
+   `consumer.Dynamic` would build for the same partitions at the same
+   defaults. Fields outside this enumerated subset (AckWait, MaxDeliver,
+   ConsumerReplicas, RecoveryStrategy, etc.) are explicitly **out of
+   equality scope for v1**.
+2. Live WorkQueuePolicy rejection: `ValidateLiveDynamicConsumers` returns the
+   same error as `Dynamic.Update` against an incompatible stream.
+
+Implementation priority:
+
+1. Pure builder + read-only alignment validation land in v1.
+2. Optional consumer **precreation** lands in **Phase 5 (Dynamic Precreate)**
+   after the pure builder is proven byte-equivalent to runtime in Phase 1.
+3. Delete/recreate of existing dynamic consumers lands in **Phase 6
+   (Force + Repair)**; cursor-loss behavior is covered by that phase's test
+   discipline.
+
+## YAML Config Examples
+
+The v1 CLI consumes YAML files matching the `provision.Config` struct shape
+defined under [Proposed SDK](#proposed-sdk). All field names below are
+canonical — they correspond verbatim to the `yaml` tags on the public structs.
+
+### Minimal — control plane only
+
+```yaml
+apiVersion: parti.io/v1
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s
+```
+
+Bucket names default to the same values as `parti.KVBucketConfig`
+(`parti-stableid`, `parti-election`, `parti-heartbeat`, `parti-assignment`,
+`parti-handoff`), so they can be omitted unless overridden. `assignmentTtl`
+defaults to `0` ("no expiration"). Handoff is off unless
+`enableTwoPhaseHandoff: true`.
+
+### Full — every v1 block populated
+
+```yaml
+# Schema version. Required. v1 accepts only "parti.io/v1".
+apiVersion: parti.io/v1
+
+# Optional logical environment name. Stamped on every created resource as
+# parti.io/instance metadata. Used for `partictl view -instance=...`
+# filtering. The marker is annotation-only — NATS bucket names are globally
+# unique, so true multi-environment isolation requires distinct bucket names
+# per environment.
+instance: prod-us-east
+
+# v1 only accepts "warn" (create missing, never mutate existing).
+# safe-update and force are rejected by static Validate in v1.
+policy: warn
+
+controlPlane:
+  # Bucket names. Defaults match parti.KVBucketConfig defaults.
+  stableIdBucket: parti-stableid
+  electionBucket: parti-election
+  heartbeatBucket: parti-heartbeat
+  assignmentBucket: parti-assignment
+  handoffBucket: parti-handoff
+
+  # TTLs. Field names and values mirror parti.Config exactly so a single
+  # canonical source can populate both this file and runtime parti.Config.
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s
+  assignmentTtl: 0s         # 0 = no expiration (matches runtime default)
+  handoffTtl: 2m
+
+  # Gate for the optional handoff bucket. When true, handoffTtl must be > 0.
+  enableTwoPhaseHandoff: true
+
+partitionSource:
+  # Bucket that holds the partition definition KV. Provisioned in v1.
+  bucket: parti-partitions
+  # Key under which the partition list lives. v1 provisions the bucket
+  # only — partition record writes land in Phase 3 (Partition Records).
+  key: partitions/v1
+  replicas: 3
+  storage: file              # "file" | "memory"; default "file"
+  history: 1                 # default 1
+  maxValueSize: 1048576      # optional
+  ttl: 0s                    # optional; 0 = no expiration
+
+dynamicConsumers:
+  # v1: alignment-check only. Precreation is a deferred follow-up.
+  - streamName: orders
+    consumerPrefix: ord-worker
+    subjectTemplate: "orders.{partition_id}.>"
+    partitionsRef: ./partitions.yaml   # caller-owned partition list
+```
+
+### Intentionally absent from v1
+
+- `controlPlane.replicas` — runtime `KeyValueConfig` doesn't set Replicas
+  (nats.go normalizes 0→1 server-side). Operators needing multi-replica
+  control-plane KV must pre-create those buckets; they will appear as
+  `adopted` drift in v1. The field lands in **Phase 2 (Safe Update + Adopt)**
+  alongside the safe-update contract for live-replica changes.
+- `streams:` block — **Phase 4 (Streams)**; no field on `Config` in v1.
+- `partitions:` records — partition-source bucket is provisioned but its key
+  contents are never written by v1.
+- Templating / overlays — none. Dev/stage/prod are separate rendered files.
+- `policy: safe-update` and `policy: force` — rejected by static `Validate`.
+
+### Validation behavior
+
+The YAML-unmarshal test (see [Test Plan](#test-plan)) asserts every nested
+field above populates via its declared YAML tag, not Go default-name mapping.
+A representative YAML file matching the "Full" example is the canonical
+fixture for that test.
+
+## CLI
+
+Add `cmd/partictl` with a testable `run(args []string, stdout, stderr io.Writer) int`
+entrypoint.
+
+Commands (v1):
+
+- `partictl view [-f parti-env.yaml]`
+- `partictl validate -f parti-env.yaml [-live]`
+- `partictl plan -f parti-env.yaml`
+- `partictl apply -f parti-env.yaml [-dry-run]`
+
+Deferred to later phases (see [Phased Roadmap](#phased-roadmap)):
+
+- `partictl partitions plan/apply` — **Phase 3 (Partition Records)**.
+- `partictl adopt` — **Phase 2 (Safe Update + Adopt)**.
+- `partictl stream view/plan/apply` — **Phase 4 (Streams)**.
+- `partictl init` / `partictl emit` (config generators) — cross-cutting
+  follow-up, not gated on a specific phase.
+
+Common flags:
+
+- `-f`: YAML config path.
+- `-server`: NATS URL; default from `NATS_URL`, then `nats.DefaultURL`.
+- `-creds`, `-nkey`, `-token`: authentication options.
+- `-timeout`: operation timeout (default 30s).
+- `-json`: emit machine-readable output (`Snapshot`, `Plan`, or `Report`
+  depending on command; each carries `apiVersion` + `kind`).
+- `-fail-on-drift`: when `plan` (or `apply -dry-run`) finds any unresolved
+  drift, exit with code 2. In v1, `warn` policy never resolves drift, so any
+  non-informational drift triggers code 2 when the flag is set.
+- `-instance`: for `view` (no `-f`) and `validate`, restrict results to
+  resources whose `parti.io/instance` metadata matches this value. Ignored
+  when `-f` is set (config-scoped commands derive instance from
+  `Config.Instance`). Default is "" (all instances).
+
+### Exit codes
+
+| Code | Meaning                                                  |
+|------|----------------------------------------------------------|
+| 0    | success / `ok`                                           |
+| 1    | runtime / generic error (operation failed after preflight passed) |
+| 2    | drift detected and not resolved (only with `-fail-on-drift`) |
+| 3    | static or live validation error                          |
+| 4    | NATS connect, auth, or context timeout/cancel failure    |
+
+### Exit code precedence
+
+When multiple error conditions occur during a single command, the highest-
+priority code wins. Highest priority first:
+
+1. Command/flag parse error → code `3`.
+2. Static `Validate` failure → code `3`.
+3. NATS connect, auth, or context cancellation/timeout → code `4`.
+4. Live validation failure (`ValidateLive`) → code `3`.
+5. Runtime operation failure during `plan`/`apply` (e.g., partial NATS error)
+   → code `1`.
+6. Unresolved drift with `-fail-on-drift` set → code `2`.
+7. Otherwise → code `0`.
+
+A context-deadline or `SIGINT` during `apply` maps to code `4`; the partial
+`Report` is still emitted on stdout when `-json` is set.
+
+### Output
+
+- `view`: live resource table scoped by `-f` (or all marker-matched if absent).
+- `validate`: validation errors or `ok`.
+- `plan`: deterministic action table (sorted by `Kind`, then `Name`) plus
+  drift findings grouped by severity.
+- `apply`: executed/skipped/failed action table; with `-dry-run`, emits the
+  same `Plan` payload as `plan` (byte-identical for `-json`).
+
+## Safety Rules
+
+- Default and only v1 policy is `warn`: non-disruptive, create-missing only.
+- v1 emits exactly one `PlannedAction.Kind`: `"create-kv"`. Stream and
+  consumer action kinds are reserved and never emitted in v1.
+- Existing resource drift is reported but never mutated in v1.
+- Config-scoped operations always resolve resources by **exact NATS name
+  first**. The ownership marker only affects drift classification of resources
+  that already exist by name. Marker-first filtering of config-scoped
+  operations is a bug.
+- `apply` never writes when `-dry-run` is set.
+- Partition content writes are out of scope for v1; the partition-source
+  bucket is provisioned but never written to.
+- Planner output is deterministic: actions and drift findings are sorted by
+  `(Kind, Name)`. Wall-clock timestamps are excluded from default text output
+  and included only in `-json` output (e.g., `Snapshot.ObservedAt`).
+- `plan` is the canonical dry run. `apply --dry-run` calls the same planning
+  path and emits an identical `Plan` JSON payload.
+- `Validate` and `ValidateLive` are both called by `Apply` in v1. There is no
+  skip path.
+
+### KV field mutability (informational; v1 does not mutate)
+
+When `safe-update` lands in **Phase 2** and `force` lands in **Phase 6**, the
+following NATS KV field mutability rules apply. v1 reports drift only — it
+neither mutates nor delete/recreates — but the categories below are recorded
+here so later phases inherit a consistent contract.
+
+| Field          | Mutability        | v1 drift severity   |
+|----------------|-------------------|---------------------|
+| `Description`  | mutable in place  | drift-mutable       |
+| `Metadata`     | mutable in place  | drift-mutable       |
+| `MaxBytes`     | mutable in place  | drift-mutable       |
+| `MaxValueSize` | mutable in place  | drift-mutable       |
+| `TTL`          | mutable in place  | drift-mutable       |
+| `History`      | immutable         | drift-immutable     |
+| `Storage`      | immutable         | drift-immutable     |
+| `Replicas`     | conditionally mutable (server-version-dependent) | drift-immutable (conservative) |
+
+v1 reports immutable drift as **manual remediation required** in the
+`plan`/`apply -dry-run` output. Operators must decide whether to delete and
+recreate themselves; v1 will not.
+
+## Work Items
+
+0. **Extract shared `KeyValueConfig` builder.** Move the
+   `(*Manager).ensureKVBucket` `KeyValueConfig` literal
+   (`manager_setup.go:148-156`) behind a pure, exported builder that takes
+   `(bucket string, ttl time.Duration, storage jetstream.StorageType)` and
+   returns `jetstream.KeyValueConfig` without performing I/O. Place it in an
+   importable package (`internal/kvbuckets` or similar, re-exported via a thin
+   `parti` wrapper for `provision`'s use). Update `manager_setup.go` to call
+   the new builder; behavior is unchanged. This is a prerequisite for the
+   byte-equivalence invariant in W1/W2 — without it, provision tests would
+   either duplicate the literal (defeating the invariant) or call unexported
+   runtime code. W0 ships as a refactor PR with no behavior change.
+1. Add `provision.Config`, `apiVersion` handling, `Validate` (static), `View`,
+   and read-only `Plan` for Parti control-plane KV buckets. Implement marker
+   read/parse helpers. Each `create-kv` action's `KeyValueConfig` is built by
+   calling the W0 shared builder and then adding the Parti `Metadata` marker.
+   (`apply` deferred to W2.)
+2. Add create-missing `Apply` for control-plane KV buckets, stamping the
+   ownership marker in `Metadata`. Add `ValidateLive` (API-call-accurate
+   pre-flight permissions/reachability). Wire `Apply` to always call
+   `Validate` + `ValidateLive` internally.
+3. Add partition-source bucket provisioning (`view`/`plan`/`apply`). Partition
+   record management remains deferred.
+4. Add dynamic-consumer alignment: pure `PlanDynamicConsumers` builder
+   (extracting shared logic from `internal/durable`) plus
+   `ValidateLiveDynamicConsumers` for WorkQueuePolicy compatibility checks.
+5. Add `cmd/partictl` with `view`, `validate [-live]`, `plan`,
+   `apply [-dry-run]`. Wire exit codes (with documented precedence) and
+   `-json` output (with `apiVersion`/`kind` envelopes).
+
+Work items 0–5 form the **Phase 1** launch gate; W0 is a no-behavior-change
+refactor prerequisite. Phases 2–7 each land their own work items in their
+own design plans (see [Phased Roadmap](#phased-roadmap)). Each later phase
+inherits this plan's invariants verbatim — the W0 shared `KeyValueConfig`
+builder, the ownership marker shape, the JSON envelope schema, the CLI exit
+codes, and the determinism rules.
+
+## Implementation Workflow
+
+Each work item ships as its own PR. The standard per-PR loop, matching the
+project convention recorded in CLAUDE memory and `AGENTS.md`:
+
+```
+sub-spec (if needed) → impl → /simplify → /codex:review (or /post-impl-review)
+  → fix → re-review → squash on merge verdict
+```
+
+- A **sub-spec** is a short markdown file (1–2 pages) under
+  `docs/plans/provision-sdk-cli/` named `<NN>-<wname>-spec.md` (e.g.
+  `02-w2-apply-validatelive-spec.md`). It is required when a work item adds
+  public API surface or new contract semantics not fully nailed down in this
+  plan. For mechanical refactors (W0) and straightforward CLI wiring (W5),
+  the work-item bullet above is sufficient.
+- **`/simplify`** runs after the implementation lands to fold redundancy and
+  cut accidental complexity before review.
+- **`/codex:review`** is the default post-impl reviewer. Fall back to
+  `/post-impl-review` (copilot) only if codex is unavailable. Effort levels
+  match `AGENTS.md`: `xhigh` for v1/v2 reviews of new public-API PRs, `high`
+  for refactor PRs and v3+ rounds.
+- **Squash** on merge once the reviewer returns a clean verdict.
+
+### Recommended model + effort per work item
+
+The implementer column refers to the local Claude Code model that writes the
+code (or this CLI's planner if a sub-spec is required first). The reviewer
+column is the codex effort level for the post-impl review.
+
+| W  | Title                                            | Sub-spec needed? | Sub-spec planner          | Implementer       | Codex review effort |
+|----|--------------------------------------------------|------------------|---------------------------|-------------------|---------------------|
+| W0 | Shared `KeyValueConfig` builder (refactor)       | No               | —                         | **Sonnet 4.6**    | `medium`            |
+| W1 | `Config`, `Validate`, `View`, read-only `Plan`   | No (this plan covers it) | —                  | **Opus 4.7**      | `xhigh`             |
+| W2 | `Apply` + `ValidateLive` (perm probes, retry)    | **Yes**          | **Opus 4.7**              | **Opus 4.7**      | `xhigh`             |
+| W3 | Partition-source bucket view/plan/apply          | No               | —                         | **Sonnet 4.6**    | `high`              |
+| W4 | Dynamic-consumer alignment (extraction + live)   | **Yes**          | **Opus 4.7**              | **Opus 4.7**      | `xhigh`             |
+| W5 | `cmd/partictl` CLI (commands, exit codes, JSON)  | No               | —                         | **Sonnet 4.6**    | `high`              |
+
+Rationale:
+
+- **W0** is a behavior-preserving refactor of a 9-line literal in
+  `manager_setup.go` behind a new pure helper. Sonnet 4.6 is the efficient
+  default; `medium` codex effort is enough to verify the literal is
+  preserved and no caller drifts.
+- **W1** introduces the public `provision.Config`, `Plan`, `Snapshot`, and
+  `View` surface. Opus 4.7 for the implementer because the public-API shape
+  is load-bearing on every later PR and on operator JSON tooling. `xhigh`
+  review because new public API.
+- **W2** adds `Apply` and `ValidateLive` with the API-call-accurate
+  permission probes and the `AllowDirect` single-retry. The permission table
+  is correct in the plan but the per-probe sequence (info read → probe →
+  refresh-on-failure → retry) needs a short sub-spec to nail down error
+  classes, retry conditions, and which permission failures map to which
+  exit codes. Opus 4.7 for both the sub-spec and the implementation; `xhigh`
+  review because the mutation path is here.
+- **W3** is parallel to W1/W2 but for the partition-source bucket only.
+  Sonnet 4.6 is sufficient because the shape mirrors W1/W2's contract; the
+  partition-source-specific subtleties (immutable `History`, AllowDirect
+  probe, never-write-key invariant) are already locked in this plan.
+- **W4** is the dynamic-consumer alignment work. A sub-spec is required
+  because the pure builder must be extracted from `internal/durable` at a
+  named seam (subject build, durable name, ConsumerConfig construction) and
+  `ValidateLiveDynamicConsumers` must reuse `checkWorkQueueRecoveryCompat`
+  without copying. Opus 4.7 for both the sub-spec and the implementation
+  because the extraction touches runtime code paths; `xhigh` review.
+- **W5** is the CLI surface (flag parsing, exit-code precedence, JSON
+  envelopes, golden tests). Sonnet 4.6 because there is no new public-API
+  reasoning beyond what the SDK already establishes; the CLI is glue. `high`
+  codex review (not `xhigh`) because the SDK underneath has already been
+  reviewed at `xhigh` and the CLI surface is mostly mechanical.
+
+### Final plan review before W0 starts
+
+This plan has already cleared four rounds of `codex:codex-rescue` review
+(see `tmp/operator/codex-review-v1.md` through `v4.md`, verdict CLEAN).
+Before opening the W0 PR, run a single `/final-plan-review` pass to catch
+any residual drift introduced by additions to this plan (YAML examples,
+this workflow section). That review is `high` effort — a precision pass,
+not another architectural round.
+
+## Test Plan
+
+Static / unit:
+
+- `provision.Config` defaults, YAML/JSON tags, required `apiVersion` (only
+  `parti.io/v1` accepted), rejection of `safe-update` / `force` policy values
+  in v1.
+- `Validate` applies runtime bucket-name defaults to omitted/empty
+  `StableIDBucket` / `ElectionBucket` / `HeartbeatBucket` /
+  `AssignmentBucket` / `HandoffBucket` before validating; rejects any
+  bucket name still empty after defaulting (this case is unreachable from
+  valid YAML and exists only to guard against API callers explicitly
+  zeroing a field after defaulting). Rejects zero `WorkerIDTTL` /
+  `ElectionTimeout` / `HeartbeatTTL`, and `EnableTwoPhaseHandoff=true`
+  with zero `HandoffTTL`. `AssignmentTTL=0` is accepted (matches runtime
+  default "no expiration"). Includes a test asserting the minimal YAML
+  example (control-plane block with only the three required TTLs) passes
+  validation after defaulting.
+- Deterministic `Plan` output: shuffle inputs, assert identical sorted output.
+- `Scope`, `ScopeAll`, `ScopeFromConfig` correctness.
+- Exit code mapping for each error class, including precedence, via the
+  testable `run` entrypoint.
+- JSON envelope: `Snapshot`, `Plan`, `Report` all carry `apiVersion` and
+  `kind` fields in their JSON encoding.
+
+Embedded-NATS integration:
+
+- `view` against an empty server returns an empty snapshot.
+- `view` against a server with mixed marked / unmarked buckets includes only
+  marked ones by default.
+- `view` (no `-f`, no `-instance`) against a server with two
+  `parti.io/instance` values returns both groups under their respective
+  control-plane / partition-source slices (inventory mode).
+- `view -instance=prod` returns only resources stamped with
+  `parti.io/instance=prod`; unstamped resources and other instance values are
+  excluded.
+- `view -instance=prod -f cfg.yaml` (where cfg.yaml has
+  `instance: staging`): the `-f` config wins; `-instance` is ignored and
+  results are config-scoped to staging resources.
+- `plan` against an empty server lists `create-kv` actions for each
+  control-plane and partition-source bucket in config; each control-plane
+  action's would-be `KeyValueConfig` is **byte-equivalent** to what the shared
+  W0 builder returns for the same inputs (Bucket, History=1, Storage, TTL when
+  > 0; Replicas unset), plus the Parti ownership marker in `Metadata`. The
+  test calls the W0 builder directly and compares against `provision.Plan`'s
+  emitted `KeyValueConfig` with `Metadata` removed.
+- Unmarshalling a representative `parti-env.yaml` populates every nested
+  field on `ControlPlaneConfig`, `PartitionSourceConfig`, and
+  `DynamicConsumerCfg` via the documented YAML tags. Test fails if any
+  nested field uses Go default-name mapping rather than its declared tag.
+- `apply` creates missing control-plane buckets with the correct
+  `Metadata["parti.io/managed"]` and `Metadata["parti.io/component"]`;
+  re-running `plan` reports no drift; re-running `apply` is a no-op.
+- **Marker-doesn't-hide-by-name invariant:** create a bucket manually (no
+  marker) with a name matching config; `plan` reports `adopted` drift and
+  emits **no** `create-kv` action. `apply` performs no mutation. Re-run with
+  a different name: `plan` correctly emits `create-kv` for the unrelated
+  desired bucket.
+- `plan` against a manually-created bucket with mismatched mutable fields
+  reports `drift-mutable`; with mismatched immutable fields reports
+  `drift-immutable`. v1 emits no `update-*` actions in either case.
+- `ValidateLive` returns permission errors that map to API subjects in the
+  [Permissions](#permissions) table when those grants are missing.
+- `ValidateLive` for `partitionSource` succeeds when the bucket exists and is
+  readable but the configured key does not yet exist. The test covers both
+  `AllowDirect=true` (nats.go-created) and `AllowDirect=false` (pre-existing)
+  bucket variants, asserting the appropriate API subject is probed in each
+  case.
+- `Apply` with cancellation **before** any mutation: returns `Report{}`
+  with `Aborted=true`, empty `Executed`, error is `ctx.Err()`.
+- `Apply` with cancellation **mid-way**: returns partial `Report` with
+  `Aborted=true`, `Executed` lists completed creates, remaining actions are
+  in `Skipped` with reason `context-cancelled`, error is `ctx.Err()`.
+- `Apply` with a **non-cancellation** mid-flight failure (e.g., server
+  rejects a create due to a forced server error): returns partial `Report`
+  with `Aborted=false`, `Executed` lists completed creates, the failing
+  action is in `Errors` once, remaining planned actions are in `Skipped`
+  with reason `prior-error`, and the returned error wraps the underlying
+  NATS error with the resource name.
+- Dynamic-consumer alignment: planned durable names and the enumerated
+  subset of `ConsumerConfig` fields (defined in the W4 sub-spec) match
+  what `consumer.Dynamic` would create for the same partitions at runtime
+  defaults; fields outside the enumerated subset are not asserted.
+- Dynamic-consumer live: `ValidateLiveDynamicConsumers` returns the same
+  WorkQueuePolicy recovery-strategy error as `Dynamic.Update` against an
+  incompatible stream.
+
+CLI:
+
+- Each command's text and `-json` output is golden-tested against fixtures.
+- `apply -dry-run` and `plan` emit byte-identical `-json` output.
+- `-fail-on-drift` exits 2 when drift is present and 0 otherwise.
+- Exit-code precedence: simultaneous invalid YAML + unreachable NATS → exit
+  3 (parse wins). Permission denied during `plan` → exit 3. Drift +
+  successful read → exit 2 with `-fail-on-drift`, exit 0 without.
+
+## Acceptance Criteria
+
+- A user can run `partictl view` against any NATS server with credentials and
+  see every Parti-managed resource (filtered by the `parti.io/managed`
+  metadata key) without supplying a config.
+- A user can run `partictl plan -f parti-env.yaml` against an empty NATS
+  server and see the exact Parti control-plane and partition-source resources
+  that would be created. Each control-plane `create-kv` action's
+  `KeyValueConfig` is byte-equivalent to what `manager_setup.go:ensureKVBucket`
+  would build for the same `parti.Config` values (Bucket, History=1, Storage,
+  TTL when > 0; Replicas unset), plus the Parti ownership marker in
+  `Metadata`.
+- A user can run `partictl apply -f parti-env.yaml` to create missing
+  control-plane buckets and the partition-source bucket, each stamped with
+  `Metadata["parti.io/managed"] = "v1"` and the appropriate
+  `parti.io/component` value.
+- Re-running `apply` against matching resources is a no-op and reports the
+  same plan.
+- Re-running `plan` against drifted resources reports drift without mutation;
+  immutable drift is flagged as **manual remediation required**.
+- A manually-created bucket without the Parti marker is reported as `adopted`
+  drift and **never mutated** by v1 `apply`.
+- `partictl validate -f parti-env.yaml -live` catches unavailable JetStream,
+  missing per-subject NATS permissions (matching the
+  [Permissions](#permissions) table), and unsupported policy values before
+  workers start.
+- `partictl apply -f parti-env.yaml -dry-run` performs no mutation and emits
+  a `Plan` JSON byte-identical to `partictl plan`.
+- `Apply` cancelled mid-flight returns a partial `Report` with `Aborted=true`
+  whose `Executed` + `Skipped` cover every planned action.
+- Dynamic-consumer alignment checks report whether planned durable names
+  and the enumerated subset of config fields (defined in the W4 sub-spec)
+  match what runtime `consumer.Dynamic` would create at runtime defaults.
+- `ValidateLiveDynamicConsumers` rejects WorkQueuePolicy streams with
+  incompatible recovery strategies, matching the runtime check.
+- CLI exits with the documented codes and precedence for each error class.
+- Every `-json` output payload carries `apiVersion: "parti.io/provision/v1"`
+  and a `kind` field.
+- `partictl view -instance=<name>` returns only resources whose
+  `parti.io/instance` metadata matches `<name>`. When `-instance` is absent,
+  no-config `view` returns all marker-matched resources grouped by instance
+  (including unstamped resources under instance `""`).
+- `partictl validate -f parti-env.yaml -live` correctly probes the
+  partition-source key using `$JS.API.DIRECT.GET.KV_<bucket>.$KV.<bucket>.<key>`
+  when the bucket has `AllowDirect=true` and falls back to
+  `$JS.API.STREAM.MSG.GET.KV_<bucket>` otherwise.
+- The before/after operational impact is visible in review: a fresh
+  environment can move from manual NATS setup to one validated plan/apply
+  loop, while drift is reported before runtime startup rather than discovered
+  as worker failures.
+
+## Assumptions
+
+- CLI file input is YAML-only in v1.
+- `apiVersion: parti.io/v1` is the only schema accepted by v1; mismatched
+  versions are a static validation error.
+- All JSON output payloads use `apiVersion: parti.io/provision/v1` (note the
+  `provision/` segment to distinguish output schema from input config schema).
+- Public config structs include JSON tags even though the v1 CLI does not need
+  a JSON loader.
+- The default provision path is create-missing plus drift reporting; no
+  mutation of existing resources in v1.
+- Destructive repair (delete/recreate) is out of scope for v1; it lands in
+  **Phase 6 (Force + Repair)**.
+- Kubernetes controller integration lands in **Phase 7 (K8s Controller)** as
+  a layer on top of the SDK, not a replacement.
+- Dev/stage/prod differences are handled by separate rendered config files
+  or SDK-owned config construction in v1; first-class overlays are a
+  cross-cutting follow-up (see [Phased Roadmap](#phased-roadmap)).
+- Partition record management (`partictl partitions plan/apply`) lands in
+  **Phase 3 (Partition Records)**; v1 provisions the bucket but never
+  writes records.
+- Stream provisioning lands in **Phase 4 (Streams)**; v1 exposes no
+  stream-related public API.

--- a/docs/plans/provision-sdk-cli/02-w2-apply-validatelive-spec.md
+++ b/docs/plans/provision-sdk-cli/02-w2-apply-validatelive-spec.md
@@ -1,0 +1,507 @@
+# W2 — `Apply` + `ValidateLive` Sub-Spec
+
+This sub-spec resolves the implementation details the master plan
+(`docs/plans/provision-sdk-cli/00-implementation-plan.md`) leaves implicit
+for W2. It does not redesign anything; every behavioral contract it states
+either cites the master plan by header or refines its "TBD"-style language
+into a single deterministic algorithm.
+
+Cross-references to the master plan use its headers verbatim. Cross-references
+to nats.go are pinned at `v1.50.0` (`go.mod`).
+
+---
+
+## 1. `ValidateLive`
+
+### 1.A Order of probes (deterministic)
+
+`ValidateLive(ctx, js, cfg)` executes the following steps in order. Each step
+is fail-fast: the first error short-circuits the rest of `ValidateLive` and is
+returned. The function never mutates NATS.
+
+1. **Reachability probe** — exactly once per call (see 1.B).
+2. **Per-bucket info probes** for every named bucket in `cfg`, in the same
+   deterministic order Plan visits them
+   (`provision/plan.go:80-96` — control-plane component order, optional
+   handoff appended last). PartitionSource follows the control-plane block
+   (W3 wires its bucket here; this sub-spec specifies the seam, W3 lands
+   the call site).
+3. **Partition-source key probe** — only when `cfg.PartitionSource != nil`
+   and step 2 succeeded for the partition-source bucket (see 1.D).
+4. **Dynamic-consumer live checks** — only when `cfg.DynamicConsumers` is
+   non-empty. W4 lands the call site; this sub-spec only fixes the
+   ordering slot.
+
+Steps that have no corresponding config block are **skipped silently** (1.F).
+Step 1 always runs.
+
+### 1.B Reachability probe
+
+Single call: `js.AccountInfo(ctx)`
+(`jetstream.go:1008-1031` in nats.go v1.50.0).
+
+Rationale: this is the canonical "JetStream is reachable and the caller has
+the minimum account-level grant" check and is the same call the master plan's
+[Permissions](../../plans/provision-sdk-cli/00-implementation-plan.md#permissions)
+table assigns to `$JS.API.INFO`. nats.go folds the no-responders case (which
+includes both "JS not enabled" and "no permission on `$JS.API.INFO`") into
+`ErrJetStreamNotEnabled` (`jetstream.go:1015-1017`), so the client cannot
+discriminate JS-disabled from no-perm from the error alone.
+
+**Classification of reachability errors → exit code 4:**
+
+- `errors.Is(err, jetstream.ErrJetStreamNotEnabled)` → 4 (covers both
+  "JS truly down" and "caller lacks `$JS.API.INFO`" — both are operationally
+  pre-flight failures that prevent the worker from starting).
+- `errors.Is(err, jetstream.ErrJetStreamNotEnabledForAccount)` → 4.
+- `errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)`
+  → 4 (cancellation).
+- Any other error → 4 (conservative: if reachability is in question, we
+  exit 4, not 3; the operator's first remediation is "can the client talk
+  to NATS at all").
+
+This is the **only** probe where `ErrNoResponders` / its
+`ErrJetStreamNotEnabled` rewrap maps to exit code 4. Every probe **after**
+this one (steps 2–4) treats the same surface error as **permission denied**
+(exit code 3), because reachability has already been proven.
+
+### 1.C Bucket info probe
+
+For each named bucket `<bucket>`, call `js.Stream(ctx, "KV_" + bucket)` then
+`stream.Info(ctx)`. (This matches Plan's existing lookup at
+`provision/plan.go:104-117`.)
+
+Classification:
+
+- `errors.Is(err, jetstream.ErrStreamNotFound)` → **not an error**. The
+  bucket is missing; `apply` will create it. ValidateLive records nothing
+  and proceeds to the next bucket. (Step 3, partition-source key probe,
+  short-circuits in this case for that bucket — there is no live stream to
+  probe a key against.)
+- `errors.Is(err, jetstream.ErrJetStreamNotEnabled)` after step 1 succeeded
+  → permission denied on `$JS.API.STREAM.INFO.KV_<bucket>`. nats.go cannot
+  distinguish "no responders" from "permission denied" at this level
+  (NATS server silently drops API requests without the publish grant on
+  the API subject). Because step 1 proved reachability, this surface
+  error reclassifies as a **permission denied** ValidateLive error → exit
+  code 3.
+- `errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)`
+  → exit code 4.
+- Any other error → exit code 1 (unknown / generic).
+
+### 1.D Partition-source key probe — `AllowDirect` retry protocol
+
+The master plan's [Permissions](../../plans/provision-sdk-cli/00-implementation-plan.md#permissions)
+section punts the exact retry algorithm to this sub-spec. The algorithm
+below is the single source of truth.
+
+**Why this is subtle:** `kv.Get(ctx, key)` goes through `stream.getMsg`
+which branches on `s.info.Config.AllowDirect` **cached at stream-handle-open
+time** (`jetstream/stream.go:539`). A handle opened against an
+`AllowDirect=true` snapshot will keep using the direct path even if the
+operator toggles the stream to `AllowDirect=false` between handle-open and
+probe. We therefore do **not** use `kv.KeyValue(...).Get(...)`; we probe
+through a freshly resolved `stream.GetLastMsgForSubject` so the
+`AllowDirect` branch is re-evaluated on retry.
+
+**Subject for the underlying call** (informational — nats.go computes it
+internally from `info.Config.AllowDirect`):
+
+- `AllowDirect=true`:
+  `$JS.API.DIRECT.GET.KV_<bucket>.$KV.<bucket>.<key>`
+  (`jetstream/stream.go:540-547`, format string `apiDirectMsgGetLastBySubjectT`).
+- `AllowDirect=false`:
+  `$JS.API.STREAM.MSG.GET.KV_<bucket>`
+  (`jetstream/stream.go:557`, format string `apiMsgGetT`).
+
+**Algorithm:**
+
+```text
+// Pre-condition: step 1.C succeeded for KV_<bucket> and we hold a `stream`
+// handle whose info is the just-read STREAM.INFO response.
+key := cfg.PartitionSource.Key
+subject := "$KV." + cfg.PartitionSource.Bucket + "." + key
+
+err := probeKey(ctx, stream, subject)   // stream.GetLastMsgForSubject
+if err == nil || errors.Is(err, jetstream.ErrMsgNotFound) {
+    return nil   // key missing is OK (Phase 3 manages records)
+}
+if !isPermissionDenied(err, ctxStillLive) {
+    return classify(err)  // see 1.E
+}
+
+// One retry with refreshed STREAM.INFO.
+freshInfo, err2 := stream.Info(ctx)
+if err2 != nil {
+    return classify(err2)
+}
+// `stream.Info` updates the cached info in nats.go; the next call to
+// GetLastMsgForSubject re-evaluates AllowDirect from freshInfo.
+err = probeKey(ctx, stream, subject)
+if err == nil || errors.Is(err, jetstream.ErrMsgNotFound) {
+    return nil
+}
+return classifyPermission(err)  // surface as permission-denied ValidateLive error
+```
+
+`isPermissionDenied(err, ctxStillLive)` is true when:
+`errors.Is(err, jetstream.ErrJetStreamNotEnabled) ||
+ errors.Is(err, nats.ErrNoResponders) ||
+ errors.Is(err, nats.ErrPermissionViolation)` **and** `ctx.Err() == nil`.
+(The ctx-live guard avoids misclassifying a cancellation as a
+permission failure.)
+
+Sentinel-error mapping:
+
+- `jetstream.ErrMsgNotFound` (`jetstream/stream.go:564-565`) ← key not
+  present. **Success.** Equivalent to `jetstream.ErrKeyNotFound`
+  (`jetstream/kv.go:1004-1014`); we bypass `kv.Get` so the
+  `ErrMsgNotFound` form is what surfaces.
+- `nats.ErrPermissionViolation` (`nats.go:117`) ← rarely seen for JS
+  request/reply (the server normally silently drops the request producing
+  no-responders), but we accept it as a permission signal too.
+- `nats.ErrNoResponders` / `jetstream.ErrJetStreamNotEnabled` after step
+  1 passed → permission-denied surface (see 1.B rationale).
+
+**No `kv.Get` fallback.** `kv.Get` would re-use a cached `AllowDirect`,
+which is exactly what we are trying to avoid; we always probe through
+`stream.GetLastMsgForSubject`.
+
+### 1.E Error classification → exit code mapping
+
+Single table for all `ValidateLive` probes, applied uniformly by the CLI's
+exit-code precedence
+(`docs/plans/provision-sdk-cli/00-implementation-plan.md#exit-code-precedence`):
+
+| Probe surface error                                                                | Exit code | Notes                                                              |
+|------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------|
+| `ErrJetStreamNotEnabled` / `ErrJetStreamNotEnabledForAccount` **during step 1.B**  | 4         | Reachability/JS-account failure                                    |
+| `context.Canceled` / `context.DeadlineExceeded` (any probe)                        | 4         | Cancellation always wins over permission classification            |
+| Permission-denied surface (`ErrNoResponders`, `ErrJetStreamNotEnabled`, `ErrPermissionViolation`) **after step 1.B succeeded** | 3 | Live-validation permission error                                  |
+| `ErrStreamNotFound` (1.C)                                                          | —         | Not an error; bucket is creatable                                  |
+| `ErrMsgNotFound` (1.D, after probe)                                                | —         | Not an error; key is creatable in Phase 3                          |
+| Any other error                                                                    | 1         | Unknown / generic                                                  |
+
+The classifier returns a typed `*ValidateLiveError` (or wraps with a new
+sentinel `ErrLiveValidation` — implementation choice; the CLI keys on the
+exit code, not the error type identity). The error message must include
+the resource Kind and Name for operator diagnostics.
+
+### 1.F Per-resource skipping rules
+
+- `cfg.ControlPlane == nil` → skip every control-plane bucket info probe.
+  Step 1.B still runs.
+- `cfg.PartitionSource == nil` → skip the partition-source bucket info
+  probe **and** the key probe (1.D). Step 1.B still runs.
+- `cfg.DynamicConsumers` empty → skip the dynamic-consumer live checks
+  slot (W4 wires the actual call; W2 only needs the slot).
+
+Step 1.B (`AccountInfo`) is unconditional even when `cfg` declares no
+resources, because an empty Config is still a valid `validate -live`
+invocation and the operator wants reachability confirmed.
+
+---
+
+## 2. `Apply`
+
+### 2.A Pre-flight invocation
+
+```go
+func Apply(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, error) {
+    if err := Validate(cfg); err != nil {
+        return Report{}, err            // static validation error → exit 3
+    }
+    if err := validateLive(ctx, js, cfg); err != nil {
+        return Report{}, err            // live validation error → exit 3 or 4
+    }
+    plan, err := Plan(ctx, js, cfg)     // re-uses W1's plan; deterministic
+    if err != nil {
+        return Report{}, err
+    }
+    return applyPlan(ctx, js, cfg, plan)
+}
+```
+
+Ordering matches the master plan's
+[`Validate` / `ValidateLive` / `Plan` / `Apply` boundary](../../plans/provision-sdk-cli/00-implementation-plan.md#validate--validatelive--plan--apply-boundary)
+and the
+[Exit code precedence](../../plans/provision-sdk-cli/00-implementation-plan.md#exit-code-precedence)
+table (static-validate → 3, JS/auth/cancel → 4, live-validate → 3,
+operation failure → 1, drift → 2).
+
+There is no skip-validation flag in v1.
+
+### 2.B Apply algorithm (pseudocode)
+
+```text
+report := Report{APIVersion: "parti.io/provision/v1", Kind: "Report"}
+
+for i, action := range plan.Actions {
+    if err := ctx.Err(); err != nil {
+        // Mid-mutation cancel (i > 0) or pre-mutation cancel (i == 0).
+        report.Aborted = true
+        for _, rem := range plan.Actions[i:] {
+            report.Skipped = append(report.Skipped, SkippedAction{
+                Kind: rem.Kind, Name: rem.Name, Reason: "context-cancelled",
+            })
+        }
+        return report, err
+    }
+
+    switch action.Kind {
+    case ActionCreateKV:
+        kvCfg := action.Resource.(jetstream.KeyValueConfig)
+        // kvCfg.Metadata is already stamped (provision/plan.go:130-138).
+        _, err := js.CreateKeyValue(ctx, kvCfg)
+        switch {
+        case err == nil:
+            report.Executed = append(report.Executed, ExecutedAction{
+                Kind: action.Kind, Name: action.Name,
+            })
+        case errors.Is(err, jetstream.ErrStreamNameAlreadyInUse) ||
+             errors.Is(err, jetstream.ErrBucketExists):
+            // Race: bucket appeared between Plan and Apply. See 2.E.
+            report.Executed = append(report.Executed, ExecutedAction{
+                Kind: action.Kind, Name: action.Name,
+                // Implementations may add a "raced: pre-existing" note in
+                // the JSON Detail map (additive field; not load-bearing
+                // for v1 callers).
+            })
+        case errors.Is(err, context.Canceled) ||
+             errors.Is(err, context.DeadlineExceeded):
+            report.Aborted = true
+            // current action plus rest go to Skipped/context-cancelled
+            for _, rem := range plan.Actions[i:] {
+                report.Skipped = append(report.Skipped, SkippedAction{
+                    Kind: rem.Kind, Name: rem.Name, Reason: "context-cancelled",
+                })
+            }
+            return report, err
+        default:
+            // Non-cancellation failure: fail-fast (2.C).
+            report.Errors = append(report.Errors, ResourceError{
+                Kind: action.Kind, Name: action.Name, Error: err.Error(),
+            })
+            for _, rem := range plan.Actions[i+1:] {
+                report.Skipped = append(report.Skipped, SkippedAction{
+                    Kind: rem.Kind, Name: rem.Name, Reason: "prior-error",
+                })
+            }
+            return report, fmt.Errorf("provision: apply %s %q: %w",
+                action.Kind, action.Name, err)
+        }
+
+    default:
+        // v1 only emits "create-kv"; defensive guard.
+        return report, fmt.Errorf("provision: apply: unsupported action kind %q", action.Kind)
+    }
+}
+
+// All actions succeeded. Drift list from Plan is carried through unchanged.
+return report, nil
+```
+
+**Why `js.CreateKeyValue`, not `kvutil.EnsureKVBucketWithRetry`:**
+`EnsureKVBucketWithRetry` is get-first (`kvutil/bucket.go:48-54`) — on the
+Plan→Apply race it would silently return the pre-existing bucket
+**without applying the Parti marker**, and the resulting `Executed` entry
+would not distinguish "we created it" from "we opened someone else's
+bucket." Plan already proved the bucket was missing at Plan-time; Apply
+should attempt to create exactly that bucket with the marker stamped in
+one shot, so we use `js.CreateKeyValue(ctx, kvCfg)` directly. The race
+case is handled explicitly (see 2.E).
+
+**Marker stamping:** Plan stamps `kvCfg.Metadata` via `BuildMarker` at
+plan-build time (`provision/plan.go:130-138`); `js.CreateKeyValue` writes
+the marker as part of the create call. No separate update step.
+
+**Drift findings:** `plan.Drift` is **not** echoed into `Report` by Apply
+in v1. Apply's Report is mutation-outcome only; the CLI's `apply` command
+prints `plan.Drift` separately (CLI concern, lands in W5). This matches
+the master plan's "Apply does not mutate based on drift findings in v1"
+clause under [Safety Rules](../../plans/provision-sdk-cli/00-implementation-plan.md#safety-rules).
+
+### 2.C Non-cancellation failure semantics (fail-fast)
+
+Verbatim from the master plan's
+[Apply failure semantics (non-cancellation)](../../plans/provision-sdk-cli/00-implementation-plan.md#apply-failure-semantics-non-cancellation)
+section, restated for the W2 implementer:
+
+- Pre-error completed actions stay in `Report.Executed`.
+- The failed action is appended **once** to `Report.Errors` as a
+  `ResourceError` whose `Kind`/`Name` identify the resource and whose
+  `Error` is the underlying NATS error string (`err.Error()`).
+- All remaining planned actions (everything after the failing index) go
+  to `Report.Skipped` with `Reason = "prior-error"`. The failing action
+  itself does **not** appear in `Skipped`.
+- `Report.Aborted` stays **false**. `Aborted` is reserved for context
+  cancellation only.
+- Apply returns the wrapped error
+  (`fmt.Errorf("provision: apply %s %q: %w", kind, name, err)`) plus the
+  partial Report.
+- CLI exit code → **1** (runtime / generic).
+
+### 2.D Cancellation semantics (restated)
+
+Matches the master plan's
+[Cancellation contract](../../plans/provision-sdk-cli/00-implementation-plan.md#cancellation-contract).
+
+- **Pre-mutation cancel** (`ctx.Err()` observed before any
+  `js.CreateKeyValue` call): returns `(Report{Aborted: true,
+  Skipped: [every planned action with reason "context-cancelled"]},
+  ctx.Err())`. `Executed` and `Errors` are empty. Exit code → **4**.
+- **Mid-mutation cancel** (`ctx.Err()` observed between iterations, or a
+  `js.CreateKeyValue` call returns `context.Canceled`/`DeadlineExceeded`):
+  returns `(partial Report with Aborted=true; Executed lists completed
+  creates; current+remaining actions in Skipped with reason
+  "context-cancelled"; Errors empty)`, error = `ctx.Err()`. Exit
+  code → **4**.
+
+Cancellation is **never** recorded in `Report.Errors`. The `Aborted`
+flag is the discriminator.
+
+### 2.E Race conditions
+
+Between `Plan(ctx, js, cfg)` and the `js.CreateKeyValue` call inside
+`applyPlan`, another caller may create a stream named `KV_<bucket>`. The
+NATS server returns `ErrStreamNameAlreadyInUse` (which wraps as
+`ErrBucketExists` at the KV API layer); see
+`jetstream/errors.go:91, jetstream/kv.go:581`.
+
+**Resolution:** treat the race as a successful outcome of this Apply
+action. The action is appended to `Report.Executed` (not `Report.Errors`).
+Apply does **not** re-read live state to drift-check the now-existing
+bucket; doing so would smear Plan's snapshot semantics across Apply and
+complicate the failure-semantics contract in 2.C. The canonical drift
+report for this run is `plan.Drift` (already computed in 2.A).
+
+Operator-visible effect: re-running `partictl plan` after the race
+surfaces the pre-existing bucket's marker/drift status. If the racing
+creator did not stamp the Parti marker, the next `plan` reports `adopted`
+drift, which is the standard W1 path.
+
+### 2.F No update path in v1
+
+When `plan.Actions` is empty — every named resource already exists and
+matches, or exists with drift — Apply does nothing and returns
+`(Report{APIVersion, Kind, Executed: nil, Skipped: nil, Errors: nil,
+Aborted: false}, nil)`. The CLI exit code is **0** (or **2** if
+`-fail-on-drift` is set and any drift is non-informational). Apply
+itself never produces exit code 2 — that is a CLI concern.
+
+---
+
+## 3. Behavior table
+
+| Scenario                                                | Validate | ValidateLive | Apply mutation | `Report.Aborted` | `Report.Executed`      | `Report.Errors`   | `Report.Skipped`               | Returned error          | CLI exit |
+|---------------------------------------------------------|----------|--------------|----------------|------------------|------------------------|-------------------|--------------------------------|-------------------------|----------|
+| Static-validate fails                                   | fail     | —            | —              | false            | empty                  | empty             | empty                          | `ErrInvalidConfig`-wrapped | 3        |
+| AccountInfo fails (JS down / no `$JS.API.INFO`)         | ok       | fail (1.B)   | —              | false            | empty                  | empty             | empty                          | `ErrJetStreamNotEnabled` | 4        |
+| AccountInfo ok; STREAM.INFO returns ErrNoResponders     | ok       | fail (1.C)   | —              | false            | empty                  | empty             | empty                          | live-validation error    | 3        |
+| Partition-source key probe permission denied (after retry) | ok    | fail (1.D)   | —              | false            | empty                  | empty             | empty                          | live-validation error    | 3        |
+| Partition-source key probe AllowDirect-flip retry succeeds | ok    | ok           | full           | false            | every action           | empty             | empty                          | nil                      | 0        |
+| Live cancel during ValidateLive                         | ok      | fail (cancel)| —              | false (\*)       | empty                  | empty             | empty                          | `ctx.Err()`              | 4        |
+| All planned creates succeed                             | ok      | ok           | full           | false            | every action           | empty             | empty                          | nil                      | 0        |
+| Pre-mutation cancel (ctx already done)                  | ok      | ok           | none           | **true**         | empty                  | empty             | every action / `context-cancelled` | `ctx.Err()`           | 4        |
+| Mid-mutation cancel                                     | ok      | ok           | partial        | **true**         | actions completed before cancel | empty    | current+remaining / `context-cancelled` | `ctx.Err()`         | 4        |
+| Mid-mutation resource error (e.g. server rejection)     | ok      | ok           | partial        | false            | actions completed before failure | failing action × 1 | actions after failure / `prior-error` | wrapped NATS err  | 1        |
+| Plan→Apply race (`ErrBucketExists`)                     | ok      | ok           | full           | false            | every action (raced row marked) | empty    | empty                          | nil                      | 0        |
+| Empty plan (all desired resources exist)                | ok      | ok           | no-op          | false            | empty                  | empty             | empty                          | nil                      | 0 (or 2 with `-fail-on-drift`) |
+
+(\*) Cancellation observed strictly inside `ValidateLive` does not produce
+a populated Report because Apply has not yet reached `applyPlan`.
+`Report{}` is returned (zero value: `Aborted = false`).
+
+---
+
+## 4. Test plan (W2-specific)
+
+The tests below are additive to the master plan's
+[Test Plan](../../plans/provision-sdk-cli/00-implementation-plan.md#test-plan)
+embedded-NATS section. Names are illustrative.
+
+1. **`TestValidateLive_AccountInfoFailure_ExitCode4`** — start the
+   embedded NATS server without JetStream enabled (or with a user that
+   has no `$JS.API.INFO` publish grant); assert ValidateLive returns an
+   error that maps to exit code 4.
+2. **`TestValidateLive_BucketInfoPermissionDenied_ExitCode3`** — create
+   a user with `$JS.API.INFO` but **not** `$JS.API.STREAM.INFO.KV_*`;
+   assert ValidateLive returns a permission-denied error mapping to
+   exit code 3. (Cross-references the master plan's
+   [Permissions](../../plans/provision-sdk-cli/00-implementation-plan.md#permissions)
+   table row for `ValidateLive`.)
+3. **`TestValidateLive_PartitionSourceKey_AllowDirectTrue_KeyMissing_OK`**
+   — create the partition-source bucket with `AllowDirect=true` (nats.go
+   default for `CreateKeyValue`), assert ValidateLive succeeds for the
+   absent key.
+4. **`TestValidateLive_PartitionSourceKey_AllowDirectFalse_KeyMissing_OK`**
+   — create the bucket with `AllowDirect=false` via `js.CreateStream`
+   with an explicit `StreamConfig`; assert ValidateLive succeeds for the
+   absent key.
+5. **`TestValidateLive_PartitionSourceKey_AllowDirectFlip_RetrySucceeds`**
+   — open a bucket with `AllowDirect=true`, race-update it to
+   `AllowDirect=false` between STREAM.INFO and the first probe (use
+   `js.UpdateStream` to flip), assert the second probe succeeds. This
+   exercises the §1.D retry protocol.
+6. **`TestValidateLive_PartitionSourceKey_PermissionDenied_ExitCode3`** —
+   user has bucket read but no `$JS.API.DIRECT.GET.*` and no
+   `$JS.API.STREAM.MSG.GET.*`; assert ValidateLive returns a
+   permission-denied error after the single retry, exit code 3.
+7. **`TestApply_NonCancellationFailure_FailFast`** — pre-create a
+   non-KV stream named `KV_parti-heartbeat` (e.g. via `js.CreateStream`
+   with subjects `KV_parti-heartbeat.*` and `MaxMsgsPerSubject != 1` so
+   the create-KV call's underlying create-stream returns a non-race
+   conflict). Assert: first create-kv succeeds, second fails, the
+   failing action lands in `Errors` with the heartbeat resource, the
+   third (assignment) lands in `Skipped` with reason `prior-error`,
+   `Aborted == false`, and the returned error wraps the NATS error.
+8. **`TestApply_MidMutationCancel`** — install a stream-create hook
+   that cancels `ctx` on the second action; assert first action in
+   `Executed`, remaining in `Skipped` with reason `context-cancelled`,
+   `Aborted == true`, error is `ctx.Err()`.
+9. **`TestApply_PreMutationCancel`** — pass an already-cancelled `ctx`
+   (post-`ValidateLive` — easiest to test by canceling after
+   `validateLive` returns but before `applyPlan` starts; equivalent
+   harness: a fake `js` that succeeds reachability + info but the
+   harness cancels `ctx` before the create loop). Assert
+   `Report{Aborted: true, Skipped: every-action/context-cancelled}`,
+   `Executed/Errors` empty.
+10. **`TestApply_PlanRaceBucketExists_Success`** — between Plan and
+    Apply, create the second bucket out-of-band; assert Apply still
+    returns success with all actions in `Executed`.
+11. **`TestApply_EmptyPlan_NoOp`** — pre-create all desired buckets with
+    matching markers; assert Apply returns `Report{}` (zero value
+    except `APIVersion`/`Kind`) and `nil` error.
+
+Tests 1–6 exercise ValidateLive; 7–11 exercise Apply. All tests use the
+existing embedded-NATS harness.
+
+---
+
+## 5. Open questions
+
+All resolved here; nothing carries forward as open.
+
+- **Q: Does Apply re-read live state per action, or trust Plan's snapshot?**
+  Resolution: **trust Plan**. Apply only inspects live state when
+  `js.CreateKeyValue` returns an error, and only to classify
+  `ErrBucketExists`/`ErrStreamNameAlreadyInUse` as a benign race. Re-doing
+  drift classification inside Apply would smear Plan's snapshot
+  semantics and complicate fail-fast.
+- **Q: How is the Plan→Apply race recorded?**
+  Resolution: **as `Executed` with no error**. The mutation outcome of
+  "the desired bucket exists now" is achieved; the next `plan` reveals
+  drift (including `adopted` drift if the racing creator was not Parti).
+- **Q: Does `ValidateLive` short-circuit on the first missing-bucket
+  case?** Resolution: **no**. `ErrStreamNotFound` is not an error for
+  `ValidateLive`; it merely means "this bucket will be created by
+  apply" and the per-bucket probe loop continues.
+
+---
+
+## Master plan amendments
+
+None. The master plan delegated the retry algorithm (§1.D), the Apply
+race semantics (§2.E), and the create-vs-ensure choice (§2.B) to this
+sub-spec, and this sub-spec resolves all three. Every other behavior is
+restated from existing master-plan sections by header reference.

--- a/docs/plans/provision-sdk-cli/04-w4-dynamic-consumer-spec.md
+++ b/docs/plans/provision-sdk-cli/04-w4-dynamic-consumer-spec.md
@@ -1,0 +1,433 @@
+# W4 — Dynamic-Consumer Alignment Sub-Spec
+
+Companion to [`00-implementation-plan.md`](00-implementation-plan.md). Scope:
+the pure `PlanDynamicConsumers` builder, the live
+`ValidateLiveDynamicConsumers` companion, the extraction seam in
+`internal/durable`, and the v1 equality subset. Public API surface is
+not redesigned here — see the master plan's
+[Dynamic Consumer Planning](00-implementation-plan.md#dynamic-consumer-planning)
+section. This sub-spec only fills in the implementation contract.
+
+## 1. Extraction seam
+
+### Chosen option: (b) — pure-helper sub-package
+
+Create **`internal/dynamicbuild`** (new package). It exports pure
+functions and is imported by both `consumer/` (existing runtime path)
+and `provision/` (new W4 path). The runtime `WorkerConsumer` keeps its
+method receivers but delegates the actual work to the pure helpers.
+
+Rationale:
+
+- The three pieces of logic the master plan calls out
+  (`buildSubjects`/`generateSubject`, `perSubjectDurableName`, and the
+  `ConsumerConfig` literal in `ensurePerSubjectConsumer`) are tightly
+  coupled to `*WorkerConsumer` receiver state
+  (`wc.subjectTemplate`, `wc.partitionPrefix/Suffix`, `wc.config.*`).
+  Pure functions that take their inputs explicitly are cleaner than
+  in-place `*WorkerConsumer` method export and remove the need for
+  `provision` to construct a half-initialized `WorkerConsumer`.
+- `consumer/` and `provision/` both live under the module root, so
+  both may import `internal/dynamicbuild`. This satisfies the
+  master-plan invariant *"No private durable-naming code is duplicated
+  in `provision`. The pure builder is consumed by `provision`; runtime
+  `consumer.Dynamic` continues to call the same shared logic."*
+- `consumer.Dynamic` does **not** change its public shape. Internal
+  callsites in `internal/durable/worker_consumer.go` are rewritten to
+  call `dynamicbuild` helpers; runtime behavior is preserved.
+
+### Exact code to extract
+
+All file:line references are against this worktree's
+`internal/durable/worker_consumer.go` and `subject_utils.go`.
+
+| Source                                                       | Target in `internal/dynamicbuild`                              |
+|--------------------------------------------------------------|-----------------------------------------------------------------|
+| `worker_consumer.go:479-495` (`perSubjectDurableName`)       | `func DurableName(prefix, subject, partitionPrefix, partitionSuffix string) string` |
+| `worker_consumer.go:498-525` (`sanitizeConsumerName`, `isAllowedConsumerRune`) | unexported helpers in the new package                          |
+| `worker_consumer.go:544-593` (`doBuildSubjects`, `generateSubject`) | `func BuildSubjects(subjectTemplate string, partitions []types.Partition) ([]string, error)` and an internal `generateSubject` |
+| `worker_consumer.go:461-473` (the canonical `ConsumerConfig` literal in `ensurePerSubjectConsumer`) | `func ConsumerConfig(durable, subject string, defaults Defaults) jetstream.ConsumerConfig` |
+| `subject_utils.go:18-25` (`parseSubjectTemplateParts`)       | re-exported as `ParseSubjectTemplateParts` (already pure)       |
+
+The runtime literal at `worker_consumer.go:414-426` (inside
+`addSubjectLoop`) is a **second copy** of the same shape, used to
+populate `partitionConsumerOpts.consumerConfig` (metadata for
+recovery). W4 must rewrite that callsite to use the same
+`dynamicbuild.ConsumerConfig` helper so the two literals cannot drift
+from each other in the future. This is a small ancillary refactor —
+no behavior change at the runtime level.
+
+`Defaults` is a thin value type that captures the seven runtime
+tunables the runtime literal currently reads off
+`wc.config.*`:
+
+```go
+type Defaults struct {
+    AckPolicy             jetstream.AckPolicy
+    AckWait               time.Duration
+    MaxDeliver            int
+    InactiveThreshold     time.Duration
+    MaxWaiting            int
+    MaxAckPending         int
+    ConsumerMemoryStorage bool
+    ConsumerReplicas      int
+}
+```
+
+`provision.PlanDynamicConsumers` constructs `Defaults` using the
+runtime-default values listed in §2 below (i.e. what
+`durable.WorkerConsumerConfig.SetDefaults()` would produce after
+`fuda.SetDefaults` runs against an empty struct). Runtime keeps
+passing `wc.config.*` and gets identical behavior.
+
+`PlanDynamicConsumers` **must not** expose `Defaults` as a parameter
+in v1 — the master plan explicitly forbids an option variadic on the
+builder. The runtime defaults are hard-coded inside
+`PlanDynamicConsumers` and asserted by the v1 equality test against
+`durable.WorkerConsumerConfig.SetDefaults()` output. (See
+[§5 Test plan](#5-test-plan-for-w4).)
+
+## 2. Enumerated equality subset
+
+Runtime evidence: the canonical literal at
+`internal/durable/worker_consumer.go:461-473` is the one passed to
+`jsutil.EnsureConsumer`, i.e. the bytes that hit JetStream.
+`DeliverPolicy` is intentionally absent from the literal — the
+runtime relies on the `jetstream.DeliverPolicy` zero value
+`DeliverAllPolicy` (`jetstream/consumer_config.go:411`). Likewise
+`AckPolicy` defaults to `AckExplicitPolicy` (zero value,
+`jetstream/consumer_config.go:493`) when
+`durable.WorkerConsumerConfig.AckPolicy` is unset.
+
+The v1 equality table below enumerates **every field on
+`jetstream.ConsumerConfig` that runtime touches** in the construction
+path of `ensurePerSubjectConsumer`. The implementer must be able to
+write the v1 equality test from this table alone.
+
+### v1 in-scope fields (asserted by the W4 test)
+
+| Field            | Runtime source                              | v1 default value             | Reason in scope                          |
+|------------------|---------------------------------------------|------------------------------|------------------------------------------|
+| `Name`           | `worker_consumer.go:462`                    | `<prefix>_<partitionId>_<hash>` | Identity; deterministic from inputs.   |
+| `Durable`        | `worker_consumer.go:463`                    | `<prefix>_<partitionId>_<hash>` | Identity; deterministic from inputs.   |
+| `FilterSubject`  | `worker_consumer.go:464`                    | derived from `subjectTemplate`+`partition.SubjectKey()` | Identity; deterministic from inputs. |
+| `AckPolicy`      | `worker_consumer.go:465`                    | `jetstream.AckExplicitPolicy` | Semantic constant for Parti dynamic.    |
+| `DeliverPolicy`  | **not in literal** (zero-value `DeliverAllPolicy`) | `jetstream.DeliverAllPolicy` | Semantic constant; load-bearing for WorkQueuePolicy compat. |
+
+The pure builder must hard-code `AckPolicy: jetstream.AckExplicitPolicy`
+and `DeliverPolicy: jetstream.DeliverAllPolicy` in the
+`ConsumerConfig` it returns, **not** rely on Go zero-value coincidence.
+The runtime literal currently relies on zero values for both; the
+builder's explicit assignment is documented and the test is robust to
+any future `iota` reordering in nats.go. (Tightening the runtime
+literal the same way is a follow-up nit, **not** a W4 deliverable.)
+
+### v1 out-of-scope fields (tunables; runtime sets them from options)
+
+The implementer must **not** assert these in the W4 equality test.
+Each is set in the runtime literal at `worker_consumer.go:466-472`
+but its value depends on options the v1 builder does not accept:
+
+| Field                  | Runtime source              | Default after `SetDefaults` | Reason out of scope                                 |
+|------------------------|-----------------------------|-----------------------------|-----------------------------------------------------|
+| `AckWait`              | `worker_consumer.go:466`    | `30s` (`config.go:174`)     | Tunable via `consumer.WithAckWait`.                 |
+| `MaxDeliver`           | `worker_consumer.go:467`    | `-1` (`config.go:178`)      | Tunable via `consumer.WithMaxDeliver`.              |
+| `InactiveThreshold`    | `worker_consumer.go:468`    | `24h` (`config.go:220`)     | Tunable via `consumer.WithInactiveThreshold`.       |
+| `MaxWaiting`           | `worker_consumer.go:469`    | `2` (`config.go:190`)       | Tunable via `consumer.WithMaxWaiting`.              |
+| `MaxAckPending`        | `worker_consumer.go:470`    | `0` (server default)        | Tunable via `consumer.WithMaxAckPending`.           |
+| `MemoryStorage`        | `worker_consumer.go:471`    | `false`                     | Tunable via `consumer.WithConsumerMemoryStorage`.   |
+| `Replicas`             | `worker_consumer.go:472`    | `0` (inherit stream)        | Tunable via `consumer.WithConsumerReplicas`.        |
+
+### `jetstream.ConsumerConfig` fields runtime does NOT touch (also out of scope)
+
+`Description`, `DeliverSubject`, `OptStartSeq`, `OptStartTime`,
+`Heartbeat`, `FlowControl`, `DeliverGroup`, `RateLimit`, `SampleFrequency`,
+`HeadersOnly`, `MaxRequestBatch`, `MaxRequestExpires`, `MaxRequestMaxBytes`,
+`BackOff`, `Metadata`, `FilterSubjects`, `PauseUntil`, `PriorityPolicy`,
+`PriorityGroups`, `PinnedTTL`, `OverflowMinPending`, `OverflowMinAckPending`,
+plus any field added by nats.go after this writing. The runtime literal
+at `worker_consumer.go:461-473` does not set any of them, so the
+builder must not set them either, and the equality test must not
+assert them.
+
+## 3. Public surface (recap, do not redesign)
+
+The master plan locks the W4 public surface:
+
+```go
+type PlannedConsumer struct {
+    StreamName string
+    Subject    string
+    Durable    string
+    Config     jetstream.ConsumerConfig
+}
+
+func PlanDynamicConsumers(
+    streamName, consumerPrefix, subjectTemplate string,
+    partitions []types.Partition,
+) ([]PlannedConsumer, error)
+
+func ValidateLiveDynamicConsumers(
+    ctx context.Context,
+    js jetstream.JetStream,
+    cfgs []DynamicConsumerCfg,
+) error
+```
+
+W4 narrows `provision.PlannedConsumer.Config` from `any`
+(`provision/types.go:169`) to `jetstream.ConsumerConfig`.
+
+### Input validation rules (`PlanDynamicConsumers`)
+
+All wrap a single sentinel `provision.ErrInvalidInput` (already
+present in v1 conventions; reuse the existing static-validation error
+sentinel rather than introducing a new one):
+
+- `streamName == ""` → `fmt.Errorf("%w: streamName is required", ErrInvalidInput)`.
+- `consumerPrefix == ""` → `fmt.Errorf("%w: consumerPrefix is required", ErrInvalidInput)`.
+  Additionally, `consumerPrefix` must contain only the runes allowed
+  by `internal/durable.isAllowedConsumerRune` (a-z, A-Z, 0-9, `-`, `_`);
+  same rule and same wording as `consumer.DynamicConfig.Validate`
+  (`consumer/dynamic.go:382-385`).
+- `subjectTemplate == ""` → `fmt.Errorf("%w: subjectTemplate is required", ErrInvalidInput)`.
+  Additionally, the template must contain the `{{.PartitionID}}`
+  placeholder and must parse + render to a valid subject — delegate
+  to `dynamicbuild.ValidateSubjectTemplate` (a re-export of
+  `internal/durable.validateSubjectTemplate`, `subject_utils.go:63-79`).
+  Wildcards are allowed (matches runtime).
+- `len(partitions) == 0` → `fmt.Errorf("%w: at least one partition is required", ErrInvalidInput)`.
+- Any individual partition with no keys → wrapping the runtime error
+  from `dynamicbuild.BuildSubjects` (currently `errors.New("partition has no keys")`,
+  `worker_consumer.go:576`), unchanged.
+
+Output ordering: deterministic by subject (matches runtime
+`buildSubjects`, `worker_consumer.go:559-567`, which sorts subjects
+via `slices.Sort`). Two partitions that resolve to the same subject
+deduplicate (matches runtime). `PlannedConsumer` entries are emitted
+in subject-sorted order.
+
+### `ValidateLiveDynamicConsumers` semantics
+
+- Returns `nil` on success.
+- For each `DynamicConsumerCfg`, performs the WorkQueuePolicy
+  compatibility check (see §4 below). The recovery-strategy parameter
+  passed to the check is **`RecoveryDisabled`** for v1 — the builder
+  has no option variadic, so the value mirrors what
+  `consumer.Dynamic` would produce with no `WithRecoveryStrategy`
+  option. This is the conservative choice: `RecoveryDisabled` and
+  `RecoverFromBeginning` always pass `checkWorkQueueRecoveryCompat`
+  (`consumer/common.go:187`), so v1 alignment-check will never raise a
+  false positive against a WorkQueuePolicy stream.
+  Phase 5 (precreation) is where a configurable recovery strategy
+  re-enters the picture; v1 documents the default and stops there.
+- Returns the **first** error encountered (fail-fast). The error
+  is wrapped with the cfg's `StreamName` for operator clarity:
+  `fmt.Errorf("dynamic consumer alignment for stream %q: %w", cfg.StreamName, err)`.
+- Best-effort connectivity errors: `checkWorkQueueRecoveryCompat`
+  swallows transient stream-info fetch failures
+  (`consumer/common.go:191-198`); `ValidateLiveDynamicConsumers`
+  inherits that behavior verbatim. Operators get the same forgiving
+  pre-flight semantics as runtime.
+
+## 4. Live coupling — WorkQueuePolicy compatibility
+
+The runtime function is `consumer.checkWorkQueueRecoveryCompat`
+(`consumer/common.go:179-210`), currently unexported and used by all
+three runtime consumers (`static.go:236`, `dynamic.go:311`,
+`queue.go:280`).
+
+**W4 chosen path: export it.** Rename to
+`consumer.CheckWorkQueueRecoveryCompat` (capitalize the leading rune)
+and update the three internal callsites. `provision` imports
+`consumer` and calls the exported function directly — no shim, no
+duplication, no internal indirection.
+
+Rationale:
+
+- Exporting is the minimal-diff path that preserves the master-plan
+  invariant *"byte-equivalent error semantics with `Dynamic.Update`"*
+  trivially: there is exactly one implementation, in exactly one
+  place, and `provision` calls it. The returned error already wraps
+  `consumer.ErrInvalidConfig`; provision propagates it unchanged.
+- The function is well-scoped, documented, and stable. Exporting it
+  costs one Godoc paragraph and changes no behavior at any of the
+  three runtime callsites.
+- The hard constraint *"any change made for W4 must not regress
+  `consumer.Dynamic.Update`"* is satisfied automatically: renaming an
+  unexported identifier to exported does not change semantics, and
+  the three runtime callsites are mechanically updated.
+
+Alternative paths considered and rejected:
+
+- **Move into `internal/dynamicbuild`**: would force `consumer/` to
+  import `internal/dynamicbuild` for what is presently a `consumer/`
+  private helper. Net: more code, no benefit.
+- **Duplicate in `provision/`**: violates the no-duplication
+  invariant. Rejected.
+
+`provision.ValidateLiveDynamicConsumers` returns the
+`consumer.CheckWorkQueueRecoveryCompat` error wrapped with the stream
+name (see §3). Test coverage pins behavioral equivalence (see §5).
+
+## 5. Test plan (for W4)
+
+All test files land under `provision/` for the public-surface tests
+and `internal/dynamicbuild/` for the pure-builder unit tests.
+
+### Pure builder unit tests (`internal/dynamicbuild/*_test.go`)
+
+- **DurableName determinism**: same inputs → same name; subject
+  hashing (xxh3) and length truncation match
+  `worker_consumer.go:486-494` exactly. Golden table covers
+  small-ASCII, unicode (sanitized to `_`), >50-char partition IDs
+  (truncation), and collision-prone names.
+- **BuildSubjects determinism**: shuffle the input partition slice and
+  assert identical sorted, deduplicated output.
+- **BuildSubjects template errors**: missing `{{.PartitionID}}`,
+  malformed template, partition with zero keys all return matching
+  error wraps.
+- **ConsumerConfig literal**: assert each of the 12 fields (5 in §2
+  in-scope + 7 out-of-scope tunables, given via `Defaults`) matches the
+  runtime literal byte-for-byte. This is the seam that prevents
+  silent drift between runtime and the extracted helper.
+
+### Provision roundtrip equivalence test (`provision/plan_dynamic_test.go`)
+
+Critical: this is the load-bearing v1 byte-equivalence assertion.
+
+Build the runtime-default golden by exercising the same code
+runtime exercises:
+
+```go
+runtimeCfg := durable.WorkerConsumerConfig{
+    StreamName:      "orders",
+    ConsumerPrefix:  "ord-worker",
+    SubjectTemplate: "orders.{{.PartitionID}}.>",
+}
+if err := runtimeCfg.SetDefaults(); err != nil { t.Fatal(err) }
+// runtimeCfg now reflects what consumer.Dynamic would carry after
+// its own fuda.SetDefaults pass (consumer/dynamic.go:374-381 calls
+// SetDefaults via Validate).
+expectedConsumerCfg := dynamicbuild.ConsumerConfig(
+    dynamicbuild.DurableName(runtimeCfg.ConsumerPrefix, subject, prefix, suffix),
+    subject,
+    dynamicbuild.Defaults{
+        AckPolicy:             runtimeCfg.AckPolicy,
+        AckWait:               runtimeCfg.AckWait,
+        MaxDeliver:            runtimeCfg.MaxDeliver,
+        InactiveThreshold:     runtimeCfg.InactiveThreshold,
+        MaxWaiting:            runtimeCfg.MaxWaiting,
+        MaxAckPending:         runtimeCfg.MaxAckPending,
+        ConsumerMemoryStorage: runtimeCfg.ConsumerMemoryStorage,
+        ConsumerReplicas:      runtimeCfg.ConsumerReplicas,
+    },
+)
+```
+
+Then call `provision.PlanDynamicConsumers("orders", "ord-worker",
+"orders.{{.PartitionID}}.>", partitions)` and assert, for each
+emitted `PlannedConsumer`:
+
+- `Name`, `Durable`, `FilterSubject`, `AckPolicy`, `DeliverPolicy`
+  match `expectedConsumerCfg` (the §2 in-scope subset).
+- Out-of-scope fields are explicitly **not** asserted (a comment
+  marks them as intentionally skipped).
+
+The test must explicitly call `runtimeCfg.SetDefaults()` before
+reading defaults; comparing against an un-defaulted zero-value
+config is a bug that defeats the purpose of the equivalence
+assertion.
+
+### Live coupling integration tests (embedded NATS, `provision/dynamic_live_integration_test.go`)
+
+- **WorkQueuePolicy rejection (negative)**: create a stream with
+  `Retention: WorkQueuePolicy`. Call
+  `ValidateLiveDynamicConsumers` with a single `DynamicConsumerCfg`
+  pointing at the stream. Build a parallel `consumer.Dynamic` with
+  `WithRecoveryStrategy(RecoverFromNew)` against the same stream and
+  call `Update`. Assert both return errors wrapping
+  `consumer.ErrInvalidConfig` and that the messages match the same
+  template (modulo the outer stream-name wrap on the provision side).
+  Note: the v1 provision builder uses `RecoveryDisabled`, which
+  **passes** the WQ check; the test injects `RecoverFromNew`
+  via a test-only helper or by exercising the lower-level
+  `consumer.CheckWorkQueueRecoveryCompat` directly to prove the
+  shared-implementation contract. The shared-function call is what
+  pins behavioral equivalence; the provision wrapper is a thin
+  forwarder.
+- **WorkQueuePolicy with `RecoveryDisabled` (positive)**: the v1
+  builder's default strategy. Same stream as above. Assert
+  `ValidateLiveDynamicConsumers` returns `nil`.
+- **Non-WorkQueuePolicy stream (positive)**: standard
+  `InterestPolicy` or `LimitsPolicy` stream with subjects matching
+  `subjectTemplate`. Assert `ValidateLiveDynamicConsumers` returns
+  `nil`.
+
+### Input-validation tests (`provision/plan_dynamic_validate_test.go`)
+
+- Empty `streamName`, `consumerPrefix`, `subjectTemplate` each return
+  the wrapped `ErrInvalidInput`.
+- `consumerPrefix` with disallowed characters
+  (e.g. `"foo bar"`, `"foo/bar"`) returns the same error wording as
+  `consumer.DynamicConfig.Validate` (a string-substring assertion is
+  fine).
+- `subjectTemplate` missing `{{.PartitionID}}` returns the wrapped
+  template-validation error.
+- `len(partitions) == 0` returns the wrapped input error.
+- A single partition with zero keys returns the wrapped
+  `partition has no keys` error from the extracted builder.
+
+### Determinism test
+
+Shuffle a 16-partition input and call `PlanDynamicConsumers` against
+each permutation; assert the output `[]PlannedConsumer` slices are
+identical (deep-equal).
+
+## 6. Open questions
+
+Each carries a default proposed resolution; the implementer may adopt
+the default without further design review unless a reviewer objects.
+
+1. **Should `PlanDynamicConsumers` hard-code `AckPolicy` and
+   `DeliverPolicy` rather than relying on Go zero values?**
+   *Default: YES.* The pure builder explicitly assigns
+   `AckPolicy: jetstream.AckExplicitPolicy` and
+   `DeliverPolicy: jetstream.DeliverAllPolicy` in the constructed
+   `ConsumerConfig`. Explicit > coincidental; survives any future
+   `iota` reordering in nats.go. The runtime literal at
+   `worker_consumer.go:461-473` is not modified in W4; that's a
+   separate, optional tightening that does not gate this PR.
+
+2. **What recovery strategy does v1 alignment use against
+   WorkQueuePolicy streams?**
+   *Default: `RecoveryDisabled`.* The W4 builder has no option
+   variadic, so the recovery strategy mirrors what
+   `consumer.Dynamic` would produce with no `WithRecoveryStrategy`
+   option — i.e. the zero value `RecoveryDisabled`
+   (`recovery/strategy.go`: zero value). `RecoveryDisabled` and
+   `RecoverFromBeginning` both pass the WorkQueuePolicy check
+   (`consumer/common.go:186-188`), so v1 alignment-check will never
+   raise a false WorkQueuePolicy error. Phase 5 (precreation) is
+   where a configurable recovery strategy returns; W4 documents the
+   default and stops.
+
+3. **Where do `ErrInvalidInput` and other provision-level error
+   sentinels live?**
+   *Default: reuse the existing `provision/errors.go` (or the file
+   W1/W2 settled on; the implementer reuses whatever sentinel
+   `Validate` already uses for static input rejection). No new
+   sentinel is introduced in W4.*
+
+4. **Should `Defaults` be exported from `internal/dynamicbuild`?**
+   *Default: YES (as `dynamicbuild.Defaults`).* `provision` needs to
+   construct one to call `dynamicbuild.ConsumerConfig`. It is an
+   internal-package export, not a public-API export, so the
+   compatibility surface is internal to the module.
+
+5. **Does W4 modify the secondary `ConsumerConfig` literal at
+   `worker_consumer.go:414-426`?**
+   *Default: YES, rewrite that callsite to use
+   `dynamicbuild.ConsumerConfig` with the same `Defaults`.* This
+   prevents the two literals from drifting silently. Behavior is
+   unchanged at the runtime layer; the only observable effect is one
+   construction call instead of two literal copies.

--- a/docs/plans/worker-state-hardening/00-fix-plan.md
+++ b/docs/plans/worker-state-hardening/00-fix-plan.md
@@ -1,0 +1,172 @@
+# Worker-State Mechanism Hardening — Priority Fix Plan
+
+Derived from `tmp/worker_state_analysis/00-report.md` v3 (Codex-reviewed) and the consolidated review at `tmp/worker_state_analysis/02-consolidated.md`. Sorted by **user impact**, not severity tier — see the audit's §6 for the explanation.
+
+---
+
+## Re-ranked findings
+
+### Tier P1 — Ship before next release
+
+**W12 (S2)** — **Legacy assignment-alias watcher exits permanently on channel close.** No rewatch, no reconcile. Mid-upgrade workers from v2.3.0→v2.x can miss a fresher legacy alias and stay on a stale assignment until restart.
+- **Evidence:** `manager_assignment.go:287-289, 336-340` (watcher exits clean on `!ok`); contrast `monitorCommitChanges` (`manager_assignment.go:407-432`) which rewatches.
+- **Effort:** ~30 LOC + 2 tests. Pattern-mirror of `monitorCommitChanges` is direct.
+- **Why P1:** Only S2 with authority impact. Every other S2 lies about state; W12 can leave a worker holding the wrong partitions.
+- **Spec:** [`01-pr1-spec.md`](./01-pr1-spec.md)
+
+**W1 (S2)** (subsumes prior W5) — **`Manager.State()` lies during real leader-side work.** Two causes:
+- (a) calculator-state subscriber drops on full buffer (`internal/assignment/state_subscriber.go:24-29`) and `monitorCalculatorState` has no fallback reconcile (`manager_assignment.go:164-191`).
+- (b) `monitorPartitions` bypasses the FSM entirely (`calculator.go:648-656, 675-728`), violating the contract that says `Rebalancing` means "active partition rebalance in progress" (`types/state.go:35-36`, `types/calculator_state.go:24-25`).
+
+Single PR must cover BOTH causes — half-fixing leaves half the symptom.
+- **Effort:** ~50 LOC + 2 tests + 1 design call (route partition lifecycle through FSM vs narrow contract).
+- **Why P1:** Operator-pervasive. Dashboards, hooks, readiness probes all read `Manager.State()`.
+
+### Tier P2 — Bundle into PR-3/4/5
+
+**W2 (S3)** — **Heartbeat watcher: no rewatch on close + no active-recovery on silent stall.** Polling preserves convergence at 7.5s default cadence; the gap with the watcher fast-path (~100ms) is 75× wider than v2 originally claimed.
+- **Evidence:** `worker_monitor.go:329-332` (exit on close, no rewatch); `worker_monitor.go:235-247` (polling fallback).
+- **Effort:** Bundle with W13 in PR-3 (~30 LOC + 1 test for the watcher portion).
+
+**W13 (S3)** — **Heartbeat publisher synchronous `Put` blocks past short `HeartbeatTTL`.** 5s Put timeout (`internal/heartbeat/publisher.go:310-314`) can exceed `HeartbeatTTL` under aggressive tuning, causing the worker's own heartbeat to expire while it's healthy.
+- **Effort:** Bundle with W2 in PR-3 (~20 LOC + validation + 2 tests for the publisher portion).
+
+**W3 (S3)** — **Direct rebalances leave `lastWorkers` stale.** `TriggerRebalance` and `triggerPartitionRebalance` update `currentWorkers` but not `lastWorkers`; next poll fires a duplicate `planned_scale` after cooldown.
+- **Evidence:** `calculator.go:399-417` (`TriggerRebalance`), `calculator.go:648-656` (partition lifecycle), `calculator.go:1278-1285` (`rebalance` updates `currentWorkers` only), `calculator.go:1057-1075` (`handleRebalance` is the only path that repairs `lastWorkers`).
+- **Effort:** ~10 LOC (move `setLastWorkersLocked` into `rebalance` success path) + 1 test. Most visible to operators despite S3 severity — likely PR-4 because the fix is so small.
+
+**W10 (S3)** — **Long Stop sequence can let election TTL expire while heartbeat is still in KV.** Real risk only when Stop body exceeds 10s election TTL; defensive reorder is cheap.
+- **Effort:** ~20 LOC + 1 test in PR-5.
+
+### Tier P2 (cont.) — Pre-existing concurrency bugs surfaced during PR-1 v2 review
+
+**W15 (S2)** — **Cross-path stale-store: blocked commit can overwrite fresher alias.** A commit (LR=3, V=10) holds `pendingApplyInFlight` and is blocked inside `handoffCoordinator.Apply`. A fresher alias (LR=4, V=10) arrives, is picked by `selectAuthority`, and applies — `m.assignment` now stores LR=4. The blocked commit resumes and `m.assignment.Store`s LR=3 over the LR=4 snapshot. No post-`Apply` authority recheck (`manager_assignment.go:728-781`).
+- **Evidence:** `manager_assignment.go:540-553, 582-596, 745-781`. Surfaced by Codex during the PR-1 v2 review (`tmp/01-pr1-spec_pr1-impl-spec_v2_review.md` P0 #1).
+- **Effort:** ~30 LOC + 2 tests. Either (a) post-`Apply` pre-`Store` revalidation against `m.CurrentAssignment()`, or (b) extend `pendingApplyInFlight` into a shared apply-interlock covering both commit and alias paths.
+- **Why P2:** correctness-class bug under rolling-upgrade + heavy churn. Same severity tier as W12, but PR-1's W12 fix doesn't widen the race window — both paths already drive concurrent apply attempts today through their independent watcher goroutines.
+
+**W16 (S3)** — **`scheduleApplyRetry` concurrent with new applies.** Failed apply retries run in a separate goroutine (`manager_assignment.go:849-908`) that calls `applyAssignment` directly without participating in any in-flight gate. Stale-retry `Store` can regress the snapshot — same shape as W15, different trigger.
+- **Effort:** Bundle with W15. The fix shape (pre-`Store` revalidation OR shared interlock) closes both at the same site.
+- **Why P2/P3:** less reachable than W15 (requires a transient apply failure first), but should be closed by the same PR as W15.
+
+### Tier P3 — Operational / cosmetic
+
+**W7 (S3)** — **Tight `EmergencyGracePeriod` vs GC pauses.** Config validation only enforces `EmergencyGracePeriod ≤ HeartbeatTTL`; the actual hysteresis budget is the spread between TTL and grace.
+- **Effort:** ~15 LOC validation warning in PR-6.
+
+**W6 (S3)** — **No `pendingWorkerUpdate` flag for workers blocked by grace/cooldown.** Asymmetric with `pendingPartitionUpdate`. Next poll re-detects within 7.5s anyway.
+- **Effort:** Optional; only if PR-3 (W2) is deferred and the latency matters.
+
+**W4 (S3)** — **Resolver reconcile cadence dependency.** Already warned at startup (`manager_setup.go:213-230`). No code change required.
+
+**W9 (S3)** — **Concurrent emergency + partition-lifecycle ordering untested.** Theoretical; add a targeted test in PR-2 or PR-5.
+
+**W8 (S4)** — **Detector resets on every leader handoff.** Metric undercount only; partition coverage preserved. Document or accept.
+
+**W11 (S4)** — **Watchers ignore delete events.** Documentation pass.
+
+**W14 (S4)** — **Cold-start monitor-start gap.** Not a bug; documented for completeness.
+
+### Tier P-open — Verify before scoping
+
+Three scenarios neither the audit nor either reviewer closed. Need a separate investigation pass before they can be promoted to PRs:
+
+- **Capability-bit propagation.** Does any code path advertise `CapAckV1` while the ack-publish wiring is broken? (Reference: `types/heartbeat.go:40-47` capability bit semantics.)
+- **Rolling-upgrade `LeaderRevision` consistency.** Does `m.lastSeenLeaderRevision` initialize correctly across handoff under all bootstrap paths?
+- **Source-revision rollback handling.** Custom `WatchablePartitionSource` implementations emitting a regressed `SourceRevision` — defensive guard or contract-only?
+
+---
+
+## Recommended PR sequence
+
+| PR | Bundle | Effort |
+|---|---|---|
+| **PR-1** | W12 — legacy alias watcher rewatch + reconcile | ~30 LOC + 5 tests |
+| **PR-2** | W15+W16 — cross-path stale-store + apply-retry race (pre-`Store` revalidation OR shared apply-interlock) | ~30 LOC + 3 tests |
+| **PR-3** | W1+W5 — `Manager.State()` reconcile + partition-lifecycle FSM contract | ~50 LOC + 2 tests + design call |
+| **PR-4** | W2+W13 — heartbeat watcher rewatch + publisher backpressure | ~50 LOC + 3 tests |
+| **PR-5** | W3 — `lastWorkers` symmetry across direct rebalance paths | ~10 LOC + 1 test |
+| **PR-6** | W10 — Stop ordering / election release timing | ~20 LOC + 1 test |
+| **PR-7** | W7 — config validation warning + W6 if needed | ~15 LOC + 1 test |
+| Doc | W11, W14, open-verification items | ~50 LOC doc |
+
+Total in-scope correctness effort: **~205 LOC + 15 tests + 2 design calls + doc pass** (PR-2's revalidation-vs-interlock decision and PR-3's FSM-route-vs-narrow-contract decision), excluding the open-verification round.
+
+**Why PR-2 (W15+W16) is sequenced right after PR-1:** they are the second-highest user impact after PR-1 (both S2 authority concerns), and PR-1's narrowing relies on §10 documenting these as deferred — closing them in PR-2 cleans up that deferral promptly.
+
+---
+
+## Model & effort recommendations per PR
+
+The prior `assignment-correctness-fixes` plan didn't bake model recommendations into the spec — they were left to the reviewer skills' defaults. This plan makes them explicit so each phase can be dispatched with the right cost/effort tradeoff.
+
+**Conventions used below:**
+
+- **Planning** = drafting the per-PR implementation spec (e.g., `01-pr1-spec.md`).
+- **Implementation** = writing the actual code changes against the spec.
+- **Plan review** = `/plan-review` (or `/final-plan-review` for the precision pass after architectural review is settled).
+- **Post-impl review** = `/post-impl-review` (spec-compliance + lint/build/test validation).
+- Models: Opus 4.7 (deepest reasoning), Sonnet 4.6 (capable + fast), Haiku 4.5 (mechanical).
+- Codex effort tiers: `xhigh` (correctness-critical first passes), `high` (subsequent rounds / smaller scope).
+
+### Per-PR matrix
+
+| PR | Planning | Implementation | Plan-review (skill / model) | Post-impl-review (skill / model) |
+|---|---|---|---|---|
+| **PR-1 (W12)** — legacy alias watcher | **Opus 4.7** — needs reasoning about mixed-version rolling-upgrade semantics, `LeaderRevision` fences, and idempotent re-application | **Opus 4.7** — same; subtle interleavings with `selectAuthority` | `/plan-review` Codex **xhigh** (high-stakes authority path) | `/post-impl-review` Codex **xhigh** v1; **high** v2+ |
+| **PR-2 (W15+W16)** — cross-path stale-store + apply-retry race | **Opus 4.7** — design call between post-`Apply` revalidation vs shared apply-interlock; both options touch the load-bearing apply path | **Opus 4.7** — invariant-critical; must preserve commit case-(e) coalescing semantics | `/plan-review` Codex **xhigh** | `/post-impl-review` Codex **xhigh** v1; **high** v2+ |
+| **PR-3 (W1+W5)** — `Manager.State()` reconcile + FSM contract | **Opus 4.7** — includes a design call (route partition lifecycle through FSM vs narrow public contract); needs to reason about subscriber semantics, hook-firing order, contract drift across `types/state.go` and `types/calculator_state.go` | **Opus 4.7** — touches the state machine; needs to preserve existing strict-source CAS semantics | `/plan-review` Codex **xhigh** | `/post-impl-review` Codex **xhigh** v1; **high** v2+ |
+| **PR-4 (W2+W13)** — heartbeat watcher rewatch + publisher backpressure | **Sonnet 4.6** — pattern-mirror of `monitorCommitChanges`; little novel design | **Sonnet 4.6** — mechanical translation of the commit-watcher pattern + a non-blocking publish path | `/plan-review` Codex **high** (template is known) | `/post-impl-review` Codex **xhigh** v1 (touches a load-bearing detection path); **high** v2+ |
+| **PR-5 (W3)** — `lastWorkers` symmetry | **Sonnet 4.6** — single-line move; spec is mostly justification | **Sonnet 4.6** (or **Haiku 4.5** if straightforward) — `setLastWorkersLocked` migration into `rebalance` success path | Skip `/plan-review` (too small; LOC is ~10) — go straight to `/final-plan-review` Codex **high** if any uncertainty | `/post-impl-review` Codex **high** v1 |
+| **PR-6 (W10)** — Stop ordering | **Sonnet 4.6** — ordering analysis is bounded; election-TTL math is explicit | **Sonnet 4.6** — `manager.go` Stop reorder + bounded timeout on election release | `/plan-review` Codex **high** | `/post-impl-review` Codex **high** v1 |
+| **PR-7 (W7)** — config validation | **Haiku 4.5** — pure config-validation addition | **Haiku 4.5** — single validation rule + test | Skip | `/post-impl-review` Codex **high** v1 |
+| Doc (W11, W14, open list) | **Haiku 4.5** — doc-only | **Haiku 4.5** | Skip | Skip — manual review only |
+
+### Justification for the model tier breaks
+
+- **Opus 4.7** is reserved for the two PRs (PR-1, PR-2) where the cost of a subtle wrong assumption is high: PR-1 affects authority during rolling upgrades; PR-2 changes the state-machine contract and the hook-firing order. Both have non-trivial design space and benefit from the deepest reasoning model.
+- **Sonnet 4.6** is the default for the mechanical-but-still-careful PRs (PR-3, PR-4, PR-5). The pattern exists (commit watcher) or the change is small enough that the reasoning surface is bounded.
+- **Haiku 4.5** is fine for pure config / doc work where there's no reasoning to do.
+- **Codex `xhigh`** for the first review pass on PR-1, PR-2, PR-3 — they touch correctness-critical paths and the first review catches the most. Subsequent rounds at `high` after the structural issues are closed.
+- **Codex `high`** for the smaller PRs from the start — the surface area doesn't warrant the cost difference.
+
+### Aggregate cost estimate
+
+Assuming each `/plan-review` is ~2-5 min @ `xhigh` (~3 min @ `high`) and each `/post-impl-review` is ~3-8 min:
+
+- PR-1: ~15 min reviewer wall-time (1 plan-review + 2 post-impl rounds).
+- PR-2: ~20 min reviewer wall-time (1 plan-review + 2-3 post-impl rounds — design call may need a re-review).
+- PR-3: ~12 min reviewer wall-time.
+- PR-4: ~5 min reviewer wall-time.
+- PR-5: ~8 min reviewer wall-time.
+- PR-6 + Doc: ~5 min reviewer wall-time combined.
+
+**Total reviewer wall-time: ~65 min** across the plan (not counting human review / iteration).
+
+---
+
+## What NOT to do, and why
+
+| Item | Skip because |
+|---|---|
+| Remove the calculator state-machine subscriber pattern entirely | Hook contracts depend on it; PR-2 fixes it, doesn't replace it. |
+| Persist emergency detector state to KV across leader handoff (W8 fix) | Net loss: persistence + race surface outweighs the metric undercount. Document instead. |
+| Add a `pendingWorkerUpdate` flag (W6 standalone) | Only matters if PR-3 (W2) is deferred; otherwise redundant with the faster watcher recovery. |
+| Optimize partition-source `Watch` contract | Out of scope for `internal/assignment` correctness. Source contract is a separate surface. |
+| Touch the assignment/commit delete-event handling (W11) | "Ignore delete" is intentional for leader-transition tolerance. Document the constraint; don't change the behavior. |
+| Capability-bit propagation, `LeaderRevision` consistency, source-revision rollback | Pre-scope: needs a verification round first (see Tier P-open). |
+
+---
+
+## Summary
+
+- **PR-1 (W12, ~30 LOC + 5 tests):** legacy alias watcher rewatch + reconcile. Mechanical pattern-mirror; only S2 with watcher-level authority impact. Spec ready in `01-pr1-spec.md` (v3).
+- **PR-2 (W15+W16, ~30 LOC + 3 tests):** cross-path stale-store + apply-retry race. Post-`Apply` revalidation OR shared apply-interlock. The other S2 with authority impact, surfaced by Codex during PR-1 review.
+- **PR-3 (W1+W5, ~50 LOC + 2 tests):** `Manager.State()` reconcile + partition-lifecycle FSM contract decision. Pervasive observability fix.
+- **PR-4 (W2+W13, ~50 LOC + 3 tests):** heartbeat watcher rewatch + publisher non-blocking. Reduces detection-latency degradation.
+- **PR-5 (W3, ~10 LOC + 1 test):** `lastWorkers` symmetry. Most visible to operators.
+- **PR-6 (W10, ~20 LOC + 1 test):** Stop ordering / election release timing.
+- **PR-7 (W7, ~15 LOC + 1 test):** config validation warning.
+- **Doc:** W11, W14, open-verification items.
+
+Total: **~205 LOC + 15 tests + 2 design calls** (PR-2's revalidation-vs-interlock + PR-3's FSM-route-vs-narrow-contract), shippable in a focused 6–8 days. Reviewer wall-time budget ~80 min across all PRs.

--- a/docs/plans/worker-state-hardening/00-fix-plan.md
+++ b/docs/plans/worker-state-hardening/00-fix-plan.md
@@ -49,6 +49,11 @@ Single PR must cover BOTH causes — half-fixing leaves half the symptom.
 - **Effort:** Bundle with W15. The fix shape (pre-`Store` revalidation OR shared interlock) closes both at the same site.
 - **Why P2/P3:** less reachable than W15 (requires a transient apply failure first), but should be closed by the same PR as W15.
 
+**W19 (S3)** — **Failed-Apply partial-claim orphans after stale retry drop.** Spawned from PR-2 plan-review v2 P0-A (`tmp/02-pr2-spec_pr2-w15-w16_v2_review.md`). Coordinator's `preparePhase` can create stable claims directly for partitions with no prior owner (`internal/assignment/handoff/twophase.go:251-264`); if a later Apply phase fails and the retry is later stale-dropped (under PR-2's pre-Apply gate), those stable claims are orphaned because sweep skips stable claims (`twophase.go:455-460`). Pre-existing coordinator-level concern, not introduced by PR-2 — but PR-2 makes the stale-drop deterministic where current code would re-Apply.
+- **Effort:** Coordinator-side fix. Either (a) extend sweep to optionally reclaim expired stable claims with stronger TTL semantics, or (b) have the coordinator return a list of created-during-prepare claims so the caller can `releaseClaims` on Apply error.
+- **Why P2/P3:** observable harm only when a partition is permanently removed from the source while the failed Apply's claim was stable. Under normal churn (partitions re-included in future commits), `NextPrepare` handoff resolves orphans naturally.
+- **Documented in:** PR-2 spec §10.5.
+
 ### Tier P3 — Operational / cosmetic
 
 **W7 (S3)** — **Tight `EmergencyGracePeriod` vs GC pauses.** Config validation only enforces `EmergencyGracePeriod ≤ HeartbeatTTL`; the actual hysteresis budget is the spread between TTL and grace.

--- a/docs/plans/worker-state-hardening/01-pr1-spec.md
+++ b/docs/plans/worker-state-hardening/01-pr1-spec.md
@@ -1,0 +1,506 @@
+# PR-1 Implementation Spec — Legacy Alias Watcher Rewatch + Reconcile (W12)
+
+Implements **W12** from [`00-fix-plan.md`](./00-fix-plan.md).
+
+The legacy assignment-alias watcher (`watchAssignment` + `monitorAssignmentChanges` in `manager_assignment.go`) exits permanently when its `Updates()` channel closes. There is no rewatch, no periodic reconcile. v2.x explicitly supports rolling upgrade from v2.3.0 via `assignment.<W>` aliases, and the authority selector chooses between commit and alias by `LeaderRevision` (`manager_select_authority.go:33-66`, `CHANGELOG.md:116-128, 144-151`). A worker mid-upgrade can miss a fresher alias if its watcher closes — silently, until restart.
+
+**Resolution: mirror `monitorCommitChanges`/`watchCommit` exactly.** The pattern is already in the file 60 lines below the broken watcher and is correctness-tested.
+
+**Revision history:**
+- v1 — initial draft against audit v3.
+- v2 — first revision against Codex v1 review (added an in-flight identity gate to address what was thought to be a P0 race).
+- v3 (this revision) — address Codex v2 review `tmp/01-pr1-spec_pr1-impl-spec_v2_review.md`. **Significant scope narrowing.** Codex's v2 review established that v1's P0 was based on a structurally impossible interleaving: the watcher and reconcile arms share a single goroutine (`manager_assignment.go:331-348`, the proposed §3.1 select-loop), so they cannot race for the same alias. v2's `inFlightAlias` gate was defending against an impossible production scenario. v3 drops it entirely. v2's review also surfaced two **pre-existing latent races** (blocked-commit cross-path stale-store; `scheduleApplyRetry` concurrent with new applies) that are unrelated to W12's watcher-recovery scope; v3 documents them in §10 and defers them to future PRs (W15, W16 in `00-fix-plan.md`).
+  - Dropped: §3.4 alias-specific in-flight identity gate. The race it solved doesn't exist in the single-goroutine watcher loop.
+  - Dropped: Test 5.3 (same-alias in-flight dedup) and Test 5.5 (concurrent commit + alias). Test 5.3's "fail-before-pass" step was structurally impossible to reproduce through the production loop. Test 5.5 exposed a pre-existing cross-path race that is W15, not PR-1's concern.
+  - Renumbered: Tests 5.4→5.3, 5.6→5.4, 5.7→5.5.
+  - Added: §10 "Known pre-existing races NOT addressed by PR-1" — documents W15 and W16 with file:line evidence so a future reader sees what this PR deliberately did NOT fix.
+  - LOC estimate restored from v2's ~45 LOC + 7 tests back to ~30 LOC + 5 tests, matching v1.
+  - v2's other changes (kept in v3): rename target verified to `manager_commit_watcher_test.go:232-252` not `export_test.go`; required update to `TestMonitorAssignmentChanges_RetriesAfterWatcherFailure` (`manager_assignment_fixes_test.go:111-179`); Test 5.2 rewritten to use open-but-silent watcher (mirrors `manager_commit_watcher_test.go:232-301`); `errors.Is(err, jetstream.ErrKeyNotFound)` sentinel; bootstrap-race rationale corrected to startup ordering at `manager.go:446-484`.
+
+---
+
+## 1. Anchors (verified 2026-05-19 against HEAD `e166a84`)
+
+| Anchor | File:line | Status |
+|---|---|---|
+| Legacy alias monitor (retry loop) | `manager_assignment.go:284-310` | **rewritten** |
+| Legacy alias watch session | `manager_assignment.go:313-350` | **rewritten** |
+| Legacy alias handler (idempotent) | `manager_assignment.go:352-356` (delete) + downstream | **reused** — already idempotent via `m.handleAssignmentEntry` |
+| Commit watcher retry loop (template) | `manager_assignment.go:402-432` | **reference only — not modified** |
+| Commit watch session (template) | `manager_assignment.go:435-470` | **reference only — not modified** |
+| `commitReconcileInterval` (`var`, 30s default) | `manager_assignment.go:36` | **shared by both watchers** (commit + alias) — see §2 |
+| `watcherBaseBackoff`/`watcherMaxBackoff`/`watcherJitter` constants | `manager_assignment.go:21-23` | **reused** |
+| Authority selector | `manager_select_authority.go:33-66` | reused — confirms alias path is still load-bearing |
+| `recordKVError` (degraded-circuit feed) | `manager_degraded.go` (via `m.recordKVError` symbol) | reused — matches commit watcher's degraded-feed pattern |
+| Alias path stale-leader fence | `manager_assignment.go:363-369` | existing — rejects `LR < lastSeen`; sufficient under single-goroutine watcher loop |
+| Alias path version fence | `manager_assignment.go:371-374` | existing — rejects `oldVersion >= newVersion` against `CurrentAssignment()` |
+| Apply path monotonicity gate | `manager_assignment.go:728-743` | existing — strict `<` version-only check; **see §10 for known limitation under cross-path blocked-apply** |
+| Commit-only in-flight gate | `manager_assignment.go:553-565`; manager struct doc `manager.go:118-123` | reference only — informs §10's W15 description |
+| `scheduleApplyRetry` separate goroutine | `manager_assignment.go:849-908` | reference only — informs §10's W16 description |
+| Commit-watcher silent-stall reconcile test (template for Test 5.2) | `manager_commit_watcher_test.go:232-301` | reused as test shape template |
+| `droppingWatcherKV` test double (open-but-silent watcher) | `manager_commit_watcher_test.go:303-324` (per Codex review) | reused for Test 5.2 |
+| Test override site for the reconcile interval (NOT in `export_test.go`) | `manager_commit_watcher_test.go:232-252` | rename target — see §3.3 |
+| Conflicting existing test (currently asserts close = clean exit) | `manager_assignment_fixes_test.go:111-179` | **must be updated by this PR** — see §3.4 |
+| `kvutil.GetJSON` typed-get used by commit watcher | `kvutil/ops.go:24-31` | reference for typed deletion handling on Get |
+| `jetstream.ErrKeyNotFound` sentinel | nats.go `jetstream/errors.go` | the correct sentinel for a missing single key (NOT `ErrNoKeysFound`) |
+
+Verified against current branch `main` @ `e166a84`. Spec author MUST re-verify line numbers immediately before implementing if HEAD has advanced.
+
+---
+
+## 2. Design — single shared reconcile cadence, separate watch sessions
+
+The commit watcher and the alias watcher need the same reconcile cadence (idempotent KV re-read every 30s). Two options:
+
+**Option A — share `commitReconcileInterval` (recommended).** Rename to `watcherReconcileInterval` (or keep the existing var as the shared value). Both watchers create independent `time.NewTicker` instances from the same period. No new constant. The existing test override at `manager_commit_watcher_test.go:232-252` drives both paths after rename.
+
+**Option B — separate `aliasReconcileInterval` var.** Slightly clearer intent but doubles the test-override surface for no semantic benefit.
+
+**Decision:** Option A. Rename `commitReconcileInterval` → `watcherReconcileInterval` in a single mechanical pass. Update the test override at `manager_commit_watcher_test.go:232-252` to use the new identifier; see §3.3 for the full rename target list.
+
+If the rename triggers risk concerns (downstream test churn), fall back to Option B; the implementation downstream is identical.
+
+---
+
+## 3. Implementation
+
+### 3.1 Rewrite `watchAssignment` (`manager_assignment.go:313-350`)
+
+**Current shape:**
+
+```go
+func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue) error {
+    workerID := m.WorkerID()
+    key := fmt.Sprintf("assignment.%s", workerID)
+
+    watcher, err := kv.Watch(ctx, key)
+    if err != nil {
+        return fmt.Errorf("failed to watch assignments: %w", err)
+    }
+
+    defer func() {
+        if err := watcher.Stop(); err != nil && !natsutil.IsConsumerNotFound(err) {
+            m.logError("failed to stop watcher", "error", err)
+        }
+    }()
+
+    for {
+        select {
+        case <-ctx.Done():
+            m.logger.Debug("assignment monitor stopping (context cancelled)", "worker_id", workerID)
+            return nil
+        case entry, ok := <-watcher.Updates():
+            if !ok {
+                m.logger.Debug("assignment watcher closed", "worker_id", workerID)
+                return nil   // <-- this is the bug surface
+            }
+            if entry == nil {
+                continue
+            }
+            m.handleAssignmentEntry(workerID, entry)
+        }
+    }
+}
+```
+
+**Target shape (mirror of `watchCommit`):**
+
+```go
+// watchAssignment runs one watch session on this worker's assignment key.
+// Channel closure is returned as an error so monitorAssignmentChanges can
+// restart with backoff; context cancellation returns nil for clean exit.
+//
+// A periodic reconcile tick re-reads the alias idempotently to recover from
+// missed watcher events (channel close gaps, NATS reconnects). The reconcile
+// cadence is shared with the commit watcher (see watcherReconcileInterval).
+func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue, reconcileTickC <-chan time.Time) error {
+    workerID := m.WorkerID()
+    key := fmt.Sprintf("assignment.%s", workerID)
+
+    watcher, err := kv.Watch(ctx, key)
+    if err != nil {
+        return fmt.Errorf("failed to watch assignments: %w", err)
+    }
+
+    defer func() {
+        if serr := watcher.Stop(); serr != nil && !natsutil.IsConsumerNotFound(serr) {
+            m.logError("failed to stop assignment watcher", "error", serr)
+        }
+    }()
+
+    for {
+        select {
+        case <-ctx.Done():
+            m.logger.Debug("assignment monitor stopping (context cancelled)", "worker_id", workerID)
+            return nil
+        case entry, ok := <-watcher.Updates():
+            if !ok {
+                return errors.New("assignment watcher channel closed")
+            }
+            if entry == nil {
+                continue
+            }
+            m.handleAssignmentEntry(workerID, entry)
+        case <-reconcileTickC:
+            // Idempotent re-read. Safe because this select loop is
+            // single-goroutine — the reconcile arm cannot run while the
+            // watcher arm is mid-apply, and vice versa. Once an apply
+            // completes, the version fence at handleAssignmentEntry
+            // (manager_assignment.go:371-374) rejects a re-read of the
+            // same alias. See §4.
+            current, err := kv.Get(ctx, key)
+            if err != nil {
+                if errors.Is(err, jetstream.ErrKeyNotFound) {
+                    // Alias was deleted (or never existed). This is
+                    // normal at this point in the lifecycle.
+                    continue
+                }
+                // Transient/connectivity error: do NOT call recordKVError
+                // here. The commit watcher's symmetric reconcile arm
+                // (manager_assignment.go:464-469) also silently skips on
+                // any non-nil Get error; calling recordKVError from a
+                // 30s-ticker would amplify degraded-mode entry under
+                // transient KV stress.
+                continue
+            }
+            m.handleAssignmentEntry(workerID, current)
+        }
+    }
+}
+```
+
+Three changes from current:
+1. New `reconcileTickC <-chan time.Time` parameter.
+2. `return nil` on `!ok` → `return errors.New("assignment watcher channel closed")`.
+3. New `case <-reconcileTickC:` arm that re-Gets the alias. Uses `errors.Is(err, jetstream.ErrKeyNotFound)` for the explicit deletion case; all other errors silently continue (symmetric with commit watcher).
+
+Imports added if not already present: `errors`, `github.com/nats-io/nats.go/jetstream`.
+
+### 3.2 Rewrite `monitorAssignmentChanges` (`manager_assignment.go:284-310`)
+
+**Target shape:**
+
+```go
+func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.KeyValue) {
+    backoff := watcherBaseBackoff
+    reconcileTicker := time.NewTicker(watcherReconcileInterval)
+    defer reconcileTicker.Stop()
+
+    for {
+        err := m.watchAssignment(ctx, kv, reconcileTicker.C)
+        if err == nil || ctx.Err() != nil {
+            return
+        }
+        m.logError("assignment watcher failed, retrying", "error", err, "backoff", backoff)
+        m.recordKVError(err)
+
+        //nolint:gosec // jitter does not require crypto-secure random
+        f := rand.Float64()
+        low := 1 - watcherJitter
+        high := 1 + watcherJitter
+        delay := time.Duration(float64(backoff) * (low + f*(high-low)))
+
+        select {
+        case <-ctx.Done():
+            return
+        case <-time.After(delay):
+        }
+
+        backoff = min(backoff*2, watcherMaxBackoff)
+    }
+}
+```
+
+Two changes from current:
+1. Create the `reconcileTicker` once, outside the retry loop. Pass `reconcileTicker.C` into each `watchAssignment` session. The ticker spans rewatch boundaries — a missed event during a rewatch backoff is still recovered on the next tick.
+2. Add `m.recordKVError(err)` before backoff (matches commit watcher pattern at `manager_assignment.go:294, 417`).
+
+### 3.3 Rename `commitReconcileInterval` → `watcherReconcileInterval`
+
+Single mechanical pass. Codex's review verified the rename target list against current code; the override is **not** in `export_test.go` (which only exposes `CalculatorForTest`):
+
+- `manager_assignment.go:29-36` — declaration (rename + update Godoc to reflect shared usage).
+- `manager_assignment.go:409` — usage in `monitorCommitChanges`.
+- `manager_commit_watcher_test.go:232-252` — actual test-mutable global; the existing test (`TestMonitorCommitChanges_PeriodicReconcile_RecoversDivergence`) saves, overrides, and restores this value. Renamed identifiers must compile or the suite fails.
+
+Verification step before merging the rename: `grep -rn commitReconcileInterval .` returns zero results inside `parti` package code.
+
+Update Godoc:
+
+```go
+// watcherReconcileInterval is the period between idempotent KV re-reads
+// of the commit key and the legacy alias key. Recovers from missed
+// watcher events (channel close gaps, NATS reconnects) without depending
+// on the watcher's resync. Shared by monitorCommitChanges and
+// monitorAssignmentChanges.
+//
+// Declared as a package-level var (not a const) so reconcile-timing
+// tests can override it (see manager_commit_watcher_test.go:232-252).
+// Production callers MUST NOT mutate this value.
+var watcherReconcileInterval = 30 * time.Second
+```
+
+### 3.4 Required updates to existing tests
+
+Two existing tests intersect the changes in this PR and must be updated.
+
+**3.4.1 `TestMonitorAssignmentChanges_RetriesAfterWatcherFailure`** (`manager_assignment_fixes_test.go:111-179`).
+Currently asserts: watcher whose `Updates()` channel is immediately closed → `monitorAssignmentChanges` exits cleanly after the second `Watch` call.
+
+After this PR: channel close returns a non-nil error → `monitorAssignmentChanges` rewatches indefinitely (until ctx cancel). The test's "exits after second close" expectation is wrong under the new behavior.
+
+**Required change.** Rewrite the test to assert:
+- After two consecutive channel closes, `monitorAssignmentChanges` has called `Watch` three times (original + two rewatches) — proves the rewatch path is active.
+- After ctx cancel, the goroutine exits cleanly.
+
+If the existing fixture is structurally incompatible with the new behavior, replace the test rather than amend it. A name like `TestMonitorAssignmentChanges_RewatchesOnChannelClose` is appropriate.
+
+**3.4.2 `TestMonitorCommitChanges_PeriodicReconcile_RecoversDivergence`** (`manager_commit_watcher_test.go:232-301`).
+Currently saves/restores `commitReconcileInterval`. After §3.3's rename, the identifier must be `watcherReconcileInterval`. Mechanical change; no semantic update needed.
+
+---
+
+## 4. Idempotency contract (verified against current code)
+
+This PR's reconcile arm runs in the SAME goroutine as the watcher arm (§3.1's `select` loop). Codex's v2 review verified — and re-verified against `manager_assignment.go:331-348` — that `handleAssignmentEntry` is called synchronously: while one entry is being processed (including blocking inside `handoffCoordinator.Apply`), the next `select` iteration cannot start. **A watcher event and a reconcile tick for the same alias therefore cannot interleave concurrently within the production loop.**
+
+This is the critical correctness property that lets PR-1 stay narrow. The existing gates on the alias path are sufficient under single-goroutine serialization:
+
+| Gate | Site | What it does | Sufficient under single-goroutine loop? |
+|---|---|---|---|
+| Stale-leader fence | `manager_assignment.go:363-369` | `if newLR != 0 && newLR < lastSeen → drop` | Yes — once the first apply succeeds and advances LSR, an identical-LR re-read drops (or, with `LR == lastSeen`, falls to the version fence which now rejects because the snapshot advanced). |
+| Version fence (entry) | `manager_assignment.go:371-374` | `if oldAssignment.Version >= newAssignment.Version → drop` | Yes — after the first apply completes, `m.CurrentAssignment()` reflects the new version; a re-read of the same alias drops here. |
+| Selector | `manager_assignment.go:384-388`, `manager_select_authority.go` | Drops if commit path is fresher | Yes — orthogonal to dedup. |
+
+The reconcile arm's safety story is therefore: **reconcile re-reads an already-applied alias → version fence rejects.** No new gate is needed.
+
+### 4.1 What this PR does NOT solve
+
+Three races exist that the gates above do NOT cover. None of them are introduced by PR-1; all three are pre-existing latent issues. They are documented in **§10** and tracked as W15/W16 in `00-fix-plan.md` for separate future PRs:
+
+- Cross-path stale-store: a blocked commit can overwrite a fresher alias because there's no post-`Apply` authority recheck (`manager_assignment.go:745-781`).
+- `scheduleApplyRetry` runs in a separate goroutine and calls `applyAssignment` directly (`manager_assignment.go:849-908`), so it CAN race with watcher-driven applies.
+- An out-of-band test or future code path that invokes two concurrent `handleAssignmentEntry` calls would also bypass the version fence's snapshot-staleness window.
+
+PR-1 explicitly defers all three. The watcher recovery path delivered by this PR does not make any of them worse: reconcile only adds another single-goroutine source within the same `select` loop.
+
+---
+
+## 5. Tests
+
+Three new tests under `internal/assignment` or `manager_assignment_test.go` (placement matches the existing commit-watcher test surface — see `manager_commit_watcher_test.go`).
+
+### Test 5.1 — Watcher close triggers rewatch with backoff
+
+**Intent:** verify that closing the watcher's `Updates()` channel causes the retry loop to rewatch, instead of exiting permanently.
+
+**Mechanism:** use a test KV double that exposes `CloseWatcher()` to force a channel close. After the close, publish a new alias and assert the worker observes it.
+
+**Acceptance:**
+- After watcher close, `monitorAssignmentChanges` does NOT exit (verifiable by goroutine count or by observing the rewatch attempt via a metric).
+- After backoff completes (test override of `watcherBaseBackoff` to 10ms is acceptable), a freshly-published alias triggers `handleAssignmentEntry`.
+- Goroutine eventually exits cleanly when `ctx.Done()` fires.
+
+### Test 5.2 — Reconcile-only recovery from silent watcher stall (REWRITTEN per Codex P1)
+
+**Intent:** verify that the reconcile arm recovers from a stalled-but-open watcher — the canonical silent-stall case (NATS server restart that doesn't close `Updates()`). v1 of this spec described stopping the watcher, but a closed watcher exercises Test 5.1's rewatch path instead; the silent-stall case requires an open-but-silent watcher.
+
+**Mechanism (mirrors `manager_commit_watcher_test.go:232-301`):**
+- Use a watcher double whose `Updates()` channel is OPEN but never delivers any event (the doubles' published-but-not-watcher-delivered shape).
+- Override `watcherReconcileInterval` to ~50ms via the renamed package-private var.
+- Publish alias A directly to KV (out of band of the watcher).
+- Assert: apply count is 0 before the first reconcile tick (no recovery via watcher).
+- Wait > 50ms.
+- Assert: apply count is 1 (alias A applied via reconcile path).
+- Publish alias B (higher `LeaderRevision`) directly to KV.
+- Wait > 50ms.
+- Assert: apply count is 2 (alias B applied via reconcile path).
+
+**Acceptance:**
+- Apply 0 before first reconcile tick.
+- Apply 1 within `[watcherReconcileInterval, watcherReconcileInterval + tolerance]` after alias A is published.
+- Apply 2 within the same bound after alias B.
+- Goroutine exits cleanly on ctx cancel.
+
+This test specifically proves the reconcile arm is load-bearing for silent-stall recovery, which Test 5.1 does not.
+
+### Test 5.3 (optional) — Reconcile fired between monitor start and first watcher replay
+
+**Intent:** verify that a reconcile tick fired immediately after `monitorAssignmentChanges` starts — but BEFORE the watcher's initial replay completes — does not cause incorrect behavior.
+
+**Why this is the right framing (corrected per v1's Codex P2.2).** The previous spec drafts framed this as "before initial bootstrap" but `applyInitialAssignment` does not route through `handleAssignmentEntry` (it goes through commit handling or `applyAssignmentWithPrev` directly per `manager.go:500-571`). The real protection against pre-bootstrap reconcile is startup ordering: `Manager.Start` runs `waitForAssignment` + `applyInitialAssignment` + transitions to `StateStable` BEFORE calling `monitorAssignmentChanges` (`manager.go:446-484`). So the only window for a "reconcile before first watcher event" is between monitor-start and watcher-replay-end, not before bootstrap.
+
+**Mechanism:** start the manager normally. Override reconcile to ~20ms. After bootstrap completes, observe whether the first reconcile tick can fire before the watcher's initial replay returns its first entry. Assert no panic, no duplicate apply, no state regression.
+
+**Acceptance:** the version fence at `manager_assignment.go:371-374` rejects the redundant entry; assignment count is 1.
+
+This test is optional because the single-goroutine watcher loop + version fence make the scenario benign by construction. Include it as belt-and-braces if the implementer suspects an ordering subtlety.
+
+### Test 5.4 — Alias delete reconcile is a no-op
+
+**Intent:** verify that when the leader deletes `assignment.<W>`, a reconcile tick observing `ErrKeyNotFound` does not change the in-memory assignment or fire hooks.
+
+**Mechanism:** apply alias A normally. Delete the KV key. Wait for a reconcile tick. Assert no change to `m.CurrentAssignment()`, no `OnAssignmentChanged` hook firing, no error logged at higher than Debug level.
+
+**Acceptance:** assignment snapshot unchanged; hook count unchanged.
+
+### Test 5.5 — Graceful shutdown with stalled watcher + active reconcile ticker
+
+**Intent:** verify the reconcile ticker stops cleanly when the manager context is cancelled.
+
+**Mechanism:** start `monitorAssignmentChanges` with the silent-stall watcher double (from Test 5.2). Override reconcile to 10ms so the ticker is firing actively. Cancel the manager context. Assert the goroutine exits within a small deadline (e.g., 500ms).
+
+**Acceptance:** goroutine exits; no goroutine leak detected by the test framework.
+
+---
+
+## 6. Risks and edge cases
+
+### 6.1 Reconcile during legitimate alias deletion (sentinel verified)
+
+`handleAssignmentEntry` at `manager_assignment.go:353-356` ignores delete events. If a leader legitimately deletes an alias and the worker hasn't seen the delete (e.g., during a watcher restart gap), the reconcile arm's `kv.Get` returns `jetstream.ErrKeyNotFound` (Codex verified against nats.go v1.50.0). §3.1's `errors.Is(err, jetstream.ErrKeyNotFound)` branch covers this — the worker keeps its last in-memory assignment until a new commit lands. This matches W11's "delete is not a reassignment primitive" semantics and is consistent with the commit watcher's symmetric handling via `kvutil.GetJSON` (which converts `ErrKeyNotFound` to `(nil, 0, nil)`; `kvutil/ops.go:24-31`).
+
+**Do NOT use `ErrNoKeysFound`** — that sentinel is for empty key listings, not missing single keys (nats.go `jetstream/errors.go:360-361`).
+
+### 6.2 KV.Get failures during reconcile
+
+A non-not-found error from `kv.Get` should NOT trigger watcher rewatch — the watcher itself is still healthy. §3.1's silent `continue` is correct. Do not call `m.recordKVError` here: the commit watcher's symmetric reconcile path (`manager_assignment.go:464-469`) also does NOT feed degraded-mode tracking on Get errors. Calling `recordKVError` from a 30s ticker under transient KV stress would amplify into spurious degraded-mode entry.
+
+### 6.3 Rename collision with downstream callers
+
+`commitReconcileInterval` is package-private (lowercase). Rename is mechanical within the `parti` package. Verify with `grep -rn commitReconcileInterval .` before commit. No public API impact. The test override at `manager_commit_watcher_test.go:232-252` must be renamed in the same commit.
+
+### 6.4 Reconcile during initial bootstrap (rationale corrected per Codex P2.2)
+
+**v1's rationale was wrong.** It claimed the bootstrap path already exercises `handleAssignmentEntry`. It does not: `waitForAssignment` calls `fetchAssignment` and stores the assignment directly (`manager_election.go:305-327`); `applyInitialAssignment` routes through commit handling or `applyAssignmentWithPrev` (`manager.go:500-571`), neither of which goes through `handleAssignmentEntry`.
+
+**The actual protection** is startup ordering: `Manager.Start` waits for `waitForAssignment`, runs `applyInitialAssignment`, transitions to `StateStable`, and only then starts `monitorCommitChanges` and `monitorAssignmentChanges` (`manager.go:446-484`). The reconcile ticker therefore cannot fire until after bootstrap completes.
+
+If a reconcile tick fires BETWEEN monitor-start and the watcher's first replay, it is benign:
+- The watcher and reconcile arms share a single goroutine (`manager_assignment.go:331-348` for the current shape; §3.1 for the new shape), so they cannot interleave concurrently.
+- After the first apply completes, the version fence (line 372) rejects a same-version re-read.
+
+Test 5.3 (formerly 5.4) is optional belt-and-braces for this exact window.
+
+---
+
+## 7. Acceptance criteria
+
+Before this PR can be considered ready to merge:
+
+1. **All new tests pass** under `go test ./... -count=1 -race`:
+   - Test 5.1 (rewatch on close)
+   - Test 5.2 (silent-stall reconcile via open-but-silent watcher)
+   - Test 5.4 (alias delete reconcile is a no-op)
+   - Test 5.5 (graceful shutdown)
+   - Test 5.3 if the implementer chose to include it (optional)
+2. **Existing tests updated:**
+   - `TestMonitorAssignmentChanges_RetriesAfterWatcherFailure` rewritten per §3.4.1.
+   - `TestMonitorCommitChanges_PeriodicReconcile_RecoversDivergence` renamed identifier per §3.4.2.
+3. **Full test suite passes** — no regressions in `manager_commit_watcher_test.go`, `manager_rolling_upgrade_test.go`, or any test matching `*Apply*` or `*StateMachine*`.
+4. `go vet ./...` and the configured linter pass without new warnings.
+5. The rename `commitReconcileInterval` → `watcherReconcileInterval` is complete (verify `grep -rn commitReconcileInterval .` returns zero hits inside `parti`).
+6. PR description explicitly references §10 — calling out the pre-existing races (W15, W16) that this PR does NOT close — so a future reviewer knows the deferral was deliberate.
+7. `/post-impl-review` (Codex `xhigh` for v1) returns a MERGE verdict.
+
+---
+
+## 8. Out of scope (explicitly NOT in this PR)
+
+| Item | Why deferred |
+|---|---|
+| Audit other watchers (source watcher, claim-resolver watcher) for the same close-no-rewatch shape | Both already have reconcile loops (see audit §4.1 watcher comparison table). Heartbeat watcher is the next candidate — that's **PR-3 (W2+W13)**. |
+| Delete-event handling on the alias path (W11) | Doc-only; intentional behavior; ship in the documentation pass. |
+| Change `selectAuthority` semantics | Out of scope. The selector is correct; the bug is upstream of it (watcher dying). |
+| Persist `lastSeenLeaderRevision` across manager restarts | Separate design discussion. Not blocking. |
+
+---
+
+## 9. Implementation order
+
+Suggested sequence to minimize review surface. Each step is independently committable except where noted.
+
+1. **Step 1: Rename.** `commitReconcileInterval` → `watcherReconcileInterval`. Update `manager_assignment.go` + `manager_commit_watcher_test.go`. Run full suite; verify zero hits for the old identifier and tests still pass.
+2. **Step 2: Rewatch on close + update existing test (single commit).** Change `return nil` to `return errors.New(...)` in `watchAssignment`. Simultaneously rewrite `TestMonitorAssignmentChanges_RetriesAfterWatcherFailure` per §3.4.1 to assert rewatch instead of clean exit. Must be in one commit — the test asserts behavior the code change introduces.
+3. **Step 3: Add Test 5.1.** Watcher close triggers rewatch. Should pass against Step 2's code.
+4. **Step 4: Add the reconcile arm.** Wire `reconcileTickC` through `monitorAssignmentChanges` → `watchAssignment`. Add the `case <-reconcileTickC:` handler with `errors.Is(err, jetstream.ErrKeyNotFound)` short-circuit. Verify nothing breaks.
+5. **Step 5: Add Tests 5.2, 5.4, 5.5.** Silent-stall reconcile recovery, delete no-op, graceful shutdown. Optionally add Test 5.3.
+6. **Step 6: Full suite under `-race`.** Fix any newly surfaced flakes.
+7. **Step 7: Dispatch `/post-impl-review`** against this spec.
+
+If `/post-impl-review` flags an issue, the spec is small enough to amend recent commits.
+
+---
+
+## 10. Known pre-existing races NOT addressed by PR-1
+
+This PR deliberately defers three concurrency concerns. They are documented here so a future reader sees what was considered and intentionally left out of scope. Each is tracked as a separate item in `docs/plans/worker-state-hardening/00-fix-plan.md` for a follow-up PR.
+
+### 10.1 W15 (S2) — Cross-path stale-store: blocked commit overwrites fresher alias
+
+**The race.** A blocked commit (LR=3, V=10) holds the case-(e) `pendingApplyInFlight` flag and is suspended inside `handoffCoordinator.Apply` (`manager_assignment.go:540-553, 582-596, 745`). While blocked, the alias path observes a fresher alias (LR=4, V=10), `selectAuthority` picks the alias, and the alias apply runs to completion — `m.assignment.Store` records LR=4 (`manager_assignment.go:763-781`).
+
+The blocked commit then resumes. Between `handoffCoordinator.Apply` returning and `m.assignment.Store`, there is **no second authority check**. The pre-`Apply` monotonicity gate at `manager_assignment.go:728-743` only rejects `newAssignment.Version < curAssignment.Version` — it does not catch equal `Version` with lower `LeaderRevision`, and it ran against a stale snapshot before the alias-apply happened. So the LR=3 commit can overwrite the LR=4 alias's stored snapshot.
+
+**Why deferred.** This is a **pre-existing latent bug** in the apply path; it exists today without PR-1's changes. PR-1's watcher recovery adds another path through which a fresher alias can be observed (the reconcile arm), but does NOT widen the race window: the cross-path race already exists via concurrent commit-watcher + alias-watcher goroutines.
+
+**Suggested fix shape (for a future PR).** Either (i) post-`Apply` pre-`Store` revalidation that compares the candidate's `(Version, LR)` against `m.CurrentAssignment()` and aborts on regression, or (ii) extend `pendingApplyInFlight` into a shared apply-interlock that coalesces commit and alias applies through a single critical section.
+
+### 10.2 W16 (S3) — `scheduleApplyRetry` concurrent with new applies
+
+**The race.** Failed apply retries run in a separate goroutine via `scheduleApplyRetry` (`manager_assignment.go:849-908`), which calls `applyAssignment` directly and does NOT participate in any of the existing in-flight gates. If a retry of a stale Assignment is in progress while a fresher commit or alias arrives, the retry's stale `Store` can regress the snapshot — same shape as W15 but with a different trigger.
+
+**Why deferred.** Same as W15: pre-existing latent bug, not introduced by PR-1. The retry path was added for resilience under transient apply failures; coordinating it with the main apply path is a separate design question.
+
+**Suggested fix shape.** Whatever mechanism closes W15 should also cover the retry path (e.g., a unified pre-`Store` revalidation applied at every site that calls `m.assignment.Store`).
+
+### 10.3 Contract for any future caller of `handleAssignmentEntry`
+
+**Hard contract.** Any future production code path that calls `handleAssignmentEntry` — or otherwise applies legacy-alias payloads outside the single `watchAssignment` loop introduced by this PR — MUST either:
+
+1. **Serialize with the watcher loop** (e.g., funnel the alias through the same goroutine via a channel), OR
+2. **Add post-`Apply` pre-`Store` revalidation** at every site that calls `m.assignment.Store`, OR
+3. **Add the v2 `inFlightAlias` identity gate** (dropped from PR-1, documented in §12 scope-changes) which is correct defensive code for any out-of-loop alias source.
+
+**Why this is load-bearing.** §4's idempotency contract relies on the fact that the watcher arm and reconcile arm share one goroutine. Adding a second alias-source goroutine — admin RPC that hot-reloads a worker's alias, test injection, a new lifecycle hook, anything — breaks that invariant. The version fence at `manager_assignment.go:371-374` reads `CurrentAssignment()` (the last-APPLIED snapshot), so under concurrent applies it has a snapshot-staleness window that lets duplicates pass.
+
+A future PR that adds such a source without satisfying one of options 1–3 above will reintroduce v2's same-alias in-flight race AND make the W15 cross-path race more reachable. Treat this as a binding precondition for any PR that adds an alias-source code path.
+
+**Test-injection note.** Unit tests that invoke `handleAssignmentEntry` directly (e.g., to exercise the alias handler in isolation) can violate this contract without production impact, but should still document the violation and use the v2 `inFlightAlias` gate or per-test serialization if they want to mimic production safety.
+
+---
+
+## 11. Model & effort recommendations (from `00-fix-plan.md` §"Per-PR matrix")
+
+| Phase | Tool | Model / effort |
+|---|---|---|
+| Planning (this spec) | Claude Code | **Opus 4.7** — done |
+| Implementation | Claude Code | **Opus 4.7** — rolling-upgrade authority path; need to preserve dual-read selector semantics and the single-goroutine invariant §4 relies on |
+| Plan review (pre-impl) | `/plan-review` | Codex **xhigh** (done — v1, v2, v3 reviewed; current spec is post-v3-narrowing) |
+| Post-impl review (v1) | `/post-impl-review` | Codex **xhigh** |
+| Post-impl review (v2+) | `/post-impl-review` | Codex **high** |
+
+Rationale: PR-1 touches the rolling-upgrade authority path. The implementation surface is small (~30 LOC + 5 tests, pattern-mirror of `monitorCommitChanges`) but the cost of a subtle wrong assumption (incorrect rewatch backoff, breaking the reconcile ticker's idempotency contract, misclassifying `ErrKeyNotFound`) is high because it affects mixed-version cluster authority. Opus 4.7 for implementation; xhigh effort on the first post-impl review pass.
+
+Estimated reviewer wall-time so far: ~25 min across three `/plan-review` rounds (v1 surfaced a P0 that turned out to be structurally impossible; v2 added an in-flight gate; v3 narrowed back and deferred two pre-existing races to PR-2 / W15+W16). Post-impl reviewer wall-time budget: ~10–15 min across 1–2 rounds.
+
+---
+
+## 12. Scope changes across versions
+
+| Item | v1 | v2 | v3 (current) |
+|---|---|---|---|
+| Idempotency design | "Three gates already exist; verify them" | §3.4 added an in-flight identity gate | **Gate dropped.** v3 rationale: the race the gate addressed is structurally impossible in the single-goroutine watcher loop (Codex v2 P1). §4 now relies on existing version fence + single-goroutine serialization. |
+| In-flight identity gate | n/a | New code (~15 LOC) | **Removed.** Documented at §10.3 as the right fix shape IF a future PR introduces an out-of-loop concurrent alias source. |
+| Test 5.3 | "Three identical entries" | Strengthened blocked-apply barrier with mandatory fail-before-pass | **Dropped.** Fail-before-pass was structurally impossible to reproduce through the production loop (Codex v2 P1). |
+| Test 5.5 | n/a | Concurrent commit + alias `LeaderRevision` ordering | **Dropped.** The race it exposed is W15 (pre-existing cross-path stale-store), not a PR-1 concern. Moved to §10.1. |
+| Test renumbering | n/a | Tests 5.1–5.7 | **5.1, 5.2, 5.3 (was 5.4), 5.4 (was 5.6), 5.5 (was 5.7).** |
+| Test 5.2 design | "Stop the watcher" (closes channel) | Open-but-silent watcher (mirrors `manager_commit_watcher_test.go:232-301`) | Kept from v2. |
+| Existing-test conflict | Not flagged | §3.5.1 rewrite required | **Kept (§3.4.1).** |
+| Rename target | "`export_test.go`" (wrong) | `manager_commit_watcher_test.go:232-252` | Kept from v2. |
+| Error sentinel | "not found" generic | `errors.Is(err, jetstream.ErrKeyNotFound)` | Kept from v2. |
+| Bootstrap-race rationale | "bootstrap exercises `handleAssignmentEntry`" (wrong) | Startup ordering at `manager.go:446-484` | Kept from v2. |
+| Cross-path race | Not flagged | Surfaced via Test 5.5 but not addressed in code | **Documented in §10.1 as W15.** Deferred to a separate PR. |
+| Apply-retry race | Not flagged | Mentioned in Codex v2 review | **Documented in §10.2 as W16.** Deferred. |
+| LOC estimate | ~30 LOC + 2 tests | ~45 LOC + 7 tests | **~30 LOC + 5 tests** (matches v1's original scope). |
+

--- a/docs/plans/worker-state-hardening/02-pr2-spec.md
+++ b/docs/plans/worker-state-hardening/02-pr2-spec.md
@@ -1,0 +1,816 @@
+# PR-2 Implementation Spec — Pre-Apply Serialized (V, LR) Gate (W15+W16)
+
+Implements **W15** and **W16** from [`00-fix-plan.md`](./00-fix-plan.md). Closes the two pre-existing latent races documented in PR-1's spec §10.
+
+The current apply pipeline has a structural hole: between the pre-Apply monotonicity gate (`manager_assignment.go:777`) and `m.assignment.Store` (`manager_assignment.go:817`), there is **no synchronization across apply paths**. Three independent goroutines call `applyAssignment` today — commit watcher (`manager_assignment.go:618`), alias watcher (`manager_assignment.go:434`), and `scheduleApplyRetry`'s background goroutine (`manager_assignment.go:928`) — and `twoPhaseCoordinator.Apply` has no top-level serialization (`internal/assignment/handoff/twophase.go:21-27, 57-113`). So a stale Apply can run prepare → apply → commit → stabilize concurrently with a fresher Apply, then overwrite the fresher snapshot. The pre-Apply gate at line 777 sees a stale snapshot (the winner hasn't stored yet) and lets the loser through; the loser then stores after the winner.
+
+**Resolution: serialize the entire `(stale-check, Apply, Store)` sequence under a single mutex `applyStoreMu`, with a strict `(Version, LeaderRevision)` lex-ordered stale check at the head of the critical section.** Pre-Apply serialization (not post-Apply revalidation) avoids running the loser's Apply at all — closing the orphaned-stable-claim concern that pure post-Apply revalidation would otherwise leave open. The same helper is shared with `refreshAssignmentFromNATS`, closing the cross-path Store race surfaced by plan-review v1.
+
+**Revision history:**
+- v1 — initial draft proposing post-Apply revalidation. Plan-review (Copilot `gpt-5.5 xhigh`) returned 3 P0 / 3 P1: (P0-1) read-then-write gate non-atomic; (P0-2) sweep does not reclaim stable claims so loser Apply leaks orphan claims; (P0-3) V=0 carve-out admits regression. See `tmp/02-pr2-spec_pr2-w15-w16_review.md`.
+- v2 — switched design to pre-Apply mutex serialization, tightened V=0 carve-out, brought `refreshAssignmentFromNATS` under `monotonicStore`. Plan-review v2 returned 2 P0 / 1 P1 / 2 P2: (P0-A) failed-Apply partial-claim orphan when retry is later stale-dropped; (P0-B) heartbeat Ack outside `applyStoreMu` can regress same-V/lower-LR because the publisher's monotonicity is V-only. See `tmp/02-pr2-spec_pr2-w15-w16_v2_review.md`.
+- v3 (this revision) — addresses v2 P0/P1/P2:
+  - P0-A (failed-Apply partial-claim orphan): documented in §10 as a **pre-existing coordinator-level limitation** PR-2 does not introduce and does not close. Includes empirical reachability analysis and scope-out rationale.
+  - P0-B (Ack regression outside lock): **fixed**. `SetAppliedAssignment` is moved INSIDE `applyStoreMu` so the heartbeat publisher cannot observe out-of-order `(V, LR)` snapshots. `PublishNow` stays OUTSIDE the lock (network IO is bounded by the publisher's internal queue, not by lock-holder progress).
+  - P1-A (monotonicStore contract): **fixed**. Godoc says refresh-only; the "Used by" list no longer contains `applyAssignmentWithPrev`.
+  - P2-A (test-seam Stores): §6.1's table is explicitly titled "production `m.assignment.Store` sites" and a sub-note lists known test-only direct Stores.
+  - P2-B (metric name): renamed (v2) `RecordPostApplyStaleStoreDropped` → (v3) `RecordStaleSnapshotStoreDropped`. Godoc says it counts "candidates dropped by the pre-Apply / refresh stale-snapshot gate" with no implication that Apply ran.
+
+---
+
+## 1. Anchors (verified 2026-05-19 against HEAD `34d82c2` — PR-1 merged)
+
+| Anchor | File:line | Status |
+|---|---|---|
+| `applyAssignmentWithPrev` — single apply pipeline | `manager_assignment.go:764-851` | **modified** — serialized under `applyStoreMu`; gate at head of critical section |
+| Pre-Apply monotonicity gate (V-only, V=0 carve-out) | `manager_assignment.go:777-779` | **replaced** — old V-only gate becomes part of the new `(V, LR)` lex gate inside the critical section |
+| `handoffCoordinator.Apply` call site | `manager_assignment.go:783` | reference only |
+| `m.assignment.Store(newAssignment)` | `manager_assignment.go:817` | **inside** the new critical section |
+| `m.assignment.Store(curAssignment)` in `refreshAssignmentFromNATS` | `manager_assignment.go:970` | **modified** — routes through `monotonicStore` (gate + LSR-advance + Store), so it cannot regress mid-Apply |
+| `refreshAssignmentFromNATS` caller (degraded recovery) | `manager_degraded.go:228-244` | reference only — gains correctness automatically from §3.4 below |
+| Alias-path applyAssignment caller | `manager_assignment.go:434` | reference — one of three runtime race participants |
+| Commit-path applyAssignment caller (case c/d) | `manager_assignment.go:618` | reference — one of three runtime race participants |
+| `scheduleApplyRetry` goroutine | `manager_assignment.go:892-944` | reference — third runtime race participant |
+| `pendingApplyInFlight` (commit-only case-(e) coalescer) | `manager_assignment.go:590, 608, 629` | **left alone** — case-(e) coalescing remains intact; `applyStoreMu` is a separate lower-level primitive |
+| `stashedApplyRetry` (retry-only stash) | `manager_assignment.go:894-902, 924` | **left alone** |
+| Other `m.assignment.Store` sites (PRE-RUNTIME) | `manager.go:297` (`NewManager` init), `manager.go:551` (cold-bootstrap empty), `manager_election.go:320` (`waitForAssignment`) | **left alone** — all three execute before `monitorCommitChanges` / `monitorAssignmentChanges` start (see §6.1 lifecycle table) |
+| `RecordStaleLeaderRejected` (sibling metric pattern) | `types/metrics_collector.go:95-99`, `internal/metrics/nop.go:203-205`, recording fixture `manager_commit_state_machine_test.go:46` | template for the new `RecordStaleSnapshotStoreDropped` metric |
+| `recordingHandoff.blockFirstApply` fixture | `manager_commit_state_machine_test.go:57-100` | **extended** — add a version-keyed barrier; see §5 |
+| `recordingMetrics` fixture | `manager_commit_state_machine_test.go:26-55` | **extended** — add the new counter |
+| Authority selector (alias vs commit) | `manager_select_authority.go:33-66` | reference only — orthogonal to PR-2 |
+| `twoPhaseCoordinator.Apply` is NOT internally serialized | `internal/assignment/handoff/twophase.go:21-27, 57-113` | reference — motivates pre-Apply (not post-Apply) serialization |
+
+**Pre-existing tmp/ artifacts unrelated to this PR:** `tmp/02-pr2-spec_pr2-impl-spec_v1_review.md` and `tmp/02-pr2-spec_pr2-impl-spec_v2_review.md` review the `assignment-correctness-fixes` plan's PR-2 spec, not this `worker-state-hardening` PR-2. Ignore them for revision context. PR-2's v1 plan-review is at `tmp/02-pr2-spec_pr2-w15-w16_review.md`.
+
+Verified against current branch `main` @ `34d82c2` (PR-1 already merged). Spec author MUST re-verify line numbers immediately before implementing if HEAD has advanced.
+
+---
+
+## 2. Design — pre-Apply mutex serialization with `(V, LR)` lex gate
+
+### 2.1 The bug at a glance
+
+Three goroutines can be inside `applyAssignmentWithPrev` simultaneously, each holding their own local copy of `newAssignment`:
+
+| Path | Goroutine | Trigger |
+|---|---|---|
+| Commit watcher | `monitorCommitChanges` → `watchCommit` | new `assignment._commit` value (or PR-1 reconcile tick) |
+| Alias watcher | `monitorAssignmentChanges` → `watchAssignment` | new `assignment.<W>` value (or PR-1 reconcile tick) |
+| Apply retry | `scheduleApplyRetry`'s spawned goroutine | retry of a previously-failed apply, scheduled with exponential backoff |
+
+The current race window inside `applyAssignmentWithPrev` is:
+
+```
+T0: candidate reads m.CurrentAssignment() at line 766 (curAssignment)
+T1: pre-Apply gate at line 777 — V-only check vs curAssignment
+T2: candidate calls handoffCoordinator.Apply (LONG: prepare → apply → commit → stabilize)
+T3: candidate stores m.assignment.Store(newAssignment) at line 817
+```
+
+`[T1, T3]` is currently unprotected. The pre-Apply gate's `Version != 0 && Version < cur.Version` check misses (i) same-V-higher-LR cross-leader races (W15) and (ii) any "raced ahead during my Apply" scenario, because `cur.Version` was read BEFORE the winner's Store.
+
+### 2.2 The minimal fix: pre-Apply serialization
+
+Hold a single mutex `applyStoreMu` across the entire `(stale-check, Apply, Store)` sequence. The critical section's head re-reads `m.CurrentAssignment()` and compares the candidate's `(Version, LeaderRevision)` against the live snapshot. If stale, the function returns BEFORE calling Apply — so no coordinator-side prepare/commit/stabilize runs for the loser.
+
+**Why pre-Apply, not post-Apply.** Plan-review v1's P0-2 surfaced that `twoPhaseCoordinator.preparePhase` can create a fresh stable claim immediately (`internal/assignment/handoff/twophase.go:249-264`), and `commitPhase` + `stabilizePhase` finalize stable ownership (`twophase.go:344-370, 396-418`). The sweep loop explicitly skips stable claims (`twophase.go:455-460`). Therefore a loser whose Apply ran to completion can leave orphaned stable claims for partitions not in the winner's snapshot. Sweep does not reclaim them. The only safe fix is to **not run loser Apply at all** — which requires serialization BEFORE Apply, not after.
+
+**Mutex, not CAS.** Plan-review v1's P0-1 suggested CAS as an alternative atomicity primitive, but `m.assignment` stores `Assignment` (a struct containing `[]Partition`) via `atomic.Value`. `atomic.Value.CompareAndSwap` requires comparable types; `Assignment` is not comparable (slice fields). A `sync.Mutex` is the smallest correct primitive. (Switching to `atomic.Pointer[Assignment]` would enable pointer CAS but is a wider refactor with no correctness benefit over the mutex.)
+
+### 2.3 Alternative considered: shared apply-interlock via `pendingApplyInFlight`
+
+A natural alternative is to repurpose `pendingApplyInFlight` (currently commit-only) as a cross-path interlock. This was Option (ii) in v1's §2.3.
+
+**Rejected**, because:
+
+1. **Different scope.** `pendingApplyInFlight` is the load-bearing primitive for commit-from-commit case-(e) coalescing (stash the higher-Version target, drain on flag release). Reusing it for cross-path serialization would entangle two different concerns. The new `applyStoreMu` is purely a serialization primitive with no coalescing semantics, leaving case-(e) intact at the commit-handler layer (`manager_assignment.go:589-601, 629-633`).
+2. **Alias-side stash design surface.** Repurposing the flag would force adding an alias-side stash or relying entirely on PR-1's reconcile arm to recover dropped aliases. The mutex approach simply blocks the alias path until the winner returns, then runs the alias check + Apply normally.
+3. **Wider blast radius.** `pendingApplyInFlight`'s acquire/release boundaries are carefully tuned (lines 590, 608, 629) and have specific ordering requirements with `stashedCommit` drain. Moving them would risk an unintended semantic shift.
+
+### 2.4 The stale check — strict `(V, LR)` lex order with safe V=0
+
+```go
+// isApplyResultStale returns true iff the candidate is older than the
+// live snapshot in (Version, LeaderRevision) lex order. Used at the head
+// of the applyStoreMu critical section to drop loser candidates BEFORE
+// any coordinator-side side effect.
+//
+// V=0 semantics (W15+W16 fix, plan-review v1 P0-3):
+//   - candidate.V=0 over cur.V=0: not stale. Permits the cold-bootstrap
+//     path's idempotent re-apply over the just-initialized Assignment{}
+//     snapshot (manager.go:297 → applyInitialAssignment).
+//   - candidate.V=0 over cur.V>0: STALE. A V=0 retry/legacy candidate
+//     would otherwise regress a real snapshot. The pre-existing pre-Apply
+//     gate at line 777 admits this incorrectly; PR-2's helper does not.
+//
+// Same V same LR: not stale (idempotent reapply path).
+// Same V lower LR: STALE (the W15 cross-leader case).
+// Lower V: STALE (the W16 stale-retry case).
+func isApplyResultStale(candidate, cur Assignment) bool {
+    if candidate.Version == 0 {
+        // V=0 only OK over V=0 snapshot.
+        return cur.Version != 0
+    }
+    if candidate.Version != cur.Version {
+        return candidate.Version < cur.Version
+    }
+    return candidate.LeaderRevision < cur.LeaderRevision
+}
+```
+
+**Compatibility with the existing pre-Apply gate at line 777.** The old gate's `newAssignment.Version != 0 && newAssignment.Version < curAssignment.Version` is strictly more permissive than `isApplyResultStale`:
+
+| Scenario | Old gate (line 777) | New `isApplyResultStale` |
+|---|---|---|
+| candidate.V=10, cur.V=5 | proceed | proceed |
+| candidate.V=5, cur.V=10 | drop | drop |
+| candidate.V=0, cur.V=0 | proceed | proceed |
+| candidate.V=0, cur.V=10 | **proceed** (current bug) | **drop** (fix) |
+| candidate.V=10, cur.V=10 | proceed | proceed (idempotent) |
+| candidate.V=10/LR=3, cur.V=10/LR=5 | **proceed** (W15 bug) | **drop** (fix) |
+| candidate.V=10/LR=5, cur.V=10/LR=3 | proceed | proceed |
+
+The old gate is REPLACED by the new helper inside the critical section. PR-2 does not need to keep the old line-777 gate as a fast-path — the new helper runs inside `applyStoreMu` and is just an `atomic.Value.Load` + tuple comparison, ~20ns. Saving the cost of a contended Apply is the dominant gain; saving the ~20ns of the check itself is noise.
+
+---
+
+## 3. Implementation
+
+### 3.1 Add the `applyStoreMu` mutex to `Manager`
+
+**Location:** `manager.go` near the existing `mu` field. Brief Godoc:
+
+```go
+// applyStoreMu serializes the (stale-check, handoff Apply, snapshot Store,
+// LSR advance) critical section across all callers — commit watcher
+// (handleCommitValue → applyAssignment), alias watcher (handleAssignmentEntry
+// → applyAssignment), the scheduleApplyRetry goroutine, and the operator
+// recovery refresh path (refreshAssignmentFromNATS → monotonicStore).
+//
+// Without serialization, three independent goroutines can each pass the
+// pre-Apply gate against a stale snapshot, run handoffCoordinator.Apply
+// concurrently, and Store in arbitrary order — losing the W15 cross-leader
+// race and the W16 apply-retry race. See PR-2 spec docs/plans/worker-state-
+// hardening/02-pr2-spec.md.
+//
+// Lock contract: applyStoreMu MUST NOT be acquired while holding m.mu.
+// All Manager methods that take m.mu run quickly and do not call into the
+// apply pipeline, so there is no acquisition-order hazard today; this rule
+// is documented to keep it that way.
+applyStoreMu sync.Mutex
+```
+
+### 3.2 Refactor `applyAssignmentWithPrev`
+
+**Current shape** (`manager_assignment.go:764-851`): pre-Apply V-only gate at 777, Apply at 783, LSR advance at 812, Store at 817, ack/hooks at 833+.
+
+**Target shape:**
+
+```go
+func (m *Manager) applyAssignmentWithPrev(oldAssignment, newAssignment Assignment) error {
+    workerID := m.WorkerID()
+
+    // Critical section: (stale check, Apply, LSR advance, Store) atomic
+    // across all apply-pipeline callers. See applyStoreMu Godoc.
+    m.applyStoreMu.Lock()
+
+    curAssignment := m.CurrentAssignment()
+
+    // Stale gate (W15+W16 close). Drops the candidate BEFORE Apply, so
+    // no coordinator-side prepare/commit/stabilize runs for a loser —
+    // avoiding orphaned stable claims (plan-review v1 P0-2).
+    if isApplyResultStale(newAssignment, curAssignment) {
+        m.applyStoreMu.Unlock()
+        m.metrics.RecordStaleSnapshotStoreDropped()
+        m.logger.Info("apply dropped by (V, LR) stale gate",
+            "worker_id", workerID,
+            "candidate_version", newAssignment.Version,
+            "candidate_leader_revision", newAssignment.LeaderRevision,
+            "current_version", curAssignment.Version,
+            "current_leader_revision", curAssignment.LeaderRevision,
+        )
+        return nil
+    }
+
+    // Apply via handoff coordinator. Holds applyStoreMu throughout — this
+    // serializes coordinator Apply calls across paths and is the load-
+    // bearing change for W15+W16.
+    applyErr := m.handoffCoordinator.Apply(m.ctx, workerID, oldAssignment, newAssignment)
+
+    // Capability sampling runs unconditionally — semantics unchanged from
+    // the prior implementation. Safe under the mutex: reportConsumerCapabilities
+    // does not call back into the apply pipeline.
+    m.reportConsumerCapabilities()
+
+    if applyErr != nil {
+        m.applyStoreMu.Unlock()
+        m.logError("handoff apply failed", "error", applyErr)
+        m.scheduleApplyRetry(newAssignment)
+        return applyErr
+    }
+
+    // LSR advance + Store + heartbeat snapshot update. Order: LSR before
+    // Store (PR-1 §4 invariant), then SetAppliedAssignment inside the lock
+    // (plan-review v2 P0-B: the heartbeat publisher's monotonicity is
+    // V-only, not (V, LR) lex, so a same-V/lower-LR Ack from a slow loser
+    // could regress the heartbeat after the lock is released).
+    m.updateLastSeenLeaderRevision(newAssignment.LeaderRevision)
+    m.assignment.Store(newAssignment)
+    if hook := m.testHookAfterApplyStore; hook != nil {
+        hook(newAssignment)
+    }
+    appliedDigest := types.PartitionSetDigest(newAssignment.Partitions)
+    m.heartbeat.SetAppliedAssignment(heartbeat.AppliedAssignment{
+        LeaderRevision:        newAssignment.LeaderRevision,
+        AppliedVersion:        newAssignment.Version,
+        AppliedDigest:         appliedDigest,
+        AppliedSourceRevision: newAssignment.SourceRevision,
+        AppliedSourceRevKnown: newAssignment.SourceRevisionKnown,
+        AppliedAt:             time.Now(),
+    })
+
+    m.applyStoreMu.Unlock()
+
+    // Logging + heartbeat PUBLISH + hooks + metrics: outside the lock.
+    //   - PublishNow does network IO; holding applyStoreMu through it
+    //     would needlessly serialize publish. SetAppliedAssignment above
+    //     already updated the heartbeat's in-memory snapshot under the
+    //     lock, so PublishNow always sends a snapshot consistent with
+    //     the just-stored manager state.
+    //   - invokeAssignmentChangedHooks fires user hooks asynchronously
+    //     via the wg-managed invokeHook helper.
+    m.logger.Info("assignment applied", ...)  // existing fields
+    if err := m.heartbeat.PublishNow(m.ctx); err != nil {
+        m.logError("heartbeat publish-now after apply failed", "error", err)
+    }
+
+    m.recordAssignmentMetrics(oldAssignment, newAssignment)
+    m.invokeAssignmentChangedHooks(workerID, oldAssignment, newAssignment)
+
+    return nil
+}
+```
+
+**Key changes vs current:**
+1. `applyStoreMu.Lock()` at function head, three `applyStoreMu.Unlock()` paths (stale drop, apply error, success after Store + SetAppliedAssignment). Explicit `Unlock` instead of `defer` so `PublishNow` and hooks run outside the lock.
+2. Pre-Apply gate at line 777 replaced by `isApplyResultStale` inside the locked region.
+3. Apply, LSR advance, Store, AND `SetAppliedAssignment` now under the same lock — no third party can interleave, and the heartbeat's in-memory snapshot can never observe out-of-order `(V, LR)` (plan-review v2 P0-B fix).
+4. `PublishNow`, metrics, and hooks moved AFTER the unlock so they don't block other apply paths.
+
+### 3.3 Extract `monotonicStore(newAssignment)` helper
+
+Both `applyAssignmentWithPrev`'s critical section and `refreshAssignmentFromNATS` should share the same `(stale-check + LSR advance + Store)` logic. Extract:
+
+```go
+// monotonicStore performs the (gate-check, LSR-advance, Store) sequence
+// under applyStoreMu. Returns true if the Store landed (candidate was
+// fresh enough); false if the candidate was dropped as stale.
+//
+// Callers MUST NOT hold applyStoreMu. The helper acquires and releases
+// it itself.
+//
+// REFRESH-PATH ONLY. Used by refreshAssignmentFromNATS to bring an
+// authoritative KV snapshot under the same (V, LR) gate as the apply
+// pipeline. Not usable from applyAssignmentWithPrev because that
+// function must hold applyStoreMu ACROSS handoffCoordinator.Apply (see
+// §3.2). Inlining the same logic in both call sites is intentional.
+//
+// NOT used by pre-Start lifecycle Stores (manager.go:297, manager.go:551,
+// manager_election.go:320) — those execute before monitor goroutines start
+// and have no concurrency exposure.
+func (m *Manager) monotonicStore(newAssignment Assignment) bool {
+    m.applyStoreMu.Lock()
+    defer m.applyStoreMu.Unlock()
+
+    cur := m.CurrentAssignment()
+    if isApplyResultStale(newAssignment, cur) {
+        m.metrics.RecordStaleSnapshotStoreDropped()
+        return false
+    }
+
+    m.updateLastSeenLeaderRevision(newAssignment.LeaderRevision)
+    m.assignment.Store(newAssignment)
+    return true
+}
+```
+
+This is NOT used directly by `applyAssignmentWithPrev` — that function needs the lock held across `Apply` as well, so it inlines the critical section. The helper is for the simpler refresh path only.
+
+### 3.4 Wire `refreshAssignmentFromNATS` through `monotonicStore`
+
+**Current shape** (`manager_assignment.go:953-980`): fetches KV value, unmarshals, calls `m.assignment.Store(curAssignment)` directly. Does NOT update LSR. Does NOT acquire any lock.
+
+**Target shape:**
+
+```go
+func (m *Manager) refreshAssignmentFromNATS() error {
+    workerID := m.WorkerID()
+    if workerID == "" {
+        return errors.New("worker ID not set")
+    }
+
+    key := fmt.Sprintf("assignment.%s", workerID)
+    entry, err := m.assignmentKV.Get(m.ctx, key)
+    if err != nil {
+        return fmt.Errorf("failed to get assignment from KV: %w", err)
+    }
+
+    var curAssignment Assignment
+    if err := json.Unmarshal(entry.Value(), &curAssignment); err != nil {
+        return fmt.Errorf("failed to unmarshal assignment: %w", err)
+    }
+
+    if !m.monotonicStore(curAssignment) {
+        // The current snapshot is fresher than what KV reports — common
+        // when refresh races the apply pipeline. Not an error.
+        m.logger.Debug("refresh skipped: snapshot already at-or-newer than KV",
+            "version", curAssignment.Version,
+            "leader_revision", curAssignment.LeaderRevision,
+        )
+        return nil
+    }
+
+    m.lastAssignmentAt.Store(time.Now().UnixNano())
+    m.lastAssignment.Store(m.clonePartitions(curAssignment.Partitions))
+
+    m.logger.Info("assignment refreshed from NATS",
+        "version", curAssignment.Version,
+        "partitions", len(curAssignment.Partitions),
+    )
+
+    return nil
+}
+```
+
+**Two semantic differences from the current implementation:**
+
+1. **Acquires `applyStoreMu`** via the helper. Concurrent apply pipelines cannot interleave.
+2. **Advances LSR** on a successful refresh. The current implementation does NOT, which means a refresh that races with a stale apply could let the apply's stale-leader fence (line 366) over-fire on subsequent commits. By advancing LSR consistently with the snapshot, the LSR-before-Store invariant holds for the refresh path too.
+
+**Bookkeeping (`lastAssignmentAt`, `lastAssignment`):** these are tracked by the refresh path for observability (`m.lastAssignment.Store` clones the partitions). They are not in the apply pipeline's critical-path and remain outside the mutex.
+
+### 3.5 Add the new metric
+
+Three sites:
+
+1. **Interface declaration** in `types/metrics_collector.go` near `RecordStaleLeaderRejected` at line 95-99:
+   ```go
+   // RecordStaleSnapshotStoreDropped counts assignment candidates dropped
+   // by the pre-Apply / refresh stale-snapshot gate (W15+W16). A nonzero
+   // counter indicates concurrent apply paths racing for the same worker;
+   // small numbers are expected under churn (rolling upgrade, leader
+   // handoff).
+   //
+   // Semantics: this counter increments BEFORE handoffCoordinator.Apply
+   // runs (for `applyAssignmentWithPrev`'s pre-Apply gate) or BEFORE Store
+   // (for `refreshAssignmentFromNATS` via the `monotonicStore` helper).
+   // It does NOT fire on Apply errors — those go through scheduleApplyRetry
+   // without firing this counter.
+   RecordStaleSnapshotStoreDropped()
+   ```
+2. **Nop implementation** in `internal/metrics/nop.go` near line 203-205:
+   ```go
+   func (n *NopMetrics) RecordStaleSnapshotStoreDropped() {}
+   ```
+3. **Test fixture** in `manager_commit_state_machine_test.go`:
+   - Add `staleStoreDropped atomic.Int64` field to `recordingMetrics`.
+   - Add method `func (r *recordingMetrics) RecordStaleSnapshotStoreDropped() { r.staleStoreDropped.Add(1) }`.
+
+If the project's metrics emit to Prometheus / OTel through a non-Nop concrete type, that type also needs the new method. Verification step before commit: `grep -rn "RecordStaleLeaderRejected" .` and add `RecordStaleSnapshotStoreDropped` at every same site.
+
+### 3.6 Extend `recordingHandoff` with a version-keyed barrier
+
+Plan-review v1 P1-2 identified that the existing one-shot `blockFirstApply` CAS is insufficient for Test 5.2 (the retry path needs a SECOND block after the first Apply failed).
+
+Add to `recordingHandoff`:
+
+```go
+// blockOnVersion gates Apply on next.Version == blockOnVersion. Tests set
+// the value via SetBlockOnVersion before triggering the apply they want
+// to barrier. The barrier is one-shot per version — once released, the
+// blocker is cleared. blockOnVersionReady is closed when the barrier hits;
+// blockOnVersionRelease is closed by the test to unblock.
+blockOnVersion          atomic.Int64
+blockOnVersionReady     atomic.Pointer[chan struct{}]
+blockOnVersionRelease   atomic.Pointer[chan struct{}]
+
+// SetBlockOnVersion arms a barrier on the next Apply call whose
+// next.Version equals v. The caller can wait on the returned `ready`
+// channel for "the barrier was hit" and close the returned `release`
+// channel to unblock.
+func (h *recordingHandoff) SetBlockOnVersion(v int64) (ready, release chan struct{}) {
+    ready = make(chan struct{})
+    release = make(chan struct{})
+    h.blockOnVersionReady.Store(&ready)
+    h.blockOnVersionRelease.Store(&release)
+    h.blockOnVersion.Store(v)
+    return ready, release
+}
+
+// Apply (modified) — at function head, check blockOnVersion BEFORE
+// blockFirstApply. If the barrier fires, signal ready and wait on release.
+func (h *recordingHandoff) Apply(...) error {
+    if v := h.blockOnVersion.Load(); v != 0 && v == next.Version {
+        h.blockOnVersion.Store(0)  // one-shot
+        ready := h.blockOnVersionReady.Swap(nil)
+        release := h.blockOnVersionRelease.Swap(nil)
+        if ready != nil { close(*ready) }
+        if release != nil { <-*release }
+    }
+    // ... existing blockFirstApply logic
+}
+```
+
+The existing `blockFirstApply` one-shot stays — Test 5.1 (cross-path) uses it, Test 5.2 (retry) uses `SetBlockOnVersion`.
+
+### 3.7 Required updates to existing tests
+
+**None expected.** The new gate only fires when an apply candidate is strictly stale against the live snapshot — a scenario the existing tests do not construct. If a test breaks, investigate before patching: it likely depended on undefined cross-apply interleavings.
+
+If a test mutates `m.assignment.Store` directly (test-only seam) and expects no gate fire, that's fine — the helper is only invoked from `applyAssignmentWithPrev` and `refreshAssignmentFromNATS`.
+
+---
+
+## 4. Idempotency contract and race analysis
+
+### 4.1 Race: W15 cross-path stale-store
+
+**Setup.** Worker is mid-handoff. Commit `C1`(`V=10, LR=3`) arrives on the commit watcher and enters `applyAssignmentWithPrev`. Inside, it acquires `applyStoreMu`. Its handoff coordinator Apply blocks on a slow prepare-phase CAS. Meanwhile alias `A1`(`V=10, LR=4`) arrives on the alias watcher — a new leader (LR=4) has published the same partitioning.
+
+**Sequence with PR-2's lock.**
+1. `C1` acquires `applyStoreMu`, checks stale: cur is `Assignment{}` (V=0), `isApplyResultStale((10,3), (0,0))` = false. Proceeds to Apply.
+2. `C1`'s Apply blocks.
+3. `A1`'s goroutine enters `applyAssignmentWithPrev`, tries to acquire `applyStoreMu`, **blocks** waiting for `C1`.
+4. `C1`'s Apply returns nil. `C1` advances LSR to 3, stores `(V=10, LR=3)`. Releases lock.
+5. `A1` acquires `applyStoreMu`. Checks stale: cur is `(V=10, LR=3)`, `isApplyResultStale((10, 4), (10, 3))` = false (alias has higher LR). Proceeds.
+6. `A1` Apply, advances LSR to 4, stores `(V=10, LR=4)`. Releases.
+
+**Snapshot ends at `(V=10, LR=4)`.** The fresher leader's view wins. No regression. The metric does NOT fire (nothing was stale). The cost: `A1` waited for `C1`'s Apply to complete, which is acceptable — `A1` could not have safely run concurrently with `C1` anyway.
+
+**Reverse sequence (older leader's commit arrives FIRST under the lock).** If `A1` enters and acquires the lock FIRST (its watcher fired first), then `A1` applies and stores `(V=10, LR=4)`. `C1` waits, then acquires, checks stale: cur is `(V=10, LR=4)`, `isApplyResultStale((10, 3), (10, 4))` = true. **`C1` drops, metric fires.** Snapshot ends at `(V=10, LR=4)`. Correct.
+
+### 4.2 Race: W16 apply-retry stale-store
+
+**Setup.** Commit `C1`(`V=5, LR=10`) fails Apply (handoff coordinator returns error). `scheduleApplyRetry` stashes `C1` and arms the retry goroutine. Before the retry fires, commit `C2`(`V=10, LR=15`) arrives on the commit watcher.
+
+**Sequence with PR-2's lock.**
+1. `C1` fails Apply under `applyStoreMu`, releases lock, schedules retry.
+2. `C2` enters `applyAssignmentWithPrev`, acquires lock, checks stale: cur is `Assignment{}`, OK. Applies, advances LSR to 15, stores `(V=10, LR=15)`. Releases.
+3. Retry goroutine wakes, calls `applyAssignment(C1)`, enters `applyAssignmentWithPrev`, acquires lock.
+4. Checks stale: cur is `(V=10, LR=15)`, `isApplyResultStale((5, 10), (10, 15))` = true. **`C1` retry drops, metric fires.** No Apply runs for `C1`. Releases lock.
+
+**Snapshot ends at `(V=10, LR=15)`.** No regression. No orphaned coordinator claims (no loser Apply ran).
+
+**Counterfactual without the lock:** in the current code, `C2`'s Apply and `C1`'s retry Apply could interleave; the retry could finish Apply after `C2`'s Store and then store `(V=5, LR=10)` regressing the snapshot.
+
+### 4.3 Race: cross-path with `refreshAssignmentFromNATS`
+
+**Setup.** Degraded recovery invokes `refreshAssignmentFromNATS` while an apply pipeline goroutine is mid-`applyAssignmentWithPrev`.
+
+**Sequence with PR-2's helper.**
+1. Apply goroutine holds `applyStoreMu`, is mid-Apply.
+2. Refresh goroutine calls `monotonicStore(fetchedAssignment)`, tries to acquire `applyStoreMu`, blocks.
+3. Apply finishes its critical section, releases.
+4. Refresh acquires, checks stale: if `fetchedAssignment` is fresher than the just-stored snapshot, it stores (and LSR advances); if not, it drops with metric.
+
+Either way: no regression, no missing LSR advance.
+
+### 4.4 Same `(V, LR)` idempotent reapply
+
+The bootstrap path (`applyInitialAssignment`) calls `applyAssignmentWithPrev(Assignment{}, fetched)`. `fetched.Version` typically equals the version `waitForAssignment` stored at line 320. So at the time `applyAssignmentWithPrev` runs its stale check, `cur.Version == fetched.Version` and `cur.LeaderRevision == fetched.LeaderRevision`. `isApplyResultStale` returns false (idempotent reapply path). Apply runs, snapshot stays unchanged but coordinator state is reconciled. Correct.
+
+### 4.5 Lock contention under steady state
+
+The mutex is acquired only inside `applyAssignmentWithPrev` and `monotonicStore`. Under steady state (no churn), there's at most one apply per watcher tick — contention is zero. Under churn (multiple watchers + retry firing simultaneously), the mutex serializes 2-3 applies. Each apply's critical section is dominated by `handoffCoordinator.Apply` (the prepare/apply/commit/stabilize phases). Worst case: ~3× Apply duration sequentially. This is the same total work the system was doing before — just serialized instead of concurrent. No throughput regression except in the degenerate "all three paths fire at once" case, which is bounded by watcher cadence (a few per second at most) and retry backoff (≥1s).
+
+### 4.6 Lock ordering with `m.mu`
+
+`m.mu` is the Manager's main lock, used for short critical sections (degraded-mode bookkeeping, configuration reads). It is NEVER acquired while the apply pipeline is running (no callee of `applyAssignmentWithPrev` takes `m.mu`). PR-2's `applyStoreMu` is therefore independent. Documented in the Godoc: "`applyStoreMu` MUST NOT be acquired while holding `m.mu`."
+
+`m.assignment` is an `atomic.Value` and does not require a lock for Load. The mutex protects the higher-level invariant (atomic decide-then-commit), not the underlying field.
+
+---
+
+## 5. Tests
+
+Five tests under a new file `manager_apply_serialization_test.go` (or appended to `manager_assignment_test.go`). All reuse `recordingHandoff`, `recordingMetrics`, and `newTestManager` from `manager_commit_state_machine_test.go`.
+
+### Test 5.1 — W15: blocked commit Apply does not regress fresher alias snapshot
+
+**Intent:** prove `applyStoreMu` serializes commit Apply and alias Apply, and that the loser's stale gate fires correctly.
+
+**Mechanism:**
+1. `newTestManager(t)`. Snapshot starts at `Assignment{}` (V=0).
+2. Set `rh.blockFirstApply.Store(true)`. The first Apply call will signal `firstApplyReady` and wait for `releaseFirst`.
+3. Launch goroutine G1: `m.applyAssignment(C1)` where `C1 = Assignment{Version: 10, LeaderRevision: 3}`.
+4. Wait for `<-rh.firstApplyReady`. G1 is now blocked inside Apply, holding `applyStoreMu`.
+5. Launch goroutine G2: `m.applyAssignment(A1)` where `A1 = Assignment{Version: 10, LeaderRevision: 4}`. G2 blocks on `applyStoreMu`.
+6. Release G1: `close(rh.releaseFirst)`. G1's Apply returns nil, advances LSR to 3, stores `(V=10, LR=3)`, releases `applyStoreMu`.
+7. G2 acquires the lock. Stale check: cur is `(V=10, LR=3)`, candidate is `(V=10, LR=4)`. Not stale. G2 Applies, advances LSR to 4, stores `(V=10, LR=4)`.
+8. Wait for both G1 and G2 to return.
+9. **Assertions:**
+   - `m.CurrentAssignment()` is `(V=10, LR=4)`.
+   - `m.lastSeenLeaderRevision.Load()` is `4`.
+   - `rh.applyCount == 2` (both ran).
+   - `rm.staleStoreDropped.Load() == 0` (G2 was not stale).
+
+**Reverse-ordering variant (5.1b):** swap G1 and G2's candidates (G1 applies `A1` (V=10, LR=4); G2 applies `C1` (V=10, LR=3)). Same setup; assert at end:
+   - `m.CurrentAssignment()` is `(V=10, LR=4)` (G1 won the lock first; G2 dropped as stale).
+   - `rh.applyCount == 1` (only G1's Apply ran).
+   - `rm.staleStoreDropped.Load() == 1`.
+
+The reverse variant proves the gate FIRES on the loser path.
+
+### Test 5.2 — W16: stale apply-retry does not regress fresher snapshot
+
+**Intent:** prove the gate catches stale retry candidates without running their Apply.
+
+**Mechanism:**
+1. `newTestManager(t)`. `m.assignment` starts at `Assignment{}`.
+2. Set `rh.errOnce` to return an error on the next Apply call.
+3. `m.applyAssignment(C1)` where `C1 = (V=5, LR=10)` — Apply fails, `scheduleApplyRetry` arms with 1s+jitter backoff.
+4. `m.applyAssignment(C2)` where `C2 = (V=10, LR=15)` — succeeds, snapshot now `(V=10, LR=15)`, LSR=15.
+5. Wait `> 1.5s` for the retry to fire (use `require.Eventually` with a 5s deadline).
+6. **Assertions:**
+   - `m.CurrentAssignment()` is still `(V=10, LR=15)`.
+   - `m.lastSeenLeaderRevision.Load()` is still `15`.
+   - `rm.staleStoreDropped.Load() == 1` (retry dropped by the gate).
+   - `rh.applyCount == 2` (initial failed C1 + C2 succeeded; retry's Apply DID NOT run because the gate dropped it before Apply).
+
+**Why no barrier is needed:** with pre-Apply serialization, the retry's stale check fires BEFORE its Apply call, so the retry's Apply never runs for `C1` (V=5) once `C2`'s snapshot is stored. The version-keyed barrier from `SetBlockOnVersion` is therefore unused for this test and reserved for future scenarios that need to interleave specific Apply calls.
+
+### Test 5.3 — Idempotent reapply same `(V, LR)` is not stale
+
+**Intent:** prove the gate's lex comparison correctly admits idempotent reapply.
+
+**Mechanism:**
+1. `newTestManager(t)`. Apply `A1 = (V=5, LR=10)` — succeeds, snapshot `(V=5, LR=10)`.
+2. Re-apply `A1` again via `m.applyAssignment(A1)`.
+3. **Assertions:**
+   - `m.CurrentAssignment()` is `(V=5, LR=10)`.
+   - `rm.staleStoreDropped.Load() == 0` — gate did NOT fire.
+   - `rh.applyCount == 2` — both Applies ran (idempotent).
+
+### Test 5.4 — V=0 carve-out: only `V=0 over V=0` admits; `V=0 over V>0` drops
+
+**Intent:** prove the corrected V=0 semantics (plan-review v1 P0-3).
+
+**Mechanism (two phases):**
+1. **Phase A — bootstrap idempotent path (admits):**
+   - `newTestManager(t)`. Snapshot is `Assignment{}` (V=0).
+   - Apply `Assignment{}` (V=0, LR=0).
+   - **Assert:** `rh.applyCount == 1` (Apply ran), `rm.staleStoreDropped.Load() == 0`.
+2. **Phase B — regression case (drops):**
+   - Apply `A1 = (V=10, LR=20)` — succeeds, snapshot `(V=10, LR=20)`.
+   - Apply `Assignment{}` (V=0, LR=0) — should be dropped as stale.
+   - **Assert:** `m.CurrentAssignment()` is `(V=10, LR=20)`, `rm.staleStoreDropped.Load() == 1`, `rh.applyCount == 2` (Phase A's bootstrap apply + A1; the V=0 candidate's Apply did NOT run).
+
+### Test 5.5 — Gate does NOT fire on Apply failure
+
+**Intent:** prove the stale-gate metric is reserved for "candidate was stale" cases; Apply failures schedule retry without firing the metric.
+
+**Mechanism:**
+1. `newTestManager(t)`. Snapshot is `Assignment{}` (V=0).
+2. Set `rh.errOnce` to return an error on the next Apply call.
+3. `m.applyAssignment(A1)` where `A1 = (V=10, LR=20)` — gate admits (candidate is fresh), Apply runs, returns error. `scheduleApplyRetry` arms.
+4. **Assertions:**
+   - `rm.staleStoreDropped.Load() == 0` — gate did NOT fire (the candidate was fresh; only Apply failed).
+   - `rh.applyCount == 1` — the failed Apply call still counts.
+   - `m.CurrentAssignment()` is still `Assignment{}` (Store never ran).
+
+This proves the gate's semantics: fires only on stale candidates, not on Apply errors.
+
+### Test 5.6 — `refreshAssignmentFromNATS` honors the gate
+
+**Intent:** prove the refresh path is now serialized and obeys the (V, LR) ordering.
+
+**Mechanism:**
+1. `newTestManager(t)`. `m.assignmentKV` wired to a real embedded NATS KV (use `partitest.StartEmbeddedNATS` + `partitest.CreateJetStreamKV`).
+2. Plant alias `(V=5, LR=10)` in KV at `assignment.<workerID>`.
+3. Call `m.refreshAssignmentFromNATS()`.
+4. **Assert:** `m.CurrentAssignment()` is `(V=5, LR=10)`, `m.lastSeenLeaderRevision.Load() == 10`, `rm.staleStoreDropped.Load() == 0`.
+5. Apply `A2 = (V=10, LR=20)` via `m.applyAssignment(A2)` — succeeds, snapshot `(V=10, LR=20)`.
+6. Overwrite KV value to `(V=5, LR=11)` (something staler in V dimension but fresher in LR).
+7. Call `m.refreshAssignmentFromNATS()` again.
+8. **Assert:** snapshot still `(V=10, LR=20)` (refresh dropped as stale), `rm.staleStoreDropped.Load() == 1`.
+
+This proves both: (a) refresh admits a fresh candidate and advances LSR, (b) refresh drops a stale candidate via the same gate.
+
+### Acceptance
+
+All six tests pass. Test 5.1 (especially the reverse-ordering variant) and Test 5.2 are the load-bearing W15/W16 coverage. Test 5.4 proves the V=0 carve-out is now safe. Test 5.6 proves the refresh-path correctness.
+
+---
+
+## 6. Risks and edge cases
+
+### 6.1 Production `m.assignment.Store` sites and their concurrency model
+
+Per plan-review v1 P1-1 and v2 P2-A, every production Store site must be accounted for:
+
+| Site | File:line | Concurrency | Reason it is safe (or PR-2's protection) |
+|---|---|---|---|
+| `NewManager` initialization | `manager.go:297` | None — no monitors started yet | Pre-Start lifecycle |
+| `waitForAssignment` observational | `manager_election.go:320` | None — runs in `Manager.Start` BEFORE `monitorCommitChanges` / `monitorAssignmentChanges` are spawned (`manager.go:446-484`) | Pre-Start lifecycle |
+| Cold-bootstrap empty | `manager.go:551` | None — same pre-Start window | Pre-Start lifecycle |
+| `applyAssignmentWithPrev` success | `manager_assignment.go:817` | Concurrent with watcher + retry + refresh | **Serialized under `applyStoreMu`** |
+| `refreshAssignmentFromNATS` | `manager_assignment.go:970` | Concurrent with apply pipeline (called from `manager_degraded.go:235`) | **Serialized under `applyStoreMu` via `monotonicStore` helper** |
+
+All five sites are now explicit. The pre-Start lifecycle Stores (sites 1, 2, 3) execute in `Manager.Start` before any watcher or retry goroutine is spawned. They cannot race with the apply pipeline.
+
+**Test-only direct Stores.** Per plan-review v2 P2-A, the following test files also call `m.assignment.Store` directly to seed test state. They intentionally bypass the gate because the manager is not running in those tests (no goroutines spawned). They are NOT a concurrency concern:
+
+- `manager_commit_state_machine_test.go:160, 176`
+- `manager_hook_tracking_test.go:39`
+- `manager_stop_test.go:50`
+
+Future test files MAY do the same for state-seeding purposes; the rule is "only when the manager has no active goroutines."
+
+### 6.2 Lock-ordering: `applyStoreMu` vs `m.mu` vs `pendingApplyInFlight`
+
+| Pair | Order rule | Verification |
+|---|---|---|
+| `applyStoreMu` vs `m.mu` | **No combined acquisition** — callers MUST NOT hold `m.mu` while entering the apply pipeline (or vice versa). The two locks protect disjoint state; they should never be held together. | `grep` for callers of `applyAssignment`, `applyAssignmentWithPrev`, `monotonicStore` — confirm none hold `m.mu`. |
+| `applyStoreMu` vs `pendingApplyInFlight` | `pendingApplyInFlight` is set BEFORE acquiring `applyStoreMu` (commit case-(e) path: line 590 CAS, then line 618 `applyAssignment` which inside calls `applyStoreMu.Lock`). Released AFTER `applyStoreMu` is released (line 629, after `applyAssignment` returned). | No deadlock: alias and retry paths never touch `pendingApplyInFlight`. Commit-from-commit re-entry is prevented by case-(e) coalescing (CAS fail → stash → return). |
+| `applyStoreMu` vs `m.handoffCoordinator`'s internal locks | `handoffCoordinator.Apply` does not call back into the Manager (one-way dispatch). | Confirmed by `grep` of `internal/assignment/handoff/`. |
+| `applyStoreMu` vs `m.heartbeat.appliedMu` | `SetAppliedAssignment` runs INSIDE `applyStoreMu` (§3.2 fix for plan-review v2 P0-B). The publisher's `appliedMu` is a leaf lock with no callback into the Manager (`internal/heartbeat/publisher.go:178-195`), so this order is acyclic. `PublishNow` runs OUTSIDE `applyStoreMu`. | See §3.2 design and `internal/heartbeat/publisher.go`. |
+
+### 6.3 Apply-retry: stale retry under sustained churn
+
+If the apply pipeline is under churn and the retry path repeatedly fires stale candidates, the metric `RecordStaleSnapshotStoreDropped` will increment each time. This is benign — the snapshot is always at the freshest version, just the retry stash repeatedly hits the gate. Operators should treat a persistently rising counter under no churn as a signal that the retry stash is misconfigured (e.g., retries firing faster than watcher cadence).
+
+A pathological case: the retry stash holds `(V=5)`, snapshot is at `(V=10)`. Retry fires, drops. Stash is now empty (the retry goroutine cleared it via `Swap(nil)` at line 924). No more retries fire. Steady state: counter is at 1, snapshot stays at V=10. Correct.
+
+### 6.4 Heartbeat ack ordering — `SetAppliedAssignment` INSIDE the lock, `PublishNow` outside
+
+`heartbeat.SetAppliedAssignment` is called INSIDE `applyStoreMu` (§3.2 fix for plan-review v2 P0-B). The publisher's monotone invariant is V-only (`internal/heartbeat/publisher.go:170-195`): it rejects a lower `AppliedVersion` but ACCEPTS an equal-V call and overwrites `LeaderRevision`. Out-of-order Ack at same V with lower LR would therefore regress the heartbeat snapshot. Holding `applyStoreMu` across `SetAppliedAssignment` eliminates this: a slow apply path cannot post its Ack after a winner has stored, because the winner's `applyStoreMu` window also covered SetAppliedAssignment.
+
+`heartbeat.PublishNow` is called AFTER `applyStoreMu.Unlock`. This is safe because:
+
+- `SetAppliedAssignment` has already published the winning snapshot to the publisher's in-memory state, under the lock.
+- `PublishNow` only triggers the publisher to send the current state to NATS. If two `PublishNow` calls race (one from the loser apply's defer, one from the winner's), the NATS heartbeat stream may see two messages — but both reflect the publisher's then-current `(V, LR)`, which is the winner's. No regression.
+- Holding `applyStoreMu` across `PublishNow` would serialize network IO on the apply hot path. The publisher already coalesces ticks; serializing here would only inflate apply latency.
+
+**Edge case retired.** The v2 spec described an "out-of-order Ack" race scenario that depended on Ack-outside-lock. With v3's inside-lock fix, the scenario is unreachable: any Ack the publisher sees comes from the goroutine that won the `applyStoreMu` race.
+
+### 6.5 Hook reentry
+
+Hook callbacks (`OnAssignmentChanged`, `OnPartitionsAssigned`, `OnPartitionsRevoked`) run via `invokeHook` in a separate goroutine (`m.wg.Go`). Even if a hook were to call back into `applyAssignment` (it shouldn't), it would acquire `applyStoreMu` in a new goroutine — no self-deadlock. Documented as a contract: "Hooks MUST NOT call back into the Manager's apply pipeline."
+
+### 6.6 Test seam `testHookAfterApplyStore` runs INSIDE the lock
+
+The test hook at line 818 fires immediately after `m.assignment.Store(newAssignment)`. With PR-2, it runs INSIDE `applyStoreMu`. Existing test usage assumes the hook can call `m.CurrentAssignment()`, which is lock-free — still works. If a future test uses this hook to call `applyAssignment` or `refreshAssignmentFromNATS`, the test would self-deadlock. Document the constraint in the hook's Godoc.
+
+### 6.7 Test fixture `recordingHandoff` extension — production-side safety
+
+The new `blockOnVersion` mechanism on `recordingHandoff` is test-only. It adds three atomic fields plus a `SetBlockOnVersion` method. No production type changes. The fixture lives in `manager_commit_state_machine_test.go` (test-only file). No risk to production code.
+
+---
+
+## 7. Acceptance criteria
+
+1. **All new tests pass** under `go test ./... -count=1 -race`:
+   - Test 5.1 (W15 cross-path, both forward and reverse-ordering)
+   - Test 5.2 (W16 apply-retry)
+   - Test 5.3 (idempotent reapply admitted)
+   - Test 5.4 (V=0 carve-out: admit V=0/V=0, drop V=0/V>0)
+   - Test 5.5 (Apply failure does NOT fire the gate)
+   - Test 5.6 (refresh path honors the gate)
+2. **Existing tests unchanged or pass without modification** — `manager_commit_state_machine_test.go`, `manager_assignment_watcher_test.go`, `manager_assignment_fixes_test.go`, `manager_commit_watcher_test.go`, `manager_rolling_upgrade_test.go`. If any breaks, investigate before patching.
+3. **Full test suite passes** — `make test` green; `go vet ./...` and `make lint` clean.
+4. **Metric wired** — `RecordStaleSnapshotStoreDropped` declared in `types/metrics_collector.go`, implemented as no-op in `internal/metrics/nop.go`, recorded in the test fixture, called from both `applyAssignmentWithPrev` and `monotonicStore`.
+5. **Lock contracts documented** — Godoc on `applyStoreMu` enumerates the lock-ordering rules from §6.2.
+6. **PR description explicitly notes:**
+   - Closes W15 and W16 from `00-fix-plan.md`.
+   - Documents the change in V=0 semantics (no longer admits V=0 over a real snapshot).
+   - Notes `refreshAssignmentFromNATS` now advances LSR consistently with its Store.
+   - Lists the lock-ordering rules.
+7. `/post-impl-review` (Codex `xhigh` for v1) returns a MERGE verdict.
+
+---
+
+## 8. Out of scope (explicitly NOT in this PR)
+
+| Item | Why deferred |
+|---|---|
+| Convert `m.assignment` to `atomic.Pointer[Assignment]` and use CAS instead of mutex | Wider refactor, no correctness benefit. Mutex is the smaller correct primitive. |
+| Repurpose `pendingApplyInFlight` as the cross-path interlock | Would entangle case-(e) coalescing with PR-2's serialization. Both can coexist as independent primitives. |
+| Add `releaseClaims` cleanup hooks for any orphaned coordinator state | Under pre-Apply serialization, loser Apply does not run — no orphan claims to release. |
+| Change `selectAuthority` semantics | Orthogonal. Selector is correct; this PR addresses the apply pipeline race. |
+| `handoffCoordinator.Apply` internal serialization | Concurrent Applies cannot happen under PR-2 (the mutex serializes the callers). The coordinator's lack of internal mutex is now unobservable. |
+| W17, W18, ... (future watcher hardening) | Tracked separately in `00-fix-plan.md`. |
+| Persist `lastSeenLeaderRevision` across restarts | Separate concern; see `00-fix-plan.md` "Doc" tier. |
+
+---
+
+## 9. Implementation order
+
+Suggested sequence to minimize review surface:
+
+1. **Step 1: Add the metric.** Declare `RecordStaleSnapshotStoreDropped` on the metrics interface, implement on Nop, extend the test fixture. Independently committable.
+2. **Step 2: Add `applyStoreMu` field + `isApplyResultStale` helper + `monotonicStore` helper.** No callers wired yet. Compiles cleanly. Independently committable.
+3. **Step 3: Wire `applyAssignmentWithPrev` to use `applyStoreMu` and the helper.** Single commit. Run full suite — existing tests must still pass.
+4. **Step 4: Wire `refreshAssignmentFromNATS` to use `monotonicStore`.** Single commit. Run full suite.
+5. **Step 5: Extend `recordingHandoff` with `SetBlockOnVersion`.** Test-only change. Verify existing tests using `blockFirstApply` still pass.
+6. **Step 6: Add Tests 5.1 (both variants), 5.2, 5.3, 5.4, 5.5, 5.6.** Can be one commit or split — recommend splitting if any single test surfaces unexpected interactions.
+7. **Step 7: Full suite under `-race`.** Address any newly-surfaced flakes.
+8. **Step 8: Dispatch `/post-impl-review`.**
+
+---
+
+## 10. Known limitations NOT addressed by PR-2
+
+### 10.1 The two-phase coordinator's `Apply` lacks internal serialization
+
+`twoPhaseCoordinator.Apply` (`internal/assignment/handoff/twophase.go:57`) has no top-level mutex. PR-2 closes the concurrent-call window at the caller level (only one apply runs at a time inside `applyStoreMu`), so this is now an unreachable hazard. A future refactor of the coordinator could add internal serialization for defense-in-depth; not required for PR-2's correctness.
+
+### 10.2 Heartbeat `PublishNow` outside the lock (not a limitation; design choice)
+
+`PublishNow` runs AFTER `applyStoreMu.Unlock` (§6.4). This is deliberate: the publisher's in-memory snapshot has already been atomically updated INSIDE the lock via `SetAppliedAssignment`, so the publish is guaranteed to reflect the winning `(V, LR)`. Holding `applyStoreMu` across the network call would needlessly serialize NATS publish on the apply hot path. The publisher already coalesces concurrent calls.
+
+If a future telemetry signal shows out-of-order publish latency creating visible operator confusion, the publisher itself can be tightened to lex-monotonic `(V, LR)` — this would address the same concern at the layer where ordering matters.
+
+### 10.3 Hooks can call back into the apply pipeline
+
+Hooks are fired from a separate goroutine (`invokeHook`), so a callback into `applyAssignment` would not self-deadlock. But it could create unexpected reentrancy (an apply triggered from a hook is essentially a recursive apply). Documented as a hook contract; not enforced in code.
+
+### 10.4 Persisted LSR across worker restart
+
+`lastSeenLeaderRevision` is in-memory only. A restarted worker loses its LSR and could accept commits from any leader on cold start. Tracked separately; not addressed by PR-2.
+
+### 10.5 Failed-Apply partial-claim orphans when retry is stale-dropped (plan-review v2 P0-A)
+
+**The concern.** A first Apply can:
+1. Pass `applyStoreMu`'s pre-Apply stale gate.
+2. Successfully run `preparePhase`, which for partitions with no prior owner calls `NewInitialClaim` (`internal/assignment/handoff/twophase.go:251-264`) — creating a stable claim owned by this worker.
+3. Fail in a later phase (consumer update, commit, or stabilize).
+4. Return error; `scheduleApplyRetry` arms the retry goroutine (`manager_assignment.go:793-796`).
+
+If a fresher apply lands a snapshot in `applyStoreMu` BEFORE the retry fires, the retry's stale gate drops the retry before re-running Apply. The stable claim from step 2 is orphaned: the worker doesn't process the partition (snapshot doesn't include it) and sweep skips stable claims (`internal/assignment/handoff/twophase.go:458-460`).
+
+**Why this is a pre-existing coordinator concern, NOT introduced by PR-2.** Three pieces of evidence:
+
+1. **Sweep doesn't reclaim stable claims at all** (`twophase.go:458-460`). Even without PR-2, a stable claim owned by a worker whose snapshot doesn't include the partition is orphaned. The current code's only path to reclaiming is "a future leader assigns the partition to a different worker, which causes that worker's prepare to handoff from the orphan owner." This works as long as future leaders include the partition in someone's assignment.
+2. **Retry's prepare is idempotent on already-stable claims** (`twophase.go:282-313`, the `cur.Owner == workerID` branches return the claim as-is). Even if the retry's Apply runs to completion, prepare does NOT clean up partitions in the previous failed candidate that are not in the retry's candidate — the loser-partition-set cleanup is a coordinator-design gap that exists today.
+3. **Sweep skipping stable expired claims is a pre-existing semantic** (`twophase.go:458-460`). Stable claims have TTLs, but expired stable claims are intentionally left alone (no deletion API exists at this layer per the comment at line 459). Orphans of any kind (failed Apply, worker stop without heartbeat refresh of an unowned partition, source partition deletion) all share the same fate.
+
+**Empirical reachability.** The orphan only matters if **all three** conditions hold:
+- The first Apply fails AFTER `preparePhase` succeeded for at least one partition (i.e., between the prepare-phase return and the eventual error in apply/commit/stabilize).
+- A fresher snapshot lands and excludes that partition from its assignment.
+- No future leader ever re-includes the partition for any worker.
+
+Under steady-state operation with stable partition sets (Kafka topics rarely deleted), the third condition is the common case for blocking observable harm: as long as the partition continues to be assigned to SOMEONE in future commits, the orphan resolves via NextPrepare handoff. The persistent-orphan case is "partition was permanently removed from the source while the failed Apply's claim was stable" — a tail-latency operator concern, not a PR-2 correctness regression.
+
+**What PR-2 changes.** Under current code, a stale retry whose Apply runs would (a) re-acquire stable claims for partitions it still owns (no-op), and (b) potentially fail and re-retry. So retries with persistent failure modes could still hit the same orphan eventually. PR-2's deterministic stale-drop slightly widens the window from "may retry forever" to "definitely drops on first fresher snapshot." This is a SMALL change to the reachability of the orphan, not a NEW orphan class.
+
+**Why deferred from PR-2.**
+1. **Pre-existing.** The orphan-claim semantic exists today and is fundamental to the two-phase coordinator's design.
+2. **Out of layer.** Closing it requires either (a) coordinator-level cleanup of loser-partition stable claims, OR (b) a "stale retry releases its prepare-claimed partitions" hook driven by the Manager. Both are coordinator-design changes, not apply-pipeline changes.
+3. **Larger scope.** A clean fix would extend sweep to optionally reclaim stable claims (with TTL gating to avoid stomping live owners), or change the coordinator to return a list of "claims created" so the caller can release them on Apply error.
+
+**Future-PR follow-up.** A dedicated coordinator-side PR should:
+- Either extend sweep to reclaim expired stable claims with stronger TTL semantics, OR
+- Have the coordinator return a list of created-during-prepare claims so the caller can `releaseClaims` on Apply error.
+
+Tracked as **W19** in `00-fix-plan.md` (Tier P2 cont.).
+
+**Production telemetry signal.** Operators concerned about this case can monitor:
+- The new `RecordStaleSnapshotStoreDropped` counter (an increment indicates a stale-drop event; not all such events leak claims).
+- Existing coordinator metrics: `ClaimStoreSize` (`twophase.go:447-449`) trending upward without explanation suggests orphan accumulation.
+
+---
+
+## 11. Model & effort recommendations (from `00-fix-plan.md` §"Per-PR matrix")
+
+| Phase | Tool | Model / effort |
+|---|---|---|
+| Planning (this spec v2) | Claude Code | **Opus 4.7** — design call between post-Apply revalidation (rejected) vs pre-Apply serialization (chosen); subtle invariants around `applyStoreMu` lock-ordering and the V=0 carve-out |
+| Plan review (v1) | `/plan-review` | Copilot `gpt-5.5 xhigh` (Codex sandbox env-fail; ran via fallback) — DONE, 3 P0 / 3 P1 / 2 P2 |
+| Plan review (v2) | `/plan-review` | Codex **xhigh** (or Copilot `gpt-5.5 xhigh` fallback) — pending |
+| Implementation | Claude Code | **Opus 4.7** — touches the apply pipeline's critical section; lock-ordering and V=0 semantics are correctness-critical |
+| Post-impl review (v1) | `/post-impl-review` | Codex **xhigh** |
+| Post-impl review (v2+) | `/post-impl-review` | Codex **high** |
+
+Estimated reviewer wall-time: plan-review v2 ~5-10 min; post-impl-review v1 ~10-15 min. PR's overall reviewer budget: ~25 min across the planning loop and ~15 min for post-impl.
+
+---
+
+## 12. Scope changes across versions
+
+| Item | v1 | v2 | v3 (current) |
+|---|---|---|---|
+| Design choice | Post-Apply read-then-write revalidation | Pre-Apply mutex serialization (`applyStoreMu`) | Same as v2 |
+| Atomicity | Non-atomic decide-then-commit | Atomic under `applyStoreMu` | Same as v2 |
+| Heartbeat Ack location | Outside lock (V-only monotonicity argument) | Outside lock (incorrect — plan-review v2 P0-B: publisher monotonicity is V-only, not (V, LR) lex) | **Inside lock** — `SetAppliedAssignment` moved under `applyStoreMu`; `PublishNow` stays outside (network IO) |
+| Orphaned coordinator claims (loser-before-Apply path) | "Sweep reclaims them" (wrong) | "No loser Apply runs" | Same as v2 |
+| Orphaned claims (failed-Apply partial-prepare path) | Not addressed | Not addressed (introduced by plan-review v2 P0-A) | **Documented in §10.5 as pre-existing coordinator-level limitation** with reachability analysis and follow-up plan |
+| V=0 carve-out | "candidate.V=0 → never stale" | "V=0 stale unless cur.V=0 too" | Same as v2 |
+| `refreshAssignmentFromNATS` | Out of scope | Under `monotonicStore` | Same as v2 |
+| `monotonicStore` "Used by" | n/a | Contradictory: listed `applyAssignmentWithPrev` (plan-review v2 P1) | **Refresh-only; explicit "not callable from `applyAssignmentWithPrev` because it must hold the lock across Apply"** |
+| Production Store-site enumeration | Incomplete | Five production sites in §6.1 | Same as v2, plus test-only Stores explicitly listed (plan-review v2 P2-A) |
+| Test 5.2 barrier | "Second barrier needed" | Gate drops retry before Apply | Same as v2 |
+| Test 5.4 V=0 | "V=0 over V=10 admitted" (perpetuates bug) | Phase A admits V=0/V=0; Phase B drops V=0/V>0 | Same as v2 |
+| Metric name | `RecordStaleApplyDropped` | `RecordPostApplyStaleStoreDropped` (Godoc still mentioned post-Apply) | **`RecordStaleSnapshotStoreDropped`** with refresh-path-aware Godoc that does not imply Apply ran |
+| Test count | 5 | 6 | Same as v2 |
+| LOC estimate | ~25 LOC + 150 test LOC | ~50 LOC + 200 test LOC | Same as v2 |
+| Lock contracts | Not specified | Explicit Godoc + §6.2 table | Same as v2 |

--- a/docs/plans/worker-state-hardening/03-pr3-spec.md
+++ b/docs/plans/worker-state-hardening/03-pr3-spec.md
@@ -1,0 +1,1060 @@
+# PR-3 Implementation Spec — `Manager.State()` Reconcile + Partition-Lifecycle FSM Routing (W1+W5)
+
+Implements **W1** (merged W1 + W5) from [`00-fix-plan.md`](./00-fix-plan.md).
+
+`Manager.State()` lies during real leader-side work, via **two independent causes** that together produce one observable symptom (dashboards / hooks / readiness probes seeing `Stable` while a rebalance is in flight). The audit (`tmp/worker_state_analysis/00-report.md:275-291`) and consolidated review (`tmp/worker_state_analysis/02-consolidated.md`) explicitly require a single PR that closes BOTH — half-fixing leaves half the symptom.
+
+- **Cause A — subscriber-drop / no reconcile.** `stateSubscriber.trySend` drops on a full 4-slot buffer (`internal/assignment/state_subscriber.go:24-29`, `state_machine.go:119`); the manager-side consumer `monitorCalculatorState` is purely event-driven with no fallback (`manager_assignment.go:166-193`). A burst of `Idle→Scaling→Rebalancing→Idle` transitions can saturate the buffer; any drop is silent.
+- **Cause B — `monitorPartitions` bypasses the FSM.** Partition-source change events drive `triggerPartitionRebalance` → `rebalance` directly (`internal/assignment/calculator.go:645-656, 675-728`) without entering the calculator state machine. The public contract — `Rebalancing` means "active partition rebalance in progress" (`types/state.go:35-36`, `types/calculator_state.go:24-26`) and `Stable, Scaling, Rebalancing` are the documented readiness-OK states (`docs/OPERATIONS.md:324`, `docs/LIFECYCLE.md:66`) — is therefore violated whenever a partition lifecycle drives a rebalance.
+
+**Resolution: PR-3 fixes both causes in one bundle.**
+
+1. **Cause A.** Add a periodic reconcile tick to `monitorCalculatorState` that reads `calc.GetState()` and re-drives `syncStateFromCalculator` if it differs from the last value the manager has applied. Subscriber stays drop-tolerant; recovery cadence becomes deterministic. Mirrors PR-1's alias-watcher reconcile shape (`manager_assignment.go:282-319`). Invariant is narrowed: reconcile guarantees **eventual projection of the current calculator state**, NOT replay of every missed transition (see §2.1, §4, §10.2).
+2. **Cause B.** Route partition-lifecycle rebalances through the calculator state machine via a new strict-source claim primitive (`TryClaimRebalancing(from=Idle)`) plus a partition-specific runner (`RunClaimedRebalanceErr`) that preserves the callback's error so `restorePendingOnGraceBail` keeps working. After the partition rebalance returns to Idle, the path performs a single in-line tail-check via `observeAndDecide` so an emergency claim that lost the race during the rebalance window is retried without waiting for the next poll. On claim failure (something else is already running a rebalance), the existing `pendingPartitionUpdate` / drain-ticker path re-triggers naturally; duplicate-rebalance bound is explicitly characterized in §4.
+
+**Revision history:** this spec has cleared five revision rounds (v1 → v5). The summary bullets below cover v1 → v3 (the rounds that closed all P0 findings); the full row-per-revision table including v4 (Test 5.3 signal + Test 5.7 timeout override + 15 s derivation) and v5 (Test 5.7 `partitionRebalanceBlocker` determinism seam — final) is at the bottom of this file. **Current revision: v5 (final, ready to implement).**
+
+- v1 — initial draft against `00-fix-plan.md` and `tmp/worker_state_analysis/00-report.md` v3. Plan-review (`tmp/03-pr3-spec_pr3-w1-w5_review.md`) returned 2 P0 / 3 P1 / 1 P2:
+  - P0-A (`errShuttingDown` restore lost): the v1 design routed partition lifecycle through `RunClaimedRebalance` whose callback (`handleRebalance`) swallows `errShuttingDown` to nil; the original cause never reaches `restorePendingOnGraceBail`. **v2 fix:** add a new partition-specific runner `RunClaimedRebalanceErr` that returns the callback's error to the caller while still returning the FSM to Idle. `restorePendingOnGraceBail` stays load-bearing.
+  - P0-B (emergency drop with no marker): under Option X the partition path claims `Rebalancing`, so concurrent `TryClaimEmergency` rejects from non-Idle; no marker exists to retry. **v2 fix:** after `RunClaimedRebalanceErr` completes and FSM is back to Idle, the partition-lifecycle path performs an in-line tail-check via `c.observeAndDecide(ctx, nil)` — a single-goroutine handoff that immediately re-detects any emergency that arrived during the rebalance window.
+  - P1-A (duplicate partition rebalance on claim-failure retry): made explicit in §4 behavior table. The existing `snapshotSource` re-read inside every `rebalance` (`calculator.go:1111-1124`) means at most one extra `Stable → Rebalancing → Stable` cycle whose body is a no-op publish; bounded by one drain-tick interval. Test 5.3 is **required** (not optional) and asserts the duplicate is bounded.
+  - P1-B (reconcile cannot replay completed transitions): §1 framing, §2.1 decision, §4 behavior table, and Test 5.1 narrowed to "eventual projection of current state, not replay of missed transitions." A stronger invariant would require a lossless event path — out of PR-3 scope (§10.3).
+  - P1-C (hook firing order): §4 reworded to distinguish "calculator notification enqueue order" (deterministic, FSM-side) from "user hook execution order" (asynchronous, dispatched via `invokeHook` at `manager.go:827-839`). Test 5.2 asserts eventual presence of both transitions in the recorded stream without requiring order vs assignment hooks.
+  - P2 (public glossary worker-count-only): one-line glossary edit added to PR-3 scope (`docs/REFERENCE.md:358`).
+- v2 (2026-05-19) — closes all P0/P1/P2 from `tmp/03-pr3-spec_pr3-w1-w5_review.md`. Design Call 1 unchanged (Option A). Design Call 2 still Option X but with two additions: (i) partition-specific `RunClaimedRebalanceErr` runner that propagates the callback error, (ii) in-line emergency tail-check after the partition rebalance returns to Idle. Tests: 4 required (was 2 required + 1 optional), one optional. LOC: ~88 (was ~70). Plan-review v2 (`tmp/03-pr3-spec_pr3-w1-w5_v2_review.md`) returned 1 residual P0 + 2 P1: P0-B tail-check could reuse an exhausted rebalance context; Test 5.5 used the wrong manager state for Emergency and required a forbidden cross-tuple hook order; Test 5.3 measured an async/drop-tolerant signal that could not prove the duplicate bound.
+- v3 — closes the v2 plan-review findings. Residual P0-B: §3.5 allocates a **fresh stop-aware context** for the tail-check (`ctxFromStopCh(c.stopCh, partitionTailCheckTimeout)` with `partitionTailCheckTimeout = 15 * time.Second`) so it cannot be starved by an exhausted `reqCtx`. Test 5.7 added as a dedicated context-exhaustion regression (kept separate from Test 5.5 to keep the existing emergency-contention test focused on the FSM ordering rather than on context-exhaustion timing). P1 — Test 5.5 corrected to assert manager `Stable → Emergency → Stable` (per `manager_state.go:230-234`, `types/state.go:38-39`) and to assert **eventual presence** of all four `(from,to)` tuples without ordering between the two cycles (per async `invokeHook` at `manager.go:827-839`); a residual ordering parenthetical in Test 5.2 was also removed. P1 — Test 5.3 retargeted to count `TryClaimRebalancing` invocations via a test-only `export_test.go` counter on the calculator (lowest-surface deterministic producer-side signal vs. publisher / callback wrappers); fails if more than one extra `TryClaimRebalancing` runs per dropped partition update. §10.1 updated: "tail-check context exhaustion" is now closed; "second emergency after tail-check completes" remains the only documented residual. LOC: ~90 (was ~88; fresh-context allocation + named timeout const adds ~3 LOC of production code; test corrections add no production LOC). Ceiling raised to ~92.
+
+---
+
+## 1. Anchors (verified 2026-05-19 against HEAD `96359fe`)
+
+| Anchor | File:line | Status |
+|---|---|---|
+| `stateSubscriber.trySend` (drops on full buffer) | `internal/assignment/state_subscriber.go:17-30` | **reused** — drop-tolerant by design; not changed by PR-3 |
+| State subscriber buffer size (`make(chan, 4)`) | `internal/assignment/state_machine.go:119` | **reused** |
+| `monitorCalculatorState` (manager subscriber consumer) | `manager_assignment.go:166-193` | **rewritten** — add periodic reconcile arm |
+| `monitorCalculatorState` startup wiring (readyCh after subscribe) | `manager_assignment.go:135-137, 169-171` | **reused** — preserve subscribe-before-Start order |
+| `syncStateFromCalculator` (calc state → manager state mapping) | `manager_state.go:181-246` | **reused** — already idempotent under "skip if same target"; reconcile re-call is safe |
+| `transitionState` + `isValidTransition` | `manager_state.go:90-179` | **reused** — `isValidTransition` already permits the loops PR-3 introduces (see §2.3) |
+| `Manager.invokeHook` (async hook dispatch via goroutine) | `manager.go:827-839` | **reused** — confirms hook execution order is NOT FSM-deterministic; informs §4 wording |
+| `assignmentCalculator` interface | `manager.go:182-189` | **modified** — adds `GetState() types.CalculatorState` so `monitorCalculatorState` can run a reconcile read without depending on the concrete type |
+| `Calculator.GetState` (concrete impl exists) | `internal/assignment/calculator.go:378-384` | **reused** — already returns `c.stateMach.GetState()` |
+| `NopCalculator.GetState` (must exist after interface widening) | `internal/assignment/nop_calculator.go` (location confirmed via grep before impl) | **added** if not present — returns `types.CalcStateIdle` |
+| `monitorPartitions` select loop | `internal/assignment/calculator.go:675-728` | **modified** — both arms (immediate + drain-ticker deferred) route through FSM claim |
+| `triggerPartitionRebalance` (direct rebalance call) | `internal/assignment/calculator.go:645-656` | **modified** — replaced by FSM-claim path; calls the new runner after successful FSM claim and propagates the callback error |
+| `restorePendingOnGraceBail` | `internal/assignment/calculator.go:658-672` | **reused** — kept load-bearing by the new `RunClaimedRebalanceErr` runner that propagates `errShuttingDown` |
+| `rebalance` in-rebalance grace re-check | `internal/assignment/calculator.go:1127-1138` | **reused** — origin of the `errShuttingDown` the restore helper handles |
+| `handleRebalance` (swallows `errShuttingDown` to nil) | `internal/assignment/calculator.go:1057-1075` | **reused** — used by `RunClaimedRebalance` for emergency/scaling paths where the error is not load-bearing; partition lifecycle uses a separate callback path (see §3.4) |
+| `StateMachine.EnterRebalancing` (existing strict-source CAS from Scaling) | `internal/assignment/state_machine.go:233-254` | **reused as template** — PR-3 adds a sibling claim primitive |
+| `StateMachine.TryClaimEmergency` / `RunClaimedRebalance` (claim+run pattern) | `internal/assignment/state_machine.go:256-309` | **reused as template** — PR-3 adds `TryClaimRebalancing` mirroring this shape and a sibling `RunClaimedRebalanceErr` that returns the callback error |
+| `StateMachine.compareAndSwapState` (strict-source CAS primitive) | `internal/assignment/state_machine.go:359-361` | **reused** — new claim primitive uses it directly |
+| `StateMachine.notifyStateChange` (fanout) | `internal/assignment/state_machine.go:369-378` | **reused** |
+| `StateMachine.ReturnToIdle` | `internal/assignment/state_machine.go` — `RunClaimedRebalance` calls it at `:302, :308` | **reused** — `RunClaimedRebalanceErr` calls the same path |
+| Manager FSM contract enum + Godoc | `types/state.go:35-36, 11` | **reused** — Option X preserves the contract literally; no edit |
+| Calculator FSM contract enum + Godoc | `types/calculator_state.go:24-26, 7` | **reused** — same |
+| Readiness probe docs (Stable / Scaling / Rebalancing / Degraded ready) | `docs/OPERATIONS.md:323-324`, `docs/LIFECYCLE.md:66` | **reused** — Option X keeps these honest; no doc edit needed |
+| Public glossary entry for `Rebalancing` | `docs/REFERENCE.md:358` | **modified** — broadened wording from "after worker count changes" to "after worker or partition-source changes" (P2 fix; see §3.6) |
+| Calculator → manager state mapping (CalcStateRebalancing → StateRebalancing) | `manager_state.go:230-231` | **reused** — partition-lifecycle path will now flow through this mapping naturally |
+| `Manager.State` reader (returns `m.state`) | searched via grep; backed by `m.state` atomic | **reused** — no API surface change |
+| Hook contract `OnStateChanged` (every state transition) | `docs/REFERENCE.md:33-34, 55`, `docs/API_REFERENCE.md:752, 777-779` | **reused** — Option X makes the hook fire on partition-lifecycle rebalances as well, which is the contractual behavior users already expect |
+| `m.mu` guarding `m.calculator` | `manager_assignment.go:78-80, 249-251` | **reused** — `monitorCalculatorState` receives `calc` by parameter (see `:136`) so no new lock acquisition is needed |
+| `observeAndDecide` (poll-driven emergency detection) | `internal/assignment/calculator.go:769-861`; emergency claim at `:819-826` | **reused** — partition-lifecycle path calls this in-line as a tail-check after `RunClaimedRebalanceErr` returns (see §3.5) |
+
+Verified against current branch `main` @ `96359fe`. Spec author MUST re-verify line numbers immediately before implementing if HEAD has advanced (recent commits to this area: `6f0e6b2`, `3594c97`, `b0aff80`).
+
+---
+
+## 2. Design
+
+PR-3 must resolve two design calls. Both are listed below with options, evidence, and a single named **Decision**. Plan-review v1 findings reshape Design Call 2's implementation (the P0/P1 fixes are integrated, NOT switched to Option Y).
+
+### 2.1 Design call 1 — subscriber-drop recovery shape
+
+**Options:**
+
+- **A. Add a periodic reconcile tick to `monitorCalculatorState`.** Pulls `calc.GetState()` on a fixed cadence and re-drives `syncStateFromCalculator` if the result differs from the manager's last-observed mapping. Subscriber stays drop-tolerant; recovery cadence is deterministic and bounded by the tick. Mirrors PR-1's alias-watcher reconcile (`manager_assignment.go:292-318`).
+- **B. Replace the subscriber's drop semantics with coalescing latest-value.** Inside `stateSubscriber.trySend`, drain-then-overwrite a 1-slot channel (or convert to `atomic.Int32` + a notify channel) so the latest state always wins. Changes the drop semantics on the subscriber side; affects every consumer of `SubscribeToStateChanges`.
+- **C. Both.** Coalescing + periodic reconcile.
+- **D. Lossless event path (transition queue / sequence numbers).** Subscriber buffer becomes unbounded or per-subscriber sequence numbers expose missing transitions to consumers. Would replay every missed transition, not just project current state.
+
+**Evidence informing the choice:**
+
+- The subscriber is a `chan types.CalculatorState` buffered 4 (`state_machine.go:119`). Drop semantics are deliberate — `trySend` MUST NOT block the state machine (`state_subscriber.go:24-29`). Correct coalescing requires either reading from the producer side (lock-and-replace via a slot field — not a chan) or switching the wire type. Either change widens blast radius beyond a state-projection fix.
+- PR-1 used the same shape (Option A) for the legacy alias watcher and that pattern is now correctness-tested via the silent-stall test (`01-pr1-spec.md` §5.2). Using the same primitive here keeps the codebase's recovery model consistent.
+- The drop is rare in steady state (buffer=4 absorbs `Idle→Scaling→Rebalancing→Idle`). Reconcile only needs to be load-bearing under burst churn.
+- Option D requires a redesign of the producer side and is out of scope for a Tier-P1 ~50-LOC fix.
+
+**Decision: Option A.** Periodic reconcile tick at a package-private `calculatorStateReconcileInterval = 1 * time.Second` (test-overridable). Subscriber drop semantics unchanged.
+
+**Invariant narrowing (plan-review v1 P1-B fix):** reconcile guarantees **eventual projection of the current calculator state**, NOT replay of every missed transition or recovery of every missed `OnStateChanged` hook. If a burst `Scaling → Rebalancing → Idle` completes entirely between two reconcile ticks AND the subscriber dropped every event in that burst, reconcile sees only the final `Idle` and projects accordingly. The intermediate `Rebalancing` hook is not replayed; this is the deliberate boundary of Option A. The dominant operator-visible symptom (Cause A as framed in §1) is the *current* state lying — not the *history* lying — and the reconcile arm closes that. Stronger invariants are deferred to Option C/D as a future PR (§10.3).
+
+Fallback: if implementation reveals a corner case in which the reconcile read races subscribe initialization, escalate to Option C. No such case is visible from the audit or the current code.
+
+### 2.2 Design call 2 — partition-lifecycle FSM contract
+
+**Options:**
+
+- **X. Route partition lifecycle through the FSM.** `monitorPartitions` enters `Rebalancing` via a new strict-source FSM claim, runs the rebalance, returns to `Idle`. Public contract (`types/state.go:35-36`, `types/calculator_state.go:24-26`) holds literally. `OnStateChanged` fires on partition rebalances. Readiness probes correctly see `Rebalancing` during partition lifecycle.
+- **Y. Narrow the public contract.** Edit `types/state.go`, `types/calculator_state.go`, and the readiness-probe doc snippets so `Rebalancing` only covers "leader-driven membership rebalance." Cheaper code change; user-visible semantic shift.
+
+**Evidence informing the choice:**
+
+- `00-fix-plan.md:22-23`: "Operator-pervasive. Dashboards, hooks, readiness probes all read `Manager.State()`."
+- `docs/OPERATIONS.md:323-324`: readiness probe is documented to be OK in `Stable, Scaling, Rebalancing, Degraded`. Option Y diverges from doc.
+- `docs/REFERENCE.md:33-34, 55` and `docs/API_REFERENCE.md:777-779`: `OnStateChanged` is contracted to fire on "every state transition." Under Option Y, users keying on this hook silently miss partition-rebalance events with no upgrade signal.
+- The FSM already has the necessary primitives: `compareAndSwapState`, `notifyStateChange`, `RunClaimedRebalance`. The emergency path establishes a clean precedent: `TryClaimEmergency` CASes from Idle OR Scaling and invokes `RunClaimedRebalance` (`state_machine.go:272-287`). A sibling primitive `TryClaimRebalancing(from=Idle)` is a direct mirror.
+- `isValidTransition` already permits `Stable → Rebalancing → Stable` (`manager_state.go:165, 167`).
+- The audit (`tmp/worker_state_analysis/00-report.md:289-291`) ranks the symptom as "Operator-pervasive."
+
+**Decision: Option X — Route partition lifecycle through the FSM.**
+
+Plan-review v1 surfaced two concrete failure modes in v1's pseudocode that did NOT exist in the pre-PR-3 code; closing them is mandatory before implementation. The corrections do not change the option chosen, only how it is implemented.
+
+#### 2.2.1 P0-A fix — preserve `errShuttingDown` propagation
+
+**Problem (plan-review v1 P0-A).** v1 routed partition lifecycle through `RunClaimedRebalance` (`state_machine.go:298-309`), which calls `c.onRebalanceCb` (= `handleRebalance` at `calculator.go:1057-1075`). `handleRebalance` swallows `errShuttingDown` to nil (`:1062-1064`). `RunClaimedRebalance` has no error return. Result: the in-rebalance grace re-check at `calculator.go:1127-1138` returns `errShuttingDown`, `handleRebalance` converts it to nil, `RunClaimedRebalance` returns void, and `restorePendingOnGraceBail` at the call site sees nil — `pendingPartitionUpdate` is NOT restored. The deferred partition update is lost until the next watcher event.
+
+**Options considered:**
+
+1. **Add a partition-specific runner `RunClaimedRebalanceErr` on `StateMachine` that returns the callback's error to the caller while still returning the FSM to Idle.** Symmetric to existing `RunClaimedRebalance`. Caller decides whether to interpret the error.
+2. Capture the original cause from `rebalance` before `handleRebalance` swallows it (closure-side channel or shared variable). Adds shared state across goroutines (the watcher goroutine vs the rebalance-runner) for a clean signal — racy without a lock; with a lock, more surface than Option 1.
+3. Make `handleRebalance` distinguish "partition-lifecycle call site" via a lifecycle-string check so it stops swallowing `errShuttingDown` for those reasons. Couples error-swallowing policy to magic-string lifecycle values; the existing emergency/scaling paths intentionally swallow `errShuttingDown` and we'd have to preserve that — adds conditional behavior on a hot path.
+
+**Decision (P0-A): Option 1.** Add `StateMachine.RunClaimedRebalanceErr(ctx, reason) error` adjacent to `RunClaimedRebalance` (`state_machine.go:289-309`). Bypasses `handleRebalance` by calling a new partition-specific callback (`handlePartitionRebalance`) that does NOT swallow `errShuttingDown`. Both runners share `ReturnToIdle` for the post-callback FSM transition.
+
+Why not Option 2: shared state across goroutines for one error is a regression in clarity. Why not Option 3: error-swallowing policy belongs in the caller, not in the callback gated by a string. Option 1 keeps the swallow policy where it is (in the existing `handleRebalance` for non-partition callers) and gives partition lifecycle its own callback with the policy it actually needs.
+
+Evidence: `state_machine.go:298-309` (current `RunClaimedRebalance`), `calculator.go:1057-1075` (`handleRebalance` swallows), `calculator.go:1127-1138` (origin of `errShuttingDown`), `calculator.go:663-672` (`restorePendingOnGraceBail` is the consumer).
+
+#### 2.2.2 P0-B fix — emergency-after-partition tail-check
+
+**Problem (plan-review v1 P0-B).** Today (pre-PR-3) the partition path calls `rebalance` directly, leaving FSM `Idle`. A concurrent emergency observation can claim `Idle → Emergency` via `TryClaimEmergency` and queue behind `rebalanceMu` (`state_machine.go:272-286`, `calculator.go:819-824`). Under Option X the partition path claims `Rebalancing`; `TryClaimEmergency` rejects from `Rebalancing` (existing behavior, `:272-286`). `observeAndDecide` returns nil without a marker (`calculator.go:819-826`). If no further watcher event arrives, the emergency rebalance waits for the next poll cycle.
+
+**Options considered:**
+
+1. Add a `pendingEmergencyClaim` marker analogous to `pendingPartitionUpdate`, drained by the same drain ticker. New state, new race, new test surface; extends the marker invariant to a second concern.
+2. **Allow the partition-lifecycle runner's caller to chain-check for queued emergency after rebalance completes (single-goroutine handoff while the FSM is already back to Idle).** After `RunClaimedRebalanceErr` returns to Idle, the partition-lifecycle goroutine calls `c.observeAndDecide(ctx, nil)` once. If an emergency observation arrived during the rebalance window, `observeAndDecide` re-detects it through the existing emergency-detector path and claims `Idle → Emergency`.
+3. Stronger transition: allow `Rebalancing → Emergency` preemption with `EnterRebalancing` / `TryClaimRebalancing` cancellation. Preempting a mid-publish partition rebalance is dangerous (assignment partial-publish; loses the just-snapshotted source revision); the operational story is bad.
+
+**Decision (P0-B): Option 2.** After `c.stateMach.RunClaimedRebalanceErr(reqCtx, lifecycle)` returns (FSM has called `ReturnToIdle`), the partition-lifecycle path performs a single in-line tail-check: `_ = c.observeAndDecide(reqCtx, nil)`. The tail-check is bounded (one call, no retry loop) and runs on the same goroutine, so it executes during the time window in which the partition lifecycle would otherwise return control to the watcher select loop. Emergency detection arrived during the rebalance window is picked up immediately rather than waiting for the next `pollTicker` tick (`Calculator.run` poll loop).
+
+Why not Option 1: a marker requires a drain mechanism, a CAS, a test, and a contract for how it interacts with `pendingPartitionUpdate`. Option 2 reuses `observeAndDecide` whose emergency-detection contract is already exercised by the existing emergency tests. Why not Option 3: pre-empting an in-flight rebalance midway through publish is a correctness hazard well beyond PR-3's scope.
+
+Caveat: the tail-check only closes the window when the partition lifecycle is the runner that completed. If a worker-set Scaling rebalance was in flight instead, the existing scaling-path `RunClaimedRebalance` (called from `EnterRebalancing` at `state_machine.go:233-254` or from `claimEmergency` at `calculator.go:819-826`) is unchanged. Those paths already either claim emergency themselves or run on the poll goroutine that polls again on the next tick. The tail-check is targeted at exactly the new gap that Option X introduces.
+
+Evidence: `state_machine.go:272-286` (`TryClaimEmergency` rejects from `Rebalancing`), `calculator.go:819-826` (no marker on failed emergency claim), `calculator.go:769-861` (`observeAndDecide` is the existing emergency-detection entry point and is reentrant for back-to-back calls).
+
+#### 2.2.3 P1-A — claim-failure retry duplicate bound
+
+**Problem (plan-review v1 P1-A).** v1 set `pendingPartitionUpdate=true` on any `TryClaimRebalancing` failure. The drain ticker later calls `triggerPartitionRebalance` again. If the in-flight Scaling/Emergency rebalance already re-read the source via `snapshotSource` (`calculator.go:1111-1124, 1168-1172`), the deferred drain produces a duplicate `Stable → Rebalancing → Stable` cycle whose publish body finds nothing new.
+
+**Decision (P1-A): accept the duplicate, bound it, and test it.** §4 behavior table is amended:
+
+> When a partition update fires while FSM is in Scaling/Emergency: the in-flight rebalance picks up the fresh source via `snapshotSource`, AND the drain-ticker arm retriggers `triggerPartitionRebalance` after the in-flight rebalance completes. The retry's `rebalance` body re-snapshots and finds no source delta (assignment unchanged) so the publish is a no-op for assignment contents — but `OnStateChanged(Stable→Rebalancing→Stable)` still fires for the retry cycle. **Duplicate bound: at most one extra `Stable → Rebalancing → Stable` cycle, bounded in time by one `RebalanceGraceDrainInterval` after the original lifecycle returns to Idle.**
+
+Test 5.3 (was optional in v1) is now **required** and asserts the tight bound directly: exactly one `handlePartitionRebalance` body entry per dropped partition update (`n1 - n0 == 1`), via the producer-side counter described in §5.3. See §5.3 for the signal choice and the rejected alternatives (CAS-attempt counting, async hook-recorder counting).
+
+Why not "clear the pending bit when an in-flight rebalance observes a fresh source": adding generation/sequence tracking to `pendingPartitionUpdate` adds state that's not load-bearing for correctness (only for hook-firing economy). The duplicate cycle is operationally cheap and visibly bounded; the explicit characterization is the lower-risk fix.
+
+#### 2.2.4 P1-C — hook firing order
+
+**Problem (plan-review v1 P1-C).** v1 claimed a specific user-observable order between `OnStateChanged(Stable→Rebalancing)`, assignment hooks, and `OnStateChanged(Rebalancing→Stable)`. Hooks are dispatched via `invokeHook` which spawns a goroutine (`manager.go:827-839`). User-visible order is not deterministic.
+
+**Decision (P1-C):** §4 distinguishes "calculator notification enqueue order" (deterministic, FSM-side) from "user hook execution order" (eventual presence, not order). Test 5.2 asserts eventual presence of both transitions in the recorded stream without requiring order vs assignment hooks.
+
+#### 2.2.5 P2 — public glossary
+
+**Decision (P2):** §3.6 broadens `docs/REFERENCE.md:358` glossary entry from "after worker count changes" to "after worker or partition-source changes." One-line edit.
+
+Fallback for the design call as a whole: if `TryClaimRebalancing` introduces an unexpected interaction with `EnterScaling`'s scaling-timer goroutine or with `TryClaimEmergency`'s preemption, Option Y is the fallback. Not anticipated.
+
+### 2.3 Why no `isValidTransition` edge additions are needed
+
+The partition-lifecycle path produces `Idle → Rebalancing → Idle` on the calculator side and `Stable → Rebalancing → Stable` on the manager side (or `WaitingAssignment → Rebalancing` if a partition change fires before initial assignment lands). Both edges exist today in `isValidTransition`:
+
+- `StateStable: {..., StateRebalancing, ...}` — `manager_state.go:165`
+- `StateRebalancing: {StateStable, StateWaitingAssignment, ...}` — `manager_state.go:167`
+- `StateWaitingAssignment: {..., StateRebalancing, ...}` — `manager_state.go:164`
+
+`syncStateFromCalculator`'s mapping (`manager_state.go:194-246`) already maps `CalcStateRebalancing → StateRebalancing` (`:230-231`).
+
+---
+
+## 3. Implementation
+
+### 3.1 Widen `assignmentCalculator` to expose `GetState`
+
+**Current shape** (`manager.go:182-189`):
+
+```go
+type assignmentCalculator interface {
+    Start(ctx context.Context) error
+    Stop(ctx context.Context) error
+    SubscribeToStateChanges() (<-chan types.CalculatorState, func())
+    TriggerRebalance(ctx context.Context) error
+}
+```
+
+**Target shape:**
+
+```go
+type assignmentCalculator interface {
+    Start(ctx context.Context) error
+    Stop(ctx context.Context) error
+    SubscribeToStateChanges() (<-chan types.CalculatorState, func())
+    TriggerRebalance(ctx context.Context) error
+    // GetState returns the calculator's current state. Used by
+    // monitorCalculatorState's periodic reconcile to recover from
+    // dropped subscriber events (the buffer is fixed-size and trySend
+    // is drop-on-full; see internal/assignment/state_subscriber.go:24-29).
+    GetState() types.CalculatorState
+}
+```
+
+**Concrete implementations:**
+
+1. `internal/assignment/calculator.go:378-384` — `Calculator.GetState` already exists. **No change.**
+2. `internal/assignment/nop_calculator.go` — confirm via `grep -n "NopCalculator" internal/assignment/*.go`; add `GetState() types.CalculatorState` returning `types.CalcStateIdle` if missing.
+3. Test doubles (`stubCalculator` in `manager_assignment_test.go:35+`, `monitorTestCalculator` in `manager_assignment_fixes_test.go:249+`) — add a controllable `GetState`.
+
+### 3.2 Rewrite `monitorCalculatorState` with a reconcile arm
+
+**Current shape** (`manager_assignment.go:166-193`):
+
+```go
+func (m *Manager) monitorCalculatorState(calc assignmentCalculator, readyCh chan struct{}) {
+    m.logger.Info("starting calculator state monitor")
+    stateCh, unsubscribe := calc.SubscribeToStateChanges()
+    close(readyCh)
+    defer unsubscribe()
+
+    for {
+        select {
+        case <-m.ctx.Done():
+            m.logger.Info("calculator state monitor stopped")
+            return
+        case calcState, ok := <-stateCh:
+            if !ok {
+                m.logger.Info("calculator state channel closed, stopping monitor")
+                return
+            }
+            if err := m.syncStateFromCalculator(calcState); err != nil {
+                m.logError("failed to sync state from calculator",
+                    "calc_state", calcState, "error", err)
+            }
+        }
+    }
+}
+```
+
+**Target shape:**
+
+```go
+// calculatorStateReconcileInterval is the period between idempotent reads
+// of calc.GetState() in monitorCalculatorState. Recovers from dropped
+// subscriber events (state_subscriber.go:24-29: trySend drops on full
+// buffer; buffer size 4 at state_machine.go:119). Cadence is fast enough
+// that a missed transition is corrected within ~1s under any realistic
+// burst.
+//
+// IMPORTANT: reconcile guarantees eventual projection of the CURRENT
+// calculator state. If a transient state (e.g., Rebalancing) is dropped
+// AND completes between two reconcile ticks, the intermediate transition
+// is NOT replayed — only the current state is projected. See PR-3 §2.1
+// and §10.2.
+//
+// Declared as a package-level var (not a const) so reconcile-timing tests
+// can override it. Production callers MUST NOT mutate this value.
+var calculatorStateReconcileInterval = 1 * time.Second
+
+func (m *Manager) monitorCalculatorState(calc assignmentCalculator, readyCh chan struct{}) {
+    m.logger.Info("starting calculator state monitor")
+
+    stateCh, unsubscribe := calc.SubscribeToStateChanges()
+    close(readyCh)
+    defer unsubscribe()
+
+    reconcileTicker := time.NewTicker(calculatorStateReconcileInterval)
+    defer reconcileTicker.Stop()
+
+    var (
+        lastApplied    types.CalculatorState
+        lastAppliedSet bool
+    )
+
+    apply := func(calcState types.CalculatorState) {
+        if err := m.syncStateFromCalculator(calcState); err != nil {
+            m.logError("failed to sync state from calculator",
+                "calc_state", calcState, "error", err)
+            return
+        }
+        lastApplied = calcState
+        lastAppliedSet = true
+    }
+
+    for {
+        select {
+        case <-m.ctx.Done():
+            m.logger.Info("calculator state monitor stopped")
+            return
+
+        case calcState, ok := <-stateCh:
+            if !ok {
+                m.logger.Info("calculator state channel closed, stopping monitor")
+                return
+            }
+            apply(calcState)
+
+        case <-reconcileTicker.C:
+            current := calc.GetState()
+            if lastAppliedSet && current == lastApplied {
+                continue
+            }
+            apply(current)
+        }
+    }
+}
+```
+
+Three changes from current: new package-private interval var, new ticker with `defer Stop()`, new reconcile arm.
+
+### 3.3 Add `StateMachine.TryClaimRebalancing`
+
+**Location:** `internal/assignment/state_machine.go`, immediately below `TryClaimEmergency` (current end at `:287`).
+
+**Target shape:**
+
+```go
+// TryClaimRebalancing attempts to atomically claim the rebalancing
+// lifecycle from Idle. Strict-source CAS from Idle to Rebalancing.
+// Returns true if the claim succeeded; the caller is then responsible
+// for invoking RunClaimedRebalanceErr to execute the rebalance and
+// return to Idle.
+//
+// Designed for partition-lifecycle callers (monitorPartitions in
+// calculator.go) that need to drive a rebalance but did NOT first
+// enter Scaling. Without this primitive, monitorPartitions bypasses
+// the FSM entirely, violating the public contract that says Rebalancing
+// means "active partition rebalance in progress" (types/state.go:35-36,
+// types/calculator_state.go:24-26).
+//
+// Reason is recorded BEFORE the state-change notification fans out,
+// mirroring tryClaimEmergencyFrom so subscribers see the reason on
+// their first read of the Rebalancing state.
+func (sm *StateMachine) TryClaimRebalancing(_ context.Context, reason string) bool {
+    if !sm.compareAndSwapState(types.CalcStateIdle, types.CalcStateRebalancing) {
+        currentState := types.CalculatorState(sm.current.Load())
+        sm.logger.Debug("partition rebalance claim deferred: state machine not idle",
+            "current_state", currentState.String(),
+            "reason", reason)
+        return false
+    }
+
+    sm.mu.Lock()
+    sm.scalingReason = reason
+    sm.mu.Unlock()
+
+    sm.logger.Info("entering rebalancing state via partition-lifecycle claim",
+        "reason", reason)
+
+    sm.notifyStateChange(types.CalcStateRebalancing)
+
+    return true
+}
+```
+
+**Why CAS from Idle only (not Idle OR Scaling):** the scaling timer at `state_machine.go:201-218` will transition Scaling → Rebalancing once it fires; pre-empting Scaling invalidates the stabilization window. `rebalance` always re-reads via `snapshotSource` (`calculator.go:1116-1124, 1168-1172`), so the scaling-timer's eventual Rebalancing picks up the partition delta. The drain-ticker arm + the §3.5 tail-check together ensure no emergency is stranded.
+
+### 3.4 Add `StateMachine.RunClaimedRebalanceErr` (P0-A fix)
+
+**Location:** `internal/assignment/state_machine.go`, immediately after `RunClaimedRebalance` (current `:298-309`).
+
+**Target shape:**
+
+```go
+// RunClaimedRebalanceErr runs a rebalance callback for a previously-claimed
+// lifecycle and returns the callback's error to the caller. The FSM is
+// returned to Idle whether the callback succeeded, failed, or returned
+// errShuttingDown.
+//
+// Distinct from RunClaimedRebalance: this variant gives the caller the
+// callback error so the partition-lifecycle path can run
+// restorePendingOnGraceBail when rebalance bails on a recovery-grace
+// re-check (calculator.go:1127-1138, 1057-1065 swallows errShuttingDown
+// for legacy callers). The general RunClaimedRebalance preserves the
+// existing void contract for emergency/scaling callers that do not need
+// the error.
+//
+// Must be called after a successful TryClaimRebalancing (or another
+// strict-source CAS into Rebalancing/Emergency).
+//
+// Parameters:
+//   - ctx: Context for the rebalance operation
+//   - reason: Lifecycle reason passed to the callback
+//
+// Returns:
+//   - error: the partition-rebalance callback's error (nil on success).
+//     The FSM is back to Idle regardless of the returned value.
+func (sm *StateMachine) RunClaimedRebalanceErr(ctx context.Context, reason string) error {
+    var cbErr error
+    if sm.onPartitionRebalanceCb != nil {
+        cbErr = sm.onPartitionRebalanceCb(ctx, reason)
+        if cbErr != nil {
+            sm.logger.Error("partition rebalance failed", "reason", reason, "error", cbErr)
+        }
+    }
+    sm.ReturnToIdle()
+    return cbErr
+}
+```
+
+**StateMachine field addition:** alongside the existing `onRebalanceCb` (wired in `NewCalculator` at `calculator.go:167`), add a sibling `onPartitionRebalanceCb`. Wire it from `NewCalculator` to a new `Calculator.handlePartitionRebalance` (see §3.5) that does NOT swallow `errShuttingDown`. This keeps the existing `handleRebalance` swallow policy intact for emergency/scaling callers.
+
+LOC accounting: the new callback field is one struct line + one constructor wire + `RunClaimedRebalanceErr` body (~12 LOC) + `handlePartitionRebalance` (~12 LOC). See §3.7.
+
+### 3.5 Route `monitorPartitions` through the FSM claim with tail-check
+
+**Current shape** (`calculator.go:645-728`): `triggerPartitionRebalance` calls `rebalance` directly; both `monitorPartitions` arms call it and pass the result to `restorePendingOnGraceBail`.
+
+**Target shape:**
+
+Add `handlePartitionRebalance` (sibling to `handleRebalance`) and rewrite `triggerPartitionRebalance` to claim the FSM, run via `RunClaimedRebalanceErr`, run a tail-check on a fresh stop-aware context, and propagate the error.
+
+```go
+// partitionRebalanceRequestTimeout bounds the request context allocated for
+// the partition-lifecycle rebalance itself (the call into
+// RunClaimedRebalanceErr). Production default matches the pre-PR-3 hard-coded
+// 30 s used by the legacy triggerPartitionRebalance (calculator.go:649).
+// Declared as a package-level var (not a const) so Test 5.7 can shorten it
+// to force a deterministic context-exhaustion regression for the §3.5
+// fresh-context fix. Production callers MUST NOT mutate this value.
+var partitionRebalanceRequestTimeout = 30 * time.Second
+
+// partitionTailCheckTimeout bounds the in-line observeAndDecide tail-check
+// that runs after a partition-lifecycle rebalance returns to Idle. It MUST
+// be allocated on a fresh ctxFromStopCh derived context — NOT on the
+// rebalance's reqCtx — because reqCtx may already be cancelled or near
+// its partitionRebalanceRequestTimeout deadline (30 s default) by the time
+// RunClaimedRebalanceErr returns (PR-3 §2.2.2, plan-review v2 P0-B).
+//
+// Derivation of the 15 s value (plan-review v3 P2). The tail-check performs
+// exactly two operations: (i) one worker-set KV read via
+// `collectWorkerObservation` → `fetchWorkersWithKnown` (calculator.go:769-775),
+// which is one JetStream KV ranged read over the workers bucket; under load
+// this completes in well under 1 s in steady state and is bounded by NATS
+// round-trip + decode (single-digit seconds even under transient reconnect
+// jitter); and (ii) `TryClaimEmergency`, which is a single in-memory CAS on
+// the state machine (`state_machine.go:272-286`) — sub-microsecond. The
+// budget is therefore dominated by the KV read plus reconnect headroom. 15 s
+// gives roughly 3× headroom over the KV-read p99 we expect under a single
+// NATS reconnect storm, while staying well below the 30 s
+// `partitionRebalanceRequestTimeout` (so the tail-check cannot dominate the
+// upstream rebalance timeout) and below the default `EmergencyGracePeriod`
+// of 5 s + typical emergency rebalance duration (so a real shutdown via
+// `stopCh` aborts the tail-check long before its deadline matters). It is
+// an operational policy bound, not an empirically proven threshold, and
+// shutdown still cancels via `stopCh` regardless of the value.
+//
+// Declared as a package-level var (not a const) so tests asserting the
+// fresh-context behavior can override it. Production callers MUST NOT
+// mutate this value.
+var partitionTailCheckTimeout = 15 * time.Second
+
+// partitionRebalanceBlocker is a test-only synchronization hook consumed by
+// handlePartitionRebalance AFTER the partitionRebalanceEntries increment and
+// BEFORE the call into c.rebalance. Production callers leave it nil and the
+// guard is a single nil-check on the partition-lifecycle path; tests
+// (Test 5.7) install a non-nil channel via export_test.go and release it
+// after they have observed callback entry and slept past the
+// partitionRebalanceRequestTimeout deadline, which deterministically holds
+// the partition callback open long enough for reqCtx to expire before
+// RunClaimedRebalanceErr returns. The hook is scoped to this callback only —
+// scaling and emergency callbacks (handleRebalance) DO NOT consult it, so
+// production rebalance latency is unaffected on those paths.
+//
+// Declared as a package-level var (not a const, not a build-tagged symbol)
+// so the test can swap it from export_test.go and the production code path
+// retains a single `if h := …; h != nil { <-h }` line. Production callers
+// MUST NOT set this value.
+var partitionRebalanceBlocker chan struct{} // nil in production
+
+// handlePartitionRebalance is the partition-lifecycle rebalance callback
+// invoked by StateMachine.RunClaimedRebalanceErr. Unlike handleRebalance
+// (calculator.go:1057), it does NOT swallow errShuttingDown — the caller
+// needs that error so restorePendingOnGraceBail (calculator.go:663-672)
+// can restore pendingPartitionUpdate when grace flipped between the
+// pre-check and rebalanceMu acquisition (calculator.go:1127-1138).
+func (c *Calculator) handlePartitionRebalance(ctx context.Context, lifecycle string) error {
+    // Test 5.3 signal (v4): increment BEFORE the rebalance body so each
+    // successful CAS-and-run pair is counted exactly once, regardless of
+    // whether the body returns an error. Exposed via export_test.go.
+    c.partitionRebalanceEntries.Add(1)
+    // Test 5.7 determinism hook (v5): nil in production. When set by a test,
+    // block here until the test releases the channel — this lets the test
+    // hold the callback open until reqCtx (allocated in
+    // triggerPartitionRebalance with partitionRebalanceRequestTimeout = 10 ms
+    // in Test 5.7) has provably expired, so the assertion
+    // `reqCtx.Err() != nil at return of RunClaimedRebalanceErr` is structurally
+    // guaranteed rather than probabilistic. The check is a single nil-load on
+    // the production hot path.
+    if h := partitionRebalanceBlocker; h != nil {
+        <-h
+    }
+    if err := c.rebalance(ctx, lifecycle); err != nil {
+        // Surface errShuttingDown verbatim; surface other errors with a
+        // descriptive wrapper.
+        if errors.Is(err, errShuttingDown) {
+            c.Logger.Info("partition rebalance skipped during shutdown / grace flip",
+                "lifecycle", lifecycle)
+            return err
+        }
+        return fmt.Errorf("partition rebalance failed for %s: %w", lifecycle, err)
+    }
+    // Match handleRebalance: keep lastWorkers consistent so the next
+    // poll doesn't immediately re-enter scaling.
+    c.mu.Lock()
+    c.setLastWorkersLocked(c.currentWorkers)
+    c.mu.Unlock()
+    return nil
+}
+
+// triggerPartitionRebalance runs a partition-lifecycle rebalance via the
+// state-machine claim path. On claim success it drives the rebalance via
+// RunClaimedRebalanceErr, then runs a single tail-check observeAndDecide
+// to give any emergency that arrived during the rebalance window an
+// immediate claim opportunity (PR-3 §2.2.2 P0-B fix). On claim failure
+// it restores pendingPartitionUpdate so the drain ticker retries.
+//
+// Returns the rebalance callback's error so the caller can run
+// restorePendingOnGraceBail (PR-3 §2.2.1 P0-A fix).
+func (c *Calculator) triggerPartitionRebalance(lifecycle string) error {
+    if !c.stateMach.TryClaimRebalancing(context.Background(), lifecycle) {
+        // Another lifecycle is mid-flight. Restore the deferred bit so
+        // the drain ticker retries. See §2.2.3: this may produce one
+        // extra Rebalancing cycle once the in-flight lifecycle finishes,
+        // bounded by RebalanceGraceDrainInterval. The retry's publish
+        // body is a no-op for assignment contents (the in-flight
+        // lifecycle re-snapshots via snapshotSource).
+        c.pendingPartitionUpdate.Store(true)
+        return nil
+    }
+
+    reqCtx, cancel := ctxFromStopCh(context.Background(), c.stopCh, partitionRebalanceRequestTimeout)
+    defer cancel()
+
+    err := c.stateMach.RunClaimedRebalanceErr(reqCtx, lifecycle)
+
+    // Tail-check (PR-3 §2.2.2): FSM is back to Idle. Run one in-line
+    // observeAndDecide so an emergency that lost the TryClaimEmergency
+    // race during the rebalance window gets re-detected immediately
+    // (rather than waiting for the next poll tick).
+    //
+    // IMPORTANT (v3, plan-review v2 P0-B fix): the tail-check MUST use
+    // a FRESH stop-aware context. reqCtx above carries a
+    // partitionRebalanceRequestTimeout deadline (30 s default) that the
+    // partition rebalance may have already consumed (worker reads, partition
+    // snapshots, publish in c.rebalance at calculator.go:1140-1272).
+    // observeAndDecide collects workers as
+    // its first step (calculator.go:769-775) and exits fast on a
+    // cancelled context (calculator.go:863-870); reusing reqCtx would
+    // strand any emergency loser until the next poll tick.
+    // partitionTailCheckTimeout is a small bound (15 s) — long enough
+    // for a single worker-set read + emergency claim, short enough to
+    // not delay shutdown.
+    tailCtx, tailCancel := ctxFromStopCh(context.Background(), c.stopCh, partitionTailCheckTimeout)
+    defer tailCancel()
+    if tailErr := c.observeAndDecide(tailCtx, nil); tailErr != nil &&
+        !errors.Is(tailErr, errShuttingDown) {
+        // observeAndDecide errors are non-fatal (the poll path already
+        // swallows them and continues). Logged but NOT returned — the
+        // partition-lifecycle caller only cares about the rebalance
+        // error so restorePendingOnGraceBail still receives
+        // errShuttingDown when applicable (PR-3 §2.2.1, Test 5.4).
+        c.Logger.Debug("post-partition-rebalance tail-check observeAndDecide returned error",
+            "lifecycle", lifecycle, "error", tailErr)
+    }
+
+    return err
+}
+```
+
+**Callers of `triggerPartitionRebalance`** (`calculator.go:693-694, 724-725`): unchanged in shape — both already call `restorePendingOnGraceBail(err)` on the returned error. Under the new design that helper is once again load-bearing for `errShuttingDown` (PR-3 §2.2.1 fix).
+
+**Wiring `onPartitionRebalanceCb`:** in `NewCalculator` (`calculator.go:~167` where `onRebalanceCb` is wired), add a parallel wire to `c.handlePartitionRebalance`. Both callbacks share the same `c.rebalance` body; only the error-policy wrapper differs.
+
+### 3.6 Public-glossary edit (P2)
+
+Edit `docs/REFERENCE.md:358`:
+
+```diff
+- | **Rebalancing**         | Redistributing partitions after worker count changes                                                 |
++ | **Rebalancing**         | Redistributing partitions after worker or partition-source changes                                   |
+```
+
+Surface change: a single table row. No other doc edits required — `types/state.go:35-36`, `types/calculator_state.go:24-26`, `docs/OPERATIONS.md:323-324`, and `docs/LIFECYCLE.md:66` are already worded broadly enough to cover partition-source-driven rebalancing.
+
+### 3.7 LOC budget
+
+| Site | LOC |
+|---|---|
+| `assignmentCalculator` interface extension + Nop impl | ~5 |
+| `monitorCalculatorState` rewrite + var | ~28 |
+| `StateMachine.TryClaimRebalancing` | ~15 |
+| `StateMachine.RunClaimedRebalanceErr` + new callback field + constructor wire | ~14 |
+| `Calculator.handlePartitionRebalance` | ~12 |
+| `triggerPartitionRebalance` rewrite (FSM claim + fresh-ctx tail-check) | ~21 |
+| `partitionTailCheckTimeout` var + comment | ~2 |
+| `partitionRebalanceRequestTimeout` var + comment (v4, Test 5.7 override seam) | ~1 |
+| `Calculator.partitionRebalanceEntries atomic.Int64` field + increment in `handlePartitionRebalance` (v4, Test 5.3 signal) | ~2 |
+| `partitionRebalanceBlocker chan struct{}` package var + nil-guarded `<-h` line in `handlePartitionRebalance` (v5, Test 5.7 determinism seam) | ~2 |
+| Test-double `GetState` additions (2 sites) | ~4 |
+| `docs/REFERENCE.md` glossary edit | ~1 |
+| **Total** | **~95 LOC** |
+
+Ceiling: **~97 LOC + 5 required tests + 1 optional**. Justification for the overrun vs `00-fix-plan.md`'s 50-LOC Tier P1 target: the two P0 fixes (preserving `errShuttingDown` propagation and the emergency tail-check) require ~26 LOC of new callback + runner + tail-check that did not exist in v1; v3 added ~3 LOC for the fresh-context allocation + named timeout var (plan-review v2 P0-B); v4 adds ~3 LOC total for the `partitionRebalanceRequestTimeout` override seam (1 line declaration + comment), the `partitionRebalanceEntries` counter field + its atomic increment in `handlePartitionRebalance` (2 lines) — the increment lives inside the already-counted `handlePartitionRebalance` body, so it is not double-counted. v5 adds ~2 LOC for the test-only `partitionRebalanceBlocker` package var (its declaration plus the `if h := partitionRebalanceBlocker; h != nil { <-h }` guard inside `handlePartitionRebalance`); the var itself is test-only state but the nil-guarded receive line lives on the production code path (Test 5.7 closure for plan-review v4 P1-B). Without these the implementation regresses operationally-load-bearing paths surfaced by plan-review v1, v2, v3, and v4. The structural primitives (`TryClaimRebalancing`, `RunClaimedRebalanceErr`) are reusable; the partition-specific callback `handlePartitionRebalance` is the minimum-additional-surface way to preserve `errShuttingDown` without changing the existing emergency/scaling swallow policy.
+
+### 3.8 Required test updates (existing tests)
+
+Search by grep before commit:
+
+```sh
+grep -rn "monitorCalculatorState\|monitorPartitions\|triggerPartitionRebalance" *_test.go internal/assignment/*_test.go
+```
+
+Two patterns to watch for:
+
+1. Tests asserting `Manager.State() == StateStable` immediately after a partition-source change must switch to `WaitState(StateStable, …)`.
+2. Tests counting `OnStateChanged` invocations during a partition-source change must account for the new `(Stable, Rebalancing)` + `(Rebalancing, Stable)` pair.
+
+---
+
+## 4. Behavior summary
+
+Visible to operators / hook consumers before vs after PR-3:
+
+| Scenario | Before | After |
+|---|---|---|
+| Subscriber buffer overflow during burst transitions, transient state still current at next reconcile tick | `Manager.State()` sticks on stale state until next CAS path | Reconcile tick (≤ 1 s) re-drives correct state; `OnStateChanged` fires from `transitionState` CAS path; no duplicate (the `from==to` short-circuit at `manager_state.go:106-107` covers redelivery) |
+| Subscriber drops every event in a `Scaling→Rebalancing→Idle` burst that completes between reconcile ticks | `Manager.State()` stays in pre-burst state | Reconcile picks up `Idle` and projects to `Stable`. **Intermediate `StateRebalancing` is NOT replayed**; `OnStateChanged(Stable→Rebalancing)` and `(Rebalancing→Stable)` do NOT fire for the dropped burst. This is the deliberate boundary of Option A (§2.1, §10.2) |
+| Partition-source watch fires (worker count unchanged) | `Manager.State()` stays in `Stable`; `OnStateChanged` does not fire; calculator runs rebalance "invisibly" | Manager observes `Stable → Rebalancing → Stable`; readiness probe correctly reports `Rebalancing` during the work. `OnStateChanged` enqueue order (FSM side) is `(Stable→Rebalancing)` BEFORE `(Rebalancing→Stable)`. User-hook execution order is NOT guaranteed against assignment hooks (`OnAssignmentChanged` / `OnPartitionsAssigned`) because `invokeHook` dispatches via goroutines (`manager.go:827-839`); the test asserts **eventual presence**, not order, of all hook invocations |
+| Partition-source watch fires WHILE FSM is in Scaling | Direct rebalance from `monitorPartitions` runs concurrently with scaling timer; two rebalances possible | `TryClaimRebalancing` returns false; `pendingPartitionUpdate` set; drain ticker retries on next tick. Two outcomes possible per §2.2.3: (a) scaling timer's `EnterRebalancing` picks up the fresh source via `snapshotSource` and the drain-tick retry's `rebalance` body finds no delta (no-op publish), producing **one extra `Stable→Rebalancing→Stable` cycle** with empty assignment effects; OR (b) drain-tick retry occurs after Scaling already completed and produces a normal partition-lifecycle cycle. **Duplicate bound: at most one extra cycle.** Test 5.3 enforces |
+| Partition-source watch fires WHILE FSM is in Emergency | Concurrent emergency + partition rebalance possible | Claim fails; `pendingPartitionUpdate` set; drain ticker retries after emergency completes. Same bound as Scaling case |
+| Partition-source watch fires; recovery grace flips between pre-check and `rebalanceMu` acquisition | `triggerPartitionRebalance` returns `errShuttingDown`; `restorePendingOnGraceBail` restores `pendingPartitionUpdate`; drain ticker retries | **Same as before.** PR-3 preserves this path via the new `RunClaimedRebalanceErr` (PR-3 §2.2.1). Test 5.4 is the regression guard |
+| Emergency observation arrives DURING a partition-lifecycle rebalance | Concurrent emergency claim allowed (FSM was `Idle`) | Partition-lifecycle owns `Rebalancing`; emergency `TryClaimEmergency` rejects; AFTER partition rebalance completes and FSM returns to Idle, the tail-check `observeAndDecide` immediately re-detects the emergency and claims `Idle → Emergency` (PR-3 §2.2.2). **No marker required; no wait for next poll.** Test 5.5 enforces |
+| `WaitState(StateRebalancing, …)` keyed on partition rebalance | Times out | Resolves within window |
+
+**Calculator state notification enqueue order (deterministic, FSM side):**
+
+1. `TryClaimRebalancing` calls `notifyStateChange(CalcStateRebalancing)` BEFORE returning true.
+2. `RunClaimedRebalanceErr` invokes `onPartitionRebalanceCb` (= `handlePartitionRebalance` = `rebalance`).
+3. On callback return, `RunClaimedRebalanceErr` calls `ReturnToIdle` which notifies `CalcStateIdle`.
+
+**User hook execution order (NOT deterministic):** `OnStateChanged(Stable, Rebalancing)`, assignment hooks fired from the apply path, and `OnStateChanged(Rebalancing, Stable)` are all dispatched via `Manager.invokeHook` which spawns a goroutine per invocation (`manager.go:829-838`). Users MUST NOT rely on cross-hook order. Tests assert **eventual presence** of all relevant invocations within a bounded window.
+
+---
+
+## 5. Tests
+
+Five required tests, plus one optional. Each test states intent, setup, action, assertion, and file:line target. Test 5.7 (new in v3) is a dedicated context-exhaustion regression for the tail-check fresh-context fix; kept separate from Test 5.5 so the emergency-contention test remains focused on FSM ordering rather than mixing context-deadline timing into its assertions.
+
+### Test 5.1 — Reconcile recovers a still-current dropped state (Cause A)
+
+**Intent:** prove reconcile closes Cause A for the case it is designed for: a calculator state change that was dropped by the subscriber's full buffer AND remains current at the next reconcile tick is projected within `2 * calculatorStateReconcileInterval`. Per §2.1 invariant, this test does NOT assert recovery of completed bursts (the boundary is documented in §10.2).
+
+**Setup:**
+- `newTestManager(t)` with a controllable `assignmentCalculator` double (extend `stubCalculator` or `monitorTestCalculator`).
+- Double exposes: a `subscribers` slice with selective drop, `setState(types.CalculatorState)`, `GetState() types.CalculatorState`.
+- Override `calculatorStateReconcileInterval = 50 * time.Millisecond` for the test.
+- Bring manager to `StateStable`. Subscribe to `OnStateChanged` and record `(from, to)` tuples.
+
+**Action:**
+1. `double.setState(CalcStateScaling)` BUT drop the subscriber send (simulate `trySend` buffer-full).
+2. Wait for `2 * calculatorStateReconcileInterval`.
+
+**Assertion:**
+- `m.State() == StateScaling`.
+- `OnStateChanged` recorder contains exactly one `(StateStable, StateScaling)` tuple.
+
+**File:line target:** new file `manager_calculator_state_monitor_test.go` (or appended to `manager_assignment_test.go`).
+
+### Test 5.2 — Partition lifecycle routes through the FSM (Cause B)
+
+**Intent:** prove Cause B — a partition-source change drives the manager through `Stable → Rebalancing → Stable`. Asserts eventual presence of both transitions, NOT order against assignment hooks (per §4 P1-C wording).
+
+**Setup:**
+- Real `assignment.Calculator` wired to a controllable `WatchablePartitionSource` (locate via `grep -rn "WatchablePartitionSource" internal/assignment/*_test.go partitest/`).
+- Real `StateMachine`; real `handlePartitionRebalance` callback wired.
+- Manager subscribed to `OnStateChanged`, recording tuples.
+- Cold-bootstrap to `StateStable` with an initial partition set.
+
+**Action:**
+1. Push a partition change through the watchable source.
+2. `WaitState(StateStable, 5*time.Second)`.
+
+**Assertion:**
+- `OnStateChanged` recorder contains BOTH `(StateStable, StateRebalancing)` AND `(StateRebalancing, StateStable)` (eventual presence within a bounded window). **No ordering assertion across the two tuples** — `OnStateChanged` is dispatched via `Manager.invokeHook` which spawns a goroutine per invocation (`manager.go:827-839`), so user-hook callback execution order is NOT guaranteed even though the FSM-side notification enqueue order is deterministic. If a future test needs to verify strict enqueue order, it MUST subscribe to the calculator via `SubscribeToStateChanges` rather than read the manager hook recorder.
+- Calculator state machine transitioned `Idle → Rebalancing → Idle`.
+- Final partition assignment reflects the new partition set.
+- **NO ordering assertion** between `OnStateChanged` invocations and assignment hooks (e.g., `OnPartitionsAssigned`). The test may record both streams but only asserts presence + counts, not interleaving.
+
+**File:line target:** new file `internal/assignment/calculator_partition_lifecycle_fsm_test.go` (or appended to existing partition-lifecycle test file if one exists — search via `grep -rn "monitorPartitions\|partitionUpdate" internal/assignment/*_test.go`).
+
+### Test 5.3 — Partition claim fails during Scaling; duplicate-rebalance bound (P1-A)
+
+**Intent:** prove the claim-failure retry duplicate bound from §2.2.3. When `monitorPartitions` fires while `StateMachine` is in `Scaling`, the claim returns false, `pendingPartitionUpdate` is set, the in-flight scaling rebalance picks up the source delta via `snapshotSource`, and the drain ticker produces AT MOST one extra partition-lifecycle attempt.
+
+**Signal choice (v4, plan-review v3 P1-A fix):** the assertion counts **`handlePartitionRebalance` body entries** for the controlled partition update, exposed via a test-only `atomic.Int64` counter on the `Calculator` and read via `export_test.go`. The counter is incremented at the very top of `handlePartitionRebalance` (BEFORE the call into `c.rebalance`), so every successful CAS that drives a partition-lifecycle rebalance increments it exactly once. This signal maps directly onto the §2.2.3 / §10.3 invariant — "at most one extra `Stable → Rebalancing → Stable` cycle" — because each `handlePartitionRebalance` body entry corresponds 1:1 to one such cycle (the CAS-win is the entry guard, and `ReturnToIdle` runs unconditionally after the callback returns).
+
+v3 selected `TryClaimRebalancing` invocations (claim attempts including CAS-loss). Plan-review v3 P1-A correctly observed that this signal conflates "claim attempted but lost" with "claim won and ran" — the drain ticker can fire multiple times while Scaling/Emergency holds the FSM, each clearing `pendingPartitionUpdate`, calling `triggerPartitionRebalance` → `TryClaimRebalancing`, losing the CAS, restoring the bit, and re-attempting on the next tick. The number of failed attempts therefore depends on the test-controlled relationship between `PlannedScaleWindow` and `RebalanceGraceDrainInterval`, not on the spec's "at most one extra cycle" invariant. Counting successful callback entries restores the direct mapping. Alternatives considered and rejected:
+
+- `OnStateChanged` hook recorder (v2): drop-tolerant + async via `state_subscriber.go:16-29` and `manager.go:827-839`; can read "0 cycles" while the producer ran an unbounded retry storm.
+- `RunClaimedRebalanceErr` invocations: equivalent to counting partition callback entries (the runner is what drives the callback) but adds surface inside `StateMachine`; the partition path's `handlePartitionRebalance` is the dedicated callback and is the cleaner attachment point.
+- `TryClaimRebalancing` invocation count (v3): conflates failed CAS attempts with successful cycles; bound depends on test timing, not the spec invariant.
+- Assignment-publisher publish count: indirect — also bumped by the scaling-timer rebalance and by other lifecycles, requires source-generation filtering to disambiguate.
+
+`handlePartitionRebalance` body entry is the smallest-surface signal whose count is exactly the §2.2.3 duplicate bound.
+
+**Setup:**
+- Real calculator + state machine + watchable source.
+- Override `PlannedScaleWindow` (~200 ms) and `RebalanceGraceDrainInterval` (~50 ms) for test speed.
+- Test-only counter wired via `export_test.go`: add an unexported `atomic.Int64` field `partitionRebalanceEntries` on `Calculator`; increment unconditionally as the FIRST line of `handlePartitionRebalance` (before `c.rebalance`); expose a getter `PartitionRebalanceEntries(c *Calculator) int64` from `export_test.go`. Zero production cost beyond one field, one atomic increment, and no exported surface.
+
+**Action:**
+1. Trigger a worker-set change to put FSM into `Scaling`.
+2. Immediately push a partition-source change. Record the counter value `n0` right before pushing.
+3. Wait for `PlannedScaleWindow + 4 * RebalanceGraceDrainInterval + assignment-settle` (i.e., let Scaling complete, allow the drain-tick retry to win the now-Idle CAS, allow at least two further drain ticks during which a buggy implementation could double-fire).
+4. `WaitState(StateStable, …)`.
+
+**Assertion:**
+- During the Scaling window: `m.State() == StateScaling` (NOT `Rebalancing`).
+- Final `m.State() == StateStable`.
+- **`partitionRebalanceEntries` counter delta `n1 - n0 == 1`** for the single dropped partition update. This is exactly the §2.2.3 "at most one extra cycle" invariant: the immediate-arm `TryClaimRebalancing` lost CAS against Scaling (no callback ran, no increment); the drain ticker eventually wins the CAS once Scaling has returned the FSM to Idle (one callback runs, one increment). A wrong implementation that re-fires the partition callback under `pendingPartitionUpdate=true` after the first successful run will produce delta `≥ 2` and the test FAILS.
+- Final partition assignment reflects the new partition + worker set.
+
+**Failure model:** if `n1 - n0 ≥ 2`, the implementation has not bounded the duplicate cycle and the test fails. Critically, this bound is independent of test timing: any number of drain-tick CAS-loss attempts can fire during the Scaling window without incrementing the counter, because the counter is gated on successful claim + callback entry. The OnStateChanged hook recorder is NOT used as the primary assertion here because it cannot distinguish "0 hook cycles observed because producer ran 0 retries" from "0 hook cycles observed because the async drop-tolerant hook pipeline ate them."
+
+**Cross-check against §2.2.3 / §10.3 invariant:** §2.2.3 reads "at most one extra `Stable → Rebalancing → Stable` cycle." Each `handlePartitionRebalance` body entry corresponds to exactly one such cycle on the partition path (the callback is invoked synchronously after the CAS-win and before `ReturnToIdle`). Counting body entries therefore measures the invariant directly with the tight bound `≤ 1` rather than the looser `≤ 2` that v3 derived from a CAS-attempt counter.
+
+**File:line target:** same file as Test 5.2.
+
+### Test 5.4 — Grace-flip regression (P0-A)
+
+**Intent:** prove `restorePendingOnGraceBail` is still load-bearing under PR-3. When recovery grace flips to true between the pre-check at `calculator.go:715-718` and `rebalanceMu` acquisition at `:1127-1138`, `rebalance` returns `errShuttingDown`, `handlePartitionRebalance` surfaces it, `RunClaimedRebalanceErr` returns it, `triggerPartitionRebalance` returns it to the watcher arm, `restorePendingOnGraceBail` restores `pendingPartitionUpdate`, and the drain ticker retries after grace lifts.
+
+**Setup:**
+- Real calculator + state machine + watchable source.
+- Test hook to force `inRecoveryGrace()` to return false at the partition-watch arm pre-check (`calculator.go:715`) but TRUE at the `rebalance`-internal re-check (`shouldDeferForRecoveryGrace` at `calculator.go:1136`). One way: inject a `grace gate` test double that flips between two reads; equivalent: use a `sync.Once`-style mock that returns false on first invocation and true thereafter.
+- Override `RebalanceGraceDrainInterval` ~50 ms.
+
+**Action:**
+1. Push a partition-source change (grace pre-check sees false; lifecycle proceeds).
+2. Inside `rebalance` the re-check sees true → `errShuttingDown`.
+3. Lift grace (test hook flips back to false).
+4. Wait for ≤ 2 drain ticks.
+
+**Assertion:**
+- After step 2: `pendingPartitionUpdate.Load() == true` (restored).
+- After step 4: a partition rebalance completes; `OnStateChanged` recorder contains the `(Stable, Rebalancing) → (Rebalancing, Stable)` pair from the drain-tick retry.
+- Final partition assignment reflects the change.
+
+**File:line target:** same file as Test 5.2.
+
+### Test 5.5 — Emergency contention regression (P0-B)
+
+**Intent:** prove the tail-check from §2.2.2 closes the emergency-during-partition-rebalance gap. When partition lifecycle owns `Rebalancing` and an emergency observation arrives, the emergency rebalance runs immediately after partition rebalance completes, WITHOUT waiting for an unrelated future poll tick.
+
+**Setup:**
+- Real calculator + state machine + watchable source + controllable worker heartbeat (allowing test-driven disappearance).
+- Override `PollInterval` to a large value (~10 s) so the test cannot accidentally pass via a normal poll re-detection.
+- Override `RebalanceGraceDrainInterval` ~50 ms.
+- Manager subscribed to `OnStateChanged`.
+- Optional: a synchronization hook inside the partition `handlePartitionRebalance` to block until a test-driven worker-disappearance event is observable (so the test deterministically forces the emergency observation while the FSM is `Rebalancing`).
+
+**Action:**
+1. Begin a partition rebalance (push a source change).
+2. While `m.State() == StateRebalancing`, simulate a worker disappearance that should drive emergency (e.g., remove its heartbeat KV and wait past the emergency-detector window — the detector's grace must be tuned to fire quickly under test).
+3. Allow the partition rebalance to complete.
+
+**Assertion:**
+- After the partition rebalance completes, an **emergency rebalance runs within `2 * RebalanceGraceDrainInterval`** (well under `PollInterval`).
+- The calculator state machine transitions `Idle → Emergency → Idle` after the `Idle → Rebalancing → Idle` partition cycle. Use `SubscribeToStateChanges` on the calculator to record FSM-side transitions if strict ordering is needed (see "Ordering" below).
+- The manager-side `OnStateChanged` recorder contains, within a bounded window (e.g., 5 s), **eventual presence** of all four tuples: `(StateStable, StateRebalancing)`, `(StateRebalancing, StateStable)`, `(StateStable, StateEmergency)`, and `(StateEmergency, StateStable)`. Note: Emergency maps to `StateEmergency` on the manager side via `syncStateFromCalculator` at `manager_state.go:230-234` (`CalcStateRebalancing → StateRebalancing`; `CalcStateEmergency → StateEmergency` — distinct public states per `types/state.go:35-39`).
+- **No ordering assertion between the two cycles** on the manager hook recorder. `Manager.invokeHook` dispatches each `OnStateChanged` via a fresh goroutine (`manager.go:827-839`), so callback execution order is NOT guaranteed even when FSM-side enqueue order is. The test asserts presence within the window; it does NOT assert `(Stable→Rebalancing)` callback completes before `(Stable→Emergency)` callback.
+- The final assignment reflects the disappeared worker.
+
+**Ordering (if needed):** strict ordering of `Idle → Rebalancing → Idle → Emergency → Idle` MUST be verified via the calculator's `SubscribeToStateChanges` channel (single-goroutine FSM enqueue), NOT the manager hook recorder. The test SHOULD subscribe and assert the recorded calculator-state sequence equals `[Rebalancing, Idle, Emergency, Idle]` (starting from the post-bootstrap Idle baseline).
+
+**File:line target:** same file as Test 5.2.
+
+### Test 5.6 (optional) — Completed-burst subscriber drop is NOT replayed
+
+**Intent:** pin the §2.1 invariant boundary. Documents that if a `Scaling → Rebalancing → Idle` burst completes entirely between two reconcile ticks AND every event was dropped, reconcile projects only the final `Idle` state. NO replay of `Rebalancing`. This is the deliberate boundary of Option A.
+
+**Setup:**
+- Same as Test 5.1 but with selective drop of all three transitions in a burst.
+
+**Action:**
+1. `setState(Scaling)`, `setState(Rebalancing)`, `setState(Idle)` — all dropped by the subscriber double.
+2. Wait `2 * calculatorStateReconcileInterval`.
+
+**Assertion:**
+- `m.State() == StateStable` (manager mapping of `CalcStateIdle`).
+- `OnStateChanged` recorder does **NOT** contain `(StateStable, StateRebalancing)` for the dropped burst — only whatever pre-existed.
+- Test docstring explicitly notes this is the deliberate boundary, not a bug.
+
+**File:line target:** same file as Test 5.1.
+
+Test 5.6 is optional because it asserts a non-fix (deliberately scoped-out behavior). Recommended as a regression guard against accidental future strengthening of the invariant without the requisite producer-side redesign.
+
+### Test 5.7 — Tail-check uses a fresh context, not an exhausted rebalance context (v3, plan-review v2 P0-B)
+
+**Intent:** prove the §3.5 fix — the tail-check `observeAndDecide` runs on a fresh stop-aware context (`partitionTailCheckTimeout`) and is NOT starved when the partition rebalance has consumed or exceeded its 30 s `reqCtx` deadline. A wrong implementation that reuses `reqCtx` for the tail-check would skip emergency re-detection in this scenario and strand the emergency loser until the next poll.
+
+**Determinism mechanism (v5, plan-review v4 P1-B fix):** the v4 design overrode `partitionRebalanceRequestTimeout = 10 * time.Millisecond` and relied on the `rebalance` body taking longer than 10 ms to guarantee `reqCtx` was cancelled by the time `RunClaimedRebalanceErr` returned. Plan-review v4 surfaced that the rebalance work can in principle complete in well under 10 ms (in-memory fakes, no real KV round-trip on some test wirings), in which case the test would pass without checking the invariant under test. v5 fixes this by ADDING a second test-only seam — `partitionRebalanceBlocker chan struct{}` (introduced in §3.5) — that gates the partition callback open until the test releases it. Combined with the 10 ms `partitionRebalanceRequestTimeout` override and an explicit post-entry sleep past that deadline, this gives a deterministic ordering: callback enters → counter increments → callback blocks → test confirms entry → test sleeps past `reqCtx`'s 10 ms deadline → test releases the blocker → `rebalance` body runs against an already-cancelled `reqCtx` → `RunClaimedRebalanceErr` returns. The `reqCtx.Err() != nil` assertion at return is then structurally guaranteed, not probabilistic. Other rebalance paths (scaling, emergency via `handleRebalance`) DO NOT consult `partitionRebalanceBlocker`, so the determinism seam is scoped strictly to the partition-lifecycle callback.
+
+**Setup:**
+- Real calculator + state machine + watchable source + controllable worker heartbeat.
+- Override `PollInterval` to a large value (~10 s) so the test cannot pass via a normal poll re-detection.
+- Override `partitionRebalanceRequestTimeout` to `10 * time.Millisecond` via `export_test.go` (e.g., `SetPartitionRebalanceRequestTimeout(10 * time.Millisecond)` with a `defer` to restore). Test 5.7 lives in `package assignment` (same file as Test 5.5, see §5.5 / §5.2 file target), so helper calls are unqualified.
+- Override `partitionTailCheckTimeout` to ~500 ms via `export_test.go` so the tail-check completes quickly and any failure mode (reusing `reqCtx`) is observable within ~1 s rather than 15 s.
+- Install the v5 determinism blocker: `blocker := make(chan struct{})`; `SetPartitionRebalanceBlocker(blocker)` (exposed from `export_test.go` — co-located with `PartitionRebalanceEntries(c)` from Test 5.3). `defer SetPartitionRebalanceBlocker(nil)` to clear after the test.
+- Manager subscribed to `OnStateChanged`; calculator subscribed via `SubscribeToStateChanges` for FSM-side assertions.
+
+**Action (pseudocode — implementer should be able to write the test without re-deriving the ordering):**
+
+```go
+// 1. Setup applied above.
+// Test lives in `package assignment` (same file as Test 5.5). All helper
+// calls are unqualified.
+blocker := make(chan struct{})
+SetPartitionRebalanceBlocker(blocker)
+defer SetPartitionRebalanceBlocker(nil)
+SetPartitionRebalanceRequestTimeout(10 * time.Millisecond)
+defer SetPartitionRebalanceRequestTimeout(30 * time.Second)
+SetPartitionTailCheckTimeout(500 * time.Millisecond)
+defer SetPartitionTailCheckTimeout(15 * time.Second)
+
+// 2. Bring the cluster up; wait for WaitState(StateStable, …).
+require.NoError(t, mgr.WaitState(ctx, types.StateStable, 5*time.Second))
+
+n0 := PartitionRebalanceEntries(calc)
+
+// 3. Push a partition-source change to start the partition lifecycle.
+src.UpdatePartitions(newPartitionSet)
+
+// 4. Wait for the partition callback to ENTER (counter increments) — proves
+//    the FSM has claimed Rebalancing and the goroutine is parked on
+//    `<-partitionRebalanceBlocker` BEFORE c.rebalance runs.
+require.Eventually(t, func() bool {
+    return PartitionRebalanceEntries(calc) == n0+1
+}, time.Second, 5*time.Millisecond, "partition callback never entered")
+
+// 5. Inject the emergency observation while the FSM is Rebalancing.
+//    Because the FSM is `Rebalancing` (from step 3), TryClaimEmergency
+//    rejects; the emergency observation is the "loser" the tail-check is
+//    designed to recover.
+hb.Drop(workerB)
+
+// 6. Sleep past the reqCtx deadline. The callback is blocked on `<-blocker`
+//    inside handlePartitionRebalance; reqCtx (allocated with a 10 ms budget
+//    in triggerPartitionRebalance) expires while we sleep. Any margin >
+//    partitionRebalanceRequestTimeout suffices; 50 ms gives 5× headroom.
+time.Sleep(50 * time.Millisecond)
+
+// 7. Release the blocker. handlePartitionRebalance proceeds into c.rebalance
+//    with an already-cancelled reqCtx; rebalance returns (likely with a
+//    context error wrap or errShuttingDown if stopCh raced), then
+//    RunClaimedRebalanceErr returns to triggerPartitionRebalance.
+close(blocker)
+
+// 8. Wait at most 2 * partitionTailCheckTimeout (~1 s) for the calculator-side
+//    state stream to surface Emergency via the tail-check observeAndDecide.
+```
+
+**Assertion:**
+- `reqCtx.Err() != nil` at the moment `RunClaimedRebalanceErr` returns — guaranteed by construction: the callback is parked on `<-partitionRebalanceBlocker` from step 4 onward, and step 6 sleeps for 50 ms which is 5× the 10 ms `partitionRebalanceRequestTimeout` budget, so `reqCtx` is provably expired before step 7 unblocks the callback. Verified concretely either by asserting (a) the partition callback's returned error is non-nil (its `ctx.Err()` propagates through `c.rebalance`), or (b) by recording `reqCtx.Err()` at return via a test-only capture hook installed alongside the blocker.
+- The calculator-side state-change stream contains `Emergency` **within `2 * partitionTailCheckTimeout`** after step 7, i.e., well before the next `PollInterval` tick (~10 s).
+- A wrong implementation that reuses `reqCtx` for `observeAndDecide` will see `reqCtx` already cancelled, exit fast at `collectWorkerObservation` (`calculator.go:769-775, 863-870`), skip emergency claim, and the calculator-state stream will NOT contain `Emergency` within the window — the test FAILS.
+- Final assignment reflects the disappeared worker.
+
+**Why this is deterministic across CI runners:** the test no longer races the wall-clock duration of `c.rebalance`. The only timing involved is the 50 ms sleep in step 6 versus the 10 ms `partitionRebalanceRequestTimeout` — a 5× margin that is robust to any realistic scheduler jitter. A slow CI host makes `reqCtx` more cancelled by step 7, not less; a fast host is irrelevant because the callback is parked on the blocker until the test explicitly releases it. No assertion conditions on the duration of `c.rebalance`.
+
+**File:line target:** same file as Test 5.5.
+
+---
+
+## 6. Migration / backwards-compat
+
+**No code-level migration required.** PR-3 does not change any public API surface. The contract being repaired (`Rebalancing` means active partition rebalance) was already the documented behavior. Existing users observing `Manager.State()` or `OnStateChanged` will see partition-rebalance events surface where today they are silently suppressed — a strict improvement.
+
+**`CHANGELOG.md` entry** under `## Unreleased` (or next release header):
+
+> ### Fixed
+> - `Manager.State()` and `OnStateChanged` now correctly reflect partition-lifecycle rebalances (previously, partition-source changes ran a rebalance without entering `StateRebalancing`). Additionally, a low-frequency reconcile in `monitorCalculatorState` ensures the manager's projected state recovers within ~1 s of a dropped calculator state-machine subscriber event. Note: the reconcile path guarantees eventual projection of the current calculator state, not replay of every missed transient transition.
+>
+> ### Documentation
+> - `docs/REFERENCE.md` glossary: broaden "Rebalancing" to cover partition-source changes as well as worker-count changes.
+
+---
+
+## 7. Risks and edge cases
+
+### 7.1 Reconcile race with subscribe initialization
+
+Reconcile ticker arms after `close(readyCh)`. First tick (≤ 1 s) reads `calc.GetState()`. All cases (calculator not yet started → `CalcStateIdle`; calculator started in Idle → `CalcStateIdle`; calculator mid-Scaling/Rebalancing/Emergency → reconcile drives the right transition) are safe by the `lastApplied` gate and `transitionState`'s `from==to` short-circuit.
+
+### 7.2 Reconcile during manager shutdown
+
+`m.ctx.Done()` is first arm of select; reconcile is third. `defer reconcileTicker.Stop()` releases. No leak.
+
+### 7.3 Claim contention with `TryClaimEmergency`
+
+Both `TryClaimEmergency` and the new `TryClaimRebalancing` race for the same FSM. CAS guarantees one wins:
+
+- Emergency wins: partition claim returns false; `pendingPartitionUpdate` set; drain ticker retries after emergency completes.
+- Partition wins: emergency claim's `TryClaimEmergency` returns false; emergency-deferral logging fires (`state_machine.go:283-285`); the tail-check `observeAndDecide` at the end of `triggerPartitionRebalance` re-detects emergency immediately (§2.2.2).
+
+### 7.4 `restorePendingOnGraceBail` propagation under partition lifecycle
+
+PR-3's `RunClaimedRebalanceErr` propagates the callback error. `handlePartitionRebalance` surfaces `errShuttingDown` verbatim. `triggerPartitionRebalance` returns the error to the watcher arm. `restorePendingOnGraceBail` retains its load-bearing role. Test 5.4 is the regression guard.
+
+### 7.5 Tail-check fires during real shutdown
+
+If the partition rebalance returned `errShuttingDown` because `stopCh` is closed (real shutdown, not grace flip), the tail-check's **fresh** `tailCtx` is also derived from `ctxFromStopCh(c.stopCh, partitionTailCheckTimeout)`, so it cancels immediately when `stopCh` is closed. `observeAndDecide` is ctx-aware via `c.collectWorkerObservation` → `getActiveWorkersFiltered` → KV reads. It returns an error or no-ops in that path. Logged at Debug; non-fatal. Crucially the tail-check is NOT starved by an exhausted `reqCtx`: the only thing that can cancel `tailCtx` is `stopCh` (real shutdown) or the `partitionTailCheckTimeout` itself.
+
+### 7.6 Tail-check is single-shot, not a retry loop
+
+Intentional. If a second emergency arrives in the narrow window AFTER the tail-check's `observeAndDecide` finished but before the watcher select-loop is re-entered, the next `pollTicker` tick picks it up. A retry loop would re-enter the partition watcher's responsibility and risk starvation against other arms; one tail-check restores parity with pre-PR-3's "emergency claim was Idle→Emergency without delay" guarantee for the dominant scenario.
+
+### 7.7 Reconcile interval vs ticker drift on slow hosts
+
+Idempotent; `lastApplied` guard makes a coalesced double-tick a no-op.
+
+### 7.8 Test-double interface widening churn
+
+Every implementation of `assignmentCalculator` must add `GetState`. Grep first:
+
+```sh
+grep -rn "assignmentCalculator\b\|SubscribeToStateChanges\b" --include="*.go" .
+```
+
+Known implementations as of HEAD `96359fe`: `internal/assignment.Calculator` (already has `GetState`), `internal/assignment.NopCalculator` (confirm), `stubCalculator` and `monitorTestCalculator` test doubles.
+
+---
+
+## 8. Acceptance criteria
+
+Before this PR can be merged:
+
+1. **All new tests pass** under `go test ./... -count=1 -race`:
+   - Test 5.1 (reconcile recovers still-current dropped state).
+   - Test 5.2 (partition lifecycle routes through FSM).
+   - Test 5.3 (claim-failure duplicate-rebalance bound — required, was optional in v1; v4 retargets to a calculator-side `handlePartitionRebalance` body-entry counter with bound `== 1`).
+   - Test 5.4 (grace-flip regression — new in v2).
+   - Test 5.5 (emergency contention regression — new in v2; v3 corrected to assert `StateEmergency` and drop cross-tuple hook ordering).
+   - Test 5.7 (tail-check uses a fresh context — new in v3).
+   - Test 5.6 if included (optional invariant-boundary guard).
+2. **Existing tests pass.** No regression in `manager_assignment_test.go`, `manager_assignment_fixes_test.go`, `internal/assignment/calculator_test.go`. Any test asserting on `OnStateChanged` count for a partition-source-change scenario MUST be updated per §3.8.
+3. **Full test suite passes** under `-race`. No new flakes.
+4. `go vet ./...` and the configured linter pass without new warnings.
+5. `Manager.State()` observably enters `StateRebalancing` during a partition rebalance — verified by Test 5.2.
+6. `OnStateChanged` fires for `(Stable → Rebalancing)` and `(Rebalancing → Stable)` during partition rebalance — verified by Test 5.2.
+7. A dropped subscriber event whose state remains current is recovered within `2 * calculatorStateReconcileInterval` — verified by Test 5.1.
+8. `restorePendingOnGraceBail` is exercised under partition lifecycle — verified by Test 5.4.
+9. Emergency-during-partition-rebalance is recovered without waiting for a poll — verified by Test 5.5.
+10. Emergency-during-partition-rebalance is recovered EVEN WHEN the original rebalance `reqCtx` has been exhausted (fresh tail-check context) — verified by Test 5.7.
+11. `docs/REFERENCE.md:358` glossary edit lands — verified by `grep -n "Rebalancing.*worker or partition-source" docs/REFERENCE.md`.
+12. `/post-impl-review` (Codex `xhigh` for v1) returns a MERGE verdict.
+
+---
+
+## 9. Out of scope (explicitly NOT in this PR)
+
+| Item | Why deferred |
+|---|---|
+| Replace subscriber buffer-drop with coalescing semantics (Option B/C from §2.1) | Not needed under Option A's narrowed invariant. Future PR if reconcile cadence proves operationally too slow or if a stronger invariant (Option D — lossless event path) is required. |
+| Stronger reconcile invariant (replay of every missed transition) | Requires producer-side redesign — see §10.3. Out of PR-3's Tier-P1 budget. |
+| Add `pendingWorkerUpdate` flag (W6) | PR-4 (W2+W13) addresses heartbeat-watcher recovery latency; W6 becomes redundant per `00-fix-plan.md` Tier P3. |
+| Edit `types/state.go` / `types/calculator_state.go` Godoc | Option Y was rejected (§2.2). Existing Godoc remains correct after PR-3. |
+| Add metric for "reconcile detected divergence" | Useful diagnostic but not required for correctness. |
+| Address W2/W13 (heartbeat watcher rewatch) | PR-4 (next in sequence). |
+| Generalize the tail-check to other claim-failure paths (e.g., emergency-during-scaling) | The tail-check is targeted at the specific gap Option X introduces. Other claim-failure paths retain their pre-PR-3 behavior (poll-driven retry). |
+
+---
+
+## 10. Known limitations NOT addressed by PR-3
+
+### 10.1 Tail-check is single-shot
+
+§7.6 details. A second emergency arriving in the narrow window AFTER the tail-check completes but BEFORE the watcher select-loop re-runs falls back to the next `pollTicker` tick. Operationally equivalent to a poll-driven re-detection at the rate the existing emergency-detector grace allows. **This is the only remaining residual** for the tail-check after v3.
+
+**Closed in v3 (plan-review v2 P0-B):** "tail-check uses an already-exhausted rebalance context" is no longer a residual. §3.5 allocates a fresh stop-aware context (`ctxFromStopCh(c.stopCh, partitionTailCheckTimeout)`, 15 s) for `observeAndDecide`. Test 5.7 is the regression guard.
+
+**Suggested follow-up:** none required for the single-shot residual. If empirical poll latency under load proves problematic, a future PR could move emergency detection off the poll tick onto a dedicated watcher (separate scope, separate spec).
+
+### 10.2 Reconcile does not replay completed transitions
+
+If a `Scaling → Rebalancing → Idle` burst completes entirely between two reconcile ticks AND the subscriber dropped every event, the `Rebalancing` state is NOT re-projected: reconcile sees only the current `Idle`. `OnStateChanged` hooks for the missed transitions do NOT fire. Test 5.6 (optional) documents this boundary.
+
+**Suggested follow-up:** Option D from §2.1 — a lossless event path (sequence numbers / transition queue) or Option C (subscriber-side coalescing in addition to consumer-side reconcile). Either is a producer-side redesign — separate PR.
+
+### 10.3 Duplicate partition rebalance on claim-failure retry
+
+§2.2.3 details. Test 5.3 enforces the bound (at most one extra cycle within one `RebalanceGraceDrainInterval`). The retry cycle's `rebalance` body re-snapshots and finds no source delta; publish is a no-op for assignment contents but `OnStateChanged` still fires.
+
+**Suggested follow-up:** add a source-revision generation check to `pendingPartitionUpdate` so an in-flight rebalance that observed a fresh source generation can clear the bit. ~15 LOC + 1 test. Separate PR if the duplicate cycle proves operationally noisy in production.
+
+### 10.4 Subscriber buffer remains drop-tolerant
+
+The 4-slot buffer at `state_machine.go:119` and the `trySend` drop-on-full at `state_subscriber.go:24-29` are unchanged. PR-3 adds a reconcile arm on the consumer side; producer-side drop semantics are preserved. Any future consumer of `SubscribeToStateChanges` that depends on lossless delivery (no such consumer exists today) MUST add its own reconcile, OR PR-3's reconcile pattern MUST be promoted to a coalescing primitive (Option C). Documented here as a contract for future callers.
+
+### 10.5 No reconcile metric
+
+The reconcile arm does not increment a counter for "reconcile drove a corrective transition." Such a metric would expose buffer-overflow rate operationally. Not in PR-3's scope.
+
+---
+
+## 11. Verification checklist for the implementer
+
+Run all of the following before requesting `/post-impl-review`:
+
+1. `gofmt -l . | grep -v vendor` — no formatting diff.
+2. `go vet ./...` — clean.
+3. The configured linter (per `AGENTS.md` workflow): `make lint` or `golangci-lint run`. Resolve any new warnings.
+4. `go build ./...` — clean.
+5. `go test ./... -count=1` — pass.
+6. `go test ./... -count=1 -race` — pass.
+7. `grep -rn "monitorCalculatorState\|TryClaimRebalancing\|RunClaimedRebalanceErr\|handlePartitionRebalance\|calculatorStateReconcileInterval" --include="*.go" .` — verify call sites match §3.
+8. `grep -n "Rebalancing.*worker or partition-source" docs/REFERENCE.md` — verify glossary edit.
+9. Manual smoke test: bring up a 3-worker cluster, add a partition to the source, observe `OnStateChanged` recorder via a test hook. Expected: `Stable → Rebalancing → Stable` for each worker on the leader-side.
+10. Re-verify all `file:line` anchors in §1 against HEAD before commit; if HEAD has advanced beyond `96359fe`, refresh.
+
+---
+
+## 12. Model & effort recommendations (from `00-fix-plan.md` §"Per-PR matrix")
+
+| Phase | Tool | Model / effort |
+|---|---|---|
+| Planning (this spec, v5 — final) | Claude Code | **Opus 4.7** — done |
+| Implementation | Claude Code | **Opus 4.7** — touches state machine, adds new callback / runner, propagates errors across goroutines |
+| Plan review (pre-impl, v1/v2) | `/plan-review` | Codex **xhigh** |
+| Plan review (pre-impl, v3/v4) | `/plan-review` | Codex **high** (precision pass over earlier deltas) |
+| Final plan review (v5) | `/final-plan-review` | Codex **high** (precision sweep — stale text, numbering drift) |
+| Post-impl review (v1) | `/post-impl-review` | Codex **xhigh** |
+| Post-impl review (v2+) | `/post-impl-review` | Codex **high** |
+
+Rationale: PR-3 v5 includes the v1 design call PLUS the v2 P0 fixes (error propagation through a new FSM runner, emergency tail-check) PLUS the v3 fresh-context fix and corrected test signals PLUS the v4 retargeted `handlePartitionRebalance` body-entry counter + `partitionRebalanceRequestTimeout` override seam PLUS the v5 `partitionRebalanceBlocker` determinism seam. The implementation surface is moderate-large (~95 LOC + 5 required tests + 1 optional, ceiling ~97) but the cost of a subtle wrong assumption (incorrect claim ordering, missing notify, broken `restorePendingOnGraceBail` propagation, tail-check starved by exhausted ctx, test 5.3 measuring a drop-tolerant signal, Test 5.7 timing race) is high. Opus 4.7 for implementation; xhigh on the first review pass.
+
+Estimated reviewer wall-time budget: ~14 min across one `/plan-review` + 1–2 `/post-impl-review` rounds.
+
+---
+
+## 13. Revision history
+
+| Version | Date | Summary |
+|---|---|---|
+| v1 | 2026-05-19 | Initial draft. Design Call 1: Option A (periodic reconcile). Design Call 2: Option X (route partition lifecycle through FSM via new `TryClaimRebalancing` claim primitive). ~70 LOC + 2 tests. Plan-review returned 2 P0 / 3 P1 / 1 P2. |
+| v2 | 2026-05-19 | Closes all v1 plan-review findings. P0-A: added `StateMachine.RunClaimedRebalanceErr` + `Calculator.handlePartitionRebalance` so `errShuttingDown` propagates to `restorePendingOnGraceBail`. P0-B: added in-line tail-check via `observeAndDecide` after partition rebalance completes. P1-A: explicit duplicate-rebalance bound in §4; Test 5.3 promoted to required. P1-B: §2.1 invariant narrowed to eventual projection; §4 / §10.2 updated; Test 5.1 narrowed; optional Test 5.6 added. P1-C: §4 hook-order wording reworked to distinguish FSM enqueue order from user-hook execution order. P2: glossary edit at `docs/REFERENCE.md:358`. Tests: 2 required → 4 required + 1 optional. LOC: ~70 → ~88 (ceiling ~90). Plan-review v2 returned 1 residual P0 + 2 P1. |
+| v3 | 2026-05-19 | Closes plan-review v2 findings. **Residual P0-B (tail-check context exhaustion):** §3.5 now allocates a fresh stop-aware context for the tail-check via `ctxFromStopCh(c.stopCh, partitionTailCheckTimeout)` with `partitionTailCheckTimeout = 15 * time.Second`; tail-check is no longer starved by an exhausted `reqCtx`. New Test 5.7 added as a dedicated context-exhaustion regression (kept separate from Test 5.5 so the emergency-contention test stays focused on FSM ordering rather than context-deadline timing). §7.5 and §10.1 updated. **P1 (Test 5.5 wrong manager state + forbidden ordering):** Test 5.5 corrected to assert `StateEmergency` (per `manager_state.go:230-234`, `types/state.go:38-39`) and eventual presence of all four `(from,to)` tuples without ordering between the two cycles (per async `invokeHook` at `manager.go:827-839`); strict ordering deferred to the calculator-side `SubscribeToStateChanges` stream. Residual stale parenthetical in Test 5.2 removed. **P1 (Test 5.3 wrong signal):** Test 5.3 retargeted from the drop-tolerant async hook recorder to a deterministic producer-side `TryClaimRebalancing` invocation counter (lowest test-only surface: an `atomic.Int64` on `StateMachine` exposed via `export_test.go`); test fails if more than one extra `TryClaimRebalancing` runs per dropped partition update. LOC: ~88 → ~90 (ceiling ~92; +3 production LOC for fresh-context allocation + named timeout var, +0 test production LOC for the two test corrections). Tests: 4 required → 5 required + 1 optional. |
+| v4 | 2026-05-19 | Closes plan-review v3 residuals (0 P0, 2 P1, 1 P2). **P1-A (Test 5.3 bound):** Test 5.3 signal changed from `TryClaimRebalancing` invocation count (timing-dependent under the drain ticker) to `handlePartitionRebalance` body-entry count on the `Calculator`; bound tightened from `≤ 2` to `== 1` per dropped partition update, matching the §2.2.3 / §10.3 "at most one extra cycle" invariant directly. Counter is an `atomic.Int64` on `Calculator`, incremented as the first line of the partition-rebalance callback, exposed via `export_test.go`. **P1-B (Test 5.7 non-determinism, attempt 1):** §3.5 introduces package-level var `partitionRebalanceRequestTimeout` (default 30 s, matching legacy literal) replacing the inline `30*time.Second` in `triggerPartitionRebalance`. Test 5.7 overrides it to 10 ms via `export_test.go` so `reqCtx` is provably cancelled by the time `RunClaimedRebalanceErr` returns, removing the wall-clock race; v3's "delay-hook" option dropped. **P2 (15 s justification):** §3.5 comment for `partitionTailCheckTimeout` now derives the 15 s value from one worker-set KV read p99 + reconnect headroom, the negligible `TryClaimEmergency` CAS cost, and ratios to `partitionRebalanceRequestTimeout` (30 s) and `EmergencyGracePeriod` (5 s default); framed as an operational policy bound, not an empirically proven threshold. LOC: ~90 → ~93 (ceiling ~95). Tests: 5 required + 1 optional — unchanged in count. Plan-review v4 returned 0 P0 + 1 residual P1 (P1-B not fully closed). |
+| v5 | 2026-05-19 | Closes the v4 residual P1-B (Test 5.7 race). v4's 10 ms `partitionRebalanceRequestTimeout` override alone did not guarantee `reqCtx.Err() != nil` by the time `RunClaimedRebalanceErr` returned — a sufficiently fast `c.rebalance` body could complete in under 10 ms and let the test pass without checking the invariant. v5 adds `partitionRebalanceBlocker chan struct{}`, a nil-by-default package-level test-only seam in `internal/assignment`, consulted by `handlePartitionRebalance` AFTER the `partitionRebalanceEntries` increment and BEFORE the call into `c.rebalance`. Test 5.7 installs a non-nil channel, waits for the entry counter to bump (proving the callback is parked), sleeps past the 10 ms `reqCtx` deadline, then closes the blocker — making `reqCtx.Err() != nil` at `RunClaimedRebalanceErr` return structurally guaranteed rather than probabilistic. Other rebalance paths (scaling, emergency via `handleRebalance`) do NOT consult the blocker; production cost is one nil-load per partition-lifecycle callback invocation. v4 closures (P1-A Test 5.3 bound, P2 15 s derivation) and v3 closures (P0-A error propagation, P0-B fresh tail-check context, P1 Test 5.5/5.3 signal corrections) remain intact and unchanged. LOC: ~93 → ~95 (ceiling raised to ~97; +2 production LOC for the test-only `partitionRebalanceBlocker` var declaration and its nil-guarded `<-h` line inside `handlePartitionRebalance`). Tests: 5 required + 1 optional — unchanged in count. |

--- a/docs/plans/worker-state-hardening/README.md
+++ b/docs/plans/worker-state-hardening/README.md
@@ -1,0 +1,68 @@
+# Worker-State Mechanism Hardening
+
+Priority plan derived from the worker-state-transition audit (`tmp/worker_state_analysis/00-report.md` v3) and consolidated reviews (Codex `/plan-review`, in-conversation self-review). The audit initially surfaced 14 weak points (W1–W14); the Codex review of PR-1 v2 surfaced two additional pre-existing latent races (W15, W16). This plan ships all 16 weak points as **7 focused PRs plus a documentation pass**.
+
+## Why this exists
+
+The audit's focus was *"can the leader miss a transition and leave workers orphaned or in a falsely stable state?"* Two findings carry actual authority impact:
+
+- **W12** — the legacy assignment-alias watcher (the v2.3.0→v2.x rolling-upgrade path) exits permanently on channel close with no rewatch and no reconcile (`manager_assignment.go:287-289, 336-340`). Mid-upgrade workers can miss a fresher alias and stay on a stale assignment. **The only S2 finding that affects authority, not just observability.**
+- **W1+W5** — `Manager.State()` lies during real leader-side work, via two causes (subscriber drops + partition-lifecycle FSM bypass). Observable from dashboards, hooks, readiness probes.
+
+The rest are S3/S4 — latency, churn, metric noise, footguns — that ship as smaller PRs.
+
+## Status
+
+| Phase | State |
+|---|---|
+| Audit (v3, post-Codex review) | Done — `tmp/worker_state_analysis/00-report.md` |
+| Consolidated review | Done — `tmp/worker_state_analysis/02-consolidated.md` |
+| PR-1 (W12 — legacy alias watcher) | Pending — spec in `01-pr1-spec.md` v3 |
+| PR-2 (W15+W16 — cross-path stale-store + apply-retry race) | Pending — spec TODO; new since v1 (surfaced by Codex during PR-1 review) |
+| PR-3 (W1+W5 — `Manager.State()` reconcile + FSM contract) | Pending — spec TODO |
+| PR-4 (W2+W13 — heartbeat watcher rewatch + publisher backpressure) | Pending — spec TODO |
+| PR-5 (W3 — `lastWorkers` symmetry) | Pending — spec TODO |
+| PR-6 (W10 — Stop ordering) | Pending — spec TODO |
+| PR-7 (W7 — config validation) | Pending — spec TODO |
+| Doc (W11, W14) | Pending — bundle with PR-7 or standalone |
+| Open verification (capability bits, `LeaderRevision` consistency, source-revision rollback) | Pending — separate investigation; not part of this plan |
+
+## Layout
+
+| File | Content |
+|---|---|
+| `README.md` | This file. Entry point and status. |
+| `00-fix-plan.md` | Priority fix plan: ranked findings, PR sequencing, model/effort recommendations per phase, what NOT to fix. |
+| `01-pr1-spec.md` | PR-1 implementation spec (W12 — legacy alias watcher rewatch + reconcile). |
+| `02-pr2-spec.md` (TODO) | PR-2 implementation spec (W15+W16 — cross-path stale-store + apply-retry race; pre-`Apply` revalidation OR shared apply-interlock). |
+| `03-pr3-spec.md` (TODO) | PR-3 implementation spec (W1+W5 — `Manager.State()` reconcile + partition-lifecycle FSM contract). |
+| ... | Later PRs (PR-4 through PR-7 + Doc) written after the prior one merges (avoids speculative spec drift). |
+
+## Supporting artifacts
+
+Under `tmp/worker_state_analysis/` (not checked in):
+
+- `00-report.md` — the v3 audit
+- `00-report_worker-state-v2_review.md` — Codex external review
+- `01-self-review.md` — in-conversation self-review
+- `02-consolidated.md` — merged corrections
+
+## Cross-references
+
+- `docs/plans/assignment-correctness-fixes/00-fix-plan.md` — prior plan in the same area, used as structural template for this plan
+- `tmp/worker-state-transition-investigation.md` — GPT-5.5 reviewer's prior pass (incorporated into the audit)
+
+## PR sequencing (from `00-fix-plan.md`)
+
+| PR | Bundle | Effort | Gating |
+|---|---|---|---|
+| **PR-1** | W12 — legacy alias watcher rewatch + reconcile | ~30 LOC + 5 tests | None — pattern-mirror of `monitorCommitChanges` |
+| **PR-2** | W15+W16 — cross-path stale-store + apply-retry race | ~30 LOC + 3 tests | Design call: post-`Apply` revalidation vs shared apply-interlock |
+| **PR-3** | W1+W5 — `Manager.State()` reconcile + partition-lifecycle FSM contract | ~50 LOC + 2 tests + 1 design decision | Design call: route partition lifecycle through FSM vs narrow contract |
+| **PR-4** | W2+W13 — heartbeat watcher rewatch + bounded poll + publisher backpressure | ~50 LOC + 3 tests | None |
+| **PR-5** | W3 — `lastWorkers` symmetry across direct rebalance paths | ~10 LOC + 1 test | None — single-line move |
+| **PR-6** | W10 — Stop ordering / election release timing | ~20 LOC + 1 test | None |
+| **PR-7** | W7 — config validation warning for `EmergencyGracePeriod` spread | ~15 LOC + 1 test | None |
+| Doc | W11, W14, open-verification items | ~50 LOC doc | None |
+
+Recommended start: **PR-1** (highest authority impact; mechanical pattern; smallest spec).

--- a/internal/durable/subject_utils.go
+++ b/internal/durable/subject_utils.go
@@ -1,99 +1,34 @@
 package durable
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-	"text/template"
-	"unicode"
+	"github.com/arloliu/parti/v2/internal/dynamicbuild"
 )
 
 // partitionPlaceholder is the template token used to denote the partition id.
+// Kept here for backwards-compatible test references in subject_utils_test.go.
 const partitionPlaceholder = "{{.PartitionID}}"
 
-var errInvalidSubject = errors.New("invalid subject")
-
-// parseSubjectTemplateParts extracts the prefix and suffix surrounding the partition placeholder.
-// Returns ok=false if the placeholder is not present.
+// parseSubjectTemplateParts extracts the prefix and suffix surrounding the
+// partition placeholder. Delegates to internal/dynamicbuild so the runtime
+// and provision SDK share one implementation.
 func parseSubjectTemplateParts(tmpl string) (prefix, suffix string, ok bool) {
-	before, after, ok0 := strings.Cut(tmpl, partitionPlaceholder)
-	if !ok0 {
-		return "", "", false
-	}
-
-	return before, after, true
+	return dynamicbuild.ParseSubjectTemplateParts(tmpl)
 }
 
-func validateSubjectTokens(subject string, allowWildcard bool) error {
-	if subject == "" {
-		return errInvalidSubject
-	}
-
-	tokens := strings.Split(subject, ".")
-	for i, token := range tokens {
-		if token == "" {
-			return errInvalidSubject
-		}
-		if strings.IndexFunc(token, unicode.IsSpace) >= 0 {
-			return errInvalidSubject
-		}
-
-		if strings.ContainsAny(token, "*>") {
-			if !allowWildcard {
-				return errInvalidSubject
-			}
-			if token == ">" {
-				if i != len(tokens)-1 {
-					return errInvalidSubject
-				}
-
-				continue
-			}
-			if token == "*" {
-				continue
-			}
-
-			return errInvalidSubject
-		}
-	}
-
-	return nil
-}
-
+// validateSubjectTemplate verifies the subject template parses, renders, and
+// produces a valid subject. Delegates to internal/dynamicbuild.
 func validateSubjectTemplate(tmpl string, allowWildcard bool) error {
-	if _, _, ok := parseSubjectTemplateParts(tmpl); !ok {
-		return fmt.Errorf("invalid subject template: %q (must contain %s)", tmpl, partitionPlaceholder)
-	}
-
-	parsed, err := template.New("subject").Option("missingkey=error").Parse(tmpl)
-	if err != nil {
-		return err
-	}
-
-	var builder strings.Builder
-	if err := parsed.Execute(&builder, struct{ PartitionID string }{PartitionID: "p1"}); err != nil {
-		return err
-	}
-
-	return validateSubjectTokens(builder.String(), allowWildcard)
+	return dynamicbuild.ValidateSubjectTemplate(tmpl, allowWildcard)
 }
 
-// extractPartitionIDFromSubject returns the partition id embedded in subject using the given prefix/suffix.
-// Returns ok=false when the subject doesn't match the expected prefix/suffix framing.
+// validateSubjectTokens validates every dot-separated token of subject.
+// Used by broadcast_config.go for its WildcardFilter validation.
+func validateSubjectTokens(subject string, allowWildcard bool) error {
+	return dynamicbuild.ValidateSubjectTokens(subject, allowWildcard)
+}
+
+// extractPartitionIDFromSubject returns the partition id embedded in subject
+// using the given prefix/suffix. Delegates to internal/dynamicbuild.
 func extractPartitionIDFromSubject(subject, prefix, suffix string) (pid string, ok bool) {
-	// If both empty, we cannot reliably extract based on template shape.
-	if prefix == "" && suffix == "" {
-		return "", false
-	}
-	if !strings.HasPrefix(subject, prefix) || !strings.HasSuffix(subject, suffix) {
-		return "", false
-	}
-
-	start := len(prefix)
-	end := len(subject) - len(suffix)
-	if start > end || start < 0 || end > len(subject) {
-		return "", false
-	}
-
-	return subject[start:end], true
+	return dynamicbuild.ExtractPartitionIDFromSubject(subject, prefix, suffix)
 }

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"text/template"
@@ -13,8 +12,8 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/zeebo/xxh3"
 
+	"github.com/arloliu/parti/v2/internal/dynamicbuild"
 	"github.com/arloliu/parti/v2/jsutil"
 	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/arloliu/parti/v2/types"
@@ -411,19 +410,7 @@ func (wc *WorkerConsumer) addSubjectLoop(ctx context.Context, workerID string, s
 		Metrics:                     wc.config.Metrics,
 	}
 
-	consumerConfig := jetstream.ConsumerConfig{
-		Name:              durable,
-		Durable:           durable,
-		FilterSubject:     subject,
-		AckPolicy:         wc.config.AckPolicy,
-		AckWait:           wc.config.AckWait,
-		MaxDeliver:        wc.config.MaxDeliver,
-		InactiveThreshold: wc.config.InactiveThreshold,
-		MaxWaiting:        wc.config.MaxWaiting,
-		MaxAckPending:     wc.config.MaxAckPending,
-		MemoryStorage:     wc.config.ConsumerMemoryStorage,
-		Replicas:          wc.config.ConsumerReplicas,
-	}
+	consumerConfig := dynamicbuild.ConsumerConfig(durable, subject, wc.defaults())
 
 	pc := newPartitionConsumer(
 		wc.logger,
@@ -458,78 +445,54 @@ func (wc *WorkerConsumer) addSubjectLoop(ctx context.Context, workerID string, s
 // ensurePerSubjectConsumer creates or updates a per-subject durable with FilterSubject.
 // It employs a short retry strategy to handle transient NATS errors.
 func (wc *WorkerConsumer) ensurePerSubjectConsumer(ctx context.Context, durable string, subject string) (jetstream.Consumer, error) {
-	cfg := jetstream.ConsumerConfig{
-		Name:              durable,
-		Durable:           durable,
-		FilterSubject:     subject,
-		AckPolicy:         wc.config.AckPolicy,
-		AckWait:           wc.config.AckWait,
-		MaxDeliver:        wc.config.MaxDeliver,
-		InactiveThreshold: wc.config.InactiveThreshold,
-		MaxWaiting:        wc.config.MaxWaiting,
-		MaxAckPending:     wc.config.MaxAckPending,
-		MemoryStorage:     wc.config.ConsumerMemoryStorage,
-		Replicas:          wc.config.ConsumerReplicas,
-	}
-
+	cfg := dynamicbuild.ConsumerConfig(durable, subject, wc.defaults())
 	return jsutil.EnsureConsumer(ctx, wc.js, wc.config.StreamName, cfg)
 }
 
+// defaults captures the runtime tunables that feed dynamicbuild.ConsumerConfig.
+// Keeping this in one place ensures the two callsites (ensurePerSubjectConsumer
+// and addSubjectLoop) cannot drift from each other.
+func (wc *WorkerConsumer) defaults() dynamicbuild.Defaults {
+	return dynamicbuild.Defaults{
+		AckPolicy:             wc.config.AckPolicy,
+		AckWait:               wc.config.AckWait,
+		MaxDeliver:            wc.config.MaxDeliver,
+		InactiveThreshold:     wc.config.InactiveThreshold,
+		MaxWaiting:            wc.config.MaxWaiting,
+		MaxAckPending:         wc.config.MaxAckPending,
+		ConsumerMemoryStorage: wc.config.ConsumerMemoryStorage,
+		ConsumerReplicas:      wc.config.ConsumerReplicas,
+	}
+}
+
 // perSubjectDurableName returns a stable, sanitized durable for a given subject.
+// Delegates to internal/dynamicbuild so the runtime and provision SDK share
+// one implementation.
 func (wc *WorkerConsumer) perSubjectDurableName(prefix, subject string) string {
-	partID := wc.extractPartitionID(subject)
-	if partID == "" {
-		partID = subject
-	}
-
-	// Hash the subject to ensure uniqueness even if sanitization causes collisions
-	h := xxh3.HashString(subject)
-
-	sanitizedPartID := sanitizeConsumerName(partID)
-	if len(sanitizedPartID) > 50 {
-		sanitizedPartID = sanitizedPartID[:50]
-	}
-
-	// Format: <Prefix>_<SanitizedPartitionID>_<Hash>
-	return fmt.Sprintf("%s_%s_%016x", prefix, sanitizedPartID, h)
+	return dynamicbuild.PerSubjectDurableName(prefix, subject, wc.partitionPrefix, wc.partitionSuffix)
 }
 
 // sanitizeConsumerName sanitizes a consumer name according to allowed runes.
+// Kept as a package-level wrapper so cross-file callers (broadcast_consumer.go)
+// and tests (worker_consumer_test.go) continue to work unchanged.
 func sanitizeConsumerName(name string) string {
-	var b strings.Builder
-	b.Grow(len(name))
-	for _, r := range name {
-		if isAllowedConsumerRune(r) {
-			b.WriteRune(r)
-		} else {
-			b.WriteByte('_')
-		}
-	}
-
-	return b.String()
+	return dynamicbuild.SanitizeConsumerName(name)
 }
 
+// isAllowedConsumerRune reports whether r is allowed in a NATS consumer name.
+// Wrapper around dynamicbuild.IsAllowedConsumerRune for cross-file callers
+// (broadcast_config.go, config.go).
 func isAllowedConsumerRune(r rune) bool {
-	switch {
-	case r >= 'a' && r <= 'z':
-		return true
-	case r >= 'A' && r <= 'Z':
-		return true
-	case r >= '0' && r <= '9':
-		return true
-	case r == '-' || r == '_':
-		return true
-	default:
-		return false
-	}
+	return dynamicbuild.IsAllowedConsumerRune(r)
 }
 
-// buildSubjects generates a sorted, deduplicated list of subjects from partitions,
-// ensuring the subject template is parsed.
+// buildSubjects generates a sorted, deduplicated list of subjects from partitions.
+// Delegates to internal/dynamicbuild for the shared pure-helper implementation;
+// the wrapper exists so callers and tests can continue to invoke it on the
+// receiver and so wc.subjectTemplate stays populated for downstream use.
 func (wc *WorkerConsumer) buildSubjects(partitions []types.Partition) ([]string, error) {
-	// Ensure we have a parsed template even if constructed manually in tests
-	tmpl := wc.subjectTemplate
-	if tmpl == nil {
+	// Ensure we have a parsed template even if constructed manually in tests.
+	if wc.subjectTemplate == nil {
 		t, err := template.New("subject").Parse(wc.config.SubjectTemplate)
 		if err != nil {
 			return nil, fmt.Errorf("parse subject template: %w", err)
@@ -537,59 +500,7 @@ func (wc *WorkerConsumer) buildSubjects(partitions []types.Partition) ([]string,
 		wc.subjectTemplate = t
 	}
 
-	return wc.doBuildSubjects(partitions)
-}
-
-// buildSubjects generates a sorted, deduplicated list of subjects from partitions.
-func (wc *WorkerConsumer) doBuildSubjects(partitions []types.Partition) ([]string, error) {
-	if len(partitions) == 0 {
-		return []string{}, nil
-	}
-
-	// Deduplicate via map
-	m := make(map[string]struct{}, len(partitions))
-	for _, p := range partitions {
-		subj, err := wc.generateSubject(p)
-		if err != nil {
-			return nil, err
-		}
-		m[subj] = struct{}{}
-	}
-
-	subjects := make([]string, 0, len(m))
-	for s := range m {
-		subjects = append(subjects, s)
-	}
-
-	// Sort for deterministic ordering
-	slices.Sort(subjects)
-
-	return subjects, nil
-}
-
-// generateSubject generates a subject from the template.
-//
-// Template context contains PartitionID (keys joined with ".").
-// Example: ["source", "region", "us"] → "source.region.us"
-func (wc *WorkerConsumer) generateSubject(partition types.Partition) (string, error) {
-	if len(partition.Keys) == 0 {
-		return "", errors.New("partition has no keys")
-	}
-
-	// subjectContext is the template context for subject generation.
-	type subjectContext struct {
-		PartitionID string
-	}
-
-	ctx := subjectContext{PartitionID: partition.SubjectKey()}
-
-	// Execute template
-	var buf strings.Builder
-	if err := wc.subjectTemplate.Execute(&buf, ctx); err != nil {
-		return "", fmt.Errorf("failed to execute subject template: %w", err)
-	}
-
-	return buf.String(), nil
+	return dynamicbuild.BuildSubjects(wc.config.SubjectTemplate, partitions)
 }
 
 // ensureGateResolver lazily initializes the automatic claim-based resolver.

--- a/internal/dynamicbuild/builder.go
+++ b/internal/dynamicbuild/builder.go
@@ -1,0 +1,321 @@
+// Package dynamicbuild contains pure helpers shared by the runtime
+// dynamic-consumer code path in internal/durable and the provision SDK's
+// dynamic-consumer alignment builder. Every exported function is a pure
+// transform — no NATS I/O, no goroutines, no global state.
+//
+// The package exists because two callers need identical subject generation,
+// durable-name derivation, and jetstream.ConsumerConfig construction:
+//
+//   - The runtime worker_consumer in internal/durable, which owns the
+//     producer of the JetStream consumer (calls jsutil.EnsureConsumer with
+//     the result of ConsumerConfig).
+//   - The provision SDK's PlanDynamicConsumers, which produces a deterministic
+//     plan without touching NATS.
+//
+// Both callers must agree byte-for-byte on identity fields (Name, Durable,
+// FilterSubject, AckPolicy, DeliverPolicy). The Defaults struct captures the
+// runtime-tunable fields that vary by consumer option but do not affect
+// identity; provision passes runtime defaults, and the runtime passes its
+// configured values.
+package dynamicbuild
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"text/template"
+	"time"
+	"unicode"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/zeebo/xxh3"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// partitionPlaceholder is the template token used to denote the partition id.
+// Mirrors the constant in internal/durable so the helper is self-contained.
+const partitionPlaceholder = "{{.PartitionID}}"
+
+// errInvalidSubject is returned by validateSubjectTokens when a subject token
+// is empty, contains whitespace, or carries a disallowed wildcard.
+var errInvalidSubject = errors.New("invalid subject")
+
+// Defaults captures the runtime-tunable fields that the canonical
+// jetstream.ConsumerConfig literal in internal/durable reads off
+// WorkerConsumerConfig. These are the fields that do NOT participate in
+// the W4 v1 equality subset; provision passes runtime defaults, and the
+// runtime passes its configured values.
+//
+// The struct mirrors worker_consumer.go:461-473 one-for-one. Any addition
+// here must be matched in ConsumerConfig and in the runtime callsites.
+type Defaults struct {
+	AckPolicy             jetstream.AckPolicy
+	AckWait               time.Duration
+	MaxDeliver            int
+	InactiveThreshold     time.Duration
+	MaxWaiting            int
+	MaxAckPending         int
+	ConsumerMemoryStorage bool
+	ConsumerReplicas      int
+}
+
+// ConsumerConfig builds the per-subject jetstream.ConsumerConfig used by
+// both the runtime (internal/durable.WorkerConsumer.ensurePerSubjectConsumer)
+// and the provision SDK's PlanDynamicConsumers.
+//
+// The five identity fields — Name, Durable, FilterSubject, AckPolicy,
+// DeliverPolicy — are deterministic from the inputs. AckPolicy and
+// DeliverPolicy are explicitly assigned from def.AckPolicy and the
+// jetstream zero value DeliverAllPolicy, so the result is robust to any
+// future iota reordering in nats.go.
+//
+// Note: the runtime literal at worker_consumer.go:461-473 currently relies
+// on the jetstream.AckPolicy zero value AckExplicitPolicy when AckPolicy
+// is unset. Provision passes jetstream.AckExplicitPolicy explicitly in
+// def.AckPolicy; the runtime passes wc.config.AckPolicy which defaults to
+// AckExplicitPolicy via fuda. Both code paths therefore yield the same
+// effective value.
+func ConsumerConfig(durable, subject string, def Defaults) jetstream.ConsumerConfig {
+	return jetstream.ConsumerConfig{
+		Name:              durable,
+		Durable:           durable,
+		FilterSubject:     subject,
+		AckPolicy:         def.AckPolicy,
+		DeliverPolicy:     jetstream.DeliverAllPolicy,
+		AckWait:           def.AckWait,
+		MaxDeliver:        def.MaxDeliver,
+		InactiveThreshold: def.InactiveThreshold,
+		MaxWaiting:        def.MaxWaiting,
+		MaxAckPending:     def.MaxAckPending,
+		MemoryStorage:     def.ConsumerMemoryStorage,
+		Replicas:          def.ConsumerReplicas,
+	}
+}
+
+// PerSubjectDurableName returns a stable, sanitized durable name for a
+// given subject. The format is "<consumerPrefix>_<sanitizedPartitionID>_<hash>",
+// where the hash is the xxh3 of the subject (16 hex characters), the
+// sanitized partition id is the partition id with disallowed runes replaced
+// by underscores, and the partition id portion is truncated to 50 characters.
+//
+// The xxh3 suffix ensures uniqueness even when sanitization causes the
+// partition id portion to collide.
+//
+// partitionPrefix and partitionSuffix are the parts of the subject template
+// surrounding the {{.PartitionID}} placeholder. When the subject does not
+// match those framing parts, the partition id falls back to the full subject.
+func PerSubjectDurableName(consumerPrefix, subject, partitionPrefix, partitionSuffix string) string {
+	partID, ok := ExtractPartitionIDFromSubject(subject, partitionPrefix, partitionSuffix)
+	if !ok || partID == "" {
+		partID = subject
+	}
+
+	// Hash the subject to ensure uniqueness even if sanitization causes collisions.
+	h := xxh3.HashString(subject)
+
+	sanitizedPartID := SanitizeConsumerName(partID)
+	if len(sanitizedPartID) > 50 {
+		sanitizedPartID = sanitizedPartID[:50]
+	}
+
+	return fmt.Sprintf("%s_%s_%016x", consumerPrefix, sanitizedPartID, h)
+}
+
+// BuildSubjects generates a sorted, deduplicated list of subjects from
+// partitions using the provided subject template. The template must contain
+// the {{.PartitionID}} placeholder.
+//
+// The output ordering is deterministic via slices.Sort.
+//
+// Errors:
+//   - parse failure: wraps the text/template parse error.
+//   - empty partition Keys: returns "partition has no keys".
+//   - render failure: wraps the text/template execute error.
+func BuildSubjects(subjectTemplate string, partitions []types.Partition) ([]string, error) {
+	if len(partitions) == 0 {
+		return []string{}, nil
+	}
+
+	tmpl, err := template.New("subject").Parse(subjectTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("parse subject template: %w", err)
+	}
+
+	m := make(map[string]struct{}, len(partitions))
+	for _, p := range partitions {
+		subj, err := renderSubject(tmpl, p)
+		if err != nil {
+			return nil, err
+		}
+		m[subj] = struct{}{}
+	}
+
+	subjects := make([]string, 0, len(m))
+	for s := range m {
+		subjects = append(subjects, s)
+	}
+	slices.Sort(subjects)
+
+	return subjects, nil
+}
+
+// GenerateSubject renders the subject template for a single partition. The
+// template must already be parsed by the caller path, but GenerateSubject
+// accepts the raw template string and parses it itself so it can be called
+// from non-runtime code paths (provision builder, tests).
+//
+// Returns "partition has no keys" if partition.Keys is empty.
+func GenerateSubject(subjectTemplate string, partition types.Partition) (string, error) {
+	tmpl, err := template.New("subject").Parse(subjectTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parse subject template: %w", err)
+	}
+	return renderSubject(tmpl, partition)
+}
+
+// renderSubject is the shared rendering routine used by BuildSubjects
+// and GenerateSubject. It accepts an already-parsed template so callers
+// that render many partitions parse exactly once.
+func renderSubject(tmpl *template.Template, partition types.Partition) (string, error) {
+	if len(partition.Keys) == 0 {
+		return "", errors.New("partition has no keys")
+	}
+
+	type subjectContext struct {
+		PartitionID string
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, subjectContext{PartitionID: partition.SubjectKey()}); err != nil {
+		return "", fmt.Errorf("failed to execute subject template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// ParseSubjectTemplateParts extracts the prefix and suffix surrounding the
+// partition placeholder. Returns ok=false if the placeholder is not present.
+func ParseSubjectTemplateParts(tmpl string) (prefix, suffix string, ok bool) {
+	before, after, ok0 := strings.Cut(tmpl, partitionPlaceholder)
+	if !ok0 {
+		return "", "", false
+	}
+	return before, after, true
+}
+
+// ValidateSubjectTemplate verifies that a subject template contains the
+// {{.PartitionID}} placeholder, parses successfully (with missing-key
+// detection), and renders to a valid subject. allowWildcard controls
+// whether wildcard tokens "*" and ">" are allowed in the rendered subject.
+//
+// Used by both the runtime (internal/durable) and the provision SDK's
+// PlanDynamicConsumers static validation.
+func ValidateSubjectTemplate(tmpl string, allowWildcard bool) error {
+	if _, _, ok := ParseSubjectTemplateParts(tmpl); !ok {
+		return fmt.Errorf("invalid subject template: %q (must contain %s)", tmpl, partitionPlaceholder)
+	}
+
+	parsed, err := template.New("subject").Option("missingkey=error").Parse(tmpl)
+	if err != nil {
+		return err
+	}
+
+	var builder strings.Builder
+	if err := parsed.Execute(&builder, struct{ PartitionID string }{PartitionID: "p1"}); err != nil {
+		return err
+	}
+
+	return ValidateSubjectTokens(builder.String(), allowWildcard)
+}
+
+// ValidateSubjectTokens checks every dot-separated token of subject for
+// validity. allowWildcard controls whether "*" and ">" tokens are accepted.
+// Mirrors the validation in internal/durable.subject_utils.go so the two
+// packages stay aligned.
+func ValidateSubjectTokens(subject string, allowWildcard bool) error {
+	if subject == "" {
+		return errInvalidSubject
+	}
+
+	tokens := strings.Split(subject, ".")
+	for i, token := range tokens {
+		if token == "" {
+			return errInvalidSubject
+		}
+		if strings.IndexFunc(token, unicode.IsSpace) >= 0 {
+			return errInvalidSubject
+		}
+		if strings.ContainsAny(token, "*>") {
+			if !allowWildcard {
+				return errInvalidSubject
+			}
+			if token == ">" {
+				if i != len(tokens)-1 {
+					return errInvalidSubject
+				}
+				continue
+			}
+			if token == "*" {
+				continue
+			}
+
+			return errInvalidSubject
+		}
+	}
+
+	return nil
+}
+
+// ExtractPartitionIDFromSubject returns the partition id embedded in subject
+// using the given prefix/suffix. Returns ok=false when the subject doesn't
+// match the expected prefix/suffix framing.
+func ExtractPartitionIDFromSubject(subject, prefix, suffix string) (pid string, ok bool) {
+	if prefix == "" && suffix == "" {
+		return "", false
+	}
+	if !strings.HasPrefix(subject, prefix) || !strings.HasSuffix(subject, suffix) {
+		return "", false
+	}
+	start := len(prefix)
+	end := len(subject) - len(suffix)
+	if start > end || start < 0 || end > len(subject) {
+		return "", false
+	}
+
+	return subject[start:end], true
+}
+
+// SanitizeConsumerName replaces any rune in name that is not in the allowed
+// consumer-name charset (a-z, A-Z, 0-9, '-', '_') with '_'.
+func SanitizeConsumerName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if IsAllowedConsumerRune(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+
+	return b.String()
+}
+
+// IsAllowedConsumerRune reports whether r is allowed in a NATS consumer
+// name (a-z, A-Z, 0-9, '-', '_').
+func IsAllowedConsumerRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '-' || r == '_':
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/dynamicbuild/builder_test.go
+++ b/internal/dynamicbuild/builder_test.go
@@ -1,0 +1,205 @@
+package dynamicbuild
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+func TestSanitizeConsumerName_ReplacesInvalidRunes(t *testing.T) {
+	in := "prefix s/$ub ject!*"
+	out := SanitizeConsumerName(in)
+	require.NotContains(t, out, " ")
+	require.NotContains(t, out, "/")
+	require.NotContains(t, out, "$")
+	require.NotContains(t, out, "!")
+	for _, r := range out {
+		require.True(t, IsAllowedConsumerRune(r), "rune %q not allowed", r)
+	}
+}
+
+func TestIsAllowedConsumerRune(t *testing.T) {
+	for _, r := range "abcXYZ089-_" {
+		require.True(t, IsAllowedConsumerRune(r), "%q must be allowed", r)
+	}
+	for _, r := range " .!@#/\\$" {
+		require.False(t, IsAllowedConsumerRune(r), "%q must NOT be allowed", r)
+	}
+}
+
+func TestPerSubjectDurableName_StableAndDistinct(t *testing.T) {
+	prefix := "dur"
+	pre, suf := "work.", ""
+	d1 := PerSubjectDurableName(prefix, "work.a.b", pre, suf)
+	d2 := PerSubjectDurableName(prefix, "work.a.b", pre, suf)
+	require.Equal(t, d1, d2)
+	d3 := PerSubjectDurableName(prefix, "work.a.c", pre, suf)
+	require.NotEqual(t, d1, d3)
+}
+
+func TestPerSubjectDurableName_FallbackToSubjectWhenFramingMissing(t *testing.T) {
+	// No template framing → partID falls back to the full subject; format is
+	// prefix_<sanitizedSubject>_<hash>.
+	d := PerSubjectDurableName("dur", "work.a.b", "", "")
+	require.True(t, strings.HasPrefix(d, "dur_work_a_b_"), "got %q", d)
+}
+
+func TestPerSubjectDurableName_TruncatesLongPartID(t *testing.T) {
+	// 60-char partition id; framing is "p." prefix only.
+	pid := strings.Repeat("x", 60)
+	subject := "p." + pid
+	d := PerSubjectDurableName("dur", subject, "p.", "")
+	// Expect: dur_<50 x's>_<16hex>
+	parts := strings.Split(d, "_")
+	require.Len(t, parts, 3)
+	require.Equal(t, "dur", parts[0])
+	require.Len(t, parts[1], 50, "sanitizedPartID portion must be truncated to 50")
+	require.Len(t, parts[2], 16, "hash portion must be 16 hex chars")
+}
+
+func TestPerSubjectDurableName_UnicodeSanitized(t *testing.T) {
+	// Non-ASCII runes get replaced with underscore.
+	d := PerSubjectDurableName("dur", "p.日本語", "p.", "")
+	// The partition id "日本語" → sanitizes to "___" (3 underscores from 3 multi-byte runes).
+	require.Contains(t, d, "dur____") // dur + _ separator + 3 underscores
+}
+
+func TestBuildSubjects_DedupeAndSort(t *testing.T) {
+	parts := []types.Partition{
+		{Keys: []string{"b", "2"}},
+		{Keys: []string{"a", "1"}},
+		{Keys: []string{"a", "1"}}, // duplicate
+	}
+	subs, err := BuildSubjects("events.{{.PartitionID}}", parts)
+	require.NoError(t, err)
+	require.Equal(t, []string{"events.a.1", "events.b.2"}, subs)
+}
+
+func TestBuildSubjects_EmptyPartitionsReturnsEmptySlice(t *testing.T) {
+	subs, err := BuildSubjects("events.{{.PartitionID}}", nil)
+	require.NoError(t, err)
+	require.Empty(t, subs)
+}
+
+func TestBuildSubjects_BadTemplate(t *testing.T) {
+	_, err := BuildSubjects("events.{{.MissingClose", []types.Partition{{Keys: []string{"a"}}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse subject template")
+}
+
+func TestBuildSubjects_PartitionWithNoKeys(t *testing.T) {
+	_, err := BuildSubjects("events.{{.PartitionID}}", []types.Partition{{Keys: nil}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "partition has no keys")
+}
+
+func TestGenerateSubject(t *testing.T) {
+	s, err := GenerateSubject("events.{{.PartitionID}}.>", types.Partition{Keys: []string{"a", "1"}})
+	require.NoError(t, err)
+	require.Equal(t, "events.a.1.>", s)
+}
+
+func TestParseSubjectTemplateParts(t *testing.T) {
+	p, s, ok := ParseSubjectTemplateParts("a.{{.PartitionID}}.b")
+	require.True(t, ok)
+	require.Equal(t, "a.", p)
+	require.Equal(t, ".b", s)
+
+	_, _, ok = ParseSubjectTemplateParts("a.no-placeholder.b")
+	require.False(t, ok)
+}
+
+func TestValidateSubjectTemplate(t *testing.T) {
+	require.NoError(t, ValidateSubjectTemplate("events.{{.PartitionID}}", true))
+	require.NoError(t, ValidateSubjectTemplate("events.{{.PartitionID}}.>", true))
+	require.Error(t, ValidateSubjectTemplate("events.>", true), "missing placeholder")
+	require.Error(t, ValidateSubjectTemplate("events.{{.PartitionID}}.*", false), "wildcard disallowed")
+}
+
+func TestExtractPartitionIDFromSubject(t *testing.T) {
+	pid, ok := ExtractPartitionIDFromSubject("a.123.b", "a.", ".b")
+	require.True(t, ok)
+	require.Equal(t, "123", pid)
+
+	_, ok = ExtractPartitionIDFromSubject("anything", "", "")
+	require.False(t, ok)
+}
+
+// TestConsumerConfig_ProducesExpectedLiteral pins every field on
+// jetstream.ConsumerConfig that ConsumerConfig sets. This is the seam that
+// catches drift between the runtime literal and the extracted helper.
+func TestConsumerConfig_ProducesExpectedLiteral(t *testing.T) {
+	def := Defaults{
+		AckPolicy:             jetstream.AckExplicitPolicy,
+		AckWait:               30 * time.Second,
+		MaxDeliver:            -1,
+		InactiveThreshold:     24 * time.Hour,
+		MaxWaiting:            2,
+		MaxAckPending:         0,
+		ConsumerMemoryStorage: false,
+		ConsumerReplicas:      0,
+	}
+	got := ConsumerConfig("dur_p1_aaaa", "orders.p1", def)
+
+	require.Equal(t, "dur_p1_aaaa", got.Name)
+	require.Equal(t, "dur_p1_aaaa", got.Durable)
+	require.Equal(t, "orders.p1", got.FilterSubject)
+	require.Equal(t, jetstream.AckExplicitPolicy, got.AckPolicy)
+	require.Equal(t, jetstream.DeliverAllPolicy, got.DeliverPolicy)
+	require.Equal(t, 30*time.Second, got.AckWait)
+	require.Equal(t, -1, got.MaxDeliver)
+	require.Equal(t, 24*time.Hour, got.InactiveThreshold)
+	require.Equal(t, 2, got.MaxWaiting)
+	require.Equal(t, 0, got.MaxAckPending)
+	require.False(t, got.MemoryStorage)
+	require.Equal(t, 0, got.Replicas)
+}
+
+func TestConsumerConfig_TunablesPassThrough(t *testing.T) {
+	def := Defaults{
+		AckPolicy:             jetstream.AckExplicitPolicy,
+		AckWait:               5 * time.Second,
+		MaxDeliver:            7,
+		InactiveThreshold:     time.Hour,
+		MaxWaiting:            8,
+		MaxAckPending:         9,
+		ConsumerMemoryStorage: true,
+		ConsumerReplicas:      3,
+	}
+	got := ConsumerConfig("dur", "subj", def)
+	require.Equal(t, 5*time.Second, got.AckWait)
+	require.Equal(t, 7, got.MaxDeliver)
+	require.Equal(t, time.Hour, got.InactiveThreshold)
+	require.Equal(t, 8, got.MaxWaiting)
+	require.Equal(t, 9, got.MaxAckPending)
+	require.True(t, got.MemoryStorage)
+	require.Equal(t, 3, got.Replicas)
+}
+
+// TestConsumerConfig_NoStrayFieldsSet asserts that ConsumerConfig does not
+// touch any field beyond the 12 it documents. Adding a new field to the
+// helper without updating callers is a silent bug; this test makes that
+// surface as a failure.
+func TestConsumerConfig_NoStrayFieldsSet(t *testing.T) {
+	got := ConsumerConfig("d", "s", Defaults{AckPolicy: jetstream.AckExplicitPolicy})
+	// Fields the runtime does NOT touch — assert zero value.
+	require.Empty(t, got.Description)
+	require.Empty(t, got.DeliverSubject)
+	require.Empty(t, got.DeliverGroup)
+	require.Zero(t, got.OptStartSeq)
+	require.Nil(t, got.OptStartTime)
+	require.Zero(t, got.RateLimit)
+	require.Empty(t, got.SampleFrequency)
+	require.False(t, got.HeadersOnly)
+	require.Zero(t, got.MaxRequestBatch)
+	require.Zero(t, got.MaxRequestExpires)
+	require.Zero(t, got.MaxRequestMaxBytes)
+	require.Nil(t, got.BackOff)
+	require.Nil(t, got.Metadata)
+	require.Empty(t, got.FilterSubjects)
+}

--- a/internal/kvbuckets/builder.go
+++ b/internal/kvbuckets/builder.go
@@ -1,0 +1,46 @@
+// Package kvbuckets provides shared builders for JetStream KeyValue bucket
+// configurations used by the Parti control plane.
+package kvbuckets
+
+import (
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// BuildKeyValueConfig returns the canonical jetstream.KeyValueConfig for a
+// Parti control-plane KV bucket.
+//
+// The returned config is byte-equivalent to the literal historically produced
+// inside (*Manager).ensureKVBucket in manager_setup.go:
+//
+//	jetstream.KeyValueConfig{
+//	    Bucket:  bucket,
+//	    History: 1,
+//	    Storage: storage,
+//	    // TTL set only when ttl > 0
+//	}
+//
+// This equivalence is a hard contract: the forthcoming provision package builds
+// its KeyValueConfig by calling this function and then appending metadata. Any
+// deviation from the historical literal would silently break the byte-equality
+// invariant between live Manager buckets and provision-managed buckets.
+//
+// Rules:
+//   - Bucket, History (always 1), and Storage are always set.
+//   - TTL is set only when ttl > 0; zero and negative values leave cfg.TTL unset.
+//   - Replicas is intentionally left zero — nats.go normalizes it to 1 server-side.
+//   - This function performs no I/O.
+func BuildKeyValueConfig(bucket string, ttl time.Duration, storage jetstream.StorageType) jetstream.KeyValueConfig {
+	cfg := jetstream.KeyValueConfig{
+		Bucket:  bucket,
+		History: 1,
+		Storage: storage,
+	}
+
+	if ttl > 0 {
+		cfg.TTL = ttl
+	}
+
+	return cfg
+}

--- a/internal/kvbuckets/builder_test.go
+++ b/internal/kvbuckets/builder_test.go
@@ -1,0 +1,72 @@
+package kvbuckets
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestBuildKeyValueConfig_TTL(t *testing.T) {
+	t.Run("positive TTL is set", func(t *testing.T) {
+		ttl := 5 * time.Second
+		cfg := BuildKeyValueConfig("test-bucket", ttl, jetstream.FileStorage)
+		if cfg.TTL != ttl {
+			t.Errorf("expected TTL=%v, got %v", ttl, cfg.TTL)
+		}
+	})
+
+	t.Run("zero TTL leaves cfg.TTL unset", func(t *testing.T) {
+		cfg := BuildKeyValueConfig("test-bucket", 0, jetstream.FileStorage)
+		if cfg.TTL != 0 {
+			t.Errorf("expected TTL=0 (unset), got %v", cfg.TTL)
+		}
+	})
+
+	t.Run("negative TTL leaves cfg.TTL unset", func(t *testing.T) {
+		cfg := BuildKeyValueConfig("test-bucket", -1*time.Second, jetstream.FileStorage)
+		if cfg.TTL != 0 {
+			t.Errorf("expected TTL=0 (unset), got %v", cfg.TTL)
+		}
+	})
+}
+
+func TestBuildKeyValueConfig_Storage(t *testing.T) {
+	t.Run("FileStorage is propagated", func(t *testing.T) {
+		cfg := BuildKeyValueConfig("test-bucket", 0, jetstream.FileStorage)
+		if cfg.Storage != jetstream.FileStorage {
+			t.Errorf("expected FileStorage, got %v", cfg.Storage)
+		}
+	})
+
+	t.Run("MemoryStorage is propagated", func(t *testing.T) {
+		cfg := BuildKeyValueConfig("test-bucket", 0, jetstream.MemoryStorage)
+		if cfg.Storage != jetstream.MemoryStorage {
+			t.Errorf("expected MemoryStorage, got %v", cfg.Storage)
+		}
+	})
+}
+
+func TestBuildKeyValueConfig_HistoryAlwaysOne(t *testing.T) {
+	for _, storage := range []jetstream.StorageType{jetstream.FileStorage, jetstream.MemoryStorage} {
+		cfg := BuildKeyValueConfig("test-bucket", 10*time.Second, storage)
+		if cfg.History != 1 {
+			t.Errorf("expected History=1, got %d (storage=%v)", cfg.History, storage)
+		}
+	}
+}
+
+func TestBuildKeyValueConfig_ReplicasUnset(t *testing.T) {
+	cfg := BuildKeyValueConfig("test-bucket", 5*time.Second, jetstream.FileStorage)
+	if cfg.Replicas != 0 {
+		t.Errorf("expected Replicas=0 (unset), got %d", cfg.Replicas)
+	}
+}
+
+func TestBuildKeyValueConfig_BucketPropagated(t *testing.T) {
+	const bucketName = "parti-control-plane-elections-v2"
+	cfg := BuildKeyValueConfig(bucketName, 0, jetstream.FileStorage)
+	if cfg.Bucket != bucketName {
+		t.Errorf("expected Bucket=%q, got %q", bucketName, cfg.Bucket)
+	}
+}

--- a/internal/metrics/nop.go
+++ b/internal/metrics/nop.go
@@ -205,6 +205,11 @@ func (n *NopMetrics) RecordStaleLeaderRejected() {
 	// No-op
 }
 
+// RecordStaleSnapshotStoreDropped discards the stale-snapshot-Store gate counter.
+func (n *NopMetrics) RecordStaleSnapshotStoreDropped() {
+	// No-op
+}
+
 // RecordCommitPayloadMissing discards the malformed-commit counter.
 func (n *NopMetrics) RecordCommitPayloadMissing() {
 	// No-op

--- a/kvbuckets.go
+++ b/kvbuckets.go
@@ -1,0 +1,20 @@
+package parti
+
+import (
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// BuildControlPlaneKVConfig returns the canonical jetstream.KeyValueConfig for
+// a Parti control-plane KV bucket. It is a thin wrapper around
+// internal/kvbuckets.BuildKeyValueConfig, re-exported here so that external
+// packages (such as provision/) can construct byte-equivalent configurations
+// without importing an internal package.
+//
+// See internal/kvbuckets.BuildKeyValueConfig for the full contract, including
+// the byte-equivalence guarantee with (*Manager).ensureKVBucket.
+func BuildControlPlaneKVConfig(bucket string, ttl time.Duration, storage jetstream.StorageType) jetstream.KeyValueConfig {
+	return kvbuckets.BuildKeyValueConfig(bucket, ttl, storage)
+}

--- a/manager.go
+++ b/manager.go
@@ -147,11 +147,35 @@ type Manager struct {
 	wg     sync.WaitGroup
 	mu     sync.RWMutex
 
+	// applyStoreMu serializes the (stale-check, handoff Apply, snapshot
+	// Store, LSR advance, heartbeat SetAppliedAssignment) critical section
+	// across all callers — commit watcher (handleCommitValue → applyAssignment),
+	// alias watcher (handleAssignmentEntry → applyAssignment), the
+	// scheduleApplyRetry goroutine, and the operator recovery refresh path
+	// (refreshAssignmentFromNATS → monotonicStore).
+	//
+	// Without serialization, three independent goroutines can each pass a
+	// pre-Apply gate against a stale snapshot, run handoffCoordinator.Apply
+	// concurrently, and Store in arbitrary order — losing the W15 cross-leader
+	// race and the W16 apply-retry race. See PR-2 spec
+	// docs/plans/worker-state-hardening/02-pr2-spec.md.
+	//
+	// Lock contract: applyStoreMu and m.mu are NEVER held together.
+	// Callers must not hold m.mu when entering the apply pipeline (and vice
+	// versa). The two locks protect disjoint state.
+	applyStoreMu sync.Mutex
+
 	// testHookAfterApplyStore, when non-nil, is invoked synchronously after
 	// applyAssignmentWithPrev's m.assignment.Store(newAssignment) returns.
 	// Set ONLY by tests in this package to assert the LSR-before-Store
 	// ordering invariant (v3 review P0). Production code MUST NOT set this
 	// field; it is nil-default. See TestApplyAssignment_LSRAdvancesBeforeSnapshotStore.
+	//
+	// Concurrency contract (PR-2): the hook runs INSIDE applyStoreMu. It
+	// MUST NOT call applyAssignment, applyAssignmentWithPrev,
+	// refreshAssignmentFromNATS, or any other method that acquires
+	// applyStoreMu — doing so would self-deadlock. Lock-free reads of
+	// m.assignment / m.lastSeenLeaderRevision are safe.
 	testHookAfterApplyStore func(Assignment)
 }
 

--- a/manager_apply_serialization_test.go
+++ b/manager_apply_serialization_test.go
@@ -1,0 +1,288 @@
+package parti
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/stretchr/testify/require"
+)
+
+// PR-2 W15+W16 — pre-Apply (V, LR) serialized gate inside applyStoreMu.
+// See docs/plans/worker-state-hardening/02-pr2-spec.md.
+
+// Test 5.1 — W15 cross-path: blocked commit Apply does not regress fresher
+// alias snapshot. The slower path acquires applyStoreMu first, blocks
+// inside its Apply; the alias path waits, then acquires the lock after
+// the commit Stores (V=10, LR=3). The alias's stale check sees (V=10, LR=3)
+// vs candidate (V=10, LR=4) — alias is fresher, Apply proceeds, snapshot
+// ends at (V=10, LR=4).
+func TestApplySerialization_W15_FreshAliasWinsOverBlockedCommit(t *testing.T) {
+	t.Parallel()
+	m, rh, _, rm := newTestManager(t)
+
+	// First Apply will block until releaseFirst is closed.
+	rh.blockFirstApply.Store(true)
+
+	c1 := Assignment{Version: 10, LeaderRevision: 3}
+	a1 := Assignment{Version: 10, LeaderRevision: 4}
+
+	g1Done := make(chan struct{})
+	go func() {
+		defer close(g1Done)
+		_ = m.applyAssignment(c1)
+	}()
+
+	// Wait for G1 to enter Apply (holding applyStoreMu).
+	<-rh.firstApplyReady
+
+	g2Done := make(chan struct{})
+	go func() {
+		defer close(g2Done)
+		_ = m.applyAssignment(a1)
+	}()
+
+	// Give G2 time to block on applyStoreMu.
+	time.Sleep(50 * time.Millisecond)
+
+	// Release G1. It Stores (V=10, LR=3), then G2 acquires the lock,
+	// stale-checks (10,4) vs (10,3) → not stale → Applies, Stores (10,4).
+	close(rh.releaseFirst)
+
+	select {
+	case <-g1Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("G1 (commit C1) did not return")
+	}
+	select {
+	case <-g2Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("G2 (alias A1) did not return")
+	}
+
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version)
+	require.Equal(t, uint64(4), cur.LeaderRevision,
+		"alias's higher LR must end as the snapshot")
+	require.Equal(t, uint64(4), m.lastSeenLeaderRevision.Load(),
+		"LSR must advance to 4")
+	require.Equal(t, int64(2), rh.applyCount.Load(),
+		"both candidates applied (commit + alias)")
+	require.Equal(t, int64(0), rm.staleSnapshotStoreDropped.Load(),
+		"no stale drop — both passed the gate in sequence")
+}
+
+// Test 5.1b — reverse ordering. The fresher alias acquires the lock first;
+// the commit waits, then stale-gate-drops with the metric.
+func TestApplySerialization_W15_StaleCommitDroppedAfterFresherAlias(t *testing.T) {
+	t.Parallel()
+	m, rh, _, rm := newTestManager(t)
+
+	rh.blockFirstApply.Store(true)
+
+	a1 := Assignment{Version: 10, LeaderRevision: 4}
+	c1 := Assignment{Version: 10, LeaderRevision: 3}
+
+	g1Done := make(chan struct{})
+	go func() {
+		defer close(g1Done)
+		_ = m.applyAssignment(a1)
+	}()
+
+	<-rh.firstApplyReady
+
+	g2Done := make(chan struct{})
+	go func() {
+		defer close(g2Done)
+		_ = m.applyAssignment(c1)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(rh.releaseFirst)
+
+	select {
+	case <-g1Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("G1 (alias A1) did not return")
+	}
+	select {
+	case <-g2Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("G2 (commit C1) did not return")
+	}
+
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version)
+	require.Equal(t, uint64(4), cur.LeaderRevision,
+		"alias's snapshot must remain — commit was stale-dropped")
+	require.Equal(t, int64(1), rh.applyCount.Load(),
+		"only alias's Apply ran — commit's was gate-dropped before Apply")
+	require.Equal(t, int64(1), rm.staleSnapshotStoreDropped.Load())
+}
+
+// Test 5.2 — W16: stale apply-retry does not regress fresher snapshot.
+// C1 (V=5, LR=10) fails Apply → retry armed. C2 (V=10, LR=15) succeeds.
+// Retry fires after 1s backoff but is stale-gate-dropped before its Apply.
+func TestApplySerialization_W16_StaleRetryDroppedBeforeApply(t *testing.T) {
+	t.Parallel()
+	m, rh, _, rm := newTestManager(t)
+
+	rh.errOnce.Store(&errBox{err: errors.New("transient apply failure")})
+
+	c1 := Assignment{Version: 5, LeaderRevision: 10}
+	err := m.applyAssignment(c1)
+	require.Error(t, err, "first apply must fail")
+	require.Equal(t, int64(1), rh.applyCount.Load())
+
+	c2 := Assignment{Version: 10, LeaderRevision: 15}
+	err = m.applyAssignment(c2)
+	require.NoError(t, err)
+
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version)
+	require.Equal(t, uint64(15), cur.LeaderRevision)
+	require.Equal(t, int64(2), rh.applyCount.Load(),
+		"C2's Apply ran (count = failed-C1 + C2)")
+
+	// Wait past the 1s+jitter retry backoff for the retry to fire and
+	// be gate-dropped.
+	require.Eventually(t, func() bool {
+		return rm.staleSnapshotStoreDropped.Load() == 1
+	}, 5*time.Second, 50*time.Millisecond,
+		"retry must fire and be stale-gate-dropped within 5s")
+
+	// Snapshot must not have regressed; retry's Apply must NOT have run.
+	cur = m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version, "snapshot must not regress")
+	require.Equal(t, uint64(15), cur.LeaderRevision, "LSR must not regress")
+	require.Equal(t, int64(2), rh.applyCount.Load(),
+		"retry's Apply MUST NOT have run — gate dropped it before Apply")
+}
+
+// Test 5.3 — Idempotent reapply same (V, LR) is not stale.
+func TestApplySerialization_IdempotentReapplyAdmitted(t *testing.T) {
+	t.Parallel()
+	m, rh, _, rm := newTestManager(t)
+
+	a1 := Assignment{Version: 5, LeaderRevision: 10}
+	require.NoError(t, m.applyAssignment(a1))
+
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(5), cur.Version)
+	require.Equal(t, uint64(10), cur.LeaderRevision)
+
+	require.NoError(t, m.applyAssignment(a1))
+
+	cur = m.CurrentAssignment()
+	require.Equal(t, int64(5), cur.Version)
+	require.Equal(t, uint64(10), cur.LeaderRevision)
+	require.Equal(t, int64(0), rm.staleSnapshotStoreDropped.Load(),
+		"gate must NOT fire on idempotent reapply")
+	require.Equal(t, int64(2), rh.applyCount.Load(),
+		"both Applies must run (idempotent)")
+}
+
+// Test 5.4 — V=0 carve-out semantics. Phase A: V=0 over V=0 admits.
+// Phase B: V=0 over V>0 is dropped.
+func TestApplySerialization_V0_BootstrapAdmittedRegressionDropped(t *testing.T) {
+	t.Parallel()
+	m, rh, _, rm := newTestManager(t)
+
+	// Phase A: bootstrap V=0 over initial V=0 snapshot.
+	zero := Assignment{}
+	require.NoError(t, m.applyAssignment(zero))
+
+	require.Equal(t, int64(1), rh.applyCount.Load(), "bootstrap Apply ran")
+	require.Equal(t, int64(0), rm.staleSnapshotStoreDropped.Load(),
+		"V=0 over V=0 must NOT trigger gate")
+
+	// Apply a real V>0 snapshot.
+	a1 := Assignment{Version: 10, LeaderRevision: 20}
+	require.NoError(t, m.applyAssignment(a1))
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version)
+
+	// Phase B: V=0 over V=10 must be gate-dropped.
+	require.NoError(t, m.applyAssignment(zero))
+	cur = m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version,
+		"V=0 candidate must NOT regress snapshot")
+	require.Equal(t, uint64(20), cur.LeaderRevision)
+	require.Equal(t, int64(1), rm.staleSnapshotStoreDropped.Load(),
+		"V=0 over V>0 must fire the gate")
+	require.Equal(t, int64(2), rh.applyCount.Load(),
+		"V=0 candidate's Apply must NOT have run (count = bootstrap-zero + A1)")
+}
+
+// Test 5.5 — Gate does NOT fire on Apply failure.
+func TestApplySerialization_ApplyErrorDoesNotFireGate(t *testing.T) {
+	t.Parallel()
+	m, rh, _, rm := newTestManager(t)
+
+	rh.errOnce.Store(&errBox{err: errors.New("transient apply failure")})
+
+	a1 := Assignment{Version: 10, LeaderRevision: 20}
+	err := m.applyAssignment(a1)
+	require.Error(t, err, "Apply must return the error")
+
+	require.Equal(t, int64(0), rm.staleSnapshotStoreDropped.Load(),
+		"gate must NOT fire on Apply error — the candidate was fresh")
+	require.Equal(t, int64(1), rh.applyCount.Load(),
+		"failed Apply still counts")
+	require.Equal(t, Assignment{}, m.CurrentAssignment(),
+		"Store must NOT have run on Apply error")
+}
+
+// Test 5.6 — refreshAssignmentFromNATS honors the gate.
+func TestApplySerialization_RefreshHonorsGate(t *testing.T) {
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "pr2-refresh-gate")
+
+	m, _, _, rm := newTestManager(t)
+	m.assignmentKV = kv
+
+	key := fmt.Sprintf("assignment.%s", m.WorkerID())
+
+	// Plant V=5/LR=10 in KV and refresh — gate admits, snapshot advances.
+	v5 := Assignment{Version: 5, LeaderRevision: 10}
+	b5, err := json.Marshal(v5)
+	require.NoError(t, err)
+	_, err = kv.Create(t.Context(), key, b5)
+	require.NoError(t, err)
+
+	require.NoError(t, m.refreshAssignmentFromNATS())
+
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(5), cur.Version)
+	require.Equal(t, uint64(10), cur.LeaderRevision)
+	require.Equal(t, uint64(10), m.lastSeenLeaderRevision.Load(),
+		"refresh must advance LSR consistently with snapshot")
+	require.Equal(t, int64(0), rm.staleSnapshotStoreDropped.Load())
+
+	// Apply V=10/LR=20 directly — fresher than KV's V=5/LR=10.
+	a2 := Assignment{Version: 10, LeaderRevision: 20}
+	require.NoError(t, m.applyAssignment(a2))
+	cur = m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version)
+
+	// Overwrite KV to V=5/LR=11 (older V than snapshot).
+	v5b := Assignment{Version: 5, LeaderRevision: 11}
+	b5b, err := json.Marshal(v5b)
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), key, b5b)
+	require.NoError(t, err)
+
+	// Refresh: must be gate-dropped (V=5 < V=10).
+	require.NoError(t, m.refreshAssignmentFromNATS())
+
+	cur = m.CurrentAssignment()
+	require.Equal(t, int64(10), cur.Version,
+		"refresh must NOT regress the fresher snapshot")
+	require.Equal(t, uint64(20), cur.LeaderRevision)
+	require.Equal(t, int64(1), rm.staleSnapshotStoreDropped.Load(),
+		"refresh must fire the gate on stale KV")
+}

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -26,14 +26,16 @@ const (
 	commitKeyName = "_commit"
 )
 
-// commitReconcileInterval is the period between idempotent KV re-reads of
-// the commit key. Recovers from missed watcher events (channel close
-// gaps, NATS reconnects) without depending on the watcher's resync.
+// watcherReconcileInterval is the period between idempotent KV re-reads
+// of the commit key and the legacy per-worker alias key. Recovers from
+// missed watcher events (channel close gaps, NATS reconnects) without
+// depending on the watcher's resync. Shared by monitorCommitChanges and
+// monitorAssignmentChanges.
 //
-// Declared as a package-level var (not a const) so reconcile-timing tests
-// can override it via export_test.go without depending on a 30s wall-clock
-// timer. Production callers MUST NOT mutate this value.
-var commitReconcileInterval = 30 * time.Second
+// Declared as a package-level var (not a const) so reconcile-timing
+// tests can override it without depending on a 30s wall-clock timer.
+// Production callers MUST NOT mutate this value.
+var watcherReconcileInterval = 30 * time.Second
 
 // RefreshPartitions triggers partition discovery refresh.
 //
@@ -276,15 +278,21 @@ func (m *Manager) fetchAssignment(ctx context.Context, kv jetstream.KeyValue) (*
 	return asgn, nil
 }
 
-// monitorAssignmentChanges monitors for assignment changes with automatic retry.
+// monitorAssignmentChanges monitors for assignment changes with automatic
+// retry. The reconcile ticker is created once (shared with watchAssignment
+// via reconcileTicker.C) and survives rewatch boundaries — a missed event
+// during a backoff window is still recovered on the next tick.
 //
-// On watcher failure (e.g., transient NATS error), the monitor retries with
-// exponential backoff and jitter, capped at watcherMaxBackoff. A clean exit
-// (context cancelled or watcher channel closed) stops the loop immediately.
+// On watcher failure (transient NATS error, Updates() channel close), the
+// monitor records the failure into the degraded-mode circuit and retries
+// with exponential backoff + jitter, capped at watcherMaxBackoff. Only
+// context cancellation stops the loop cleanly.
 func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.KeyValue) {
 	backoff := watcherBaseBackoff
+	reconcileTicker := time.NewTicker(watcherReconcileInterval)
+	defer reconcileTicker.Stop()
 	for {
-		err := m.watchAssignment(ctx, kv)
+		err := m.watchAssignment(ctx, kv, reconcileTicker.C)
 		if err == nil || ctx.Err() != nil {
 			return
 		}
@@ -311,9 +319,17 @@ func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.Key
 }
 
 // watchAssignment runs one watch session on this worker's assignment key.
-// Returns nil on clean exit (context cancelled or channel closed normally),
-// error if the watcher could not be established.
-func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue) error {
+// Channel closure is returned as an error so monitorAssignmentChanges can
+// restart with backoff; context cancellation returns nil for clean exit.
+//
+// The reconcileTickC arm idempotently re-reads the alias key so missed
+// watcher events (channel close gaps, NATS reconnects, silent stalls) are
+// eventually recovered. The arm is safe because this select loop is
+// single-goroutine: the reconcile arm cannot run while the watcher arm is
+// mid-apply (and vice versa), and once an apply completes the existing
+// stale-leader/version fences in handleAssignmentEntry reject a re-read of
+// the same alias. See PR-1 spec §4 (idempotency contract).
+func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue, reconcileTickC <-chan time.Time) error {
 	workerID := m.WorkerID()
 	key := fmt.Sprintf("assignment.%s", workerID) // Match calculator's key format
 
@@ -323,8 +339,8 @@ func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue) er
 	}
 
 	defer func() {
-		if err := watcher.Stop(); err != nil && !natsutil.IsConsumerNotFound(err) {
-			m.logError("failed to stop watcher", "error", err)
+		if serr := watcher.Stop(); serr != nil && !natsutil.IsConsumerNotFound(serr) {
+			m.logError("failed to stop assignment watcher", "error", serr)
 		}
 	}()
 
@@ -335,8 +351,7 @@ func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue) er
 			return nil
 		case entry, ok := <-watcher.Updates():
 			if !ok {
-				m.logger.Debug("assignment watcher closed", "worker_id", workerID)
-				return nil
+				return errors.New("assignment watcher channel closed")
 			}
 			if entry == nil {
 				// Nil entry indicates end of initial values replay
@@ -345,6 +360,27 @@ func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue) er
 			}
 
 			m.handleAssignmentEntry(workerID, entry)
+		case <-reconcileTickC:
+			// Idempotent re-read. Single-goroutine serialization with the
+			// watcher arm above guarantees no concurrent application of
+			// the same alias; the version fence at handleAssignmentEntry
+			// rejects re-reads of an already-applied alias.
+			current, gerr := kv.Get(ctx, key)
+			if gerr != nil {
+				if errors.Is(gerr, jetstream.ErrKeyNotFound) {
+					// Alias deleted (or never existed). No-op — matches
+					// handleAssignmentEntry's KeyValueDelete branch and
+					// W11's "delete is not a reassignment primitive".
+					continue
+				}
+				// Transient/connectivity error: silently continue,
+				// matching the commit watcher's symmetric reconcile arm.
+				// recordKVError is intentionally NOT called here: feeding
+				// a 30s-ticker into the degraded-mode circuit would
+				// amplify entry under transient KV stress.
+				continue
+			}
+			m.handleAssignmentEntry(workerID, current)
 		}
 	}
 }
@@ -401,12 +437,12 @@ func (m *Manager) handleAssignmentEntry(workerID string, entry jetstream.KeyValu
 
 // monitorCommitChanges watches the singleton "assignment._commit" key. On
 // channel close the watcher restarts with exponential backoff (closes A2 /
-// §4.3); a periodic reconcile every commitReconcileInterval re-fetches the
-// commit and routes idempotently through handleCommitValue so missed
+// §4.3); a periodic reconcile every watcherReconcileInterval re-fetches
+// the commit and routes idempotently through handleCommitValue so missed
 // updates eventually converge.
 func (m *Manager) monitorCommitChanges(ctx context.Context, kv jetstream.KeyValue) {
 	backoff := watcherBaseBackoff
-	reconcileTicker := time.NewTicker(commitReconcileInterval)
+	reconcileTicker := time.NewTicker(watcherReconcileInterval)
 	defer reconcileTicker.Stop()
 	for {
 		err := m.watchCommit(ctx, kv, reconcileTicker.C)

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -753,6 +753,30 @@ func (m *Manager) applyAssignment(newAssignment Assignment) error {
 	return m.applyAssignmentWithPrev(m.CurrentAssignment(), newAssignment)
 }
 
+// isApplyResultStale returns true iff the candidate is older than the live
+// snapshot in (Version, LeaderRevision) lex order. Used at the head of the
+// applyStoreMu critical section to drop loser candidates BEFORE any
+// coordinator-side side effect (W15+W16, PR-2).
+//
+// V=0 semantics:
+//   - candidate.V=0 over cur.V=0: not stale. Permits the cold-bootstrap
+//     path's idempotent re-apply over the just-initialized Assignment{}.
+//   - candidate.V=0 over cur.V>0: STALE. A V=0 retry or legacy candidate
+//     would otherwise regress a real snapshot.
+//
+// Same V same LR: not stale (idempotent reapply).
+// Same V lower LR: STALE (the W15 cross-leader case).
+// Lower V: STALE (the W16 stale-retry case).
+func isApplyResultStale(candidate, cur Assignment) bool {
+	if candidate.Version == 0 {
+		return cur.Version != 0
+	}
+	if candidate.Version != cur.Version {
+		return candidate.Version < cur.Version
+	}
+	return candidate.LeaderRevision < cur.LeaderRevision
+}
+
 // applyAssignmentWithPrev runs the apply-then-store-then-ack pipeline with an
 // explicit previous-assignment argument. The default applyAssignment path
 // reads m.CurrentAssignment() for prev; the initial-bootstrap path
@@ -760,21 +784,30 @@ func (m *Manager) applyAssignment(newAssignment Assignment) error {
 // coordinator's prepare phase sees the full new partition set as "newly
 // acquired" without touching the snapshot.
 //
-// See applyAssignment for the centralized LSR advancement contract.
+// Holds applyStoreMu across (stale-check, Apply, LSR advance, Store,
+// heartbeat SetAppliedAssignment) so concurrent apply paths (commit, alias,
+// retry, refresh) cannot interleave their Stores or heartbeat acks. See
+// applyAssignment Godoc + applyStoreMu Godoc.
 func (m *Manager) applyAssignmentWithPrev(oldAssignment, newAssignment Assignment) error {
 	workerID := m.WorkerID()
-	curAssignment := m.CurrentAssignment()
 
-	// Monotonicity gate: do not regress the snapshot when a stale retry
-	// fires after a higher-version apply already succeeded. Compare against
-	// the live in-memory snapshot, not the caller-supplied oldAssignment —
-	// the initial-bootstrap path passes Assignment{} as oldAssignment to
-	// force prepare phase to treat partitions as newly acquired, but the
-	// snapshot is already at the to-be-applied version (waitForAssignment
-	// stored it). Use strict less-than so the initial-bootstrap apply for
-	// the SAME version proceeds (re-applying is idempotent for the
-	// handoff coordinator).
-	if newAssignment.Version != 0 && newAssignment.Version < curAssignment.Version {
+	m.applyStoreMu.Lock()
+
+	// Stale gate (W15+W16, PR-2). Drops the candidate BEFORE Apply, so no
+	// coordinator-side prepare/commit/stabilize runs for a loser. Strict
+	// (V, LR) lex comparison via isApplyResultStale.
+	curAssignment := m.CurrentAssignment()
+	if isApplyResultStale(newAssignment, curAssignment) {
+		m.applyStoreMu.Unlock()
+		m.metrics.RecordStaleSnapshotStoreDropped()
+		m.logger.Info("apply dropped by (V, LR) stale gate",
+			"worker_id", workerID,
+			"candidate_version", newAssignment.Version,
+			"candidate_leader_revision", newAssignment.LeaderRevision,
+			"current_version", curAssignment.Version,
+			"current_leader_revision", curAssignment.LeaderRevision,
+		)
+
 		return nil
 	}
 
@@ -791,45 +824,32 @@ func (m *Manager) applyAssignmentWithPrev(oldAssignment, newAssignment Assignmen
 	m.reportConsumerCapabilities()
 
 	if applyErr != nil {
+		m.applyStoreMu.Unlock()
 		m.logError("handoff apply failed", "error", applyErr)
 		m.scheduleApplyRetry(newAssignment)
 		return applyErr
 	}
 
 	// 2) Advance lastSeenLeaderRevision (stale-leader fence) — single
-	//    source of truth for LSR. See applyAssignment Godoc. LSR MUST
-	//    advance BEFORE the snapshot Store, otherwise a concurrent
-	//    handleCommitValueOnce reader could observe (new snapshot, old
-	//    LSR) — the v3-review P0 dangerous interleaving where a stale
-	//    higher-Version commit (with commit.LR < newAssignment.LR)
-	//    bypasses case (b)'s stale-leader fence on a snapshot that has
-	//    already advanced past it via case (a)'s no-op gate. By
-	//    advancing LSR first, the only interleavings a concurrent
-	//    reader can observe are (old snap, old LSR), (old snap, new
-	//    LSR), and (new snap, new LSR) — all safe. The fence may briefly
-	//    reject commits with LR < newAssignment.LR against the old
-	//    snapshot, but that is correct: LSR has actually advanced.
+	//    source of truth for LSR. LSR MUST advance BEFORE the snapshot
+	//    Store, otherwise a concurrent handleCommitValueOnce reader could
+	//    observe (new snapshot, old LSR) — see commit at applyAssignment
+	//    Godoc.
 	m.updateLastSeenLeaderRevision(newAssignment.LeaderRevision)
 
-	// 3) Store the now-applied assignment in the manager snapshot. After
-	//    this point, (snapshot, LSR) pairs visible to concurrent readers
-	//    are safely ordered.
+	// 3) Store the now-applied assignment in the manager snapshot.
 	m.assignment.Store(newAssignment)
 	if hook := m.testHookAfterApplyStore; hook != nil {
 		hook(newAssignment)
 	}
 
-	m.logger.Info("assignment applied",
-		"worker_id", workerID,
-		"old_version", oldAssignment.Version,
-		"new_version", newAssignment.Version,
-		"old_partitions", len(oldAssignment.Partitions),
-		"new_partitions", len(newAssignment.Partitions),
-	)
-
-	// 4) Ack via heartbeat publisher (Phase 2/4 receipt). Failures here are
-	//    non-fatal — the next tick will publish a snapshot containing the
-	//    same AppliedVersion (monotone).
+	// 4) Update heartbeat in-memory snapshot INSIDE the lock (W15+W16
+	//    plan-review v2 P0-B fix). The heartbeat publisher's monotonicity
+	//    is V-only (internal/heartbeat/publisher.go:170-195); equal-V Acks
+	//    overwrite LeaderRevision unconditionally. If we released the lock
+	//    before SetAppliedAssignment, a slow loser path could post its
+	//    same-V/lower-LR Ack after a winner has stored, regressing the
+	//    heartbeat. PublishNow stays outside the lock (network IO).
 	appliedDigest := types.PartitionSetDigest(newAssignment.Partitions)
 	m.heartbeat.SetAppliedAssignment(heartbeat.AppliedAssignment{
 		LeaderRevision:        newAssignment.LeaderRevision,
@@ -839,15 +859,57 @@ func (m *Manager) applyAssignmentWithPrev(oldAssignment, newAssignment Assignmen
 		AppliedSourceRevKnown: newAssignment.SourceRevisionKnown,
 		AppliedAt:             time.Now(),
 	})
+
+	m.applyStoreMu.Unlock()
+
+	m.logger.Info("assignment applied",
+		"worker_id", workerID,
+		"old_version", oldAssignment.Version,
+		"new_version", newAssignment.Version,
+		"old_partitions", len(oldAssignment.Partitions),
+		"new_partitions", len(newAssignment.Partitions),
+	)
+
+	// 5) Publish heartbeat (network IO, OUTSIDE lock). Failures here are
+	//    non-fatal — the next tick will publish a snapshot containing the
+	//    same AppliedVersion (monotone).
 	if err := m.heartbeat.PublishNow(m.ctx); err != nil {
 		m.logError("heartbeat publish-now after apply failed", "error", err)
 	}
 
-	// 5) Metrics + hooks.
+	// 6) Metrics + hooks.
 	m.recordAssignmentMetrics(oldAssignment, newAssignment)
 	m.invokeAssignmentChangedHooks(workerID, oldAssignment, newAssignment)
 
 	return nil
+}
+
+// monotonicStore performs the (gate-check, LSR-advance, Store) sequence
+// under applyStoreMu. Returns true if the Store landed; false if dropped
+// as stale.
+//
+// REFRESH-PATH ONLY. Used by refreshAssignmentFromNATS to bring an
+// authoritative KV snapshot under the same (V, LR) gate as the apply
+// pipeline. NOT usable from applyAssignmentWithPrev because that function
+// must hold applyStoreMu ACROSS handoffCoordinator.Apply; inlining the
+// same primitive in both call sites is intentional.
+//
+// Callers MUST NOT hold applyStoreMu — the helper acquires and releases
+// it itself.
+func (m *Manager) monotonicStore(newAssignment Assignment) bool {
+	m.applyStoreMu.Lock()
+	defer m.applyStoreMu.Unlock()
+
+	cur := m.CurrentAssignment()
+	if isApplyResultStale(newAssignment, cur) {
+		m.metrics.RecordStaleSnapshotStoreDropped()
+		return false
+	}
+
+	m.updateLastSeenLeaderRevision(newAssignment.LeaderRevision)
+	m.assignment.Store(newAssignment)
+
+	return true
 }
 
 // invokeAssignmentChangedHooks dispatches OnAssignmentChanged and the
@@ -967,7 +1029,18 @@ func (m *Manager) refreshAssignmentFromNATS() error {
 		return fmt.Errorf("failed to unmarshal assignment: %w", err)
 	}
 
-	m.assignment.Store(curAssignment)
+	// Route the Store through monotonicStore so a refresh racing the apply
+	// pipeline cannot regress a fresher snapshot (W15+W16, PR-2 §3.4). The
+	// helper handles the (V, LR) gate, LSR advance, and Store under
+	// applyStoreMu.
+	if !m.monotonicStore(curAssignment) {
+		m.logger.Debug("refresh skipped: snapshot already at-or-newer than KV",
+			"version", curAssignment.Version,
+			"leader_revision", curAssignment.LeaderRevision,
+		)
+		return nil
+	}
+
 	m.lastAssignmentAt.Store(time.Now().UnixNano())
 	m.lastAssignment.Store(m.clonePartitions(curAssignment.Partitions))
 

--- a/manager_assignment_fixes_test.go
+++ b/manager_assignment_fixes_test.go
@@ -117,7 +117,7 @@ type mockKeyWatcher struct {
 
 func newMockKeyWatcher() *mockKeyWatcher {
 	ch := make(chan jetstream.KeyValueEntry)
-	close(ch) // Immediately signal watcher closed (clean exit)
+	close(ch) // Immediately signal Updates() closed → watchAssignment returns err.
 	return &mockKeyWatcher{
 		updatesCh: ch,
 		errCh:     make(chan error),
@@ -129,7 +129,8 @@ func (w *mockKeyWatcher) Updates() <-chan jetstream.KeyValueEntry { return w.upd
 func (w *mockKeyWatcher) Stop() error                             { return nil }
 func (w *mockKeyWatcher) Error() <-chan error                     { return w.errCh }
 
-// mockRetryKV fails Watch on the first call and succeeds on subsequent calls.
+// mockRetryKV fails Watch on the first call and succeeds (with a watcher
+// whose Updates() channel is immediately closed) on subsequent calls.
 type mockRetryKV struct {
 	jetstream.KeyValue
 	watchCalls atomic.Int32
@@ -143,40 +144,51 @@ func (m *mockRetryKV) Watch(_ context.Context, _ string, _ ...jetstream.WatchOpt
 	return newMockKeyWatcher(), nil
 }
 
-// TestMonitorAssignmentChanges_RetriesAfterWatcherFailure verifies that
-// monitorAssignmentChanges retries when the initial Watch call fails, rather
-// than permanently stopping the monitor.
-func TestMonitorAssignmentChanges_RetriesAfterWatcherFailure(t *testing.T) {
+// TestMonitorAssignmentChanges_RewatchesOnChannelClose verifies that
+// monitorAssignmentChanges treats both an initial Watch error and a closed
+// Updates() channel as recoverable conditions: each triggers a re-Watch via
+// the backoff loop instead of exiting permanently. The monitor only stops
+// when its context is cancelled.
+//
+// W12 / PR-1 changed `watchAssignment` to return an error on channel close
+// (previously it returned nil → clean exit). Before that change, a closed
+// channel silently terminated the monitor and any subsequent alias updates
+// (including rolling-upgrade alias.<W>) were missed until process restart.
+func TestMonitorAssignmentChanges_RewatchesOnChannelClose(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	// Generous timeout: 2s base backoff + jitter for the first rewatch,
+	// 4s + jitter for the second.
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 
 	kv := &mockRetryKV{}
 	m := &Manager{
 		logger: logging.NewNop(),
 	}
-	// Set workerID so the key path is non-empty
 	m.workerID.Store("worker-0")
 
-	// Run monitorAssignmentChanges in a background goroutine.
-	// The mock KV fails the first Watch call (returns error), then the second
-	// Watch call succeeds and returns a closed channel (clean exit).
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		m.monitorAssignmentChanges(ctx, kv)
 	}()
 
+	// Three Watch calls = original + two rewatches: proves the rewatch
+	// path triggers on both the initial Watch error AND on each
+	// subsequent channel-close.
+	require.Eventually(t, func() bool {
+		return kv.watchCalls.Load() >= 3
+	}, 12*time.Second, 50*time.Millisecond,
+		"monitorAssignmentChanges must rewatch after Watch error AND after channel close")
+
+	// Cancel context: goroutine must exit cleanly.
+	cancel()
 	select {
 	case <-done:
-		// goroutine exited cleanly after second Watch succeeded
-	case <-time.After(8 * time.Second):
-		t.Fatal("monitorAssignmentChanges did not complete within timeout — retry may be broken")
+	case <-time.After(3 * time.Second):
+		t.Fatal("monitorAssignmentChanges did not exit after ctx cancel")
 	}
-
-	require.GreaterOrEqual(t, kv.watchCalls.Load(), int32(2),
-		"Watch must have been called at least twice (first failure + successful retry)")
 }
 
 // ============================================================================

--- a/manager_assignment_watcher_test.go
+++ b/manager_assignment_watcher_test.go
@@ -1,0 +1,295 @@
+package parti
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMonitorAssignmentChanges_ChannelCloseTriggersBackoffAndRestart exercises
+// PR-1's W12 fix: the legacy per-worker alias watcher (`assignment.<W>`)
+// must NOT exit permanently when its Updates() channel closes. Instead,
+// channel close becomes a retryable error so monitorAssignmentChanges loops
+// through the same exponential-backoff + re-Watch path as monitorCommitChanges.
+//
+// Mirrors TestMonitorCommitChanges_ChannelCloseTriggersBackoffAndRestart in
+// shape (forceCloseWatcherKV + post-restart Put).
+func TestMonitorAssignmentChanges_ChannelCloseTriggersBackoffAndRestart(t *testing.T) {
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "alias-close-restart")
+
+	m, rh, _, _ := newTestManager(t)
+	m.assignmentKV = kv
+
+	key := fmt.Sprintf("assignment.%s", m.WorkerID())
+
+	// Plant initial alias V=4/LR=15. With no commit observed, the dual-read
+	// selector picks the alias and applyAssignment runs.
+	v4 := Assignment{
+		Version:        4,
+		LeaderRevision: 15,
+	}
+	b4, err := json.Marshal(v4)
+	require.NoError(t, err)
+	_, err = kv.Create(t.Context(), key, b4)
+	require.NoError(t, err)
+
+	wrap := &forceCloseWatcherKV{KeyValue: kv}
+	done := make(chan struct{})
+	go func() {
+		m.monitorAssignmentChanges(m.ctx, wrap)
+		close(done)
+	}()
+
+	// Watcher #1 must observe the initial replay and apply the alias.
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 4
+	}, 2*time.Second, 25*time.Millisecond, "first watcher must apply V=4")
+
+	// Force-close watcher #1. The monitor must record a KV error and
+	// re-Watch (watcher #2) after the backoff window.
+	wrap.forceCloseLatest()
+
+	// Drop a second alias at higher Version+LR. Watcher #2's initial
+	// replay (or a subsequent Put delivery) must apply it. Long
+	// Eventually because watcherBaseBackoff (2s) + jitter precedes the
+	// restart.
+	v5 := Assignment{
+		Version:        5,
+		LeaderRevision: 16,
+	}
+	b5, err := json.Marshal(v5)
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), key, b5)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 5
+	}, 8*time.Second, 50*time.Millisecond,
+		"restarted alias watcher must observe the second alias (backoff ~2s)")
+
+	require.GreaterOrEqual(t, wrap.watchCallsLoaded(), int32(2),
+		"monitorAssignmentChanges must re-Watch after channel close")
+	require.GreaterOrEqual(t, rh.applyCount.Load(), int64(2),
+		"both pre- and post-restart aliases must apply")
+
+	m.cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("monitorAssignmentChanges did not exit after ctx cancel")
+	}
+}
+
+// silentWatcherKV wraps a jetstream.KeyValue but always returns a
+// silent-watcher whose Updates() channel is OPEN and NEVER delivers any
+// event. KV.Get is delegated to the upstream KV intact, so the reconcile
+// arm of watchAssignment can still re-read the key. This is the
+// canonical "watcher stalled but not closed" double for testing the
+// reconcile path in isolation from the watcher-replay path.
+//
+// Mirrors droppingWatcherKV (used by the commit-watcher reconcile test)
+// but kept as a distinct type because of its different semantic: Stop()
+// here returns nil WITHOUT closing the channel, so the production
+// `select { case <-Updates() }` never fires and watchAssignment cannot
+// observe a "channel closed" signal.
+type silentWatcherKV struct {
+	jetstream.KeyValue
+	mu      sync.Mutex
+	watcher *silentWatcher
+}
+
+func (s *silentWatcherKV) Watch(_ context.Context, _ string, _ ...jetstream.WatchOpt) (jetstream.KeyWatcher, error) {
+	w := &silentWatcher{updates: make(chan jetstream.KeyValueEntry)}
+	s.mu.Lock()
+	s.watcher = w
+	s.mu.Unlock()
+	return w, nil
+}
+
+type silentWatcher struct {
+	updates   chan jetstream.KeyValueEntry
+	closeOnce sync.Once
+}
+
+func (w *silentWatcher) Updates() <-chan jetstream.KeyValueEntry { return w.updates }
+
+// Stop closes the channel — but only when the production code Stops the
+// watcher (i.e., on context cancel / function exit). The test never
+// invokes Stop from outside; cancel propagation lets watchAssignment's
+// own deferred Stop close the channel cleanly.
+func (w *silentWatcher) Stop() error {
+	w.closeOnce.Do(func() { close(w.updates) })
+	return nil
+}
+
+// TestMonitorAssignmentChanges_PeriodicReconcile_RecoversSilentStall
+// (PR-1 Test 5.2) exercises the reconcile arm of watchAssignment by
+// running the real watcher against a stub that NEVER delivers updates
+// over its Updates() channel (modeling a NATS server stall that doesn't
+// close the channel). The only convergence path is then the reconcile
+// ticker's idempotent KV re-read, proving the reconcile arm is
+// load-bearing for silent-stall recovery.
+//
+// Mirrors TestMonitorCommitChanges_PeriodicReconcile_RecoversDivergence
+// in shape: 1s reconcile interval, pre-tick assertion that recovery has
+// NOT happened, then post-tick assertion that it has.
+//
+// NOTE: does NOT use t.Parallel() because it mutates the package global
+// watcherReconcileInterval (matching the commit-watcher reconcile test's
+// rationale).
+func TestMonitorAssignmentChanges_PeriodicReconcile_RecoversSilentStall(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "alias-reconcile")
+
+	prev := watcherReconcileInterval
+	watcherReconcileInterval = 1 * time.Second
+	t.Cleanup(func() { watcherReconcileInterval = prev })
+
+	m, rh, _, _ := newTestManager(t)
+	m.assignmentKV = kv
+
+	key := fmt.Sprintf("assignment.%s", m.WorkerID())
+
+	// Wrap the KV with a silent-watcher: the only path to convergence
+	// is the reconcile ticker's KV.Get.
+	silent := &silentWatcherKV{KeyValue: kv}
+	go m.monitorAssignmentChanges(m.ctx, silent)
+
+	// Put alias A out-of-band. Watcher never sees it.
+	vA := Assignment{Version: 7, LeaderRevision: 21}
+	bA, err := json.Marshal(vA)
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), key, bA)
+	require.NoError(t, err)
+
+	// Pre-tick: well before 1s, no convergence is possible (the watcher
+	// is silent). This rules out the watcher accidentally leaking
+	// through the stub.
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, int64(0), rh.applyCount.Load(),
+		"no apply must happen before the first reconcile tick")
+	require.Equal(t, int64(0), m.CurrentAssignment().Version,
+		"snapshot MUST NOT advance before the first reconcile tick")
+
+	// Wait past the 1s reconcile tick: alias A must apply via the
+	// reconcile path.
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 7
+	}, 4*time.Second, 25*time.Millisecond,
+		"alias A must apply via the periodic reconcile tick")
+	require.GreaterOrEqual(t, rh.applyCount.Load(), int64(1),
+		"reconcile tick must trigger apply for alias A")
+
+	// Put alias B at a higher Version/LR. Same recovery path: only
+	// observable via reconcile.
+	vB := Assignment{Version: 8, LeaderRevision: 22}
+	bB, err := json.Marshal(vB)
+	require.NoError(t, err)
+	_, err = kv.Put(t.Context(), key, bB)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 8
+	}, 4*time.Second, 25*time.Millisecond,
+		"alias B must apply via the periodic reconcile tick")
+	require.GreaterOrEqual(t, rh.applyCount.Load(), int64(2),
+		"second reconcile tick must trigger second apply")
+}
+
+// TestMonitorAssignmentChanges_ReconcileDeleteIsNoOp (PR-1 Test 5.4)
+// verifies that when the alias key is deleted out-of-band and the
+// reconcile tick observes ErrKeyNotFound, no state change happens. The
+// last-applied snapshot is preserved and no spurious apply / handoff
+// fires.
+//
+// Same global mutation as Test 5.2 — no t.Parallel().
+func TestMonitorAssignmentChanges_ReconcileDeleteIsNoOp(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "alias-reconcile-delete")
+
+	prev := watcherReconcileInterval
+	watcherReconcileInterval = 500 * time.Millisecond
+	t.Cleanup(func() { watcherReconcileInterval = prev })
+
+	m, rh, _, _ := newTestManager(t)
+	m.assignmentKV = kv
+
+	key := fmt.Sprintf("assignment.%s", m.WorkerID())
+
+	// Plant alias A first so an apply has happened before the delete.
+	vA := Assignment{Version: 4, LeaderRevision: 12}
+	bA, err := json.Marshal(vA)
+	require.NoError(t, err)
+	_, err = kv.Create(t.Context(), key, bA)
+	require.NoError(t, err)
+
+	go m.monitorAssignmentChanges(m.ctx, kv)
+
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 4
+	}, 2*time.Second, 25*time.Millisecond, "initial alias must apply")
+
+	applyAfterInitial := rh.applyCount.Load()
+
+	// Delete the alias. The next reconcile tick must observe
+	// ErrKeyNotFound and silently continue: snapshot and apply count
+	// must remain unchanged.
+	require.NoError(t, kv.Delete(t.Context(), key))
+
+	// Wait through 3+ reconcile ticks to confirm no spurious apply.
+	time.Sleep(2 * time.Second)
+
+	cur := m.CurrentAssignment()
+	require.Equal(t, int64(4), cur.Version,
+		"delete must NOT regress the in-memory snapshot")
+	require.Equal(t, uint64(12), cur.LeaderRevision,
+		"delete must NOT regress LeaderRevision")
+	require.Equal(t, applyAfterInitial, rh.applyCount.Load(),
+		"reconcile tick on deleted key MUST NOT trigger an apply")
+}
+
+// TestMonitorAssignmentChanges_GracefulShutdownWithActiveTicker
+// (PR-1 Test 5.5) verifies that the reconcile ticker stops cleanly
+// when the manager's context is cancelled, even under a stalled
+// watcher (the silent-stall scenario). Guards against goroutine
+// leaks on shutdown.
+//
+// Same global mutation as Test 5.2 — no t.Parallel().
+func TestMonitorAssignmentChanges_GracefulShutdownWithActiveTicker(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "alias-shutdown")
+
+	prev := watcherReconcileInterval
+	watcherReconcileInterval = 10 * time.Millisecond
+	t.Cleanup(func() { watcherReconcileInterval = prev })
+
+	m, _, _, _ := newTestManager(t)
+	m.assignmentKV = kv
+
+	silent := &silentWatcherKV{KeyValue: kv}
+	done := make(chan struct{})
+	go func() {
+		m.monitorAssignmentChanges(m.ctx, silent)
+		close(done)
+	}()
+
+	// Let the reconcile ticker fire several times to confirm the
+	// goroutine is actively in the select loop.
+	time.Sleep(80 * time.Millisecond)
+
+	m.cancel()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("monitorAssignmentChanges did not exit within 500ms of ctx cancel")
+	}
+}

--- a/manager_commit_state_machine_test.go
+++ b/manager_commit_state_machine_test.go
@@ -29,21 +29,25 @@ import (
 type recordingMetrics struct {
 	*metrics.NopMetrics
 
-	staleLeaderRejected    atomic.Int64
-	commitPayloadMissing   atomic.Int64
-	payloadHashMismatch    atomic.Int64
-	setDigestMismatch      atomic.Int64
-	payloadFetchError      atomic.Int64
-	payloadDecompressError atomic.Int64
-	payloadDecodeError     atomic.Int64
-	assignmentChangeCalls  atomic.Int64
+	staleLeaderRejected       atomic.Int64
+	staleSnapshotStoreDropped atomic.Int64
+	commitPayloadMissing      atomic.Int64
+	payloadHashMismatch       atomic.Int64
+	setDigestMismatch         atomic.Int64
+	payloadFetchError         atomic.Int64
+	payloadDecompressError    atomic.Int64
+	payloadDecodeError        atomic.Int64
+	assignmentChangeCalls     atomic.Int64
 }
 
 func newRecordingMetrics() *recordingMetrics {
 	return &recordingMetrics{NopMetrics: metrics.NewNop()}
 }
 
-func (r *recordingMetrics) RecordStaleLeaderRejected()    { r.staleLeaderRejected.Add(1) }
+func (r *recordingMetrics) RecordStaleLeaderRejected() { r.staleLeaderRejected.Add(1) }
+func (r *recordingMetrics) RecordStaleSnapshotStoreDropped() {
+	r.staleSnapshotStoreDropped.Add(1)
+}
 func (r *recordingMetrics) RecordCommitPayloadMissing()   { r.commitPayloadMissing.Add(1) }
 func (r *recordingMetrics) RecordPayloadHashMismatch()    { r.payloadHashMismatch.Add(1) }
 func (r *recordingMetrics) RecordSetDigestMismatch()      { r.setDigestMismatch.Add(1) }

--- a/manager_commit_watcher_test.go
+++ b/manager_commit_watcher_test.go
@@ -235,21 +235,21 @@ func TestMonitorCommitChanges_DeleteEventIgnored(t *testing.T) {
 // convergence is then the reconcile tick — proving the periodic primitive
 // (not the manually-invoked handleCommitValue).
 //
-// We dial commitReconcileInterval down to 1s via the package-level var
+// We dial watcherReconcileInterval down to 1s via the package-level var
 // (testable because manager_assignment.go declares it as var, not const,
 // with an explicit "tests may override" contract). 1s gives us enough
 // headroom to assert the "no recovery before first tick" invariant.
 //
 // NOTE: this test does NOT use t.Parallel() because it mutates the package
-// global commitReconcileInterval (v2 review P2: avoid parallel races on a
+// global watcherReconcileInterval (v2 review P2: avoid parallel races on a
 // test-mutable global).
 func TestMonitorCommitChanges_PeriodicReconcile_RecoversDivergence(t *testing.T) {
 	_, nc := partitest.StartEmbeddedNATS(t)
 	kv := partitest.CreateJetStreamKV(t, nc, "watcher-reconcile")
 
-	prev := commitReconcileInterval
-	commitReconcileInterval = 1 * time.Second
-	t.Cleanup(func() { commitReconcileInterval = prev })
+	prev := watcherReconcileInterval
+	watcherReconcileInterval = 1 * time.Second
+	t.Cleanup(func() { watcherReconcileInterval = prev })
 
 	m, _, _, _ := newTestManager(t)
 	m.assignmentKV = kv

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
 	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
@@ -145,15 +146,7 @@ func (m *Manager) ensureKVBucket(
 	ttl time.Duration,
 	storage jetstream.StorageType,
 ) (jetstream.KeyValue, error) {
-	cfg := jetstream.KeyValueConfig{
-		Bucket:  bucket,
-		History: 1, // Keep only latest value
-		Storage: storage,
-	}
-
-	if ttl > 0 {
-		cfg.TTL = ttl
-	}
+	cfg := kvbuckets.BuildKeyValueConfig(bucket, ttl, storage)
 
 	// Use retry logic to handle concurrent creation
 	const maxRetries = 5

--- a/provision/apply.go
+++ b/provision/apply.go
@@ -1,0 +1,156 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Apply reconciles the live NATS environment to match cfg.
+//
+// The high-level sequence is:
+//
+//  1. Validate(cfg) — static validation. Failure returns Report{} + error
+//     (CLI maps to exit 3 via ErrInvalidConfig).
+//  2. ValidateLive(ctx, js, cfg) — reachability + per-bucket info probes.
+//     Failure returns Report{} + error (CLI maps the underlying error to
+//     exit 3 or 4 per the precedence table; no mutation has started yet).
+//  3. Plan(ctx, js, cfg) — compute the deterministic action list.
+//     Failure returns Report{} + error.
+//  4. Iterate Plan.Actions and call js.CreateKeyValue for each create-kv,
+//     mapping the result onto Report.{Executed, Skipped, Errors, Aborted}.
+//
+// Cancellation semantics (see sub-spec §2.D):
+//   - Pre-mutation cancel → Report{Aborted: true, Skipped: every-action
+//     with reason "context-cancelled"}, error = ctx.Err(); CLI exit 4.
+//   - Mid-mutation cancel → partial Report with Aborted=true, Executed
+//     holds completed creates, current+remaining go to Skipped with
+//     reason "context-cancelled"; error = ctx.Err(); CLI exit 4.
+//
+// Non-cancellation failure (sub-spec §2.C) is fail-fast: the failing
+// action goes to Errors once, remaining go to Skipped with reason
+// "prior-error", Aborted stays false; CLI exit 1.
+//
+// Plan→Apply race (sub-spec §2.E): if js.CreateKeyValue returns
+// ErrBucketExists / ErrStreamNameAlreadyInUse, Apply treats the outcome
+// as success and marks the ExecutedAction with Raced=true. Apply does NOT
+// re-read live state to drift-check the racing bucket; the next `plan`
+// run reports any adopted drift.
+//
+// Apply does NOT echo Plan.Drift into the returned Report. Drift findings
+// are a Plan concern; the CLI reads plan.Drift separately from apply
+// output.
+func Apply(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, error) {
+	// Step 1: static validation (normalize once, validate the resolved
+	// form, and reuse it for the live + plan steps).
+	resolved, err := normalize(cfg)
+	if err != nil {
+		return Report{}, err
+	}
+	if err := validateResolved(resolved); err != nil {
+		return Report{}, err
+	}
+
+	// Step 2: live validation. Return Report{} (zero value) on failure:
+	// no mutation has been attempted yet, so a populated Report would
+	// misleadingly resemble a mutation-outcome Report (sub-spec §2.A).
+	if _, err := ValidateLive(ctx, js, resolved); err != nil {
+		return Report{}, err
+	}
+
+	// Step 3: plan. Same zero-value return contract: no mutation started.
+	planResult, err := Plan(ctx, js, resolved)
+	if err != nil {
+		return Report{}, err
+	}
+
+	return applyPlan(ctx, js, planResult)
+}
+
+// applyPlan executes a pre-computed plan against js, applying the W2
+// semantics laid out in the package-level Apply docstring.
+func applyPlan(ctx context.Context, js jetstream.JetStream, plan PlanResult) (Report, error) {
+	report := Report{
+		APIVersion: APIVersionProvisionV1,
+		Kind:       KindReport,
+		Executed:   []ExecutedAction{},
+		Skipped:    []SkippedAction{},
+		Errors:     []ResourceError{},
+	}
+
+	for i, action := range plan.Actions {
+		// Pre-mutation / between-iteration cancellation check.
+		if err := ctx.Err(); err != nil {
+			report.Aborted = true
+			appendSkipped(&report, plan.Actions[i:], SkipReasonContextCancelled)
+			return report, err
+		}
+
+		switch action.Kind {
+		case ActionCreateKV:
+			kvCfg, ok := action.Resource.(jetstream.KeyValueConfig)
+			if !ok {
+				// Defensive guard: Plan should never emit this.
+				err := fmt.Errorf("provision: apply: create-kv action %q has wrong Resource type %T",
+					action.Name, action.Resource)
+				report.Errors = append(report.Errors, ResourceError{
+					Kind: action.Kind, Name: action.Name, Error: err.Error(),
+				})
+				appendSkipped(&report, plan.Actions[i+1:], SkipReasonPriorError)
+				return report, err
+			}
+
+			_, err := js.CreateKeyValue(ctx, kvCfg)
+			switch {
+			case err == nil:
+				report.Executed = append(report.Executed, ExecutedAction{
+					Kind: action.Kind, Name: action.Name,
+				})
+			case errors.Is(err, jetstream.ErrBucketExists),
+				errors.Is(err, jetstream.ErrStreamNameAlreadyInUse):
+				// Plan→Apply race (sub-spec §2.E): treat as success.
+				report.Executed = append(report.Executed, ExecutedAction{
+					Kind: action.Kind, Name: action.Name, Raced: true,
+				})
+			case errors.Is(err, context.Canceled),
+				errors.Is(err, context.DeadlineExceeded):
+				report.Aborted = true
+				appendSkipped(&report, plan.Actions[i:], SkipReasonContextCancelled)
+				return report, err
+			default:
+				// Non-cancellation failure: fail-fast (sub-spec §2.C).
+				report.Errors = append(report.Errors, ResourceError{
+					Kind: action.Kind, Name: action.Name, Error: err.Error(),
+				})
+				appendSkipped(&report, plan.Actions[i+1:], SkipReasonPriorError)
+				return report, fmt.Errorf("provision: apply %s %q: %w",
+					action.Kind, action.Name, err)
+			}
+
+		default:
+			// v1 only emits "create-kv". Defensive: surface as a
+			// fail-fast resource error so operators see what was rejected.
+			err := fmt.Errorf("provision: apply: unsupported action kind %q (resource %q)",
+				action.Kind, action.Name)
+			report.Errors = append(report.Errors, ResourceError{
+				Kind: action.Kind, Name: action.Name, Error: err.Error(),
+			})
+			appendSkipped(&report, plan.Actions[i+1:], SkipReasonPriorError)
+			return report, err
+		}
+	}
+
+	return report, nil
+}
+
+// appendSkipped appends every action in actions to report.Skipped with the
+// given reason. It is a no-op when actions is empty.
+func appendSkipped(report *Report, actions []PlannedAction, reason string) {
+	for _, a := range actions {
+		report.Skipped = append(report.Skipped, SkippedAction{
+			Kind: a.Kind, Name: a.Name, Reason: reason,
+		})
+	}
+}

--- a/provision/apply_helpers_test.go
+++ b/provision/apply_helpers_test.go
@@ -1,0 +1,131 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// failAccountInfoJS wraps a JetStream and always returns an error from
+// AccountInfo, causing ValidateLive to fail at step 1.B (reachability).
+// Used to verify Apply returns Report{} on pre-mutation ValidateLive failure.
+type failAccountInfoJS struct {
+	jetstream.JetStream
+	err error
+}
+
+func newFailAccountInfoJS(js jetstream.JetStream) *failAccountInfoJS {
+	return &failAccountInfoJS{
+		JetStream: js,
+		err:       errors.New("simulated reachability failure"),
+	}
+}
+
+func (f *failAccountInfoJS) AccountInfo(ctx context.Context) (*jetstream.AccountInfo, error) {
+	return nil, f.err
+}
+
+// raceOnceJS wraps a jetstream.JetStream so that on the first
+// CreateKeyValue whose bucket maps to targetStream, the wrapped JS
+// pre-creates the bucket out-of-band before forwarding the call. This
+// guarantees js.CreateKeyValue returns ErrBucketExists, exercising
+// Apply's Plan→Apply race branch (sub-spec §2.E).
+type raceOnceJS struct {
+	jetstream.JetStream
+	targetStream string // e.g. "KV_parti-election"
+	fired        atomic.Bool
+}
+
+func newRaceOnceJS(js jetstream.JetStream, targetStream string) *raceOnceJS {
+	return &raceOnceJS{JetStream: js, targetStream: targetStream}
+}
+
+func (r *raceOnceJS) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	if "KV_"+cfg.Bucket == r.targetStream && r.fired.CompareAndSwap(false, true) {
+		// Pre-create the bucket out-of-band with a DELIBERATELY
+		// DIFFERENT config so nats.go's "silent update on
+		// Discard/AllowDirect-only diff" fallback path
+		// (jetstream/kv.go:539-558) does NOT trigger. We toggle the
+		// History to force a real ErrStreamNameAlreadyInUse return on
+		// the forwarded call, which is exactly the Plan→Apply race
+		// surface (sub-spec §2.E).
+		raceCfg := cfg
+		// A different TTL leaves the underlying StreamConfig.MaxAge
+		// different from the desired config, so the forwarded call
+		// triggers ErrBucketExists / ErrStreamNameAlreadyInUse and
+		// the nats.go silent-update branch (which only fires when the
+		// only diffs are Discard and AllowDirect) is bypassed.
+		if raceCfg.TTL == 0 {
+			raceCfg.TTL = 1 * 1000 * 1000 * 1000 // 1s
+		} else {
+			raceCfg.TTL += 7 // a few ns of drift
+		}
+		if _, err := r.JetStream.CreateKeyValue(ctx, raceCfg); err != nil {
+			return nil, err
+		}
+		// Fall through to forward the original call; the server now
+		// returns ErrBucketExists / ErrStreamNameAlreadyInUse.
+	}
+
+	return r.JetStream.CreateKeyValue(ctx, cfg)
+}
+
+// cancelOnFirstCreateJS cancels the supplied context.CancelFunc the
+// moment the underlying CreateKeyValue would be invoked for the first
+// time. The wrapped JetStream returns ctx.Err() without performing the
+// create, which Apply must treat as a mid-mutation cancellation. To
+// model a pre-mutation cancel (no actions executed), the first call
+// must observe the cancellation BEFORE its CreateKeyValue runs — we
+// achieve that by cancelling and returning ctx.Err() before calling
+// through.
+type cancelOnFirstCreateJS struct {
+	jetstream.JetStream
+	cancel context.CancelFunc
+	fired  atomic.Bool
+}
+
+func newCancelOnFirstCreateJS(js jetstream.JetStream, cancel context.CancelFunc) *cancelOnFirstCreateJS {
+	return &cancelOnFirstCreateJS{JetStream: js, cancel: cancel}
+}
+
+func (c *cancelOnFirstCreateJS) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	if c.fired.CompareAndSwap(false, true) {
+		c.cancel()
+		// Return the cancellation directly so Apply observes
+		// context.Canceled from CreateKeyValue itself. (Apply also
+		// re-checks ctx.Err() at the top of each iteration, so either
+		// path lands in the cancellation branch — but returning
+		// ctx.Err() here keeps the model simple: zero actions executed.)
+		return nil, context.Canceled
+	}
+
+	return c.JetStream.CreateKeyValue(ctx, cfg)
+}
+
+// cancelAfterNthCreateJS cancels the supplied context.CancelFunc once
+// the underlying CreateKeyValue has completed N times successfully. The
+// (N+1)th and subsequent calls return ctx.Err() without invoking the
+// real CreateKeyValue. This models a mid-mutation cancellation that
+// leaves the first N actions in Apply's Executed slice.
+type cancelAfterNthCreateJS struct {
+	jetstream.JetStream
+	n      int
+	cancel context.CancelFunc
+	count  atomic.Int64
+}
+
+func newCancelAfterNthCreateJS(js jetstream.JetStream, n int, cancel context.CancelFunc) *cancelAfterNthCreateJS {
+	return &cancelAfterNthCreateJS{JetStream: js, n: n, cancel: cancel}
+}
+
+func (c *cancelAfterNthCreateJS) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	current := c.count.Add(1)
+	if current > int64(c.n) {
+		c.cancel()
+		return nil, context.Canceled
+	}
+
+	return c.JetStream.CreateKeyValue(ctx, cfg)
+}

--- a/provision/apply_integration_test.go
+++ b/provision/apply_integration_test.go
@@ -1,0 +1,314 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func applyCfg() provision.Config {
+	return provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		ControlPlane: &provision.ControlPlaneConfig{
+			WorkerIDTTL:           75 * time.Second,
+			ElectionTimeout:       10 * time.Second,
+			HeartbeatTTL:          15 * time.Second,
+			AssignmentTTL:         0,
+			HandoffTTL:            2 * time.Minute,
+			EnableTwoPhaseHandoff: true,
+		},
+	}
+}
+
+// expectedControlPlaneNamesHandoffOn is the alphabetically-sorted set of
+// bucket names Plan emits for the applyCfg() Config (handoff enabled).
+var expectedControlPlaneNamesHandoffOn = []string{
+	"parti-assignment",
+	"parti-election",
+	"parti-handoff",
+	"parti-heartbeat",
+	"parti-stableid",
+}
+
+func TestApply_EmptyServer_CreatesAllControlPlaneBuckets(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Equal(t, provision.APIVersionProvisionV1, rep.APIVersion)
+	require.Equal(t, provision.KindReport, rep.Kind)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Empty(t, rep.Skipped)
+	require.Len(t, rep.Executed, len(expectedControlPlaneNamesHandoffOn))
+
+	gotNames := map[string]bool{}
+	for _, ex := range rep.Executed {
+		require.Equal(t, provision.ActionCreateKV, ex.Kind)
+		require.False(t, ex.Raced, "no races on empty server")
+		gotNames[ex.Name] = true
+	}
+	for _, want := range expectedControlPlaneNamesHandoffOn {
+		require.True(t, gotNames[want], "expected create-kv for %q", want)
+	}
+
+	// Verify each bucket carries the Parti marker.
+	for _, name := range expectedControlPlaneNamesHandoffOn {
+		stream, err := js.Stream(ctx, "KV_"+name)
+		require.NoError(t, err)
+		info, err := stream.Info(ctx)
+		require.NoError(t, err)
+		marker := provision.ParseMarker(info.Config.Metadata)
+		require.Equal(t, provision.MarkerManagedValue, marker.Managed,
+			"bucket %s must be stamped as parti-managed", name)
+		require.NotEmpty(t, marker.Component)
+		require.Equal(t, "prod", marker.Instance)
+	}
+}
+
+func TestApply_Idempotent_SecondRunIsNoOp(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	first, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Len(t, first.Executed, len(expectedControlPlaneNamesHandoffOn))
+
+	second, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, second.Executed)
+	require.Empty(t, second.Errors)
+	require.Empty(t, second.Skipped)
+	require.False(t, second.Aborted)
+}
+
+func TestApply_PreCreatedBucket_RaceTolerated(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Pre-create parti-election out-of-band BUT with a non-matching
+	// metadata map so Plan still emits a create-kv action for the bucket.
+	// We achieve this by creating the bucket WITHOUT the Parti marker
+	// (Plan reports `adopted` drift but skips the create); to force a
+	// race-on-create we instead pre-create with mismatching metadata so
+	// Plan still emits the action — but Plan looks up by name, so any
+	// existing stream skips the action.
+	//
+	// Instead, simulate the race by:
+	//   1. Running Plan once to get the desired action list,
+	//   2. Pre-creating one of those buckets out-of-band with the same
+	//      KeyValueConfig,
+	//   3. Calling applyPlan on the original plan.
+	// Since applyPlan is unexported, we instead invoke Apply twice and
+	// inject a race between them via a parallel goroutine. A simpler
+	// equivalent: pre-create one bucket directly with the same NATS
+	// name, then call Apply against a freshly-instantiated Plan whose
+	// snapshot has not yet observed the bucket. We mimic that by
+	// pre-creating the bucket with explicit, non-Parti metadata so the
+	// Parti-managed marker is NOT present — Plan still considers the
+	// bucket as `adopted` (skipping it) and Apply observes no race.
+	//
+	// To actually exercise the §2.E branch we instead use a thin
+	// raceJetStream wrapper (declared below) that proxies all calls but
+	// inserts a pre-create on the first CreateKeyValue. This guarantees
+	// the bucket exists at Apply time even though Plan saw it absent.
+	wrapped := newRaceOnceJS(js, "KV_parti-election")
+	rep, err := provision.Apply(ctx, wrapped, cfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Empty(t, rep.Skipped)
+	require.Len(t, rep.Executed, len(expectedControlPlaneNamesHandoffOn))
+
+	var racedCount int
+	for _, ex := range rep.Executed {
+		if ex.Name == "parti-election" {
+			require.True(t, ex.Raced, "parti-election should be marked raced")
+			racedCount++
+		} else {
+			require.False(t, ex.Raced, "non-raced action %q should not be flagged", ex.Name)
+		}
+	}
+	require.Equal(t, 1, racedCount)
+}
+
+func TestApply_PreMutationCancel_AllSkipped(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	// Apply runs ValidateLive + Plan against the same ctx; to model a
+	// pre-mutation cancellation we inject the cancel at the moment the
+	// FIRST CreateKeyValue would fire, so ValidateLive and Plan see a
+	// live context and Apply hits ctx.Err() at the iteration head
+	// (yielding zero Executed entries and every action in Skipped).
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped := newCancelOnFirstCreateJS(js, cancel)
+
+	rep, err := provision.Apply(ctx, wrapped, cfg)
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Empty(t, rep.Executed)
+	require.Len(t, rep.Skipped, len(expectedControlPlaneNamesHandoffOn))
+	for _, sk := range rep.Skipped {
+		require.Equal(t, provision.SkipReasonContextCancelled, sk.Reason)
+	}
+}
+
+func TestApply_MidMutationCancel_PartialExecuted(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped := newCancelAfterNthCreateJS(js, 2, cancel)
+
+	rep, err := provision.Apply(ctx, wrapped, cfg)
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Equal(t, 2, len(rep.Executed),
+		"first 2 actions should have completed before cancellation")
+	require.Equal(t, len(expectedControlPlaneNamesHandoffOn)-2, len(rep.Skipped))
+	for _, sk := range rep.Skipped {
+		require.Equal(t, provision.SkipReasonContextCancelled, sk.Reason)
+	}
+}
+
+func TestApply_NonCancellationFailure_FailFast(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	// Pre-create a NON-KV stream that conflicts with parti-election's
+	// KV stream name (KV_parti-election). This makes the underlying
+	// CreateKeyValue call return ErrStreamNameAlreadyInUse — but we
+	// CANNOT use that path because §2.E classifies it as a race
+	// success. To force a true server-side rejection, we pre-create a
+	// stream that conflicts on the SUBJECT space ($KV.parti-election.>)
+	// without using the KV-derived name; the KV create then fails with
+	// a server error that is NOT ErrStreamNameAlreadyInUse / ErrBucketExists.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	subjectStream := jetstream.StreamConfig{
+		Name:     "shadow-election",
+		Subjects: []string{"$KV.parti-election.>"},
+		Storage:  jetstream.MemoryStorage,
+	}
+	_, err := js.CreateStream(ctx, subjectStream)
+	require.NoError(t, err)
+
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.Error(t, err)
+	require.False(t, errors.Is(err, context.Canceled))
+	require.False(t, errors.Is(err, context.DeadlineExceeded))
+	// Pin the test against a future nats.go change that might silently
+	// move the subject-conflict error into the race-tolerated branch.
+	// The shadow-stream technique must always produce a true failure, not
+	// ErrBucketExists / ErrStreamNameAlreadyInUse.
+	require.False(t, errors.Is(err, jetstream.ErrBucketExists),
+		"fail-fast test must exercise a non-race error class")
+	require.False(t, errors.Is(err, jetstream.ErrStreamNameAlreadyInUse),
+		"fail-fast test must exercise a non-race error class")
+	require.False(t, rep.Aborted)
+	require.Len(t, rep.Errors, 1)
+	require.Equal(t, "parti-election", rep.Errors[0].Name)
+	require.Equal(t, provision.ActionCreateKV, rep.Errors[0].Kind)
+
+	// Pre-error executions: parti-assignment (sorts before parti-election).
+	for _, ex := range rep.Executed {
+		require.NotEqual(t, "parti-election", ex.Name)
+		require.False(t, ex.Raced)
+	}
+	// All actions after the failing one go to Skipped with prior-error.
+	require.NotEmpty(t, rep.Skipped)
+	for _, sk := range rep.Skipped {
+		require.Equal(t, provision.SkipReasonPriorError, sk.Reason)
+		require.NotEqual(t, "parti-election", sk.Name)
+	}
+	require.Equal(t,
+		len(expectedControlPlaneNamesHandoffOn),
+		len(rep.Executed)+len(rep.Errors)+len(rep.Skipped),
+		"every planned action accounted for exactly once")
+}
+
+func TestApply_StaticValidateFailure_ReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+	cfg.APIVersion = "" // unknown apiVersion → normalize fails
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, provision.ErrInvalidConfig)
+	require.Zero(t, rep)
+}
+
+// TestApply_ValidateLiveFailure_ReturnsZeroReport verifies sub-spec §2.A:
+// when ValidateLive fails (pre-mutation), Apply must return Report{} (zero
+// value), not a populated mutation-shaped report. The pre-fix code returned
+// liveReport which contained ResourceError entries.
+func TestApply_ValidateLiveFailure_ReturnsZeroReport(t *testing.T) {
+	t.Parallel()
+	// Wrap JS to fail at AccountInfo (step 1.B reachability probe).
+	js := newFailAccountInfoJS(newJS(t))
+	cfg := applyCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.Error(t, err)
+	// No ErrInvalidConfig (static validation passed).
+	require.False(t, errors.Is(err, provision.ErrInvalidConfig))
+	// Sub-spec §2.A: pre-mutation failure → zero-value Report.
+	require.Zero(t, rep,
+		"Apply must return Report{} (zero value) when ValidateLive fails before mutation")
+}
+
+func TestApply_AlreadyExistingMarkedBucket_NotIncludedInExecuted(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := applyCfg()
+
+	// Pre-create parti-election EXACTLY as Plan would, including marker.
+	want := kvbuckets.BuildKeyValueConfig("parti-election", 10*time.Second, jetstream.MemoryStorage)
+	want.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, want)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Empty(t, rep.Skipped)
+	// 4 of 5 actions execute (parti-election skipped by Plan with
+	// informational drift).
+	require.Len(t, rep.Executed, len(expectedControlPlaneNamesHandoffOn)-1)
+	for _, ex := range rep.Executed {
+		require.NotEqual(t, "parti-election", ex.Name)
+	}
+}

--- a/provision/config.go
+++ b/provision/config.go
@@ -1,0 +1,85 @@
+package provision
+
+import "time"
+
+// Config is the desired environment state for the provision SDK. APIVersion
+// is required; v1 accepts only "parti.io/v1".
+//
+// Empty/omitted bucket-name fields are populated by Validate from runtime
+// defaults (see ControlPlaneConfig). Validate also defaults Policy to
+// PolicyWarn when empty.
+type Config struct {
+	APIVersion       string                 `yaml:"apiVersion"                  json:"apiVersion"`
+	Instance         string                 `yaml:"instance,omitempty"          json:"instance,omitempty"`
+	Policy           ReconcilePolicy        `yaml:"policy,omitempty"            json:"policy,omitempty"`
+	ControlPlane     *ControlPlaneConfig    `yaml:"controlPlane,omitempty"      json:"controlPlane,omitempty"`
+	PartitionSource  *PartitionSourceConfig `yaml:"partitionSource,omitempty"   json:"partitionSource,omitempty"`
+	DynamicConsumers []DynamicConsumerCfg   `yaml:"dynamicConsumers,omitempty"  json:"dynamicConsumers,omitempty"`
+	// Streams is intentionally absent in v1 (see Non-Goals in plan).
+}
+
+// ControlPlaneConfig mirrors the parti runtime fields that drive control-plane
+// KV bucket creation. Field names and yaml tags intentionally match
+// parti.Config / parti.KVBucketConfig so a single canonical config source can
+// populate both the runtime manager and this provisioning input.
+type ControlPlaneConfig struct {
+	// Bucket names (runtime origin: parti.KVBucketConfig).
+	// Empty/omitted fields default to the runtime defaults during Validate:
+	// "parti-stableid", "parti-election", "parti-heartbeat",
+	// "parti-assignment", "parti-handoff".
+	StableIDBucket   string `yaml:"stableIdBucket"   json:"stableIdBucket"`
+	ElectionBucket   string `yaml:"electionBucket"   json:"electionBucket"`
+	HeartbeatBucket  string `yaml:"heartbeatBucket"  json:"heartbeatBucket"`
+	AssignmentBucket string `yaml:"assignmentBucket" json:"assignmentBucket"`
+	HandoffBucket    string `yaml:"handoffBucket"    json:"handoffBucket"`
+
+	// TTLs. WorkerIDTTL/HeartbeatTTL/ElectionTimeout live on parti.Config;
+	// AssignmentTTL and HandoffTTL live on parti.KVBucketConfig.
+	WorkerIDTTL     time.Duration `yaml:"workerIdTtl"     json:"workerIdTtl"`
+	ElectionTimeout time.Duration `yaml:"electionTimeout" json:"electionTimeout"`
+	HeartbeatTTL    time.Duration `yaml:"heartbeatTtl"    json:"heartbeatTtl"`
+	AssignmentTTL   time.Duration `yaml:"assignmentTtl"   json:"assignmentTtl"` // 0 = no expiration
+	HandoffTTL      time.Duration `yaml:"handoffTtl"      json:"handoffTtl"`
+
+	// EnableTwoPhaseHandoff gates the optional handoff KV bucket. When true,
+	// HandoffTTL must be > 0.
+	EnableTwoPhaseHandoff bool `yaml:"enableTwoPhaseHandoff" json:"enableTwoPhaseHandoff"`
+}
+
+// PartitionSourceConfig declares the NATS KV bucket that holds the partition
+// definition record. v1 provisions the bucket only; partition record contents
+// are written by Phase 3 (Partition Records).
+type PartitionSourceConfig struct {
+	Bucket   string `yaml:"bucket"                 json:"bucket"`
+	Key      string `yaml:"key"                    json:"key"`
+	Replicas int    `yaml:"replicas,omitempty"     json:"replicas,omitempty"`
+	Storage  string `yaml:"storage,omitempty"      json:"storage,omitempty"` // "file" | "memory"; default "file"
+	History  uint8  `yaml:"history,omitempty"      json:"history,omitempty"` // default 1
+	// MaxValueSize is the maximum per-value size in bytes. 0 means "no limit";
+	// in live NATS state this is stored as MaxMsgSize=-1. provision.Plan
+	// normalizes these as equivalent when classifying drift, so a config
+	// MaxValueSize=0 and a live MaxMsgSize=-1 do not produce drift-mutable
+	// findings.
+	MaxValueSize int32         `yaml:"maxValueSize,omitempty" json:"maxValueSize,omitempty"`
+	TTL          time.Duration `yaml:"ttl,omitempty"          json:"ttl,omitempty"`
+}
+
+// DynamicConsumerCfg describes one dynamic-consumer alignment target. v1
+// performs alignment-check only; consumer pre-creation lands in Phase 5.
+type DynamicConsumerCfg struct {
+	StreamName      string `yaml:"streamName"              json:"streamName"`
+	ConsumerPrefix  string `yaml:"consumerPrefix"          json:"consumerPrefix"`
+	SubjectTemplate string `yaml:"subjectTemplate"         json:"subjectTemplate"`
+	PartitionsRef   string `yaml:"partitionsRef,omitempty" json:"partitionsRef,omitempty"`
+}
+
+// Runtime bucket-name defaults. These mirror parti.KVBucketConfig's
+// `default:"…"` struct tags exactly. Kept here so provision/ doesn't take
+// a dependency on the parti runtime package's defaulting machinery.
+const (
+	defaultStableIDBucket   = "parti-stableid"
+	defaultElectionBucket   = "parti-election"
+	defaultHeartbeatBucket  = "parti-heartbeat"
+	defaultAssignmentBucket = "parti-assignment"
+	defaultHandoffBucket    = "parti-handoff"
+)

--- a/provision/doc.go
+++ b/provision/doc.go
@@ -1,0 +1,32 @@
+// Package provision provides a read-only SDK for viewing, validating, and
+// planning the NATS resources Parti's runtime depends on.
+//
+// Phase 1 (W1) of the provision-sdk-cli plan delivers:
+//
+//   - Config — desired-state input loaded from YAML or constructed in Go.
+//   - Validate(cfg) — pure static validation with bucket-name defaulting.
+//   - View(ctx, js, scope) — read-only inventory of Parti-marked resources.
+//   - Plan(ctx, js, cfg) — deterministic drift report and create-kv actions
+//     for control-plane KV buckets. No mutation.
+//
+// Plan emits at most one PlannedAction kind in v1 — "create-kv" — and only
+// for control-plane buckets. Partition-source create-kv actions, dynamic-
+// consumer alignment, and the Apply mutation path land in later work items
+// (W2–W4) of the same plan. See docs/plans/provision-sdk-cli for the full
+// design and roadmap.
+//
+// Byte-equivalence invariant: every "create-kv" action's KeyValueConfig is
+// built by calling github.com/arloliu/parti/v2/internal/kvbuckets.BuildKeyValueConfig
+// and then attaching the Parti ownership marker in Metadata. The same builder
+// is used by (*Manager).ensureKVBucket at runtime, so a provision-managed
+// bucket is byte-identical (modulo the Metadata marker) to one created by
+// Parti's manager.
+//
+// ValidateLiveDynamicConsumers is best-effort: stream-info fetch failures
+// inside the underlying consumer.CheckWorkQueueRecoveryCompat helper are
+// silently ignored, mirroring the runtime's tolerance of transient stream
+// unavailability. This means a misconfigured or nonexistent stream name
+// produces an "OK" result rather than a "stream not found" error — the check
+// answers "is this stream's recovery strategy compatible with WorkQueuePolicy?"
+// not "does this stream exist?".
+package provision

--- a/provision/dynamic_consumers.go
+++ b/provision/dynamic_consumers.go
@@ -1,0 +1,158 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/dynamicbuild"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// PlanDynamicConsumers is a pure builder that produces a deterministic
+// PlannedConsumer slice for the given (streamName, consumerPrefix,
+// subjectTemplate, partitions) tuple. It performs no I/O.
+//
+// The builder produces the same per-subject jetstream.ConsumerConfig that
+// the runtime consumer.Dynamic would create (modulo runtime-tunable fields
+// supplied via Dynamic options — see the W4 sub-spec §2 for the enumerated
+// equality subset).
+//
+// In v1 the builder hard-codes:
+//   - AckPolicy = jetstream.AckExplicitPolicy
+//   - DeliverPolicy = jetstream.DeliverAllPolicy
+//
+// All other ConsumerConfig fields are populated from the zero values of
+// dynamicbuild.Defaults; runtime equivalents are tunable through consumer
+// options that the v1 builder does not accept. The runtime-defaults
+// roundtrip test (provision/dynamic_consumers_test.go) pins the equality
+// subset against durable.WorkerConsumerConfig.SetDefaults().
+//
+// Output ordering is deterministic by subject (matches the runtime
+// internal/durable.buildSubjects sort). Two partitions that resolve to the
+// same subject deduplicate; the entries are emitted in subject-sorted
+// order.
+//
+// Errors wrap ErrInvalidConfig and are surfaced as static-validation
+// failures (CLI exit code 2):
+//
+//   - streamName == ""        → "%w: streamName is required"
+//   - consumerPrefix == ""    → "%w: consumerPrefix is required"
+//   - consumerPrefix contains characters outside [a-zA-Z0-9-_]
+//   - subjectTemplate == ""   → "%w: subjectTemplate is required"
+//   - subjectTemplate missing {{.PartitionID}} or fails to render
+//   - len(partitions) == 0    → "%w: at least one partition is required"
+//   - partition with no keys  → wrapped "partition has no keys"
+func PlanDynamicConsumers(
+	streamName, consumerPrefix, subjectTemplate string,
+	partitions []types.Partition,
+) ([]PlannedConsumer, error) {
+	if streamName == "" {
+		return nil, fmt.Errorf("%w: streamName is required", ErrInvalidConfig)
+	}
+	if consumerPrefix == "" {
+		return nil, fmt.Errorf("%w: consumerPrefix is required", ErrInvalidConfig)
+	}
+	for _, r := range consumerPrefix {
+		if !dynamicbuild.IsAllowedConsumerRune(r) {
+			return nil, fmt.Errorf(
+				"%w: consumer prefix %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)",
+				ErrInvalidConfig, consumerPrefix,
+			)
+		}
+	}
+	if subjectTemplate == "" {
+		return nil, fmt.Errorf("%w: subjectTemplate is required", ErrInvalidConfig)
+	}
+	// Wildcards allowed (matches runtime: durable.WorkerConsumerConfig.Validate
+	// passes allowWildcard=true to validateSubjectTemplate).
+	if err := dynamicbuild.ValidateSubjectTemplate(subjectTemplate, true); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+	if len(partitions) == 0 {
+		return nil, fmt.Errorf("%w: at least one partition is required", ErrInvalidConfig)
+	}
+
+	subjects, err := dynamicbuild.BuildSubjects(subjectTemplate, partitions)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	// Template framing for partition-id extraction inside PerSubjectDurableName.
+	pre, suf, _ := dynamicbuild.ParseSubjectTemplateParts(subjectTemplate)
+
+	defaults := dynamicbuild.Defaults{
+		AckPolicy: jetstream.AckExplicitPolicy,
+		// Remaining tunables left at their Go zero values; the v1 equality
+		// subset does not assert them. See sub-spec §2.
+	}
+
+	out := make([]PlannedConsumer, 0, len(subjects))
+	for _, subject := range subjects {
+		durable := dynamicbuild.PerSubjectDurableName(consumerPrefix, subject, pre, suf)
+		cfg := dynamicbuild.ConsumerConfig(durable, subject, defaults)
+		out = append(out, PlannedConsumer{
+			StreamName: streamName,
+			Subject:    subject,
+			Durable:    durable,
+			Config:     cfg,
+		})
+	}
+
+	return out, nil
+}
+
+// ValidateLiveDynamicConsumers performs the WorkQueuePolicy compatibility
+// check that runtime consumer.Dynamic.Update would perform on first update,
+// for each configured dynamic-consumer alignment target.
+//
+// v1 always passes consumer.RecoveryDisabled as the strategy, mirroring
+// what consumer.Dynamic would produce when no WithRecoveryStrategy option
+// is set. Both RecoveryDisabled and RecoverFromBeginning unconditionally
+// pass the check (see consumer.CheckWorkQueueRecoveryCompat), so v1
+// alignment never raises a false positive against a WorkQueuePolicy
+// stream. Phase 5 (precreation) reintroduces a configurable strategy.
+//
+// Errors:
+//   - Returns the first error encountered (fail-fast), wrapped with the
+//     offending cfg's StreamName for operator clarity.
+//   - The underlying error is the verbatim
+//     consumer.CheckWorkQueueRecoveryCompat error (wraps
+//     consumer.ErrInvalidConfig).
+//   - On context cancellation, returns ctx.Err() without further wrapping.
+//   - Best-effort connectivity: stream-info fetch failures inside
+//     CheckWorkQueueRecoveryCompat are silently ignored, mirroring runtime.
+func ValidateLiveDynamicConsumers(
+	ctx context.Context,
+	js jetstream.JetStream,
+	cfgs []DynamicConsumerCfg,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, cfg := range cfgs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := consumer.CheckWorkQueueRecoveryCompat(
+			ctx, js, cfg.StreamName, consumer.RecoveryDisabled,
+		); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return err
+			}
+			return fmt.Errorf("dynamic consumer alignment for stream %q: %w", cfg.StreamName, err)
+		}
+		// The helper treats JS errors as benign and returns nil. If the
+		// context was cancelled during the helper call, ctx.Err() is now
+		// non-nil even though the helper returned nil. Check explicitly so
+		// we never return a clean result after mid-call cancellation.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/provision/dynamic_consumers_integration_test.go
+++ b/provision/dynamic_consumers_integration_test.go
@@ -1,0 +1,155 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// TestValidateLiveDynamicConsumers_NoConsumers asserts that an empty
+// DynamicConsumerCfg slice returns nil without contacting the server.
+func TestValidateLiveDynamicConsumers_NoConsumers(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, provision.ValidateLiveDynamicConsumers(ctx, js, nil))
+	require.NoError(t, provision.ValidateLiveDynamicConsumers(ctx, js, []provision.DynamicConsumerCfg{}))
+}
+
+// TestValidateLiveDynamicConsumers_WorkQueuePolicy_DefaultRecoveryDisabled
+// asserts that the v1 builder's default RecoveryDisabled passes the
+// WorkQueuePolicy check (positive case).
+func TestValidateLiveDynamicConsumers_WorkQueuePolicy_DefaultRecoveryDisabled(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "wq-stream",
+		Subjects:  []string{"wq.>"},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	err = provision.ValidateLiveDynamicConsumers(ctx, js, []provision.DynamicConsumerCfg{
+		{StreamName: "wq-stream", ConsumerPrefix: "p", SubjectTemplate: "wq.{{.PartitionID}}"},
+	})
+	require.NoError(t, err, "RecoveryDisabled must pass against WorkQueuePolicy")
+}
+
+// TestValidateLiveDynamicConsumers_NonWorkQueueStream_Success asserts that
+// a standard Interest/Limits policy stream is accepted unconditionally.
+func TestValidateLiveDynamicConsumers_NonWorkQueueStream_Success(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "interest-stream",
+		Subjects: []string{"int.>"},
+		Storage:  jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, provision.ValidateLiveDynamicConsumers(ctx, js, []provision.DynamicConsumerCfg{
+		{StreamName: "interest-stream", ConsumerPrefix: "p", SubjectTemplate: "int.{{.PartitionID}}"},
+	}))
+}
+
+// TestValidateLiveDynamicConsumers_NonExistentStream_Success asserts the
+// best-effort connectivity contract: missing streams do not cause failure
+// (the runtime check silently ignores stream-info fetch failures).
+func TestValidateLiveDynamicConsumers_NonExistentStream_Success(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, provision.ValidateLiveDynamicConsumers(ctx, js, []provision.DynamicConsumerCfg{
+		{StreamName: "does-not-exist", ConsumerPrefix: "p", SubjectTemplate: "x.{{.PartitionID}}"},
+	}))
+}
+
+// TestCheckWorkQueueRecoveryCompat_RejectsRecoverFromNew exercises the
+// shared-implementation contract: provision.ValidateLiveDynamicConsumers
+// and consumer.Dynamic.Update both call consumer.CheckWorkQueueRecoveryCompat,
+// so the WorkQueuePolicy rejection error is byte-equivalent across both
+// callsites. Provision's v1 default (RecoveryDisabled) cannot exercise the
+// rejection path itself, so this test reaches directly at the shared
+// helper to prove the contract.
+func TestCheckWorkQueueRecoveryCompat_RejectsRecoverFromNew(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "wq-reject",
+		Subjects:  []string{"wqr.>"},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	got := consumer.CheckWorkQueueRecoveryCompat(ctx, js, "wq-reject", consumer.RecoverFromNew)
+	require.Error(t, got)
+	require.ErrorIs(t, got, consumer.ErrInvalidConfig)
+	require.Contains(t, got.Error(), "RecoverFromNew is incompatible with WorkQueuePolicy")
+}
+
+// TestValidateLive_WiresDynamicConsumers asserts that ValidateLive invokes
+// ValidateLiveDynamicConsumers for cfg.DynamicConsumers. Since the v1
+// builder's RecoveryDisabled default always passes WorkQueuePolicy, we
+// assert that ValidateLive returns nil for a WorkQueuePolicy stream
+// configured with a dynamic-consumer entry (proving the wiring is exercised
+// without false positives).
+func TestValidateLive_WiresDynamicConsumers_Pass(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "vlw-stream",
+		Subjects:  []string{"vlw.>"},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	report, err := provision.ValidateLive(ctx, js, provision.Config{
+		APIVersion: provision.APIVersionV1,
+		DynamicConsumers: []provision.DynamicConsumerCfg{
+			{StreamName: "vlw-stream", ConsumerPrefix: "p", SubjectTemplate: "vlw.{{.PartitionID}}"},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, report.Errors)
+}
+
+// TestValidateLiveDynamicConsumers_RespectsCancellation pins the
+// cancellation contract: ctx.Err() is returned without further wrapping.
+func TestValidateLiveDynamicConsumers_RespectsCancellation(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := provision.ValidateLiveDynamicConsumers(ctx, js, []provision.DynamicConsumerCfg{
+		{StreamName: "x", ConsumerPrefix: "p", SubjectTemplate: "x.{{.PartitionID}}"},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.Canceled), "expected ctx.Canceled, got %v", err)
+}

--- a/provision/dynamic_consumers_test.go
+++ b/provision/dynamic_consumers_test.go
@@ -1,0 +1,267 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/internal/dynamicbuild"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestPlanDynamicConsumers_HappyPath asserts the v1 in-scope equality subset
+// (Name, Durable, FilterSubject, AckPolicy, DeliverPolicy) for a small
+// partition set.
+func TestPlanDynamicConsumers_HappyPath(t *testing.T) {
+	partitions := []types.Partition{
+		{Keys: []string{"a", "1"}},
+		{Keys: []string{"b", "2"}},
+	}
+
+	planned, err := PlanDynamicConsumers("orders", "ord-worker", "orders.{{.PartitionID}}.>", partitions)
+	require.NoError(t, err)
+	require.Len(t, planned, 2)
+
+	// Subjects sorted lex.
+	require.Equal(t, "orders.a.1.>", planned[0].Subject)
+	require.Equal(t, "orders.b.2.>", planned[1].Subject)
+
+	for _, pc := range planned {
+		require.Equal(t, "orders", pc.StreamName)
+		require.NotEmpty(t, pc.Durable)
+		require.Equal(t, pc.Durable, pc.Config.Name)
+		require.Equal(t, pc.Durable, pc.Config.Durable)
+		require.Equal(t, pc.Subject, pc.Config.FilterSubject)
+		require.Equal(t, jetstream.AckExplicitPolicy, pc.Config.AckPolicy)
+		require.Equal(t, jetstream.DeliverAllPolicy, pc.Config.DeliverPolicy)
+		require.True(t, strings.HasPrefix(pc.Durable, "ord-worker_"))
+	}
+}
+
+// TestPlanDynamicConsumers_RuntimeRoundtripEquivalence is the load-bearing
+// v1 byte-equivalence test. It constructs a runtime
+// durable.WorkerConsumerConfig and calls SetDefaults() — exactly as
+// consumer.Dynamic does via its Validate path — then re-derives the
+// expected per-subject ConsumerConfig via dynamicbuild and asserts every
+// field in the §2 in-scope equality subset matches PlanDynamicConsumers's
+// output.
+func TestPlanDynamicConsumers_RuntimeRoundtripEquivalence(t *testing.T) {
+	const (
+		streamName      = "orders"
+		consumerPrefix  = "ord-worker"
+		subjectTemplate = "orders.{{.PartitionID}}.>"
+	)
+	partitions := []types.Partition{
+		{Keys: []string{"a", "1"}},
+		{Keys: []string{"b", "2"}},
+		{Keys: []string{"c", "3"}},
+	}
+
+	runtimeCfg := durable.WorkerConsumerConfig{
+		StreamName:      streamName,
+		ConsumerPrefix:  consumerPrefix,
+		SubjectTemplate: subjectTemplate,
+	}
+	require.NoError(t, runtimeCfg.SetDefaults(),
+		"the equivalence assertion is only meaningful after SetDefaults runs")
+
+	pre, suf, _ := dynamicbuild.ParseSubjectTemplateParts(subjectTemplate)
+
+	planned, err := PlanDynamicConsumers(streamName, consumerPrefix, subjectTemplate, partitions)
+	require.NoError(t, err)
+	require.Len(t, planned, len(partitions))
+
+	for _, pc := range planned {
+		expectedDurable := dynamicbuild.PerSubjectDurableName(consumerPrefix, pc.Subject, pre, suf)
+		expectedCfg := dynamicbuild.ConsumerConfig(
+			expectedDurable,
+			pc.Subject,
+			dynamicbuild.Defaults{
+				AckPolicy:             runtimeCfg.AckPolicy,
+				AckWait:               runtimeCfg.AckWait,
+				MaxDeliver:            runtimeCfg.MaxDeliver,
+				InactiveThreshold:     runtimeCfg.InactiveThreshold,
+				MaxWaiting:            runtimeCfg.MaxWaiting,
+				MaxAckPending:         runtimeCfg.MaxAckPending,
+				ConsumerMemoryStorage: runtimeCfg.ConsumerMemoryStorage,
+				ConsumerReplicas:      runtimeCfg.ConsumerReplicas,
+			},
+		)
+
+		// §2 in-scope subset — these MUST match between runtime and provision.
+		require.Equal(t, expectedCfg.Name, pc.Config.Name)
+		require.Equal(t, expectedCfg.Durable, pc.Config.Durable)
+		require.Equal(t, expectedCfg.FilterSubject, pc.Config.FilterSubject)
+		require.Equal(t, expectedCfg.AckPolicy, pc.Config.AckPolicy)
+		require.Equal(t, expectedCfg.DeliverPolicy, pc.Config.DeliverPolicy)
+
+		// Out-of-scope fields (AckWait, MaxDeliver, InactiveThreshold,
+		// MaxWaiting, MaxAckPending, MemoryStorage, Replicas) are
+		// intentionally NOT asserted. The provision builder leaves them at
+		// dynamicbuild.Defaults zero values; runtime sets them from
+		// SetDefaults() output. The v1 equality subset (sub-spec §2)
+		// explicitly limits assertions to the five identity/semantic-
+		// constant fields above.
+	}
+}
+
+// TestPlanDynamicConsumers_RoundtripEquivalence_FailsOnIotaDrift documents
+// the protection against future iota reordering in nats.go. If
+// AckExplicitPolicy or DeliverAllPolicy stops being the zero value,
+// PlanDynamicConsumers's explicit assignment keeps the output stable.
+func TestPlanDynamicConsumers_HardCodesSemanticConstants(t *testing.T) {
+	planned, err := PlanDynamicConsumers("s", "p", "x.{{.PartitionID}}", []types.Partition{{Keys: []string{"k"}}})
+	require.NoError(t, err)
+	require.Len(t, planned, 1)
+	require.Equal(t, jetstream.AckExplicitPolicy, planned[0].Config.AckPolicy)
+	require.Equal(t, jetstream.DeliverAllPolicy, planned[0].Config.DeliverPolicy)
+}
+
+// TestPlanDynamicConsumers_DeterministicOrderAcrossShuffles asserts that
+// PlanDynamicConsumers produces identical output for any permutation of the
+// input partition slice.
+func TestPlanDynamicConsumers_DeterministicOrderAcrossShuffles(t *testing.T) {
+	base := make([]types.Partition, 16)
+	for i := range base {
+		base[i] = types.Partition{Keys: []string{"part", string(rune('a' + i))}}
+	}
+
+	canonical, err := PlanDynamicConsumers("s", "p", "x.{{.PartitionID}}", base)
+	require.NoError(t, err)
+
+	r := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic shuffle for test
+	for trial := 0; trial < 10; trial++ {
+		shuffled := make([]types.Partition, len(base))
+		copy(shuffled, base)
+		r.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+		got, err := PlanDynamicConsumers("s", "p", "x.{{.PartitionID}}", shuffled)
+		require.NoError(t, err)
+		require.Equal(t, canonical, got, "trial %d: output not deterministic", trial)
+	}
+}
+
+// TestPlanDynamicConsumers_DeduplicatesEqualSubjects asserts that two
+// partitions whose Keys resolve to the same subject collapse to one
+// PlannedConsumer entry (matches runtime dedup behavior).
+func TestPlanDynamicConsumers_DeduplicatesEqualSubjects(t *testing.T) {
+	partitions := []types.Partition{
+		{Keys: []string{"a", "1"}},
+		{Keys: []string{"a", "1"}}, // dup
+	}
+	planned, err := PlanDynamicConsumers("s", "p", "x.{{.PartitionID}}", partitions)
+	require.NoError(t, err)
+	require.Len(t, planned, 1)
+}
+
+// --- Input validation tests ---
+
+func TestPlanDynamicConsumers_RejectsEmptyStreamName(t *testing.T) {
+	_, err := PlanDynamicConsumers("", "p", "x.{{.PartitionID}}", []types.Partition{{Keys: []string{"a"}}})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "streamName is required")
+}
+
+func TestPlanDynamicConsumers_RejectsEmptyConsumerPrefix(t *testing.T) {
+	_, err := PlanDynamicConsumers("s", "", "x.{{.PartitionID}}", []types.Partition{{Keys: []string{"a"}}})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "consumerPrefix is required")
+}
+
+func TestPlanDynamicConsumers_RejectsBadConsumerPrefixChars(t *testing.T) {
+	cases := []string{"foo bar", "foo/bar", "foo$bar"}
+	for _, prefix := range cases {
+		t.Run(prefix, func(t *testing.T) {
+			_, err := PlanDynamicConsumers("s", prefix, "x.{{.PartitionID}}", []types.Partition{{Keys: []string{"a"}}})
+			require.ErrorIs(t, err, ErrInvalidConfig)
+			require.Contains(t, err.Error(), "invalid characters")
+		})
+	}
+}
+
+func TestPlanDynamicConsumers_RejectsEmptyTemplate(t *testing.T) {
+	_, err := PlanDynamicConsumers("s", "p", "", []types.Partition{{Keys: []string{"a"}}})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "subjectTemplate is required")
+}
+
+func TestPlanDynamicConsumers_RejectsTemplateMissingPlaceholder(t *testing.T) {
+	_, err := PlanDynamicConsumers("s", "p", "no.placeholder", []types.Partition{{Keys: []string{"a"}}})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "must contain {{.PartitionID}}")
+}
+
+func TestPlanDynamicConsumers_RejectsZeroPartitions(t *testing.T) {
+	_, err := PlanDynamicConsumers("s", "p", "x.{{.PartitionID}}", nil)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "at least one partition is required")
+}
+
+func TestPlanDynamicConsumers_RejectsPartitionWithNoKeys(t *testing.T) {
+	_, err := PlanDynamicConsumers("s", "p", "x.{{.PartitionID}}", []types.Partition{{Keys: nil}})
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "partition has no keys")
+}
+
+// --- ValidateLiveDynamicConsumers cancellation tests ---
+
+// cancelAfterNthErrCtx is a context.Context whose Err() returns
+// context.Canceled only after the Nth call. This lets a test make the
+// cancellation observable between the top-of-loop ctx.Err() check and the
+// post-helper ctx.Err() check without requiring any NATS interaction.
+//
+// Why a context wrapper rather than a JS fake: v1 hardcodes RecoveryDisabled,
+// so consumer.CheckWorkQueueRecoveryCompat short-circuits immediately (at the
+// strategy switch) without touching JetStream at all. A JS fake intercepting
+// Stream() would be a no-op. The only reliable way to simulate "context
+// cancelled during the helper call" is to inject cancellation via Err().
+type cancelAfterNthErrCtx struct {
+	context.Context
+	n     int64
+	count atomic.Int64
+}
+
+func (c *cancelAfterNthErrCtx) Err() error {
+	if c.count.Add(1) > c.n {
+		return context.Canceled
+	}
+	return c.Context.Err()
+}
+
+// TestValidateLiveDynamicConsumers_DetectsCancellationAcrossHelperCall is the
+// regression test for the P0 finding in the W4 post-impl review:
+// ValidateLiveDynamicConsumers could return nil even after the caller's
+// context was cancelled, because CheckWorkQueueRecoveryCompat treats JS errors
+// as benign and returns nil — silently masking any mid-call cancellation.
+//
+// This test MUST FAIL on the pre-fix code (which only checks ctx.Err() before
+// the helper call) and PASS after the fix (which also checks after).
+//
+// With n=2 and one cfg entry, the sequence of Err() calls is:
+//   - call 1: top-of-function guard (line 133) → returns nil
+//   - call 2: top-of-loop guard (line 137) → returns nil → loop proceeds
+//   - helper call (RecoveryDisabled): returns nil immediately with no Err() calls
+//   - call 3: post-helper guard added by the fix → returns Canceled
+//
+// Pre-fix code never reaches call 3, so it returns nil. Post-fix code hits
+// call 3 and returns context.Canceled.
+func TestValidateLiveDynamicConsumers_DetectsCancellationAcrossHelperCall(t *testing.T) {
+	// cancelAfterNthErrCtx.Err() returns nil for the first n calls, then
+	// context.Canceled. With n=2, the top-of-function guard (call 1) and
+	// top-of-loop guard (call 2) both see nil; the post-helper check (call 3,
+	// added by the fix) sees Canceled.
+	ctx := &cancelAfterNthErrCtx{Context: context.Background(), n: 2}
+
+	err := ValidateLiveDynamicConsumers(ctx, nil, []DynamicConsumerCfg{
+		{StreamName: "s", ConsumerPrefix: "p", SubjectTemplate: "x.{{.PartitionID}}"},
+	})
+	require.Error(t, err, "expected context.Canceled; pre-fix code returns nil here")
+	require.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
+}

--- a/provision/marker.go
+++ b/provision/marker.go
@@ -1,0 +1,128 @@
+package provision
+
+// Marker metadata keys stamped on every Parti-managed NATS resource. They
+// live in the resource's Metadata map (jetstream.KeyValueConfig.Metadata for
+// KV buckets), not Description. See docs/plans/provision-sdk-cli for the
+// authoritative contract.
+const (
+	// MarkerManagedKey holds the marker schema version, e.g. "v1". The
+	// default View filter treats a non-empty value as proof that the
+	// resource is Parti-managed.
+	MarkerManagedKey = "parti.io/managed"
+
+	// MarkerComponentKey categorizes the resource: one of the Component*
+	// constants below.
+	MarkerComponentKey = "parti.io/component"
+
+	// MarkerInstanceKey is an optional logical environment identifier.
+	// When set, View can filter inventory by this value.
+	MarkerInstanceKey = "parti.io/instance"
+
+	// MarkerManagedValue is the schema-version value v1 always writes.
+	MarkerManagedValue = "v1"
+)
+
+// Component values. The provision SDK never writes any other value.
+const (
+	ComponentControlPlaneID         = "control-plane:id"
+	ComponentControlPlaneElection   = "control-plane:election"
+	ComponentControlPlaneHeartbeat  = "control-plane:heartbeat"
+	ComponentControlPlaneAssignment = "control-plane:assignment"
+	ComponentControlPlaneHandoff    = "control-plane:handoff"
+	ComponentPartitionSource        = "partition-source"
+	ComponentDynamicConsumer        = "dynamic-consumer"
+	// ComponentUnknown is reported by View/Plan when a resource carries the
+	// Parti managed marker but a component value outside the enumerated set
+	// above (forward-compat).
+	ComponentUnknown = "unknown"
+)
+
+// MarkerInfo captures the parsed Parti marker fields on a resource.
+type MarkerInfo struct {
+	// Managed is the value of parti.io/managed; empty means "unmarked".
+	Managed string
+	// Component is the value of parti.io/component; empty if absent.
+	Component string
+	// Instance is the value of parti.io/instance; empty if absent.
+	Instance string
+}
+
+// IsManaged reports whether the resource is marked as Parti-managed (i.e.
+// parti.io/managed is set to a non-empty value).
+func (m MarkerInfo) IsManaged() bool {
+	return m.Managed != ""
+}
+
+// ClassifyComponent returns the component as-stamped on the resource, or
+// ComponentUnknown if the marker exists but the value is not one of the
+// enumerated v1 components.
+func (m MarkerInfo) ClassifyComponent() string {
+	if !m.IsManaged() {
+		return ""
+	}
+	switch m.Component {
+	case ComponentControlPlaneID,
+		ComponentControlPlaneElection,
+		ComponentControlPlaneHeartbeat,
+		ComponentControlPlaneAssignment,
+		ComponentControlPlaneHandoff,
+		ComponentPartitionSource,
+		ComponentDynamicConsumer:
+		return m.Component
+	default:
+		return ComponentUnknown
+	}
+}
+
+// BuildMarker constructs the Metadata map that should be set on a freshly
+// created Parti-managed resource. The instance arg is optional ("" means no
+// instance label).
+//
+// The returned map always contains MarkerManagedKey and MarkerComponentKey;
+// MarkerInstanceKey is added only when instance != "".
+func BuildMarker(component, instance string) map[string]string {
+	m := map[string]string{
+		MarkerManagedKey:   MarkerManagedValue,
+		MarkerComponentKey: component,
+	}
+	if instance != "" {
+		m[MarkerInstanceKey] = instance
+	}
+
+	return m
+}
+
+// ParseMarker reads the Parti marker keys out of a resource's Metadata.
+// Unknown parti.io/* keys are ignored (forward-compat). A nil or empty map
+// returns the zero MarkerInfo (which IsManaged()==false).
+//
+// The Component field is the classified component value: for managed resources
+// it is one of the Component* constants or ComponentUnknown for unrecognised
+// values (forward-compat). For unmanaged resources Component is always "".
+func ParseMarker(metadata map[string]string) MarkerInfo {
+	if len(metadata) == 0 {
+		return MarkerInfo{}
+	}
+	managed := metadata[MarkerManagedKey]
+	var component string
+	if managed != "" {
+		switch metadata[MarkerComponentKey] {
+		case ComponentControlPlaneID,
+			ComponentControlPlaneElection,
+			ComponentControlPlaneHeartbeat,
+			ComponentControlPlaneAssignment,
+			ComponentControlPlaneHandoff,
+			ComponentPartitionSource,
+			ComponentDynamicConsumer:
+			component = metadata[MarkerComponentKey]
+		default:
+			component = ComponentUnknown
+		}
+	}
+
+	return MarkerInfo{
+		Managed:   managed,
+		Component: component,
+		Instance:  metadata[MarkerInstanceKey],
+	}
+}

--- a/provision/marker_test.go
+++ b/provision/marker_test.go
@@ -1,0 +1,95 @@
+package provision_test
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMarker_WithInstance(t *testing.T) {
+	t.Parallel()
+	m := provision.BuildMarker(provision.ComponentControlPlaneElection, "prod-us-east")
+	require.Equal(t, provision.MarkerManagedValue, m[provision.MarkerManagedKey])
+	require.Equal(t, provision.ComponentControlPlaneElection, m[provision.MarkerComponentKey])
+	require.Equal(t, "prod-us-east", m[provision.MarkerInstanceKey])
+}
+
+func TestBuildMarker_EmptyInstanceOmitsKey(t *testing.T) {
+	t.Parallel()
+	m := provision.BuildMarker(provision.ComponentControlPlaneID, "")
+	require.Equal(t, provision.MarkerManagedValue, m[provision.MarkerManagedKey])
+	require.Equal(t, provision.ComponentControlPlaneID, m[provision.MarkerComponentKey])
+	_, hasInstance := m[provision.MarkerInstanceKey]
+	require.False(t, hasInstance, "instance key must be omitted when instance is empty")
+}
+
+func TestParseMarker_NilMetadata(t *testing.T) {
+	t.Parallel()
+	info := provision.ParseMarker(nil)
+	require.False(t, info.IsManaged())
+	require.Equal(t, "", info.ClassifyComponent())
+}
+
+func TestParseMarker_EmptyMetadata(t *testing.T) {
+	t.Parallel()
+	info := provision.ParseMarker(map[string]string{})
+	require.False(t, info.IsManaged())
+}
+
+func TestParseMarker_MissingManagedKeyIsUnmarked(t *testing.T) {
+	t.Parallel()
+	info := provision.ParseMarker(map[string]string{
+		provision.MarkerComponentKey: provision.ComponentControlPlaneID,
+	})
+	require.False(t, info.IsManaged())
+	require.Equal(t, "", info.ClassifyComponent())
+}
+
+func TestParseMarker_KnownComponent(t *testing.T) {
+	t.Parallel()
+	info := provision.ParseMarker(map[string]string{
+		provision.MarkerManagedKey:   provision.MarkerManagedValue,
+		provision.MarkerComponentKey: provision.ComponentControlPlaneAssignment,
+		provision.MarkerInstanceKey:  "stage",
+	})
+	require.True(t, info.IsManaged())
+	// Component is classified directly on parse; no need to call ClassifyComponent.
+	require.Equal(t, provision.ComponentControlPlaneAssignment, info.Component)
+	require.Equal(t, provision.ComponentControlPlaneAssignment, info.ClassifyComponent())
+	require.Equal(t, "stage", info.Instance)
+}
+
+func TestParseMarker_UnknownComponent(t *testing.T) {
+	t.Parallel()
+	info := provision.ParseMarker(map[string]string{
+		provision.MarkerManagedKey:   provision.MarkerManagedValue,
+		provision.MarkerComponentKey: "future-component",
+	})
+	require.True(t, info.IsManaged())
+	// ParseMarker must classify unknown components directly; callers need not
+	// call ClassifyComponent to get the "unknown" sentinel.
+	require.Equal(t, provision.ComponentUnknown, info.Component)
+	require.Equal(t, provision.ComponentUnknown, info.ClassifyComponent())
+}
+
+func TestParseMarker_IgnoresUnknownPartiKeys(t *testing.T) {
+	t.Parallel()
+	info := provision.ParseMarker(map[string]string{
+		provision.MarkerManagedKey:   provision.MarkerManagedValue,
+		provision.MarkerComponentKey: provision.ComponentControlPlaneID,
+		"parti.io/future":            "x",
+		"unrelated":                  "y",
+	})
+	require.True(t, info.IsManaged())
+	require.Equal(t, provision.ComponentControlPlaneID, info.ClassifyComponent())
+}
+
+func TestBuildMarker_ParseMarker_Roundtrip(t *testing.T) {
+	t.Parallel()
+	m := provision.BuildMarker(provision.ComponentPartitionSource, "envA")
+	parsed := provision.ParseMarker(m)
+	require.Equal(t, provision.MarkerManagedValue, parsed.Managed)
+	require.Equal(t, provision.ComponentPartitionSource, parsed.Component)
+	require.Equal(t, "envA", parsed.Instance)
+}

--- a/provision/partition_source.go
+++ b/provision/partition_source.go
@@ -1,0 +1,250 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// buildPartitionSourceKVConfig returns a jetstream.KeyValueConfig for the
+// partition-source bucket described by ps.
+//
+// This builder is intentionally separate from the W0 control-plane builder
+// (internal/kvbuckets.BuildKeyValueConfig) because partition-source has a
+// different shape: Storage, History, Replicas, and MaxValueSize are all
+// configurable by the operator, whereas control-plane buckets have fixed
+// Storage and History=1. The two builders must never be merged.
+//
+// Field mapping rules (ps must already be normalized by normalize()):
+//   - Bucket: ps.Bucket (required; empty is rejected by validatePartitionSource)
+//   - Storage: FileStorage when ps.Storage is "file", MemoryStorage otherwise
+//   - History: ps.History (always ≥ 1 after normalization)
+//   - Replicas: ps.Replicas (0 = server default; nats.go normalizes to 1 server-side)
+//   - MaxValueSize: ps.MaxValueSize (0 = no limit)
+//   - TTL: set only when ps.TTL > 0 (matches control-plane convention)
+func buildPartitionSourceKVConfig(ps PartitionSourceConfig) jetstream.KeyValueConfig {
+	var storage jetstream.StorageType
+	if ps.Storage == "memory" {
+		storage = jetstream.MemoryStorage
+	} else {
+		storage = jetstream.FileStorage
+	}
+
+	cfg := jetstream.KeyValueConfig{
+		Bucket:       ps.Bucket,
+		History:      ps.History,
+		Storage:      storage,
+		Replicas:     ps.Replicas,
+		MaxValueSize: ps.MaxValueSize,
+	}
+
+	if ps.TTL > 0 {
+		cfg.TTL = ps.TTL
+	}
+
+	return cfg
+}
+
+// planPartitionSource resolves the partition-source bucket against live NATS
+// state and appends actions / drift findings to out. It must only be called
+// when cfg.PartitionSource != nil.
+func planPartitionSource(ctx context.Context, js jetstream.JetStream, cfg Config, out *PlanResult) error {
+	ps := cfg.PartitionSource
+	streamName := kvStreamPrefix + ps.Bucket
+
+	stream, err := js.Stream(ctx, streamName)
+	if errors.Is(err, jetstream.ErrStreamNotFound) {
+		kv := buildPartitionSourceKVConfig(*ps)
+		kv.Metadata = BuildMarker(ComponentPartitionSource, cfg.Instance)
+		out.Actions = append(out.Actions, PlannedAction{
+			Kind:     ActionCreateKV,
+			Name:     ps.Bucket,
+			Resource: kv,
+		})
+
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("provision: lookup %s: %w", streamName, err)
+	}
+
+	info, err := stream.Info(ctx)
+	if err != nil {
+		return fmt.Errorf("provision: info %s: %w", streamName, err)
+	}
+
+	findings := classifyPartitionSourceDrift(ps, info, cfg.Instance)
+	out.Drift = append(out.Drift, findings...)
+
+	return nil
+}
+
+// classifyPartitionSourceDrift compares a live KV-bucket stream against the
+// desired partition-source config and returns one or more drift findings. v1
+// never emits update-* / delete-* actions, only findings.
+//
+// Mutability table (per KV field mutability rules in the plan):
+//   - Immutable: History, Storage. Replicas treated as drift-immutable
+//     conservatively in v1 (conditionally mutable; safe-update lands in Phase 2).
+//   - Mutable: Description, Metadata (managed, component, instance), MaxBytes,
+//     MaxValueSize, TTL.
+func classifyPartitionSourceDrift(ps *PartitionSourceConfig, info *jetstream.StreamInfo, instance string) []DriftFinding {
+	marker := ParseMarker(info.Config.Metadata)
+
+	// Unmarked bucket named by config → "adopted" drift, no action.
+	if !marker.IsManaged() {
+		return []DriftFinding{{
+			Severity: SeverityAdopted,
+			Kind:     KindPartitionSource,
+			Name:     ps.Bucket,
+			Detail: map[string]any{
+				"component": ComponentPartitionSource,
+				"reason":    "bucket exists without parti.io/managed marker",
+			},
+		}}
+	}
+
+	mutable := map[string]any{}
+	immutable := map[string]any{}
+
+	// Desired storage type.
+	var wantStorage jetstream.StorageType
+	if ps.Storage == "memory" {
+		wantStorage = jetstream.MemoryStorage
+	} else {
+		wantStorage = jetstream.FileStorage
+	}
+	if info.Config.Storage != wantStorage {
+		immutable["storage"] = map[string]any{
+			"want": storageName(wantStorage),
+			"got":  storageName(info.Config.Storage),
+		}
+	}
+
+	// History is stored as MaxMsgsPerSubject on the underlying stream.
+	wantHistory := int64(ps.History) // already ≥ 1 after normalization
+	if info.Config.MaxMsgsPerSubject != wantHistory {
+		immutable["history"] = map[string]any{
+			"want": wantHistory,
+			"got":  info.Config.MaxMsgsPerSubject,
+		}
+	}
+
+	// Replicas: 0 in config means "server default" which NATS normalizes to 1.
+	// Treat 0 and 1 as equivalent on the desired side to avoid spurious drift
+	// on every default-replica installation.
+	effectiveReplicas := ps.Replicas
+	if effectiveReplicas == 0 {
+		effectiveReplicas = 1
+	}
+	if info.Config.Replicas != effectiveReplicas {
+		immutable["replicas"] = map[string]any{
+			"want": effectiveReplicas,
+			"got":  info.Config.Replicas,
+		}
+	}
+
+	// Description is mutable in place (Phase 2). Desired is always empty string
+	// (we do not set a Description on partition-source buckets by default).
+	if info.Config.Description != "" {
+		mutable["description"] = map[string]any{
+			"want": "",
+			"got":  info.Config.Description,
+		}
+	}
+
+	// MaxBytes is mutable in place (Phase 2). Desired is always 0 ("no limit").
+	// NATS stores "no limit" as MaxBytes=-1 server-side; normalize -1→0 before
+	// comparing to avoid spurious drift on default installs.
+	liveMaxBytes := info.Config.MaxBytes
+	if liveMaxBytes == -1 {
+		liveMaxBytes = 0
+	}
+	if liveMaxBytes != 0 {
+		mutable["maxBytes"] = map[string]any{
+			"want": int64(0),
+			"got":  info.Config.MaxBytes,
+		}
+	}
+
+	// MaxValueSize is mutable in place (Phase 2).
+	// info.Config.MaxMsgSize is the stream-level field corresponding to KV MaxValueSize.
+	// NATS stores "no limit" as MaxMsgSize=-1 server-side; config uses 0 for the same
+	// semantic. Normalize -1→0 before comparing to avoid spurious drift on default installs.
+	liveMaxValueSize := info.Config.MaxMsgSize
+	if liveMaxValueSize == -1 {
+		liveMaxValueSize = 0
+	}
+	if liveMaxValueSize != ps.MaxValueSize {
+		mutable["maxValueSize"] = map[string]any{
+			"want": ps.MaxValueSize,
+			"got":  info.Config.MaxMsgSize,
+		}
+	}
+
+	// TTL is stored as MaxAge on the underlying stream. Mutable (Phase 2).
+	wantTTL := ps.TTL // 0 means "no expiration"
+	if info.Config.MaxAge != wantTTL {
+		mutable["ttl"] = map[string]any{
+			"want": wantTTL.String(),
+			"got":  info.Config.MaxAge.String(),
+		}
+	}
+
+	// Marker fields are mutable in place (Phase 2). Report any deviation from
+	// the expected v1 marker values as drift-mutable, including managed version
+	// and component mismatches.
+	if marker.Managed != MarkerManagedValue {
+		mutable["managed"] = map[string]any{
+			"want": MarkerManagedValue,
+			"got":  marker.Managed,
+		}
+	}
+	if marker.Component != ComponentPartitionSource {
+		mutable["component"] = map[string]any{
+			"want": ComponentPartitionSource,
+			"got":  marker.Component,
+		}
+	}
+
+	// Instance mismatch on a managed bucket is surfaced as drift-mutable
+	// since Metadata is live-editable in Phase 2.
+	if marker.Instance != instance {
+		mutable["instance"] = map[string]any{
+			"want": instance,
+			"got":  marker.Instance,
+		}
+	}
+
+	findings := make([]DriftFinding, 0, 2)
+	if len(immutable) > 0 {
+		findings = append(findings, DriftFinding{
+			Severity: SeverityDriftImmutable,
+			Kind:     KindPartitionSource,
+			Name:     ps.Bucket,
+			Detail:   immutable,
+		})
+	}
+	if len(mutable) > 0 {
+		findings = append(findings, DriftFinding{
+			Severity: SeverityDriftMutable,
+			Kind:     KindPartitionSource,
+			Name:     ps.Bucket,
+			Detail:   mutable,
+		})
+	}
+	if len(findings) == 0 {
+		findings = append(findings, DriftFinding{
+			Severity: SeverityInformational,
+			Kind:     KindPartitionSource,
+			Name:     ps.Bucket,
+			Detail: map[string]any{
+				"component": ComponentPartitionSource,
+			},
+		})
+	}
+
+	return findings
+}

--- a/provision/partition_source_integration_test.go
+++ b/provision/partition_source_integration_test.go
@@ -1,0 +1,540 @@
+package provision_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// partitionSourceCfg returns a Config with PartitionSource populated and no
+// ControlPlane, so tests focus exclusively on partition-source behaviour.
+func partitionSourceCfg() provision.Config {
+	return provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:       "parti-partitions",
+			Key:          "partitions/v1",
+			Storage:      "file",
+			History:      2,
+			Replicas:     1,
+			MaxValueSize: 512,
+			TTL:          5 * time.Minute,
+		},
+	}
+}
+
+// TestPlan_PartitionSource_EmptyServer_EmitsCreateKV verifies that Plan
+// emits a create-kv action for the partition-source bucket when none exists,
+// that the marker is correct, and that the KeyValueConfig fields match the
+// builder output exactly.
+func TestPlan_PartitionSource_EmptyServer_EmitsCreateKV(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Equal(t, provision.APIVersionProvisionV1, plan.APIVersion)
+	require.Equal(t, provision.KindPlan, plan.Kind)
+	require.Empty(t, plan.Drift)
+	require.Len(t, plan.Actions, 1)
+
+	action := plan.Actions[0]
+	require.Equal(t, provision.ActionCreateKV, action.Kind)
+	require.Equal(t, "parti-partitions", action.Name)
+
+	kv, ok := action.Resource.(jetstream.KeyValueConfig)
+	require.True(t, ok, "Resource must be jetstream.KeyValueConfig")
+
+	// Field-level checks.
+	require.Equal(t, "parti-partitions", kv.Bucket)
+	require.Equal(t, jetstream.FileStorage, kv.Storage)
+	require.Equal(t, uint8(2), kv.History)
+	require.Equal(t, 1, kv.Replicas)
+	require.Equal(t, int32(512), kv.MaxValueSize)
+	require.Equal(t, 5*time.Minute, kv.TTL)
+
+	// Marker checks.
+	require.Equal(t, provision.MarkerManagedValue, kv.Metadata[provision.MarkerManagedKey])
+	require.Equal(t, provision.ComponentPartitionSource, kv.Metadata[provision.MarkerComponentKey])
+	require.Equal(t, "prod", kv.Metadata[provision.MarkerInstanceKey])
+
+	// Byte-equivalence: stripping Metadata must match what the builder
+	// returns for the same inputs. This verifies the builder is the
+	// single source of truth for KeyValueConfig construction.
+	wantKV := jetstream.KeyValueConfig{
+		Bucket:       "parti-partitions",
+		History:      2,
+		Storage:      jetstream.FileStorage,
+		Replicas:     1,
+		MaxValueSize: 512,
+		TTL:          5 * time.Minute,
+	}
+	stripped := kv
+	stripped.Metadata = nil
+	require.True(t, reflect.DeepEqual(stripped, wantKV),
+		"create-kv resource (sans metadata) must equal expected builder output\nwant: %#v\ngot:  %#v",
+		wantKV, stripped)
+}
+
+// TestApply_PartitionSource_EmptyServer_CreatesBucket verifies that Apply
+// creates the partition-source bucket with the correct config and marker.
+func TestApply_PartitionSource_EmptyServer_CreatesBucket(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Empty(t, rep.Skipped)
+	require.Len(t, rep.Executed, 1)
+	require.Equal(t, provision.ActionCreateKV, rep.Executed[0].Kind)
+	require.Equal(t, "parti-partitions", rep.Executed[0].Name)
+	require.False(t, rep.Executed[0].Raced, "no races on empty server")
+
+	// Verify the bucket was created with the expected settings and marker.
+	stream, err := js.Stream(ctx, "KV_parti-partitions")
+	require.NoError(t, err)
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, jetstream.FileStorage, info.Config.Storage)
+	require.Equal(t, int64(2), info.Config.MaxMsgsPerSubject) // History=2
+	require.Equal(t, int32(512), info.Config.MaxMsgSize)      // MaxValueSize=512
+	require.Equal(t, 5*time.Minute, info.Config.MaxAge)       // TTL=5m
+
+	marker := provision.ParseMarker(info.Config.Metadata)
+	require.Equal(t, provision.MarkerManagedValue, marker.Managed)
+	require.Equal(t, provision.ComponentPartitionSource, marker.Component)
+	require.Equal(t, "prod", marker.Instance)
+}
+
+// TestPlan_PartitionSource_ImmutableHistoryDrift verifies that Plan reports
+// drift-immutable when the live bucket's History differs from config.
+func TestPlan_PartitionSource_ImmutableHistoryDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg() // wants History=2
+
+	// Pre-create a marked bucket with History=5 (differs from config).
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  5,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// No create-kv action must be emitted.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name,
+			"must not emit create-kv for existing bucket with history drift")
+	}
+
+	// A drift-immutable finding with "history" detail must be present.
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftImmutable {
+			require.Contains(t, d.Detail, "history")
+			found = true
+		}
+	}
+	require.True(t, found, "expected drift-immutable for history mismatch")
+}
+
+// TestPlan_PartitionSource_UnmarkedBucket_ReportsAdopted verifies that Plan
+// reports adopted drift for an existing unmarked bucket and emits no action.
+func TestPlan_PartitionSource_UnmarkedBucket_ReportsAdopted(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Pre-create an unmarked bucket with the same name.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-partitions",
+		History: 1,
+		Storage: jetstream.FileStorage,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, partitionSourceCfg())
+	require.NoError(t, err)
+
+	// No create-kv action.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name,
+			"must not emit create-kv for an existing unmarked bucket")
+	}
+
+	// Exactly one adopted drift entry.
+	var adopted []provision.DriftFinding
+	for _, d := range plan.Drift {
+		if d.Severity == provision.SeverityAdopted && d.Name == "parti-partitions" {
+			adopted = append(adopted, d)
+		}
+	}
+	require.Len(t, adopted, 1)
+}
+
+// TestView_PartitionSource_AppearsInPartitionSourceSlice verifies that View
+// routes a partition-source-marked bucket to Snapshot.PartitionSource.
+// (The basic routing is already covered by view_integration_test.go;
+// this test confirms the W3 path with a fully-specified config round-trip.)
+func TestView_PartitionSource_AppearsInPartitionSourceSlice(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  2,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	snap, err := provision.View(ctx, js, provision.ScopeAll())
+	require.NoError(t, err)
+	require.Empty(t, snap.ControlPlane)
+	require.Len(t, snap.PartitionSource, 1)
+	require.Equal(t, "parti-partitions", snap.PartitionSource[0].Bucket)
+	require.Equal(t, provision.ComponentPartitionSource, snap.PartitionSource[0].Component)
+	require.Equal(t, "prod", snap.PartitionSource[0].Instance)
+}
+
+// TestApply_PartitionSource_Idempotent verifies that applying twice is a no-op
+// on the second run.
+func TestApply_PartitionSource_Idempotent(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// First apply: creates the bucket.
+	rep1, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Len(t, rep1.Executed, 1)
+	require.Empty(t, rep1.Errors)
+
+	// Second apply: bucket already exists and matches → no actions.
+	rep2, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep2.Executed, "second Apply must produce no executions")
+	require.Empty(t, rep2.Errors)
+
+	// Plan after second apply must also be empty of actions.
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, plan.Actions, "Plan after idempotent apply must emit no actions")
+}
+
+// TestPlan_PartitionSource_MemoryStorage verifies that Plan correctly emits a
+// MemoryStorage bucket when cfg.Storage is "memory".
+func TestPlan_PartitionSource_MemoryStorage(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:  "parti-partitions",
+			Key:     "partitions/v1",
+			Storage: "memory",
+			History: 1,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Len(t, plan.Actions, 1)
+
+	kv, ok := plan.Actions[0].Resource.(jetstream.KeyValueConfig)
+	require.True(t, ok)
+	require.Equal(t, jetstream.MemoryStorage, kv.Storage)
+}
+
+// TestPlan_PartitionSource_StorageDefaultsToFile verifies that omitting
+// Storage in config results in file storage being used.
+func TestPlan_PartitionSource_StorageDefaultsToFile(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket: "parti-partitions",
+			Key:    "partitions/v1",
+			// Storage intentionally omitted → should default to "file"
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Len(t, plan.Actions, 1)
+
+	kv, ok := plan.Actions[0].Resource.(jetstream.KeyValueConfig)
+	require.True(t, ok)
+	require.Equal(t, jetstream.FileStorage, kv.Storage)
+	require.Equal(t, uint8(1), kv.History, "History must default to 1")
+}
+
+// TestApply_PartitionSource_ZeroMaxValueSize_Idempotent verifies that a bucket
+// created with MaxValueSize=0 ("no limit") does not produce spurious
+// drift-mutable on the subsequent Plan. NATS stores "no limit" as MaxMsgSize=-1
+// internally; drift classification must normalise -1→0 before comparing.
+func TestApply_PartitionSource_ZeroMaxValueSize_Idempotent(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:       "parti-partitions-zero",
+			Key:          "partitions/v1",
+			Storage:      "file",
+			History:      1,
+			MaxValueSize: 0, // "no limit"
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// First Apply: creates bucket.
+	_, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// Second Plan: must emit no actions and no drift-mutable for maxValueSize.
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, plan.Actions, "Plan after Apply with MaxValueSize=0 must not re-emit create-kv")
+
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions-zero" && d.Severity == provision.SeverityDriftMutable {
+			t.Errorf("spurious drift-mutable: %+v", d.Detail)
+		}
+	}
+}
+
+// TestPlan_PartitionSource_ImmutableStorageDrift verifies that Plan reports
+// drift-immutable when the live bucket's Storage type differs from config.
+func TestPlan_PartitionSource_ImmutableStorageDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:  "parti-partitions",
+			Key:     "partitions/v1",
+			Storage: "memory", // desired storage
+			History: 1,
+		},
+	}
+
+	// Pre-create a marked bucket with the opposite storage (file).
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  1,
+		Storage:  jetstream.FileStorage, // differs from desired "memory"
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// No create-kv action must be emitted.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name,
+			"must not emit create-kv for existing bucket with storage drift")
+	}
+
+	// A drift-immutable finding with "storage" detail must be present.
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftImmutable {
+			require.Contains(t, d.Detail, "storage")
+			found = true
+		}
+	}
+	require.True(t, found, "expected drift-immutable for storage mismatch")
+}
+
+// TestPlan_PartitionSource_MutableDescriptionDrift verifies that Plan reports
+// drift-mutable when the live bucket has a non-empty Description (desired is
+// empty — we set no Description by default).
+func TestPlan_PartitionSource_MutableDescriptionDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg()
+
+	// Pre-create a marked bucket with a Description set by an operator.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:      "parti-partitions",
+		History:     2,
+		Storage:     jetstream.FileStorage,
+		Description: "operator note",
+		Metadata:    provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// No create-kv action.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name, "no action for mutable description drift")
+	}
+
+	// A drift-mutable finding with "description" detail must be present.
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftMutable {
+			if _, ok := d.Detail["description"]; ok {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "expected drift-mutable for description mismatch")
+}
+
+// TestPlan_PartitionSource_MutableMaxBytesDrift verifies that Plan reports
+// drift-mutable when the live bucket has a non-zero MaxBytes (desired is 0 —
+// no limit).
+func TestPlan_PartitionSource_MutableMaxBytesDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg()
+
+	// Pre-create a marked bucket with MaxBytes set.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  2,
+		Storage:  jetstream.FileStorage,
+		MaxBytes: 1024,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// No create-kv action.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name, "no action for mutable maxBytes drift")
+	}
+
+	// A drift-mutable finding with "maxBytes" detail must be present.
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftMutable {
+			if _, ok := d.Detail["maxBytes"]; ok {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "expected drift-mutable for maxBytes mismatch")
+}
+
+// TestPlan_PartitionSource_MutableMarkerDrift verifies that Plan reports
+// drift-mutable when the live bucket's marker has a managed version other than
+// "v1" (e.g. "v0" written by an older version of the tool).
+func TestPlan_PartitionSource_MutableMarkerDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg()
+
+	// Pre-create a marked bucket with a stale managed version.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-partitions",
+		History: 2,
+		Storage: jetstream.FileStorage,
+		Metadata: map[string]string{
+			provision.MarkerManagedKey:   "v0", // wrong version
+			provision.MarkerComponentKey: provision.ComponentPartitionSource,
+			provision.MarkerInstanceKey:  "prod",
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// No create-kv action.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name, "no action for mutable marker drift")
+	}
+
+	// A drift-mutable finding with "managed" detail must be present.
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftMutable {
+			if _, ok := d.Detail["managed"]; ok {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "expected drift-mutable for marker managed version mismatch")
+}
+
+// TestPlan_PartitionSource_MutableTTLDrift verifies that TTL mismatch on a
+// marked bucket is reported as drift-mutable (no action).
+func TestPlan_PartitionSource_MutableTTLDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := partitionSourceCfg() // TTL = 5 minutes
+
+	// Pre-create marked bucket with a different TTL.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  2,
+		Storage:  jetstream.FileStorage,
+		TTL:      10 * time.Minute,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-partitions", a.Name, "no action for mutable TTL drift")
+	}
+
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftMutable {
+			require.Contains(t, d.Detail, "ttl")
+			found = true
+		}
+	}
+	require.True(t, found, "expected drift-mutable for TTL mismatch")
+}

--- a/provision/plan.go
+++ b/provision/plan.go
@@ -1,0 +1,272 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Plan computes the deterministic list of create-kv actions and drift
+// findings needed to bring the live NATS environment into agreement with cfg.
+//
+// Plan is read-only — it never mutates NATS. It is also strict about
+// boundaries:
+//
+//   - Static validation is performed up front (same rules as Validate).
+//   - Each desired bucket is looked up by exact NATS name (KV_<bucket>);
+//     marker presence is never used to authorize or skip the lookup.
+//   - The partition-source key is NOT probed in Plan (that is a ValidateLive
+//     concern, landing in W2).
+//
+// Partition-source create-kv emission and drift classification are implemented
+// (W3). Dynamic-consumer alignment lands in W4. The PlanResult struct supports
+// those slots already.
+//
+// Cancellation: ctx cancellation returns a zero-value PlanResult plus
+// ctx.Err().
+func Plan(ctx context.Context, js jetstream.JetStream, cfg Config) (PlanResult, error) {
+	if err := ctx.Err(); err != nil {
+		return PlanResult{}, err
+	}
+	resolved, err := normalize(cfg)
+	if err != nil {
+		return PlanResult{}, err
+	}
+	if err := validateResolved(resolved); err != nil {
+		return PlanResult{}, err
+	}
+
+	out := PlanResult{
+		APIVersion: APIVersionProvisionV1,
+		Kind:       KindPlan,
+		Actions:    []PlannedAction{},
+		Drift:      []DriftFinding{},
+	}
+
+	if resolved.ControlPlane != nil {
+		if err := planControlPlane(ctx, js, resolved, &out); err != nil {
+			if ctx.Err() != nil {
+				return PlanResult{}, ctx.Err()
+			}
+			return PlanResult{}, err
+		}
+	}
+
+	if resolved.PartitionSource != nil {
+		if err := planPartitionSource(ctx, js, resolved, &out); err != nil {
+			if ctx.Err() != nil {
+				return PlanResult{}, ctx.Err()
+			}
+			return PlanResult{}, err
+		}
+	}
+
+	// DynamicConsumers Plan output is intentionally empty in W1/W3. The
+	// slot exists so W4 inherits a stable shape.
+
+	sortActions(out.Actions)
+	sortDrift(out.Drift)
+
+	return out, nil
+}
+
+// controlPlaneSpec describes one desired control-plane bucket. The slice is
+// built once per Plan call from resolved cfg in a fixed component order so
+// Plan output is deterministic before sorting.
+type controlPlaneSpec struct {
+	component string
+	bucket    string
+	ttl       time.Duration
+	storage   jetstream.StorageType
+}
+
+func buildControlPlaneSpecs(cp ControlPlaneConfig) []controlPlaneSpec {
+	specs := []controlPlaneSpec{
+		{ComponentControlPlaneID, cp.StableIDBucket, cp.WorkerIDTTL, jetstream.FileStorage},
+		{ComponentControlPlaneElection, cp.ElectionBucket, cp.ElectionTimeout, jetstream.MemoryStorage},
+		{ComponentControlPlaneHeartbeat, cp.HeartbeatBucket, cp.HeartbeatTTL, jetstream.MemoryStorage},
+		{ComponentControlPlaneAssignment, cp.AssignmentBucket, cp.AssignmentTTL, jetstream.FileStorage},
+	}
+	if cp.EnableTwoPhaseHandoff {
+		specs = append(specs, controlPlaneSpec{
+			component: ComponentControlPlaneHandoff,
+			bucket:    cp.HandoffBucket,
+			ttl:       cp.HandoffTTL,
+			storage:   jetstream.FileStorage,
+		})
+	}
+
+	return specs
+}
+
+func planControlPlane(ctx context.Context, js jetstream.JetStream, cfg Config, out *PlanResult) error {
+	specs := buildControlPlaneSpecs(*cfg.ControlPlane)
+	for _, spec := range specs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		streamName := kvStreamPrefix + spec.bucket
+		stream, err := js.Stream(ctx, streamName)
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			out.Actions = append(out.Actions, newCreateKVAction(spec, cfg.Instance))
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("provision: lookup %s: %w", streamName, err)
+		}
+
+		info, err := stream.Info(ctx)
+		if err != nil {
+			return fmt.Errorf("provision: info %s: %w", streamName, err)
+		}
+
+		findings := classifyControlPlaneDrift(spec, info, cfg.Instance)
+		out.Drift = append(out.Drift, findings...)
+	}
+
+	return nil
+}
+
+// newCreateKVAction builds the create-kv PlannedAction for one control-plane
+// bucket. The KeyValueConfig is built by the shared kvbuckets builder and
+// then stamped with the Parti ownership marker; nothing else may construct
+// the KeyValueConfig (this preserves the byte-equivalence invariant).
+func newCreateKVAction(spec controlPlaneSpec, instance string) PlannedAction {
+	kv := kvbuckets.BuildKeyValueConfig(spec.bucket, spec.ttl, spec.storage)
+	kv.Metadata = BuildMarker(spec.component, instance)
+	return PlannedAction{
+		Kind:     ActionCreateKV,
+		Name:     spec.bucket,
+		Resource: kv,
+	}
+}
+
+// classifyControlPlaneDrift compares a live KV-bucket stream against the
+// desired spec and returns one or more drift findings. v1 never emits
+// update-* / delete-* actions, only findings.
+func classifyControlPlaneDrift(spec controlPlaneSpec, info *jetstream.StreamInfo, instance string) []DriftFinding {
+	marker := ParseMarker(info.Config.Metadata)
+
+	// Unmarked bucket named by config → "adopted" drift, no action.
+	if !marker.IsManaged() {
+		return []DriftFinding{{
+			Severity: SeverityAdopted,
+			Kind:     KindControlPlaneKV,
+			Name:     spec.bucket,
+			Detail: map[string]any{
+				"component": spec.component,
+				"reason":    "bucket exists without parti.io/managed marker",
+			},
+		}}
+	}
+
+	mutable := map[string]any{}
+	immutable := map[string]any{}
+
+	if info.Config.Storage != spec.storage {
+		immutable["storage"] = map[string]any{
+			"want": storageName(spec.storage),
+			"got":  storageName(info.Config.Storage),
+		}
+	}
+	// KV History is stored on the underlying stream as MaxMsgsPerSubject.
+	// The shared builder always sets History=1, so any non-1 value is
+	// immutable drift.
+	if info.Config.MaxMsgsPerSubject != 1 {
+		immutable["history"] = map[string]any{
+			"want": int64(1),
+			"got":  info.Config.MaxMsgsPerSubject,
+		}
+	}
+	// KV TTL is stored on the underlying stream as MaxAge.
+	if info.Config.MaxAge != spec.ttl {
+		mutable["ttl"] = map[string]any{
+			"want": spec.ttl.String(),
+			"got":  info.Config.MaxAge.String(),
+		}
+	}
+	// Instance mismatch on a managed bucket is surfaced as drift-mutable
+	// since Metadata is live-editable in Phase 2.
+	if marker.Instance != instance {
+		mutable["instance"] = map[string]any{
+			"want": instance,
+			"got":  marker.Instance,
+		}
+	}
+	// Component mismatch: a bucket marked as one Parti component but named
+	// in config under a different role. Treat as immutable drift — the
+	// safe remediation is operator-driven.
+	if marker.Component != spec.component {
+		immutable["component"] = map[string]any{
+			"want": spec.component,
+			"got":  marker.Component,
+		}
+	}
+
+	findings := make([]DriftFinding, 0, 2)
+	if len(immutable) > 0 {
+		findings = append(findings, DriftFinding{
+			Severity: SeverityDriftImmutable,
+			Kind:     KindControlPlaneKV,
+			Name:     spec.bucket,
+			Detail:   immutable,
+		})
+	}
+	if len(mutable) > 0 {
+		findings = append(findings, DriftFinding{
+			Severity: SeverityDriftMutable,
+			Kind:     KindControlPlaneKV,
+			Name:     spec.bucket,
+			Detail:   mutable,
+		})
+	}
+	if len(findings) == 0 {
+		findings = append(findings, DriftFinding{
+			Severity: SeverityInformational,
+			Kind:     KindControlPlaneKV,
+			Name:     spec.bucket,
+			Detail: map[string]any{
+				"component": spec.component,
+			},
+		})
+	}
+
+	return findings
+}
+
+func sortActions(s []PlannedAction) {
+	slices.SortStableFunc(s, func(a, b PlannedAction) int {
+		if c := stringsCmp(a.Kind, b.Kind); c != 0 {
+			return c
+		}
+
+		return stringsCmp(a.Name, b.Name)
+	})
+}
+
+func sortDrift(s []DriftFinding) {
+	slices.SortStableFunc(s, func(a, b DriftFinding) int {
+		if c := stringsCmp(a.Kind, b.Kind); c != 0 {
+			return c
+		}
+
+		return stringsCmp(a.Name, b.Name)
+	})
+}
+
+// stringsCmp returns -1/0/1 to satisfy slices.SortStableFunc's int contract.
+func stringsCmp(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/provision/plan_integration_test.go
+++ b/provision/plan_integration_test.go
@@ -1,0 +1,314 @@
+package provision_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// planTestConfig builds a Config with all five control-plane buckets enabled
+// (handoff on) and distinct fixed values so byte-equivalence checks are
+// unambiguous.
+func planTestConfig() provision.Config {
+	return provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		ControlPlane: &provision.ControlPlaneConfig{
+			StableIDBucket:        "parti-stableid",
+			ElectionBucket:        "parti-election",
+			HeartbeatBucket:       "parti-heartbeat",
+			AssignmentBucket:      "parti-assignment",
+			HandoffBucket:         "parti-handoff",
+			WorkerIDTTL:           75 * time.Second,
+			ElectionTimeout:       10 * time.Second,
+			HeartbeatTTL:          15 * time.Second,
+			AssignmentTTL:         0,
+			HandoffTTL:            2 * time.Minute,
+			EnableTwoPhaseHandoff: true,
+		},
+	}
+}
+
+func TestPlan_EmptyServer_EmitsCreateKVForAllControlPlaneBuckets(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := planTestConfig()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Equal(t, provision.APIVersionProvisionV1, plan.APIVersion)
+	require.Equal(t, provision.KindPlan, plan.Kind)
+	require.Empty(t, plan.Drift)
+
+	expected := []struct {
+		bucket    string
+		ttl       time.Duration
+		storage   jetstream.StorageType
+		component string
+	}{
+		{"parti-assignment", 0, jetstream.FileStorage, provision.ComponentControlPlaneAssignment},
+		{"parti-election", 10 * time.Second, jetstream.MemoryStorage, provision.ComponentControlPlaneElection},
+		{"parti-handoff", 2 * time.Minute, jetstream.FileStorage, provision.ComponentControlPlaneHandoff},
+		{"parti-heartbeat", 15 * time.Second, jetstream.MemoryStorage, provision.ComponentControlPlaneHeartbeat},
+		{"parti-stableid", 75 * time.Second, jetstream.FileStorage, provision.ComponentControlPlaneID},
+	}
+	require.Len(t, plan.Actions, len(expected))
+
+	// Plan sorts actions by (Kind, Name). All Kinds are "create-kv" so the
+	// resulting order is purely by Name lexicographic.
+	for i, want := range expected {
+		got := plan.Actions[i]
+		require.Equal(t, provision.ActionCreateKV, got.Kind)
+		require.Equal(t, want.bucket, got.Name)
+
+		kv, ok := got.Resource.(jetstream.KeyValueConfig)
+		require.True(t, ok, "action %d Resource is not jetstream.KeyValueConfig", i)
+
+		// Byte-equivalence invariant: stripping Metadata yields exactly the
+		// shared builder output for the same inputs.
+		stripped := kv
+		stripped.Metadata = nil
+		shared := kvbuckets.BuildKeyValueConfig(want.bucket, want.ttl, want.storage)
+		require.True(t, reflect.DeepEqual(stripped, shared),
+			"create-kv resource (sans metadata) must equal kvbuckets.BuildKeyValueConfig output\nwant: %#v\ngot:  %#v",
+			shared, stripped)
+
+		// Marker contents.
+		require.Equal(t, provision.MarkerManagedValue, kv.Metadata[provision.MarkerManagedKey])
+		require.Equal(t, want.component, kv.Metadata[provision.MarkerComponentKey])
+		require.Equal(t, "prod", kv.Metadata[provision.MarkerInstanceKey])
+	}
+}
+
+func TestPlan_HandoffDisabled_OmitsHandoffAction(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := planTestConfig()
+	cfg.ControlPlane.EnableTwoPhaseHandoff = false
+	cfg.ControlPlane.HandoffTTL = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-handoff", a.Name,
+			"handoff bucket must not appear when EnableTwoPhaseHandoff=false")
+	}
+	require.Len(t, plan.Actions, 4)
+}
+
+func TestPlan_UnmarkedExistingBucket_ReportsAdoptedNoAction(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Manually create an unmarked bucket with the same name as
+	// parti-stableid. Plan must report this as `adopted` drift and emit
+	// no `create-kv` action for that name.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-stableid",
+		History: 1,
+		Storage: jetstream.FileStorage,
+		TTL:     75 * time.Second,
+	})
+
+	cfg := planTestConfig()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-stableid", a.Name,
+			"plan must not emit create-kv for an existing unmarked bucket")
+	}
+
+	// Other buckets still get create-kv.
+	names := map[string]bool{}
+	for _, a := range plan.Actions {
+		names[a.Name] = true
+	}
+	require.True(t, names["parti-election"])
+	require.True(t, names["parti-heartbeat"])
+	require.True(t, names["parti-assignment"])
+	require.True(t, names["parti-handoff"])
+
+	// Drift: exactly one `adopted` entry for parti-stableid.
+	var adopted []provision.DriftFinding
+	for _, d := range plan.Drift {
+		if d.Severity == provision.SeverityAdopted {
+			adopted = append(adopted, d)
+		}
+	}
+	require.Len(t, adopted, 1)
+	require.Equal(t, "parti-stableid", adopted[0].Name)
+}
+
+func TestPlan_MarkedBucketMatchingConfig_ReportsInformational(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Build the parti-election bucket exactly as Plan would.
+	want := kvbuckets.BuildKeyValueConfig("parti-election", 10*time.Second, jetstream.MemoryStorage)
+	want.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, want)
+
+	cfg := planTestConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// No create-kv for parti-election.
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-election", a.Name)
+	}
+	// Drift contains exactly one informational entry for parti-election.
+	var info []provision.DriftFinding
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" {
+			info = append(info, d)
+		}
+	}
+	require.Len(t, info, 1)
+	require.Equal(t, provision.SeverityInformational, info[0].Severity)
+}
+
+func TestPlan_MismatchedTTL_ReportsDriftMutableNoAction(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Create parti-election with a mismatching TTL (mutable drift in v2).
+	live := kvbuckets.BuildKeyValueConfig("parti-election", 30*time.Second, jetstream.MemoryStorage)
+	live.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, live)
+
+	cfg := planTestConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-election", a.Name, "no update-* action should be emitted in v1")
+	}
+	// Drift carries drift-mutable for parti-election with a "ttl" detail.
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" && d.Severity == provision.SeverityDriftMutable {
+			require.Contains(t, d.Detail, "ttl")
+			found = true
+		}
+	}
+	require.True(t, found, "expected drift-mutable for parti-election")
+}
+
+func TestPlan_MismatchedStorage_ReportsImmutableNoAction(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Election bucket should be MemoryStorage; create as FileStorage.
+	live := kvbuckets.BuildKeyValueConfig("parti-election", 10*time.Second, jetstream.FileStorage)
+	live.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, live)
+
+	cfg := planTestConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-election", a.Name)
+	}
+	var found bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" && d.Severity == provision.SeverityDriftImmutable {
+			require.Contains(t, d.Detail, "storage")
+			found = true
+		}
+	}
+	require.True(t, found, "expected drift-immutable for parti-election storage")
+}
+
+func TestPlan_Deterministic_AcrossRepeats(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := planTestConfig()
+	// Add a partition-source so it is included in the determinism check
+	// (W3 emits a create-kv for it when the bucket is absent).
+	cfg.PartitionSource = &provision.PartitionSourceConfig{Bucket: "parti-partitions", Key: "partitions/v1"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Pre-create some buckets in a specific order to introduce drift into the
+	// plan result, which exercises the drift-sorting path.  Create in
+	// non-alphabetical order so map-iteration variance in Plan is observable.
+	//
+	// Run 1: unmarked parti-heartbeat → adopted drift.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-heartbeat",
+		History: 1,
+		Storage: jetstream.MemoryStorage,
+		TTL:     15 * time.Second,
+	})
+	// Run 1: marked parti-election with mismatched TTL → drift-mutable.
+	liveElection := kvbuckets.BuildKeyValueConfig("parti-election", 30*time.Second, jetstream.MemoryStorage)
+	liveElection.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, liveElection)
+
+	first, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// Call Plan multiple more times (exploiting Go map-iteration randomness)
+	// and assert full PlanResult equality, not just name/kind tuples.
+	for i := 0; i < 9; i++ {
+		again, err := provision.Plan(ctx, js, cfg)
+		require.NoError(t, err)
+		require.True(t, reflect.DeepEqual(first, again),
+			"Plan must be fully deterministic across repeated calls (iteration %d):\nfirst=%#v\nagain=%#v",
+			i+1, first, again)
+	}
+}
+
+func TestPlan_CancelledContext(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	plan, err := provision.Plan(ctx, js, planTestConfig())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, plan)
+}
+
+func TestPlan_DifferentNameBucketStillGetsCreateKV(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	// Pre-create an unrelated unmarked bucket (not named by config).
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "some-other-bucket",
+		History: 1,
+		Storage: jetstream.MemoryStorage,
+	})
+
+	cfg := planTestConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// All five control-plane buckets get create-kv (the unrelated bucket
+	// is invisible to a config-scoped Plan).
+	require.Len(t, plan.Actions, 5)
+	require.Empty(t, plan.Drift, "unrelated buckets must not appear in Plan drift")
+}

--- a/provision/policy.go
+++ b/provision/policy.go
@@ -1,0 +1,21 @@
+package provision
+
+// ReconcilePolicy controls how Apply handles drift. v1 only supports
+// PolicyWarn; PolicySafeUpdate lands in Phase 2 and PolicyForce in Phase 6,
+// each with explicit field/test coverage. Validate rejects the future values
+// by string match so callers receive a clear error today.
+type ReconcilePolicy string
+
+const (
+	// PolicyWarn creates missing resources and reports drift, never mutating
+	// existing resources. This is the v1 default.
+	PolicyWarn ReconcilePolicy = "warn"
+)
+
+// Reserved string values for future phases. They are documented here so
+// Validate can reject them with a clear "not supported in v1" message,
+// without forcing callers to type the literal strings themselves.
+const (
+	reservedPolicySafeUpdate = "safe-update" // Phase 2 (Safe Update + Adopt)
+	reservedPolicyForce      = "force"       // Phase 6 (Force + Repair)
+)

--- a/provision/scope.go
+++ b/provision/scope.go
@@ -1,0 +1,39 @@
+package provision
+
+// Scope selects which resource kinds View should consider, plus an optional
+// instance filter.
+type Scope struct {
+	ControlPlane     bool
+	PartitionSource  bool
+	DynamicConsumers bool
+
+	// Instance optionally restricts results to resources whose
+	// parti.io/instance metadata equals this value. Empty means "all
+	// instances, including resources marked without an instance value".
+	Instance string
+}
+
+// ScopeAll returns a Scope that includes every resource kind v1 understands,
+// with no instance filter (inventory mode).
+func ScopeAll() Scope {
+	return Scope{
+		ControlPlane:     true,
+		PartitionSource:  true,
+		DynamicConsumers: true,
+		Instance:         "",
+	}
+}
+
+// ScopeFromConfig returns a Scope that enables every resource kind present in
+// cfg, and sets Instance from cfg.Instance.
+//
+// "Present" means: ControlPlane != nil, PartitionSource != nil, and
+// len(DynamicConsumers) > 0 respectively.
+func ScopeFromConfig(cfg Config) Scope {
+	return Scope{
+		ControlPlane:     cfg.ControlPlane != nil,
+		PartitionSource:  cfg.PartitionSource != nil,
+		DynamicConsumers: len(cfg.DynamicConsumers) > 0,
+		Instance:         cfg.Instance,
+	}
+}

--- a/provision/scope_test.go
+++ b/provision/scope_test.go
@@ -1,0 +1,55 @@
+package provision_test
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeAll_IncludesEveryKind(t *testing.T) {
+	t.Parallel()
+	s := provision.ScopeAll()
+	require.True(t, s.ControlPlane)
+	require.True(t, s.PartitionSource)
+	require.True(t, s.DynamicConsumers)
+	require.Equal(t, "", s.Instance)
+}
+
+func TestScopeFromConfig_ControlPlaneOnly(t *testing.T) {
+	t.Parallel()
+	cfg := provision.Config{
+		ControlPlane: &provision.ControlPlaneConfig{},
+	}
+	s := provision.ScopeFromConfig(cfg)
+	require.True(t, s.ControlPlane)
+	require.False(t, s.PartitionSource)
+	require.False(t, s.DynamicConsumers)
+	require.Equal(t, "", s.Instance)
+}
+
+func TestScopeFromConfig_AllSet(t *testing.T) {
+	t.Parallel()
+	cfg := provision.Config{
+		Instance:        "prod",
+		ControlPlane:    &provision.ControlPlaneConfig{},
+		PartitionSource: &provision.PartitionSourceConfig{},
+		DynamicConsumers: []provision.DynamicConsumerCfg{
+			{StreamName: "orders"},
+		},
+	}
+	s := provision.ScopeFromConfig(cfg)
+	require.True(t, s.ControlPlane)
+	require.True(t, s.PartitionSource)
+	require.True(t, s.DynamicConsumers)
+	require.Equal(t, "prod", s.Instance)
+}
+
+func TestScopeFromConfig_EmptyDynamicConsumersDoesNotEnable(t *testing.T) {
+	t.Parallel()
+	cfg := provision.Config{
+		DynamicConsumers: []provision.DynamicConsumerCfg{},
+	}
+	s := provision.ScopeFromConfig(cfg)
+	require.False(t, s.DynamicConsumers)
+}

--- a/provision/testdata/full.yaml
+++ b/provision/testdata/full.yaml
@@ -1,0 +1,35 @@
+# Canonical "Full" provision config matching the example in
+# docs/plans/provision-sdk-cli. Each field uses a distinct value so the
+# YAML-unmarshal test can verify every nested field is populated via its
+# declared yaml tag (a missing tag would surface as a zero-value comparison).
+apiVersion: parti.io/v1
+instance: prod-us-east
+policy: warn
+
+controlPlane:
+  stableIdBucket: parti-stableid
+  electionBucket: parti-election
+  heartbeatBucket: parti-heartbeat
+  assignmentBucket: parti-assignment
+  handoffBucket: parti-handoff
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s
+  assignmentTtl: 1m30s
+  handoffTtl: 2m
+  enableTwoPhaseHandoff: true
+
+partitionSource:
+  bucket: parti-partitions
+  key: partitions/v1
+  replicas: 3
+  storage: file
+  history: 1
+  maxValueSize: 1048576
+  ttl: 7m
+
+dynamicConsumers:
+  - streamName: orders
+    consumerPrefix: ord-worker
+    subjectTemplate: "orders.{partition_id}.>"
+    partitionsRef: ./partitions.yaml

--- a/provision/testdata/minimal.yaml
+++ b/provision/testdata/minimal.yaml
@@ -1,0 +1,7 @@
+# Minimal provision config — control-plane block with only the three
+# required TTLs. Bucket names default to runtime defaults during Validate.
+apiVersion: parti.io/v1
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s

--- a/provision/types.go
+++ b/provision/types.go
@@ -1,0 +1,190 @@
+package provision
+
+import (
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Snapshot is the read-only live state returned by View. Resource slices are
+// plural so a single NATS account hosting multiple Parti environments (each
+// distinguished by parti.io/instance) appears as one Snapshot.
+//
+// ObservedAt is emitted in JSON output only; text renderers (CLI) should
+// omit it.
+type Snapshot struct {
+	APIVersion      string          `json:"apiVersion"`
+	Kind            string          `json:"kind"`
+	ObservedAt      time.Time       `json:"observedAt"`
+	ControlPlane    []KVBucketState `json:"controlPlane"`
+	PartitionSource []KVBucketState `json:"partitionSource"`
+	// DynamicConsumers is reserved for Phase 5 (dynamic-consumer
+	// precreation). In v1 it is always empty: alignment-check is the
+	// only dynamic-consumer surface and it does not produce ConsumerState
+	// entries because v1 does not stamp the ownership marker on
+	// dynamic consumers.
+	DynamicConsumers []ConsumerState `json:"dynamicConsumers"`
+}
+
+// KVBucketState is the live view of a NATS KV bucket relevant to provision.
+type KVBucketState struct {
+	// Bucket is the NATS KV bucket name (without the "KV_" stream prefix).
+	Bucket string `json:"bucket"`
+	// Component is the parti.io/component value the bucket is stamped with,
+	// or "unknown" if marked but with an unrecognized component, or "" if
+	// the bucket is unmarked (only possible when the caller explicitly
+	// asked for unmarked inventory in a future phase — v1 View filters
+	// unmarked out).
+	Component string `json:"component,omitempty"`
+	// Instance is the parti.io/instance value the bucket is stamped with,
+	// or "" if absent.
+	Instance string `json:"instance,omitempty"`
+	// Managed is the raw parti.io/managed value ("" if unmarked).
+	Managed string `json:"managed,omitempty"`
+	// History from the live stream config.
+	History uint8 `json:"history,omitempty"`
+	// Storage is "file" or "memory".
+	Storage string `json:"storage,omitempty"`
+	// TTL is the bucket TTL; zero means "no expiration".
+	TTL time.Duration `json:"ttl,omitempty"`
+	// Replicas reported by NATS for the stream (informational).
+	Replicas int `json:"replicas,omitempty"`
+	// MaxBytes from the live config (informational).
+	MaxBytes int64 `json:"maxBytes,omitempty"`
+	// MaxValueSize from the live config (informational).
+	MaxValueSize int32 `json:"maxValueSize,omitempty"`
+}
+
+// ConsumerState is a placeholder; populated in W4 (dynamic-consumer alignment).
+type ConsumerState struct {
+	StreamName string `json:"streamName,omitempty"`
+	Durable    string `json:"durable,omitempty"`
+	Component  string `json:"component,omitempty"`
+	Instance   string `json:"instance,omitempty"`
+	Managed    string `json:"managed,omitempty"`
+}
+
+// PlanResult is the deterministic list of actions Apply would take, plus any
+// drift findings discovered during planning. Actions and drift are
+// independently sorted by (Kind, Name).
+//
+// The Go type is named PlanResult (not Plan) because the package exposes a
+// top-level Plan(ctx, js, cfg) constructor function; in Go the function and
+// type cannot share an identifier. The JSON envelope's "kind" field is still
+// the string "Plan" — operator tooling that keys on kind sees "Plan", not
+// "PlanResult".
+type PlanResult struct {
+	APIVersion string          `json:"apiVersion"`
+	Kind       string          `json:"kind"`
+	Actions    []PlannedAction `json:"actions"`
+	Drift      []DriftFinding  `json:"drift"`
+}
+
+// PlannedAction is one operation Apply would perform. In v1, Kind is always
+// "create-kv" (update-* lands in Phase 2; consumer-create in Phase 5;
+// delete-* in Phase 6). The Resource field carries the would-be NATS config
+// — for "create-kv" this is a jetstream.KeyValueConfig value.
+type PlannedAction struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	Resource any    `json:"resource"`
+}
+
+// Action kind constants.
+const (
+	ActionCreateKV = "create-kv"
+)
+
+// DriftFinding describes how a live resource differs from the desired state,
+// or that an existing resource is unmarked ("adopted"). v1 emits drift
+// findings but never emits update-* / delete-* actions.
+//
+// Severity values:
+//   - "informational": resource exists and matches; no action needed.
+//   - "drift-mutable": fields differ but would be safe to live-edit (v2).
+//   - "drift-immutable": fields differ and require delete/recreate (v6).
+//   - "adopted": resource exists without the Parti marker; reported only.
+type DriftFinding struct {
+	Severity string         `json:"severity"`
+	Kind     string         `json:"kind"`
+	Name     string         `json:"name"`
+	Detail   map[string]any `json:"detail,omitempty"`
+}
+
+// Drift severity constants.
+const (
+	SeverityInformational  = "informational"
+	SeverityDriftMutable   = "drift-mutable"
+	SeverityDriftImmutable = "drift-immutable"
+	SeverityAdopted        = "adopted"
+)
+
+// Drift kind constants.
+const (
+	KindControlPlaneKV  = "control-plane-kv"
+	KindPartitionSource = "partition-source-kv"
+	KindDynamicConsumer = "dynamic-consumer"
+)
+
+// Report is the result of Apply: what executed, what was skipped, what failed.
+// v1 never emits Apply, but the type is part of the load-bearing W1 surface
+// so later phases inherit it verbatim.
+type Report struct {
+	APIVersion string           `json:"apiVersion"`
+	Kind       string           `json:"kind"`
+	Executed   []ExecutedAction `json:"executed"`
+	Skipped    []SkippedAction  `json:"skipped"`
+	Errors     []ResourceError  `json:"errors"`
+	// Aborted is true if the caller's ctx was cancelled mid-apply. It is
+	// false for ordinary resource-level errors (those go in Errors).
+	Aborted bool `json:"aborted"`
+}
+
+// ExecutedAction is a PlannedAction that Apply completed successfully.
+//
+// Raced is true when the desired resource already existed at the moment
+// Apply called js.CreateKeyValue (a Plan→Apply race). The outcome is still
+// "the desired resource exists now," so Apply records the action as
+// Executed rather than as a resource-level error. Operator-visible drift
+// for racing creators that did not stamp the Parti marker surfaces on the
+// next `plan` invocation (as `adopted` drift).
+type ExecutedAction struct {
+	Kind  string `json:"kind"`
+	Name  string `json:"name"`
+	Raced bool   `json:"raced,omitempty"`
+}
+
+// SkippedAction is a PlannedAction Apply did not run.
+//
+// Reason values (W2+):
+//   - "context-cancelled": ctx was cancelled before this action started.
+//   - "prior-error": an earlier action errored; Apply is fail-fast.
+type SkippedAction struct {
+	Kind   string `json:"kind"`
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
+// Skip reason constants.
+const (
+	SkipReasonContextCancelled = "context-cancelled"
+	SkipReasonPriorError       = "prior-error"
+)
+
+// ResourceError records a single resource-level failure during Apply. The
+// underlying NATS error is wrapped in the returned error of Apply itself.
+type ResourceError struct {
+	Kind  string `json:"kind"`
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+// PlannedConsumer is the W4 dynamic-consumer alignment output type. The
+// struct lives here so the Plan surface is stable across phases; v1 never
+// populates dynamic-consumer entries (alignment-check ships in W4).
+type PlannedConsumer struct {
+	StreamName string                   `json:"streamName"`
+	Subject    string                   `json:"subject"`
+	Durable    string                   `json:"durable"`
+	Config     jetstream.ConsumerConfig `json:"config,omitempty"`
+}

--- a/provision/types_test.go
+++ b/provision/types_test.go
@@ -1,0 +1,58 @@
+package provision_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvelopes_CarryAPIVersionAndKind verifies that every JSON-emitted
+// output envelope carries the v1 provision apiVersion and the documented
+// kind field. Operator CI keys on these.
+func TestEnvelopes_CarryAPIVersionAndKind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Snapshot", func(t *testing.T) {
+		t.Parallel()
+		s := provision.Snapshot{
+			APIVersion: provision.APIVersionProvisionV1,
+			Kind:       provision.KindSnapshot,
+		}
+		b, err := json.Marshal(s)
+		require.NoError(t, err)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(b, &m))
+		require.Equal(t, "parti.io/provision/v1", m["apiVersion"])
+		require.Equal(t, "Snapshot", m["kind"])
+	})
+
+	t.Run("PlanResult", func(t *testing.T) {
+		t.Parallel()
+		p := provision.PlanResult{
+			APIVersion: provision.APIVersionProvisionV1,
+			Kind:       provision.KindPlan,
+		}
+		b, err := json.Marshal(p)
+		require.NoError(t, err)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(b, &m))
+		require.Equal(t, "parti.io/provision/v1", m["apiVersion"])
+		require.Equal(t, "Plan", m["kind"])
+	})
+
+	t.Run("Report", func(t *testing.T) {
+		t.Parallel()
+		r := provision.Report{
+			APIVersion: provision.APIVersionProvisionV1,
+			Kind:       provision.KindReport,
+		}
+		b, err := json.Marshal(r)
+		require.NoError(t, err)
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(b, &m))
+		require.Equal(t, "parti.io/provision/v1", m["apiVersion"])
+		require.Equal(t, "Report", m["kind"])
+	})
+}

--- a/provision/validate.go
+++ b/provision/validate.go
@@ -1,0 +1,214 @@
+package provision
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidConfig is the sentinel returned by Validate for any static
+// validation failure. Callers can use errors.Is(err, ErrInvalidConfig) to
+// distinguish static-validation errors from I/O failures.
+var ErrInvalidConfig = errors.New("provision: invalid config")
+
+// Validate performs pure static validation of cfg. It does not mutate the
+// caller's Config — defaulting is performed on an internal copy.
+//
+// Validation rules (see docs/plans/provision-sdk-cli for the authoritative
+// spec):
+//
+//   - APIVersion must equal APIVersionV1.
+//   - Policy defaults to PolicyWarn when empty; "safe-update" and "force"
+//     are rejected as not-supported-in-v1.
+//   - ControlPlane bucket name fields default to runtime defaults; any
+//     bucket name still empty after defaulting is rejected.
+//   - ControlPlane.WorkerIDTTL, .ElectionTimeout, .HeartbeatTTL must be > 0.
+//   - ControlPlane.AssignmentTTL may be 0 (runtime default: no expiration).
+//   - When ControlPlane.EnableTwoPhaseHandoff is true, HandoffTTL must be > 0.
+//
+// PartitionSource static validation is active (W3): Bucket, Key, Storage,
+// Replicas, MaxValueSize, and TTL are all validated. DynamicConsumers deeper
+// validation lands in W4.
+func Validate(cfg Config) error {
+	resolved, err := normalize(cfg)
+	if err != nil {
+		return err
+	}
+	return validateResolved(resolved)
+}
+
+// ApplyDefaults returns a defaulted copy of cfg without running any
+// validation. Callers who want to inspect the post-default values (e.g.
+// CLI dry-run renderers) use this directly. The returned Config is a deep
+// copy; the input is not mutated.
+//
+// ApplyDefaults does NOT validate; an APIVersion mismatch returns an error
+// because defaulting an unknown schema is unsafe.
+func ApplyDefaults(cfg Config) (Config, error) {
+	return normalize(cfg)
+}
+
+// normalize deep-copies cfg, applies runtime defaults, and rejects the
+// `apiVersion` mismatch up front. Returns a new Config; the input is never
+// mutated.
+func normalize(cfg Config) (Config, error) {
+	if cfg.APIVersion != APIVersionV1 {
+		return Config{}, fmt.Errorf("%w: apiVersion %q is not supported (expected %q)",
+			ErrInvalidConfig, cfg.APIVersion, APIVersionV1)
+	}
+
+	out := cfg // shallow copy of value fields
+
+	// Default Policy.
+	if out.Policy == "" {
+		out.Policy = PolicyWarn
+	}
+
+	// Deep-copy ControlPlane before defaulting so the caller's pointer
+	// target is not mutated.
+	if cfg.ControlPlane != nil {
+		cp := *cfg.ControlPlane
+		if cp.StableIDBucket == "" {
+			cp.StableIDBucket = defaultStableIDBucket
+		}
+		if cp.ElectionBucket == "" {
+			cp.ElectionBucket = defaultElectionBucket
+		}
+		if cp.HeartbeatBucket == "" {
+			cp.HeartbeatBucket = defaultHeartbeatBucket
+		}
+		if cp.AssignmentBucket == "" {
+			cp.AssignmentBucket = defaultAssignmentBucket
+		}
+		if cp.HandoffBucket == "" {
+			cp.HandoffBucket = defaultHandoffBucket
+		}
+		out.ControlPlane = &cp
+	}
+
+	// Deep-copy PartitionSource and apply defaults.
+	if cfg.PartitionSource != nil {
+		ps := *cfg.PartitionSource
+		if ps.Storage == "" {
+			ps.Storage = "file"
+		}
+		if ps.History == 0 {
+			ps.History = 1
+		}
+		out.PartitionSource = &ps
+	}
+
+	// DynamicConsumers is a slice of value structs; copy the backing array
+	// so caller-owned entries are not mutated by later phases.
+	if len(cfg.DynamicConsumers) > 0 {
+		dc := make([]DynamicConsumerCfg, len(cfg.DynamicConsumers))
+		copy(dc, cfg.DynamicConsumers)
+		out.DynamicConsumers = dc
+	}
+
+	return out, nil
+}
+
+func validateResolved(cfg Config) error {
+	// Policy: reject reserved-future values by string match; anything else
+	// not PolicyWarn is also rejected.
+	switch string(cfg.Policy) {
+	case string(PolicyWarn):
+		// ok
+	case reservedPolicySafeUpdate:
+		return fmt.Errorf("%w: policy %q is not supported in v1 (lands in Phase 2)",
+			ErrInvalidConfig, reservedPolicySafeUpdate)
+	case reservedPolicyForce:
+		return fmt.Errorf("%w: policy %q is not supported in v1 (lands in Phase 6)",
+			ErrInvalidConfig, reservedPolicyForce)
+	default:
+		return fmt.Errorf("%w: policy %q is not recognized (v1 supports only %q)",
+			ErrInvalidConfig, cfg.Policy, PolicyWarn)
+	}
+
+	if cfg.ControlPlane != nil {
+		if err := validateControlPlane(*cfg.ControlPlane); err != nil {
+			return err
+		}
+	}
+
+	if cfg.PartitionSource != nil {
+		if err := validatePartitionSource(*cfg.PartitionSource); err != nil {
+			return err
+		}
+	}
+
+	// DynamicConsumers: deeper validation lands in W4.
+	return nil
+}
+
+// validatePartitionSource validates a PartitionSourceConfig that has already
+// had Storage and History defaults applied by normalize.
+func validatePartitionSource(ps PartitionSourceConfig) error {
+	if ps.Bucket == "" {
+		return fmt.Errorf("%w: partitionSource.bucket must not be empty", ErrInvalidConfig)
+	}
+	if ps.Key == "" {
+		return fmt.Errorf("%w: partitionSource.key must not be empty", ErrInvalidConfig)
+	}
+	switch ps.Storage {
+	case "file", "memory":
+		// valid; normalize already set the default
+	default:
+		return fmt.Errorf("%w: partitionSource.storage %q is not valid (must be %q or %q)",
+			ErrInvalidConfig, ps.Storage, "file", "memory")
+	}
+	// ps.History is uint8, so negative values are impossible by type; no check needed.
+	// ps.Replicas is int; 0 means "server default" (accepted).
+	if ps.Replicas < 0 {
+		return fmt.Errorf("%w: partitionSource.replicas must be >= 0", ErrInvalidConfig)
+	}
+	if ps.MaxValueSize < 0 {
+		return fmt.Errorf("%w: partitionSource.maxValueSize must be >= 0", ErrInvalidConfig)
+	}
+	if ps.TTL < 0 {
+		return fmt.Errorf("%w: partitionSource.ttl must be >= 0", ErrInvalidConfig)
+	}
+
+	return nil
+}
+
+func validateControlPlane(cp ControlPlaneConfig) error {
+	if cp.StableIDBucket == "" {
+		return fmt.Errorf("%w: controlPlane.stableIdBucket must not be empty", ErrInvalidConfig)
+	}
+	if cp.ElectionBucket == "" {
+		return fmt.Errorf("%w: controlPlane.electionBucket must not be empty", ErrInvalidConfig)
+	}
+	if cp.HeartbeatBucket == "" {
+		return fmt.Errorf("%w: controlPlane.heartbeatBucket must not be empty", ErrInvalidConfig)
+	}
+	if cp.AssignmentBucket == "" {
+		return fmt.Errorf("%w: controlPlane.assignmentBucket must not be empty", ErrInvalidConfig)
+	}
+	if cp.EnableTwoPhaseHandoff && cp.HandoffBucket == "" {
+		// Unreachable from YAML because HandoffBucket defaults; here as a
+		// defense against API callers explicitly zeroing the field.
+		return fmt.Errorf("%w: controlPlane.handoffBucket must not be empty when enableTwoPhaseHandoff is true",
+			ErrInvalidConfig)
+	}
+
+	if cp.WorkerIDTTL <= 0 {
+		return fmt.Errorf("%w: controlPlane.workerIdTtl must be > 0", ErrInvalidConfig)
+	}
+	if cp.ElectionTimeout <= 0 {
+		return fmt.Errorf("%w: controlPlane.electionTimeout must be > 0", ErrInvalidConfig)
+	}
+	if cp.HeartbeatTTL <= 0 {
+		return fmt.Errorf("%w: controlPlane.heartbeatTtl must be > 0", ErrInvalidConfig)
+	}
+	// AssignmentTTL == 0 is valid (matches runtime default: no expiration).
+	if cp.AssignmentTTL < 0 {
+		return fmt.Errorf("%w: controlPlane.assignmentTtl must be >= 0", ErrInvalidConfig)
+	}
+	if cp.EnableTwoPhaseHandoff && cp.HandoffTTL <= 0 {
+		return fmt.Errorf("%w: controlPlane.handoffTtl must be > 0 when enableTwoPhaseHandoff is true",
+			ErrInvalidConfig)
+	}
+
+	return nil
+}

--- a/provision/validate_live.go
+++ b/provision/validate_live.go
@@ -1,0 +1,260 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ErrLiveValidation is the sentinel returned by ValidateLive for any live
+// validation failure that is not a reachability or cancellation error.
+// Callers can use errors.Is(err, ErrLiveValidation) to distinguish
+// live-validation errors from static-validation (ErrInvalidConfig) and from
+// reachability/cancellation surfaces.
+//
+// CLI exit-code mapping (per the master plan's Exit code precedence):
+//   - reachability failure (ErrJetStreamNotEnabled / ErrJetStreamNotEnabledForAccount
+//     during step 1.B), or context cancellation → exit code 4. These do NOT
+//     wrap ErrLiveValidation; callers detect them via errors.Is against the
+//     underlying error.
+//   - ErrLiveValidation (permission-denied or generic) → exit code 3.
+var ErrLiveValidation = errors.New("provision: live validation failed")
+
+// ValidateLive performs the live (NATS-reachable) preflight for cfg without
+// mutating any resource. It executes a deterministic probe sequence (see
+// docs/plans/provision-sdk-cli/02-w2-apply-validatelive-spec.md §1):
+//
+//  1. Reachability probe via js.AccountInfo.
+//  2. Per-bucket stream-info probe for every named bucket in cfg.
+//     ErrStreamNotFound is NOT an error (Apply will create the bucket).
+//  3. Partition-source key probe (only when cfg.PartitionSource != nil) with
+//     a single retry on permission-denied to handle a live AllowDirect flip.
+//
+// ValidateLive normalizes cfg internally (applying the same defaults as Plan
+// and Validate) so that callers are not required to pre-normalize. This makes
+// ValidateLive safe to call directly from partictl validate -live or any
+// standalone caller, not just from Apply.
+//
+// On success, ValidateLive returns a Report with empty action slices (the
+// Report is informational; Apply's Report is the mutation-outcome surface).
+// On failure, ValidateLive returns a Report containing a ResourceError entry
+// for the failing probe plus the underlying error.
+//
+// Cancellation: ctx cancellation returns a zero-value Report plus ctx.Err().
+func ValidateLive(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, error) {
+	if err := ctx.Err(); err != nil {
+		return Report{}, err
+	}
+
+	// Normalize cfg (apply bucket-name defaults, etc.) so probes target the
+	// correct stream names even when the caller omits optional fields.
+	// This mirrors Plan's public-entrypoint pattern (provision/plan.go:36-42)
+	// and makes ValidateLive safe to call directly without pre-normalization.
+	resolved, err := normalize(cfg)
+	if err != nil {
+		return Report{}, err
+	}
+	cfg = resolved
+
+	// Step 1.B: reachability probe.
+	if _, err := js.AccountInfo(ctx); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return Report{}, ctxErr
+		}
+		// All reachability errors are surfaced as-is (no ErrLiveValidation
+		// wrap); the CLI maps them to exit code 4 via errors.Is against
+		// the underlying error. We still return a Report containing a
+		// ResourceError so JSON callers can render the failure.
+		return liveErrorReport("reachability", "$JS.API.INFO", err), fmt.Errorf("provision: validatelive: reachability: %w", err)
+	}
+
+	// Step 1.C: per-bucket info probes (control-plane block; W3 adds
+	// partition-source bucket info probe in this slot).
+	if cfg.ControlPlane != nil {
+		specs := buildControlPlaneSpecs(*cfg.ControlPlane)
+		for _, spec := range specs {
+			if err := ctx.Err(); err != nil {
+				return Report{}, err
+			}
+			if err := probeBucketInfo(ctx, js, spec.bucket); err != nil {
+				return liveErrorReport(KindControlPlaneKV, spec.bucket, err),
+					fmt.Errorf("provision: validatelive: stream info %q: %w", spec.bucket, err)
+			}
+		}
+	}
+
+	// Step 1.D: partition-source key probe — only when configured.
+	if cfg.PartitionSource != nil {
+		if err := ctx.Err(); err != nil {
+			return Report{}, err
+		}
+		if err := probePartitionSourceKey(ctx, js, *cfg.PartitionSource); err != nil {
+			return liveErrorReport(KindPartitionSource, cfg.PartitionSource.Bucket, err),
+				fmt.Errorf("provision: validatelive: partition-source key probe %q/%q: %w",
+					cfg.PartitionSource.Bucket, cfg.PartitionSource.Key, err)
+		}
+	}
+
+	// Step 4 (W4) — dynamic-consumer live checks. Only runs when the caller
+	// declared one or more dynamic-consumer alignment targets. A failure here
+	// is a config-mismatch (WorkQueuePolicy + incompatible recovery strategy),
+	// so it's surfaced under ErrLiveValidation (CLI exit code 3).
+	if len(cfg.DynamicConsumers) > 0 {
+		if err := ValidateLiveDynamicConsumers(ctx, js, cfg.DynamicConsumers); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return Report{}, err
+			}
+			// Use the first cfg's stream name for the Report; the error
+			// message already carries the offending stream.
+			name := cfg.DynamicConsumers[0].StreamName
+			return liveErrorReport(KindDynamicConsumer, name, err),
+				fmt.Errorf("%w: %w", ErrLiveValidation, err)
+		}
+	}
+
+	return Report{
+		APIVersion: APIVersionProvisionV1,
+		Kind:       KindReport,
+	}, nil
+}
+
+// probeBucketInfo runs the per-bucket info probe described in sub-spec §1.C.
+// Returns nil on success or on ErrStreamNotFound (the bucket is creatable);
+// otherwise classifies the error per §1.E.
+func probeBucketInfo(ctx context.Context, js jetstream.JetStream, bucket string) error {
+	stream, err := js.Stream(ctx, kvStreamPrefix+bucket)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return nil
+		}
+		return classifyLiveError(ctx, err)
+	}
+	if _, err := stream.Info(ctx); err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return nil
+		}
+		return classifyLiveError(ctx, err)
+	}
+
+	return nil
+}
+
+// probePartitionSourceKey implements the §1.D algorithm: read STREAM.INFO,
+// probe via stream.GetLastMsgForSubject (which re-evaluates AllowDirect from
+// the cached stream info), and retry exactly once after refreshing the
+// stream info if the first probe returned a permission-denied surface error.
+func probePartitionSourceKey(ctx context.Context, js jetstream.JetStream, ps PartitionSourceConfig) error {
+	stream, err := js.Stream(ctx, kvStreamPrefix+ps.Bucket)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			// Bucket does not exist live; the key probe is vacuously OK.
+			// (Apply or W3 will create the bucket.)
+			return nil
+		}
+		return classifyLiveError(ctx, err)
+	}
+	// Refresh stream info so the AllowDirect branch is current.
+	if _, err := stream.Info(ctx); err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return nil
+		}
+		return classifyLiveError(ctx, err)
+	}
+
+	subject := "$KV." + ps.Bucket + "." + ps.Key
+	probeMsg := func(ctx context.Context) error {
+		_, err := stream.GetLastMsgForSubject(ctx, subject)
+		return err
+	}
+	refreshInfo := func(ctx context.Context) error {
+		_, err2 := stream.Info(ctx)
+		return err2
+	}
+
+	return probeWithAllowDirectRetry(ctx, probeMsg, refreshInfo)
+}
+
+// probeWithAllowDirectRetry implements the §1.D AllowDirect retry algorithm
+// with injected probe and refresh functions. This seam allows the retry
+// logic to be tested independently of NATS.
+//
+// probe(ctx) must return nil / ErrMsgNotFound for success or a permission /
+// generic error. refresh(ctx) refreshes the stream's cached info so the
+// next probe re-evaluates AllowDirect. If the first probe returns a
+// permission-denied surface and the refresh succeeds, the probe is retried
+// exactly once; a second permission-denied result is returned classified.
+func probeWithAllowDirectRetry(
+	ctx context.Context,
+	probe func(ctx context.Context) error,
+	refresh func(ctx context.Context) error,
+) error {
+	err := probe(ctx)
+	if err == nil || errors.Is(err, jetstream.ErrMsgNotFound) {
+		return nil
+	}
+	if !isPermissionDeniedSurface(ctx, err) {
+		return classifyLiveError(ctx, err)
+	}
+
+	// Single retry: refresh stream info (re-evaluates AllowDirect) and
+	// re-probe.
+	if err2 := refresh(ctx); err2 != nil {
+		if errors.Is(err2, jetstream.ErrStreamNotFound) {
+			return nil
+		}
+		return classifyLiveError(ctx, err2)
+	}
+	err = probe(ctx)
+	if err == nil || errors.Is(err, jetstream.ErrMsgNotFound) {
+		return nil
+	}
+
+	return classifyLiveError(ctx, err)
+}
+
+// isPermissionDeniedSurface returns true when err looks like a permission
+// failure that the §1.D retry protocol should respond to. The ctx-live guard
+// avoids misclassifying a cancellation as a permission failure.
+func isPermissionDeniedSurface(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	return errors.Is(err, jetstream.ErrJetStreamNotEnabled) ||
+		errors.Is(err, nats.ErrNoResponders) ||
+		errors.Is(err, nats.ErrPermissionViolation)
+}
+
+// classifyLiveError wraps err into a ValidateLive-style error per the §1.E
+// table. Cancellation always wins over permission classification.
+func classifyLiveError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if errors.Is(err, jetstream.ErrJetStreamNotEnabled) ||
+		errors.Is(err, jetstream.ErrJetStreamNotEnabledForAccount) ||
+		errors.Is(err, nats.ErrNoResponders) ||
+		errors.Is(err, nats.ErrPermissionViolation) {
+		return fmt.Errorf("%w: permission denied: %w", ErrLiveValidation, err)
+	}
+
+	return fmt.Errorf("%w: %w", ErrLiveValidation, err)
+}
+
+// liveErrorReport builds the Report returned alongside a ValidateLive error.
+// The kind/name pair identifies the resource (or "reachability"/"$JS.API.INFO"
+// for step 1.B failures).
+func liveErrorReport(kind, name string, err error) Report {
+	return Report{
+		APIVersion: APIVersionProvisionV1,
+		Kind:       KindReport,
+		Errors: []ResourceError{
+			{Kind: kind, Name: name, Error: err.Error()},
+		},
+	}
+}

--- a/provision/validate_live_integration_test.go
+++ b/provision/validate_live_integration_test.go
@@ -1,0 +1,311 @@
+package provision_test
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// streamRecordingJS wraps jetstream.JetStream and records every stream name
+// passed to Stream(). Used to assert that ValidateLive probes the resolved
+// (post-default) stream names, not raw empty names.
+type streamRecordingJS struct {
+	jetstream.JetStream
+	mu      sync.Mutex
+	streams []string
+}
+
+func newStreamRecordingJS(js jetstream.JetStream) *streamRecordingJS {
+	return &streamRecordingJS{JetStream: js}
+}
+
+func (r *streamRecordingJS) Stream(ctx context.Context, stream string) (jetstream.Stream, error) {
+	r.mu.Lock()
+	r.streams = append(r.streams, stream)
+	r.mu.Unlock()
+	return r.JetStream.Stream(ctx, stream)
+}
+
+func (r *streamRecordingJS) recordedStreams() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]string, len(r.streams))
+	copy(cp, r.streams)
+	return cp
+}
+
+// validateLiveCfg builds a Config with all five control-plane buckets
+// enabled and a partition-source target pointing at a Parti-style bucket.
+func validateLiveCfg() provision.Config {
+	return provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		ControlPlane: &provision.ControlPlaneConfig{
+			WorkerIDTTL:           75 * time.Second,
+			ElectionTimeout:       10 * time.Second,
+			HeartbeatTTL:          15 * time.Second,
+			AssignmentTTL:         0,
+			HandoffTTL:            2 * time.Minute,
+			EnableTwoPhaseHandoff: true,
+		},
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket: "parti-partitions",
+			Key:    "partitions/v1",
+		},
+	}
+}
+
+func TestValidateLive_EmptyServer_AllBucketsMissing_OK(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rep, err := provision.ValidateLive(ctx, js, validateLiveCfg())
+	require.NoError(t, err)
+	require.Equal(t, provision.APIVersionProvisionV1, rep.APIVersion)
+	require.Equal(t, provision.KindReport, rep.Kind)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_CancelledContext_ReturnsCtxErr(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rep, err := provision.ValidateLive(ctx, js, validateLiveCfg())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, rep)
+}
+
+func TestValidateLive_PartitionSourceKey_AllowDirectTrue_KeyMissing_OK(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := validateLiveCfg()
+	// Pre-create only the partition-source bucket. nats.go's default
+	// CreateKeyValue sets AllowDirect=true (verified below).
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   cfg.PartitionSource.Bucket,
+		History:  1,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Sanity: confirm AllowDirect=true on the underlying stream.
+	stream, err := js.Stream(ctx, "KV_"+cfg.PartitionSource.Bucket)
+	require.NoError(t, err)
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	require.True(t, info.Config.AllowDirect, "default CreateKeyValue should set AllowDirect=true")
+
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_PartitionSourceKey_AllowDirectFalse_KeyMissing_OK(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := validateLiveCfg()
+
+	// Create the partition-source bucket via raw CreateStream with
+	// AllowDirect=false. We mirror the KV stream shape (KV_ prefix,
+	// MaxMsgsPerSubject=1, KV_-style subject filter, deny-delete /
+	// deny-purge defaults). The shape need not be exact — only enough
+	// that GetLastMsgForSubject can be invoked.
+	bucket := cfg.PartitionSource.Bucket
+	streamCfg := jetstream.StreamConfig{
+		Name:              "KV_" + bucket,
+		Subjects:          []string{"$KV." + bucket + ".>"},
+		Storage:           jetstream.FileStorage,
+		MaxMsgsPerSubject: 1,
+		AllowDirect:       false,
+		Discard:           jetstream.DiscardNew,
+		DenyDelete:        true,
+		DenyPurge:         false,
+		AllowRollup:       true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := js.CreateStream(ctx, streamCfg)
+	require.NoError(t, err)
+
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_PartitionSourceKey_AllowDirectFlip_RetrySucceeds(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := validateLiveCfg()
+	bucket := cfg.PartitionSource.Bucket
+
+	// Start with AllowDirect=true (the nats.go default).
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		History:  1,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	// Flip AllowDirect=false via UpdateStream. The cached stream handle
+	// the ValidateLive opens internally will see the post-flip info on
+	// its first stream.Info() call, so this test mainly verifies that
+	// ValidateLive does the right thing across an AllowDirect transition
+	// — the retry branch is exercised when a permission failure is also
+	// returned, but the post-flip key probe should still succeed (key
+	// absent) when permissions allow both direct and non-direct paths.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stream, err := js.Stream(ctx, "KV_"+bucket)
+	require.NoError(t, err)
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	updatedCfg := info.Config
+	updatedCfg.AllowDirect = false
+	_, err = js.UpdateStream(ctx, updatedCfg)
+	require.NoError(t, err)
+
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_PartitionSourceMissingBucket_OK(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := validateLiveCfg()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Partition-source bucket is not pre-created — ValidateLive must
+	// short-circuit the key probe (the bucket will be created by W3 /
+	// Phase 3).
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_NoPartitionSource_SkipsKeyProbe(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := validateLiveCfg()
+	cfg.PartitionSource = nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_PartitionSourceKey_PresentValue_OK(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := validateLiveCfg()
+	bucket := cfg.PartitionSource.Bucket
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		History:  1,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Write a value to the key so the probe sees data, not ErrMsgNotFound.
+	kv, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, cfg.PartitionSource.Key, []byte(`{"v":1}`))
+	require.NoError(t, err)
+
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+func TestValidateLive_StreamInfoUsesSharedBuilderShape(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	cfg := validateLiveCfg()
+
+	// Pre-create one of the control-plane buckets so stream.Info actually
+	// runs (rather than short-circuiting on ErrStreamNotFound).
+	live := kvbuckets.BuildKeyValueConfig("parti-election", 10*time.Second, jetstream.MemoryStorage)
+	live.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, live)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rep, err := provision.ValidateLive(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+}
+
+// TestValidateLive_DefaultBuckets_ProbesResolvedNames verifies the P0 fix:
+// when the caller omits control-plane bucket names, ValidateLive must
+// normalize cfg internally and probe the default names, not "KV_" (empty
+// suffix). This test would fail on the pre-fix code that used raw cfg.
+func TestValidateLive_DefaultBuckets_ProbesResolvedNames(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Config with NO explicit bucket names (the common operator case).
+	// After normalization the control-plane defaults must be applied.
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		ControlPlane: &provision.ControlPlaneConfig{
+			WorkerIDTTL:     75 * time.Second,
+			ElectionTimeout: 10 * time.Second,
+			HeartbeatTTL:    15 * time.Second,
+		},
+	}
+
+	rec := newStreamRecordingJS(js)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rep, err := provision.ValidateLive(ctx, rec, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	// Verify that the probed stream names are the resolved default names —
+	// NOT "KV_" (which would indicate that normalization was skipped).
+	probed := rec.recordedStreams()
+	slices.Sort(probed)
+
+	// The 4 control-plane buckets (handoff disabled → 4 not 5).
+	wantStreams := []string{
+		"KV_parti-assignment",
+		"KV_parti-election",
+		"KV_parti-heartbeat",
+		"KV_parti-stableid",
+	}
+
+	require.Equal(t, wantStreams, probed,
+		"ValidateLive must probe resolved default bucket names, not empty ones")
+
+	// Additionally verify that "KV_" (empty suffix) is never probed.
+	for _, s := range probed {
+		require.NotEqual(t, "KV_", s,
+			"ValidateLive must not probe KV_ (empty suffix); normalization missing")
+	}
+}

--- a/provision/validate_live_unit_test.go
+++ b/provision/validate_live_unit_test.go
@@ -1,0 +1,262 @@
+package provision
+
+// Same-package tests for classifyLiveError, isPermissionDeniedSurface, and
+// probeWithAllowDirectRetry. These cover the classifier and retry algorithm
+// with injected errors — no embedded NATS needed.
+//
+// These tests must live in package provision (not provision_test) so they can
+// reach the unexported helpers.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// --- classifyLiveError table ---
+
+func TestClassifyLiveError_Table(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	type tc struct {
+		name      string
+		ctx       context.Context
+		err       error
+		wantIs    []error // must match via errors.Is
+		wantNotIs []error // must NOT match via errors.Is
+	}
+
+	tests := []tc{
+		{
+			name:   "ErrNoResponders → permission-denied (wraps ErrLiveValidation)",
+			ctx:    ctx,
+			err:    nats.ErrNoResponders,
+			wantIs: []error{ErrLiveValidation, nats.ErrNoResponders},
+		},
+		{
+			name:   "ErrPermissionViolation → permission-denied (wraps ErrLiveValidation)",
+			ctx:    ctx,
+			err:    nats.ErrPermissionViolation,
+			wantIs: []error{ErrLiveValidation, nats.ErrPermissionViolation},
+		},
+		{
+			name:   "ErrJetStreamNotEnabled → permission-denied after step1 (wraps ErrLiveValidation)",
+			ctx:    ctx,
+			err:    jetstream.ErrJetStreamNotEnabled,
+			wantIs: []error{ErrLiveValidation, jetstream.ErrJetStreamNotEnabled},
+		},
+		{
+			name:   "ErrJetStreamNotEnabledForAccount → permission-denied (wraps ErrLiveValidation)",
+			ctx:    ctx,
+			err:    jetstream.ErrJetStreamNotEnabledForAccount,
+			wantIs: []error{ErrLiveValidation, jetstream.ErrJetStreamNotEnabledForAccount},
+		},
+		{
+			name:      "ErrMsgNotFound should not be passed to classifyLiveError (but if it is → generic wrap)",
+			ctx:       ctx,
+			err:       jetstream.ErrMsgNotFound,
+			wantIs:    []error{ErrLiveValidation},
+			wantNotIs: []error{nats.ErrPermissionViolation},
+		},
+		{
+			name:      "context.Canceled → returned as-is (no ErrLiveValidation wrap)",
+			ctx:       ctx,
+			err:       context.Canceled,
+			wantIs:    []error{context.Canceled},
+			wantNotIs: []error{ErrLiveValidation},
+		},
+		{
+			name:      "context.DeadlineExceeded → returned as-is (no ErrLiveValidation wrap)",
+			ctx:       ctx,
+			err:       context.DeadlineExceeded,
+			wantIs:    []error{context.DeadlineExceeded},
+			wantNotIs: []error{ErrLiveValidation},
+		},
+		{
+			name:      "cancelled ctx beats any error → ctx.Err() returned",
+			ctx:       cancelledCtx,
+			err:       nats.ErrPermissionViolation, // would otherwise be permission-denied
+			wantIs:    []error{context.Canceled},
+			wantNotIs: []error{ErrLiveValidation},
+		},
+		{
+			name:      "generic/wrapped error → wraps ErrLiveValidation",
+			ctx:       ctx,
+			err:       errors.New("some nats error"),
+			wantIs:    []error{ErrLiveValidation},
+			wantNotIs: []error{nats.ErrPermissionViolation},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyLiveError(tt.ctx, tt.err)
+			require.Error(t, got)
+			for _, want := range tt.wantIs {
+				require.True(t, errors.Is(got, want),
+					"expected errors.Is(got, %v) = true; got %v", want, got)
+			}
+			for _, notWant := range tt.wantNotIs {
+				require.False(t, errors.Is(got, notWant),
+					"expected errors.Is(got, %v) = false; got %v", notWant, got)
+			}
+		})
+	}
+}
+
+// --- isPermissionDeniedSurface ---
+
+func TestIsPermissionDeniedSurface_Table(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"ErrNoResponders+live ctx", ctx, nats.ErrNoResponders, true},
+		{"ErrPermissionViolation+live ctx", ctx, nats.ErrPermissionViolation, true},
+		{"ErrJetStreamNotEnabled+live ctx", ctx, jetstream.ErrJetStreamNotEnabled, true},
+		{"generic error+live ctx", ctx, errors.New("oops"), false},
+		{"ErrNoResponders+cancelled ctx", cancelledCtx, nats.ErrNoResponders, false},
+		{"ErrPermissionViolation+cancelled ctx", cancelledCtx, nats.ErrPermissionViolation, false},
+		{"nil error", ctx, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isPermissionDeniedSurface(tt.ctx, tt.err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- probeWithAllowDirectRetry ---
+
+// retryCall is a helper to build an injected probe or refresh function from a
+// slice of returns: each successive call pops the next error off the slice.
+type callSeq struct {
+	returns []error
+	calls   int
+}
+
+func newCallSeq(returns ...error) *callSeq { return &callSeq{returns: returns} }
+
+func (s *callSeq) call(_ context.Context) error {
+	if s.calls < len(s.returns) {
+		err := s.returns[s.calls]
+		s.calls++
+		return err
+	}
+	return errors.New("callSeq: no more returns configured")
+}
+
+func TestProbeWithAllowDirectRetry_Success_FirstCall(t *testing.T) {
+	t.Parallel()
+	probe := newCallSeq(nil)
+	refresh := newCallSeq() // should not be called
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.NoError(t, err)
+	require.Equal(t, 1, probe.calls, "probe called once")
+	require.Equal(t, 0, refresh.calls, "refresh not called on success")
+}
+
+func TestProbeWithAllowDirectRetry_ErrMsgNotFound_Success(t *testing.T) {
+	t.Parallel()
+	probe := newCallSeq(jetstream.ErrMsgNotFound)
+	refresh := newCallSeq()
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.NoError(t, err)
+	require.Equal(t, 1, probe.calls)
+	require.Equal(t, 0, refresh.calls, "refresh not called: ErrMsgNotFound is success")
+}
+
+func TestProbeWithAllowDirectRetry_PermissionDenied_RetrySucceeds(t *testing.T) {
+	t.Parallel()
+	// First probe: permission denied. After refresh: success.
+	probe := newCallSeq(nats.ErrPermissionViolation, nil)
+	refresh := newCallSeq(nil)
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.NoError(t, err)
+	require.Equal(t, 2, probe.calls, "probe called twice (initial + retry)")
+	require.Equal(t, 1, refresh.calls, "refresh called once between attempts")
+}
+
+func TestProbeWithAllowDirectRetry_PermissionDenied_RetryAlsoFails(t *testing.T) {
+	t.Parallel()
+	// Both probes: permission denied → classified as ErrLiveValidation.
+	probe := newCallSeq(nats.ErrPermissionViolation, nats.ErrPermissionViolation)
+	refresh := newCallSeq(nil)
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrLiveValidation),
+		"second permission denial must surface as ErrLiveValidation")
+	require.Equal(t, 2, probe.calls)
+	require.Equal(t, 1, refresh.calls)
+}
+
+func TestProbeWithAllowDirectRetry_PermissionDenied_RefreshFails(t *testing.T) {
+	t.Parallel()
+	// First probe: permission denied. Refresh fails with generic error.
+	probe := newCallSeq(nats.ErrNoResponders)
+	refresh := newCallSeq(errors.New("refresh error"))
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrLiveValidation),
+		"refresh failure must also surface as ErrLiveValidation (generic wrap)")
+	require.Equal(t, 1, probe.calls)
+	require.Equal(t, 1, refresh.calls)
+}
+
+func TestProbeWithAllowDirectRetry_PermissionDenied_RefreshFindsStreamGone(t *testing.T) {
+	t.Parallel()
+	// First probe: permission denied. Refresh returns ErrStreamNotFound → OK.
+	probe := newCallSeq(nats.ErrNoResponders)
+	refresh := newCallSeq(jetstream.ErrStreamNotFound)
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.NoError(t, err, "ErrStreamNotFound on refresh is treated as success (stream gone)")
+	require.Equal(t, 1, probe.calls)
+	require.Equal(t, 1, refresh.calls)
+}
+
+func TestProbeWithAllowDirectRetry_GenericError_NoRetry(t *testing.T) {
+	t.Parallel()
+	// Non-permission generic error: no retry, classify immediately.
+	probe := newCallSeq(errors.New("timeout or similar"))
+	refresh := newCallSeq()
+	err := probeWithAllowDirectRetry(context.Background(), probe.call, refresh.call)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrLiveValidation))
+	require.Equal(t, 1, probe.calls)
+	require.Equal(t, 0, refresh.calls, "no retry on non-permission error")
+}
+
+func TestProbeWithAllowDirectRetry_CancelledCtx_NoRetry(t *testing.T) {
+	t.Parallel()
+	// Cancelled context: isPermissionDeniedSurface returns false, so no retry.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Even a permission-surface error must not trigger retry when ctx is done.
+	probe := newCallSeq(nats.ErrPermissionViolation)
+	refresh := newCallSeq()
+	err := probeWithAllowDirectRetry(cancelledCtx, probe.call, refresh.call)
+	require.Error(t, err)
+	// classifyLiveError with a cancelled ctx returns ctx.Err() directly.
+	require.True(t, errors.Is(err, context.Canceled))
+	require.Equal(t, 1, probe.calls)
+	require.Equal(t, 0, refresh.calls, "no retry when context is cancelled")
+}

--- a/provision/validate_test.go
+++ b/provision/validate_test.go
@@ -1,0 +1,469 @@
+package provision_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func validControlPlane() *provision.ControlPlaneConfig {
+	return &provision.ControlPlaneConfig{
+		StableIDBucket:   "parti-stableid",
+		ElectionBucket:   "parti-election",
+		HeartbeatBucket:  "parti-heartbeat",
+		AssignmentBucket: "parti-assignment",
+		HandoffBucket:    "parti-handoff",
+		WorkerIDTTL:      75 * time.Second,
+		ElectionTimeout:  10 * time.Second,
+		HeartbeatTTL:     15 * time.Second,
+		AssignmentTTL:    0,
+		HandoffTTL:       2 * time.Minute,
+	}
+}
+
+func TestValidate_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(c *provision.Config)
+		wantErr bool
+		// errSubstr is checked against err.Error() to ensure the test
+		// fails for the right reason.
+		errSubstr string
+	}{
+		{
+			name:    "valid_minimal_control_plane",
+			mutate:  func(*provision.Config) {},
+			wantErr: false,
+		},
+		{
+			name: "apiversion_mismatch_rejected",
+			mutate: func(c *provision.Config) {
+				c.APIVersion = "parti.io/v2"
+			},
+			wantErr:   true,
+			errSubstr: "apiVersion",
+		},
+		{
+			name: "apiversion_empty_rejected",
+			mutate: func(c *provision.Config) {
+				c.APIVersion = ""
+			},
+			wantErr:   true,
+			errSubstr: "apiVersion",
+		},
+		{
+			name: "policy_safe_update_rejected",
+			mutate: func(c *provision.Config) {
+				c.Policy = "safe-update"
+			},
+			wantErr:   true,
+			errSubstr: "safe-update",
+		},
+		{
+			name: "policy_force_rejected",
+			mutate: func(c *provision.Config) {
+				c.Policy = "force"
+			},
+			wantErr:   true,
+			errSubstr: "force",
+		},
+		{
+			name: "policy_unknown_rejected",
+			mutate: func(c *provision.Config) {
+				c.Policy = "yolo"
+			},
+			wantErr:   true,
+			errSubstr: "policy",
+		},
+		{
+			name: "policy_warn_explicit_accepted",
+			mutate: func(c *provision.Config) {
+				c.Policy = provision.PolicyWarn
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero_workerid_ttl_rejected",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.WorkerIDTTL = 0
+			},
+			wantErr:   true,
+			errSubstr: "workerIdTtl",
+		},
+		{
+			name: "zero_election_timeout_rejected",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.ElectionTimeout = 0
+			},
+			wantErr:   true,
+			errSubstr: "electionTimeout",
+		},
+		{
+			name: "zero_heartbeat_ttl_rejected",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.HeartbeatTTL = 0
+			},
+			wantErr:   true,
+			errSubstr: "heartbeatTtl",
+		},
+		{
+			name: "zero_assignment_ttl_accepted",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.AssignmentTTL = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative_assignment_ttl_rejected",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.AssignmentTTL = -1
+			},
+			wantErr:   true,
+			errSubstr: "assignmentTtl",
+		},
+		{
+			name: "handoff_enabled_without_ttl_rejected",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.EnableTwoPhaseHandoff = true
+				c.ControlPlane.HandoffTTL = 0
+			},
+			wantErr:   true,
+			errSubstr: "handoffTtl",
+		},
+		{
+			name: "handoff_enabled_with_ttl_accepted",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.EnableTwoPhaseHandoff = true
+				c.ControlPlane.HandoffTTL = 2 * time.Minute
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty_bucket_names_filled_by_defaults",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.StableIDBucket = ""
+				c.ControlPlane.ElectionBucket = ""
+				c.ControlPlane.HeartbeatBucket = ""
+				c.ControlPlane.AssignmentBucket = ""
+				c.ControlPlane.HandoffBucket = ""
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := provision.Config{
+				APIVersion:   provision.APIVersionV1,
+				ControlPlane: validControlPlane(),
+			}
+			tc.mutate(&cfg)
+
+			err := provision.Validate(cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, provision.ErrInvalidConfig)
+				if tc.errSubstr != "" {
+					require.Contains(t, err.Error(), tc.errSubstr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidate_DoesNotMutateCaller(t *testing.T) {
+	t.Parallel()
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		ControlPlane: &provision.ControlPlaneConfig{
+			WorkerIDTTL:     75 * time.Second,
+			ElectionTimeout: 10 * time.Second,
+			HeartbeatTTL:    15 * time.Second,
+			// Bucket names intentionally empty so defaults apply.
+		},
+	}
+	err := provision.Validate(cfg)
+	require.NoError(t, err)
+	// Caller's pointer target must remain empty.
+	require.Equal(t, "", cfg.ControlPlane.StableIDBucket)
+	require.Equal(t, "", cfg.ControlPlane.ElectionBucket)
+	require.Equal(t, "", cfg.ControlPlane.HeartbeatBucket)
+	require.Equal(t, "", cfg.ControlPlane.AssignmentBucket)
+	require.Equal(t, "", cfg.ControlPlane.HandoffBucket)
+	require.Equal(t, provision.ReconcilePolicy(""), cfg.Policy)
+}
+
+func TestApplyDefaults_FillsBucketsAndPolicy(t *testing.T) {
+	t.Parallel()
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		ControlPlane: &provision.ControlPlaneConfig{
+			WorkerIDTTL:     75 * time.Second,
+			ElectionTimeout: 10 * time.Second,
+			HeartbeatTTL:    15 * time.Second,
+		},
+	}
+	got, err := provision.ApplyDefaults(cfg)
+	require.NoError(t, err)
+	require.Equal(t, provision.PolicyWarn, got.Policy)
+	require.Equal(t, "parti-stableid", got.ControlPlane.StableIDBucket)
+	require.Equal(t, "parti-election", got.ControlPlane.ElectionBucket)
+	require.Equal(t, "parti-heartbeat", got.ControlPlane.HeartbeatBucket)
+	require.Equal(t, "parti-assignment", got.ControlPlane.AssignmentBucket)
+	require.Equal(t, "parti-handoff", got.ControlPlane.HandoffBucket)
+}
+
+func TestApplyDefaults_RejectsAPIVersionMismatch(t *testing.T) {
+	t.Parallel()
+	_, err := provision.ApplyDefaults(provision.Config{APIVersion: "bogus"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, provision.ErrInvalidConfig)
+}
+
+func TestErrInvalidConfig_Sentinel(t *testing.T) {
+	t.Parallel()
+	err := provision.Validate(provision.Config{APIVersion: ""})
+	require.True(t, errors.Is(err, provision.ErrInvalidConfig))
+}
+
+// TestValidate_FullYAMLFixture verifies the canonical "Full" YAML example
+// from the plan unmarshals into Config and passes Validate. It also
+// double-checks every nested field is populated via the declared YAML tag
+// (the test fixture uses distinct values per field so any tag mistake
+// surfaces as a zero-value comparison).
+func TestValidate_FullYAMLFixture(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile(filepath.Join("testdata", "full.yaml"))
+	require.NoError(t, err)
+
+	var cfg provision.Config
+	require.NoError(t, yaml.Unmarshal(raw, &cfg))
+
+	require.NoError(t, provision.Validate(cfg))
+
+	// Spot-check every field is populated via its declared YAML tag.
+	require.Equal(t, provision.APIVersionV1, cfg.APIVersion)
+	require.Equal(t, "prod-us-east", cfg.Instance)
+	require.Equal(t, provision.PolicyWarn, cfg.Policy)
+
+	require.NotNil(t, cfg.ControlPlane)
+	require.Equal(t, "parti-stableid", cfg.ControlPlane.StableIDBucket)
+	require.Equal(t, "parti-election", cfg.ControlPlane.ElectionBucket)
+	require.Equal(t, "parti-heartbeat", cfg.ControlPlane.HeartbeatBucket)
+	require.Equal(t, "parti-assignment", cfg.ControlPlane.AssignmentBucket)
+	require.Equal(t, "parti-handoff", cfg.ControlPlane.HandoffBucket)
+	require.Equal(t, 75*time.Second, cfg.ControlPlane.WorkerIDTTL)
+	require.Equal(t, 10*time.Second, cfg.ControlPlane.ElectionTimeout)
+	require.Equal(t, 15*time.Second, cfg.ControlPlane.HeartbeatTTL)
+	require.Equal(t, 90*time.Second, cfg.ControlPlane.AssignmentTTL)
+	require.Equal(t, 2*time.Minute, cfg.ControlPlane.HandoffTTL)
+	require.True(t, cfg.ControlPlane.EnableTwoPhaseHandoff)
+
+	require.NotNil(t, cfg.PartitionSource)
+	require.Equal(t, "parti-partitions", cfg.PartitionSource.Bucket)
+	require.Equal(t, "partitions/v1", cfg.PartitionSource.Key)
+	require.Equal(t, 3, cfg.PartitionSource.Replicas)
+	require.Equal(t, "file", cfg.PartitionSource.Storage)
+	require.Equal(t, uint8(1), cfg.PartitionSource.History)
+	require.Equal(t, int32(1048576), cfg.PartitionSource.MaxValueSize)
+	require.Equal(t, 7*time.Minute, cfg.PartitionSource.TTL)
+
+	require.Len(t, cfg.DynamicConsumers, 1)
+	dc := cfg.DynamicConsumers[0]
+	require.Equal(t, "orders", dc.StreamName)
+	require.Equal(t, "ord-worker", dc.ConsumerPrefix)
+	require.Equal(t, "orders.{partition_id}.>", dc.SubjectTemplate)
+	require.Equal(t, "./partitions.yaml", dc.PartitionsRef)
+}
+
+// TestValidate_MinimalYAMLFixture covers the minimal example from the plan
+// (control-plane block with only the three required TTLs; bucket names
+// defaulted) — must pass validation after defaulting.
+func TestValidate_MinimalYAMLFixture(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile(filepath.Join("testdata", "minimal.yaml"))
+	require.NoError(t, err)
+
+	var cfg provision.Config
+	require.NoError(t, yaml.Unmarshal(raw, &cfg))
+	require.NoError(t, provision.Validate(cfg))
+
+	// Bucket names should still be the empty strings as written
+	// (Validate does not mutate the caller); defaults appear only on the
+	// internal copy.
+	require.Equal(t, "", cfg.ControlPlane.StableIDBucket)
+}
+
+// validPartitionSource returns a fully-specified PartitionSourceConfig that
+// passes Validate. Tests mutate copies of this.
+func validPartitionSource() *provision.PartitionSourceConfig {
+	return &provision.PartitionSourceConfig{
+		Bucket:       "parti-partitions",
+		Key:          "partitions/v1",
+		Storage:      "file",
+		History:      1,
+		Replicas:     1,
+		MaxValueSize: 1048576,
+		TTL:          0,
+	}
+}
+
+func TestValidate_PartitionSource_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mutate    func(*provision.PartitionSourceConfig)
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid_full_config",
+			mutate:  func(*provision.PartitionSourceConfig) {},
+			wantErr: false,
+		},
+		{
+			name: "empty_bucket_rejected",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Bucket = ""
+			},
+			wantErr:   true,
+			errSubstr: "partitionSource.bucket",
+		},
+		{
+			name: "empty_key_rejected",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Key = ""
+			},
+			wantErr:   true,
+			errSubstr: "partitionSource.key",
+		},
+		{
+			name: "invalid_storage_rejected",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Storage = "disk"
+			},
+			wantErr:   true,
+			errSubstr: "partitionSource.storage",
+		},
+		{
+			name: "storage_file_accepted",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Storage = "file"
+			},
+			wantErr: false,
+		},
+		{
+			name: "storage_memory_accepted",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Storage = "memory"
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative_replicas_rejected",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Replicas = -1
+			},
+			wantErr:   true,
+			errSubstr: "partitionSource.replicas",
+		},
+		{
+			name: "zero_replicas_accepted",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.Replicas = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative_max_value_size_rejected",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.MaxValueSize = -1
+			},
+			wantErr:   true,
+			errSubstr: "partitionSource.maxValueSize",
+		},
+		{
+			name: "zero_max_value_size_accepted",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.MaxValueSize = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative_ttl_rejected",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.TTL = -1
+			},
+			wantErr:   true,
+			errSubstr: "partitionSource.ttl",
+		},
+		{
+			name: "zero_ttl_accepted",
+			mutate: func(ps *provision.PartitionSourceConfig) {
+				ps.TTL = 0
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ps := validPartitionSource()
+			tc.mutate(ps)
+			cfg := provision.Config{
+				APIVersion:      provision.APIVersionV1,
+				PartitionSource: ps,
+			}
+			err := provision.Validate(cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, provision.ErrInvalidConfig)
+				if tc.errSubstr != "" {
+					require.Contains(t, err.Error(), tc.errSubstr)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestApplyDefaults_PartitionSource verifies that normalize() applies the
+// storage and history defaults and that the caller's struct is not mutated.
+func TestApplyDefaults_PartitionSource(t *testing.T) {
+	t.Parallel()
+
+	ps := &provision.PartitionSourceConfig{
+		Bucket: "parti-partitions",
+		Key:    "partitions/v1",
+		// Storage and History intentionally zero to trigger defaults.
+	}
+	cfg := provision.Config{
+		APIVersion:      provision.APIVersionV1,
+		PartitionSource: ps,
+	}
+
+	got, err := provision.ApplyDefaults(cfg)
+	require.NoError(t, err)
+
+	// Defaults applied on the copy.
+	require.Equal(t, "file", got.PartitionSource.Storage)
+	require.Equal(t, uint8(1), got.PartitionSource.History)
+
+	// Caller's struct must not be mutated.
+	require.Equal(t, "", ps.Storage, "caller struct must not be mutated")
+	require.Equal(t, uint8(0), ps.History, "caller struct must not be mutated")
+}

--- a/provision/version.go
+++ b/provision/version.go
@@ -1,0 +1,18 @@
+package provision
+
+// APIVersionV1 is the only input-config schema accepted by v1 of the
+// provision SDK. YAML/JSON callers must set `apiVersion: parti.io/v1` on
+// the top-level Config.
+const APIVersionV1 = "parti.io/v1"
+
+// APIVersionProvisionV1 is the schema string stamped on every JSON output
+// envelope (Snapshot, Plan, Report). The "/provision/" segment distinguishes
+// output schema from input config schema.
+const APIVersionProvisionV1 = "parti.io/provision/v1"
+
+// Output envelope Kind values.
+const (
+	KindSnapshot = "Snapshot"
+	KindPlan     = "Plan"
+	KindReport   = "Report"
+)

--- a/provision/view.go
+++ b/provision/view.go
@@ -1,0 +1,172 @@
+package provision
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// kvStreamPrefix is the prefix JetStream stamps on every KV-bucket stream.
+const kvStreamPrefix = "KV_"
+
+// View returns a Snapshot of every Parti-marked NATS resource visible to js,
+// filtered by scope.
+//
+// In v1 the implementation walks $JS.API.STREAM.LIST (via jetstream.ListStreams)
+// once, filters for KV streams (Name starts with "KV_"), and reads
+// stream.Config.Metadata to decide which buckets are Parti-managed. Unmarked
+// buckets are excluded from default View output.
+//
+// Cancellation: ctx cancellation returns a zero-value Snapshot plus ctx.Err().
+func View(ctx context.Context, js jetstream.JetStream, scope Scope) (Snapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return Snapshot{}, err
+	}
+
+	snap := Snapshot{
+		APIVersion:       APIVersionProvisionV1,
+		Kind:             KindSnapshot,
+		ObservedAt:       time.Now().UTC(),
+		ControlPlane:     []KVBucketState{},
+		PartitionSource:  []KVBucketState{},
+		DynamicConsumers: []ConsumerState{},
+	}
+
+	// Short-circuit: nothing to do if no KV kinds are requested. (The
+	// W1 scope never has DynamicConsumers populated; that lands in W4.)
+	if !scope.ControlPlane && !scope.PartitionSource {
+		return snap, nil
+	}
+
+	lister := js.ListStreams(ctx)
+	for info := range lister.Info() {
+		if err := ctx.Err(); err != nil {
+			return Snapshot{}, err
+		}
+		if info == nil {
+			continue
+		}
+		state, ok := kvBucketStateFromStreamInfo(info)
+		if !ok {
+			continue
+		}
+		// Default View filter: skip resources without a Parti marker.
+		if state.Managed == "" {
+			continue
+		}
+		// Instance filter: when set, drop entries with a mismatching
+		// (or absent) instance value.
+		if scope.Instance != "" && state.Instance != scope.Instance {
+			continue
+		}
+
+		// Categorize by component value. Known control-plane components
+		// and unknown forward-compat values both surface under
+		// ControlPlane (operators don't lose visibility of new
+		// components). PartitionSource has its own slot. Anything else
+		// (dynamic-consumer, future categories) is dropped in W1 and
+		// will land in its own switch case in W4.
+		switch state.Component {
+		case ComponentPartitionSource:
+			if scope.PartitionSource {
+				snap.PartitionSource = append(snap.PartitionSource, state)
+			}
+		case ComponentControlPlaneID,
+			ComponentControlPlaneElection,
+			ComponentControlPlaneHeartbeat,
+			ComponentControlPlaneAssignment,
+			ComponentControlPlaneHandoff,
+			ComponentUnknown:
+			if scope.ControlPlane {
+				snap.ControlPlane = append(snap.ControlPlane, state)
+			}
+		}
+	}
+	if err := lister.Err(); err != nil {
+		// Distinguish ctx cancellation (handled at top) from server-side
+		// errors. The latter we propagate to the caller.
+		if ctx.Err() != nil {
+			return Snapshot{}, ctx.Err()
+		}
+		return Snapshot{}, err
+	}
+
+	sortBucketStates(snap.ControlPlane)
+	sortBucketStates(snap.PartitionSource)
+
+	return snap, nil
+}
+
+// kvBucketStateFromStreamInfo decodes a *jetstream.StreamInfo into a
+// KVBucketState if the underlying stream is a KV bucket (its Name starts with
+// "KV_"). Returns (state, false) for non-KV streams.
+func kvBucketStateFromStreamInfo(info *jetstream.StreamInfo) (KVBucketState, bool) {
+	name := info.Config.Name
+	if !strings.HasPrefix(name, kvStreamPrefix) {
+		return KVBucketState{}, false
+	}
+	bucket := strings.TrimPrefix(name, kvStreamPrefix)
+	marker := ParseMarker(info.Config.Metadata)
+
+	// Normalize MaxMsgSize: NATS stores "no limit" as -1 at the stream
+	// level, but provision convention (and Plan's drift classifier) use 0
+	// for "no limit". Surfacing -1 here would create an asymmetry between
+	// what View reports and what Plan classifies as drift-free.
+	maxValueSize := info.Config.MaxMsgSize
+	if maxValueSize == -1 {
+		maxValueSize = 0
+	}
+
+	state := KVBucketState{
+		Bucket:       bucket,
+		Managed:      marker.Managed,
+		Component:    marker.ClassifyComponent(),
+		Instance:     marker.Instance,
+		History:      uint8MaxClamp(info.Config.MaxMsgsPerSubject),
+		Storage:      storageName(info.Config.Storage),
+		TTL:          info.Config.MaxAge,
+		Replicas:     info.Config.Replicas,
+		MaxBytes:     info.Config.MaxBytes,
+		MaxValueSize: maxValueSize,
+	}
+
+	return state, true
+}
+
+// uint8MaxClamp converts a JetStream history-equivalent int64 to a uint8.
+// nats.go stores KV "History" via MaxMsgsPerSubject (always 1..64 for KV);
+// values outside that window indicate the stream was not created by nats.go
+// as a KV bucket, but we still want a sensible report.
+func uint8MaxClamp(v int64) uint8 {
+	if v <= 0 {
+		return 0
+	}
+	if v > 255 {
+		return 255
+	}
+	return uint8(v)
+}
+
+func storageName(s jetstream.StorageType) string {
+	switch s {
+	case jetstream.FileStorage:
+		return "file"
+	case jetstream.MemoryStorage:
+		return "memory"
+	default:
+		return ""
+	}
+}
+
+func sortBucketStates(s []KVBucketState) {
+	slices.SortStableFunc(s, func(a, b KVBucketState) int {
+		if c := stringsCmp(a.Component, b.Component); c != 0 {
+			return c
+		}
+
+		return stringsCmp(a.Bucket, b.Bucket)
+	})
+}

--- a/provision/view_integration_test.go
+++ b/provision/view_integration_test.go
@@ -1,0 +1,160 @@
+package provision_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// newJS returns a jetstream.JetStream attached to a fresh embedded NATS
+// server. Cleanup is registered via t.Cleanup automatically by partitest.
+func newJS(t *testing.T) jetstream.JetStream {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	return js
+}
+
+func createKV(t *testing.T, js jetstream.JetStream, cfg jetstream.KeyValueConfig) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := js.CreateKeyValue(ctx, cfg)
+	require.NoError(t, err)
+}
+
+func TestView_EmptyServer_ReturnsEmptySnapshot(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	snap, err := provision.View(ctx, js, provision.ScopeAll())
+	require.NoError(t, err)
+	require.Equal(t, provision.APIVersionProvisionV1, snap.APIVersion)
+	require.Equal(t, provision.KindSnapshot, snap.Kind)
+	require.Empty(t, snap.ControlPlane)
+	require.Empty(t, snap.PartitionSource)
+}
+
+func TestView_MixedMarkedAndUnmarked_OnlyMarkedReturned(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Marked bucket: stamped with Parti marker, control-plane:election.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "marked-election",
+		History:  1,
+		Storage:  jetstream.MemoryStorage,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, ""),
+	})
+	// Unmarked bucket: no Parti metadata at all.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "external-bucket",
+		History: 1,
+		Storage: jetstream.MemoryStorage,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	snap, err := provision.View(ctx, js, provision.ScopeAll())
+	require.NoError(t, err)
+	require.Len(t, snap.ControlPlane, 1)
+	require.Equal(t, "marked-election", snap.ControlPlane[0].Bucket)
+	require.Equal(t, provision.ComponentControlPlaneElection, snap.ControlPlane[0].Component)
+}
+
+func TestView_InstanceFilter_OnlyMatchingInstance(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "prod-election",
+		History:  1,
+		Storage:  jetstream.MemoryStorage,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, "prod"),
+	})
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "stage-election",
+		History:  1,
+		Storage:  jetstream.MemoryStorage,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, "stage"),
+	})
+	// Marked without instance.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "shared-election",
+		History:  1,
+		Storage:  jetstream.MemoryStorage,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, ""),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	scope := provision.ScopeAll()
+	scope.Instance = "prod"
+	snap, err := provision.View(ctx, js, scope)
+	require.NoError(t, err)
+	require.Len(t, snap.ControlPlane, 1)
+	require.Equal(t, "prod-election", snap.ControlPlane[0].Bucket)
+	require.Equal(t, "prod", snap.ControlPlane[0].Instance)
+}
+
+func TestView_InventoryMode_IncludesAllInstances(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "prod-election",
+		History:  1,
+		Storage:  jetstream.MemoryStorage,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, "prod"),
+	})
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "stage-election",
+		History:  1,
+		Storage:  jetstream.MemoryStorage,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, "stage"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	snap, err := provision.View(ctx, js, provision.ScopeAll())
+	require.NoError(t, err)
+	require.Len(t, snap.ControlPlane, 2)
+}
+
+func TestView_PartitionSourceCategory(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  1,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, ""),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	snap, err := provision.View(ctx, js, provision.ScopeAll())
+	require.NoError(t, err)
+	require.Empty(t, snap.ControlPlane)
+	require.Len(t, snap.PartitionSource, 1)
+	require.Equal(t, "parti-partitions", snap.PartitionSource[0].Bucket)
+}
+
+func TestView_CancelledContext(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	snap, err := provision.View(ctx, js, provision.ScopeAll())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, snap)
+}

--- a/test/integration/provision/provision_e2e_test.go
+++ b/test/integration/provision/provision_e2e_test.go
@@ -1,0 +1,317 @@
+package provision_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/kvbuckets"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// makeE2EConfig returns a pair of configs that share bucket names and TTL
+// values. parti.Config is built first (from IntegrationTestConfig defaults
+// with per-test suffixed bucket names); provision.Config is derived from it
+// so both configs are driven by a single source of truth.
+//
+// HandoffTTL is 30s to satisfy the provision validator's "HandoffTTL > 0 when
+// EnableTwoPhaseHandoff" constraint while staying within the test budget.
+func makeE2EConfig(t *testing.T, suffix string) (provision.Config, parti.Config) {
+	t.Helper()
+
+	// Build the runtime config first.
+	partiCfg := testutil.IntegrationTestConfig()
+	partiCfg.WorkerIDPrefix = "e2e-smoke-" + suffix
+	partiCfg.EnableTwoPhaseHandoff = true
+	partiCfg.KVBuckets.StableIDBucket = "parti-stableid-" + suffix
+	partiCfg.KVBuckets.ElectionBucket = "parti-election-" + suffix
+	partiCfg.KVBuckets.HeartbeatBucket = "parti-heartbeat-" + suffix
+	partiCfg.KVBuckets.AssignmentBucket = "parti-assignment-" + suffix
+	partiCfg.KVBuckets.HandoffBucket = "parti-handoff-" + suffix
+	partiCfg.KVBuckets.HandoffTTL = 30 * time.Second
+
+	// Derive the provision config from the runtime config so all TTLs and
+	// bucket names stay in sync.
+	provCfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "e2e-smoke-" + suffix,
+		Policy:     provision.PolicyWarn,
+		ControlPlane: &provision.ControlPlaneConfig{
+			StableIDBucket:        partiCfg.KVBuckets.StableIDBucket,
+			ElectionBucket:        partiCfg.KVBuckets.ElectionBucket,
+			HeartbeatBucket:       partiCfg.KVBuckets.HeartbeatBucket,
+			AssignmentBucket:      partiCfg.KVBuckets.AssignmentBucket,
+			HandoffBucket:         partiCfg.KVBuckets.HandoffBucket,
+			WorkerIDTTL:           partiCfg.WorkerIDTTL,
+			ElectionTimeout:       partiCfg.ElectionTimeout,
+			HeartbeatTTL:          partiCfg.HeartbeatTTL,
+			AssignmentTTL:         partiCfg.KVBuckets.AssignmentTTL,
+			HandoffTTL:            partiCfg.KVBuckets.HandoffTTL,
+			EnableTwoPhaseHandoff: true,
+		},
+	}
+
+	return provCfg, partiCfg
+}
+
+// expectedBuckets returns the sorted bucket names for the control-plane when
+// EnableTwoPhaseHandoff is true (5 total).
+func expectedBuckets(suffix string) []string {
+	return []string{
+		"parti-assignment-" + suffix,
+		"parti-election-" + suffix,
+		"parti-handoff-" + suffix,
+		"parti-heartbeat-" + suffix,
+		"parti-stableid-" + suffix,
+	}
+}
+
+// TestProvisionApply_ManagerStartsCleanly is the golden path: after
+// provision.Apply creates the control-plane KV buckets, a real parti.Manager
+// must reach StateStable without errors. This proves that the byte-equivalence
+// between provision's bucket configs and Manager's ensureKVBucket is
+// operationally meaningful.
+func TestProvisionApply_ManagerStartsCleanly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	const suffix = "clean"
+	provCfg, partiCfg := makeE2EConfig(t, suffix)
+	buckets := expectedBuckets(suffix)
+
+	// Step 1: Apply provisions all 5 control-plane buckets.
+	rep, err := provision.Apply(ctx, js, provCfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Empty(t, rep.Skipped)
+	require.Len(t, rep.Executed, len(buckets),
+		"expected exactly %d create-kv actions (one per control-plane bucket)", len(buckets))
+	for _, ex := range rep.Executed {
+		require.Equal(t, provision.ActionCreateKV, ex.Kind)
+		require.False(t, ex.Raced, "no races on empty server")
+	}
+
+	// Step 2: Verify each bucket exists with the correct Parti marker.
+	instance := "e2e-smoke-" + suffix
+	for _, bucket := range buckets {
+		stream, serr := js.Stream(ctx, "KV_"+bucket)
+		require.NoError(t, serr, "bucket KV_%s must exist after Apply", bucket)
+		info, ierr := stream.Info(ctx)
+		require.NoError(t, ierr)
+
+		marker := provision.ParseMarker(info.Config.Metadata)
+		require.Equal(t, provision.MarkerManagedValue, marker.Managed,
+			"bucket %s must carry parti.io/managed=v1", bucket)
+		require.Equal(t, instance, marker.Instance,
+			"bucket %s must carry parti.io/instance=%s", bucket, instance)
+		require.NotEmpty(t, marker.Component,
+			"bucket %s must carry parti.io/component", bucket)
+	}
+
+	// Step 3: Start Manager against the provisioned buckets.
+	src := source.NewStatic(testutil.CreateTestPartitions(3))
+	assignStrat := strategy.NewConsistentHash()
+
+	mgr, err := parti.NewManager(&partiCfg, js, src, assignStrat)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Start(ctx),
+		"Manager must start cleanly against provision-created buckets (byte-equivalence check)")
+	require.Equal(t, parti.StateStable, mgr.State())
+
+	// Step 4: Clean shutdown.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, mgr.Stop(stopCtx))
+	require.Equal(t, parti.StateShutdown, mgr.State())
+}
+
+// TestProvisionApply_IdempotentAfterManagerStart verifies that re-running
+// provision.Plan (and Apply) after Manager has been running produces zero new
+// mutations and no spurious drift findings. The Manager's presence must not
+// modify bucket configs in any way detectable by the provision scanner.
+func TestProvisionApply_IdempotentAfterManagerStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	const suffix = "idempotent"
+	provCfg, partiCfg := makeE2EConfig(t, suffix)
+
+	// Step 1: Apply once on empty server.
+	rep, err := provision.Apply(ctx, js, provCfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+	require.Len(t, rep.Executed, len(expectedBuckets(suffix)))
+
+	// Step 2: Start Manager and wait for it to reach StateStable.
+	src := source.NewStatic(testutil.CreateTestPartitions(3))
+	assignStrat := strategy.NewConsistentHash()
+
+	mgr, err := parti.NewManager(&partiCfg, js, src, assignStrat)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Start(ctx))
+	require.Equal(t, parti.StateStable, mgr.State())
+
+	// Step 3: Re-run Plan with Manager running. All buckets exist and
+	// match. Expect zero create-kv actions and no drift-mutable or
+	// drift-immutable findings (only informational is allowed).
+	planResult, err := provision.Plan(ctx, js, provCfg)
+	require.NoError(t, err)
+	require.Empty(t, planResult.Actions,
+		"second Plan must produce zero create-kv actions (all buckets exist)")
+	for _, finding := range planResult.Drift {
+		require.NotEqual(t, provision.SeverityDriftMutable, finding.Severity,
+			"unexpected drift-mutable finding for bucket %q after Manager start", finding.Name)
+		require.NotEqual(t, provision.SeverityDriftImmutable, finding.Severity,
+			"unexpected drift-immutable finding for bucket %q after Manager start", finding.Name)
+	}
+
+	// Step 4: Apply again with Manager running. Zero executed, no errors.
+	rep2, err := provision.Apply(ctx, js, provCfg)
+	require.NoError(t, err)
+	require.Empty(t, rep2.Executed, "second Apply must execute nothing")
+	require.Empty(t, rep2.Errors)
+	require.Empty(t, rep2.Skipped)
+	require.False(t, rep2.Aborted)
+
+	// Cleanup.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, mgr.Stop(stopCtx))
+}
+
+// TestProvisionApply_AdoptsManuallyCreatedBuckets verifies the "operator's
+// manual setup" path. A bucket pre-created without the Parti marker is
+// reported as "adopted" drift and never mutated by Apply. Manager must still
+// reach StateStable when using a mix of provision-created and manually-created
+// buckets.
+func TestProvisionApply_AdoptsManuallyCreatedBuckets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	const suffix = "adopted"
+	provCfg, partiCfg := makeE2EConfig(t, suffix)
+
+	// Step 1: Manually pre-create the StableID bucket WITHOUT a Parti
+	// marker. Use the same config the provision builder would produce
+	// (same Storage, History=1, TTL) so there is no field drift — only
+	// the marker is absent.
+	stableIDBucket := partiCfg.KVBuckets.StableIDBucket
+	manualCfg := kvbuckets.BuildKeyValueConfig(
+		stableIDBucket,
+		partiCfg.WorkerIDTTL,
+		jetstream.FileStorage,
+	)
+	// Intentionally NO Metadata — this is what makes it "manually created".
+	_, err = js.CreateKeyValue(ctx, manualCfg)
+	require.NoError(t, err, "pre-create %s without marker", stableIDBucket)
+
+	// Step 2: Plan — the pre-created bucket must appear as "adopted" drift
+	// with NO create-kv action for it. Other buckets appear as create-kv.
+	planResult, err := provision.Plan(ctx, js, provCfg)
+	require.NoError(t, err)
+
+	allBuckets := expectedBuckets(suffix)
+	// Exactly (N-1) create-kv actions: all buckets except the pre-created one.
+	require.Len(t, planResult.Actions, len(allBuckets)-1,
+		"Plan must emit create-kv for all buckets except the pre-created one")
+	for _, action := range planResult.Actions {
+		require.NotEqual(t, stableIDBucket, action.Name,
+			"Plan must NOT emit create-kv for the pre-created (adopted) bucket")
+	}
+
+	// The pre-created bucket must appear as SeverityAdopted drift.
+	var adoptedFound bool
+	for _, finding := range planResult.Drift {
+		if finding.Name == stableIDBucket {
+			require.Equal(t, provision.SeverityAdopted, finding.Severity,
+				"pre-created bucket %q must be reported as adopted, not %s",
+				stableIDBucket, finding.Severity)
+			adoptedFound = true
+		}
+	}
+	require.True(t, adoptedFound, "Plan must contain an adopted finding for %q", stableIDBucket)
+
+	// Step 3: Apply — only the non-pre-created buckets are created; the
+	// adopted bucket is NOT touched.
+	rep, err := provision.Apply(ctx, js, provCfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+	require.Len(t, rep.Executed, len(allBuckets)-1,
+		"Apply must create all buckets except the pre-created (adopted) one")
+	for _, ex := range rep.Executed {
+		require.NotEqual(t, stableIDBucket, ex.Name,
+			"Apply must NOT execute a create-kv for the adopted bucket")
+	}
+
+	// Step 4: Load-bearing invariant — the adopted bucket's metadata must
+	// still be empty (no marker added by Apply).
+	adoptedStream, serr := js.Stream(ctx, "KV_"+stableIDBucket)
+	require.NoError(t, serr)
+	adoptedInfo, ierr := adoptedStream.Info(ctx)
+	require.NoError(t, ierr)
+	require.False(t, provision.ParseMarker(adoptedInfo.Config.Metadata).IsManaged(),
+		"Apply must never add the Parti marker to an adopted (pre-existing) bucket")
+
+	// Step 5: Start Manager — must reach StateStable using a mix of
+	// provision-created and manually-created buckets.
+	src := source.NewStatic(testutil.CreateTestPartitions(3))
+	assignStrat := strategy.NewConsistentHash()
+
+	mgr, err := parti.NewManager(&partiCfg, js, src, assignStrat)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Start(ctx),
+		"Manager must start cleanly with one manually-created bucket (no marker)")
+	require.Equal(t, parti.StateStable, mgr.State())
+
+	// Cleanup.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, mgr.Stop(stopCtx))
+}

--- a/types/metrics_collector.go
+++ b/types/metrics_collector.go
@@ -96,6 +96,19 @@ type AuditMetrics interface {
 	// worker-side stale-leader fence (§4.5).
 	RecordStaleLeaderRejected()
 
+	// RecordStaleSnapshotStoreDropped counts assignment candidates dropped
+	// by the pre-Apply / refresh stale-snapshot gate (W15+W16, PR-2). A
+	// nonzero counter indicates concurrent apply paths racing for the
+	// same worker; small numbers are expected under churn (rolling
+	// upgrade, leader handoff).
+	//
+	// Semantics: this counter increments BEFORE handoffCoordinator.Apply
+	// runs (for applyAssignmentWithPrev's pre-Apply gate) or BEFORE the
+	// snapshot Store (for refreshAssignmentFromNATS via monotonicStore).
+	// It does NOT fire on Apply errors — those route through
+	// scheduleApplyRetry without firing this counter.
+	RecordStaleSnapshotStoreDropped()
+
 	// RecordCommitPayloadMissing counts case (c) commits where the worker
 	// appears in Workers but Payloads[worker] is missing.
 	RecordCommitPayloadMissing()


### PR DESCRIPTION
## Summary

Adds the `provision/` SDK and `cmd/partictl` CLI so operators can manage the NATS resources Parti depends on from declarative YAML config — view live state, validate config, plan drift, and apply missing resources. Replaces ad-hoc NATS CLI commands plus runtime startup error chasing with a single validated plan/apply loop.

This is the v1 launch from `docs/plans/provision-sdk-cli/00-implementation-plan.md` (cleared four codex review rounds plus a precision pass before implementation began). Phases 2–7 (safe-update, adopt, partition records, streams, dynamic precreation, force/repair, K8s controller) land in their own design plans.

## What lands

- **`provision/`** — public SDK
  - `Config` (`apiVersion: parti.io/v1`) with `ControlPlaneConfig`, `PartitionSourceConfig`, `DynamicConsumerCfg` blocks. Static `Validate` + `ApplyDefaults` mirror runtime `parti.KVBucketConfig` defaults.
  - `View` (read-only inventory of Parti-marker-stamped resources, optional `-instance` filter)
  - `Plan` (deterministic `create-kv` actions + drift findings, sorted by `(Kind, Name)`)
  - `Apply` (Validate → ValidateLive → Plan → `js.CreateKeyValue`, fail-fast on non-cancellation errors, mid-cancel produces partial Report with `Aborted=true`, race-tolerant via `ExecutedAction.Raced`)
  - `ValidateLive` with reachability probe, per-bucket info probe, and AllowDirect-aware partition-source key probe (single retry on permission failure, refreshes `stream.Info` between attempts)
  - `PlanDynamicConsumers` + `ValidateLiveDynamicConsumers` (alignment-check, no precreation in v1)
  - Ownership marker (`parti.io/managed=v1` + `parti.io/component` + `parti.io/instance`) in `Metadata`; never authorizes mutation, only classifies drift
  - JSON envelopes: every output carries `apiVersion: parti.io/provision/v1` + `kind`
- **`cmd/partictl/`** — standard-library CLI on top of the SDK
  - Commands: `view`, `validate [-live]`, `plan`, `apply [-dry-run]`
  - `flag.FlagSet` only (no CLI framework added)
  - Exit codes per the plan's precedence: parse → static → NATS connect → live → runtime → drift. NATS permission errors (`ErrPermissionViolation`, `ErrNoResponders`, `ErrJetStreamNotEnabled`) map to exit 3.
  - `apply -dry-run --json` is byte-identical to `plan --json` (asserted with `bytes.Equal`)
- **`internal/kvbuckets/`** — shared `BuildKeyValueConfig` builder, byte-equivalent to the historical `manager_setup.go:ensureKVBucket` literal. Re-exported as `parti.BuildControlPlaneKVConfig`.
- **`internal/dynamicbuild/`** — pure builder for per-subject `ConsumerConfig`, durable name, subject template. Both literal sites in `internal/durable/worker_consumer.go` (canonical + recovery metadata) now call the shared helper.
- **`consumer/CheckWorkQueueRecoveryCompat`** exported so `provision.ValidateLiveDynamicConsumers` can reuse the same check `consumer.Dynamic.Update` performs.

## Invariants pinned by tests

- **Byte equivalence** between provisioned and runtime-created control-plane buckets — `provision/plan_integration_test.go` strips `Metadata` from a planned `KeyValueConfig` and runs `reflect.DeepEqual` against `kvbuckets.BuildKeyValueConfig(...)`.
- **Marker is informational, not authoritative** — `provision.Plan` looks up resources by exact NATS name first; marker only affects drift classification (`adopted` for unmarked, `informational`/`drift-mutable`/`drift-immutable` for marked). Regression-tested.
- **Dynamic-consumer 5-field subset equality** — runtime roundtrip test feeds identical inputs through `consumer.Dynamic` (post-`SetDefaults`) and `PlanDynamicConsumers`, asserts `Name`, `Durable`, `FilterSubject`, `AckPolicy=AckExplicit`, `DeliverPolicy=DeliverAll`. Out-of-scope tunables intentionally not asserted.
- **End-to-end smoke** under `test/integration/provision/`: Apply → start `parti.Manager` → reach `StateStable` → Stop. Proves byte-equivalence is operationally meaningful, not just unit-test theater. Includes idempotency-after-Manager-start and adopt-without-mutation paths.

## v1 scope

Single `ReconcilePolicy: warn` (create missing, never mutate existing). `safe-update` and `force` are statically rejected.

Out of scope (deferred to future phases per the plan):
- `controlPlane.replicas` — Phase 2
- Partition record writes — Phase 3
- Application JetStream streams — Phase 4
- Dynamic consumer precreation — Phase 5
- `force` / delete-recreate — Phase 6
- Kubernetes controller — Phase 7

## Known follow-ups (filed as v1.x tickets, not blocking this PR)

1. `partitest.StartEmbeddedNATSWithAuth` + W2 sub-spec §4 permission-denied integration tests (currently mitigated by exhaustive unit-level classifier coverage in `validate_live_unit_test.go` and `exitcodes_test.go`).
2. NATS cluster (3-node) provision tests for `Replicas=0→1` normalization.
3. `Replicas > 1` adopted-drift specific scenario.
4. `partictl` text-output golden file fixtures (current text tests are substring-based; JSON tests are golden).
5. CLI "no changes applied" empty-state branch coverage.
6. Combined AllowDirect-flip + permission-denied integration scenario.
7. Partition-source bucket end-to-end with `source.NewNatsKV` (deferred from this PR's smoke test).

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./internal/kvbuckets/... ./internal/dynamicbuild/... ./consumer/... ./provision/... ./cmd/partictl/... ./test/integration/provision/... -race -count=1` — all pass
- [x] `go test ./internal/durable/... -race -count=1` — byte-equivalence in the extracted dynamicbuild helpers preserved; existing tests pass unchanged
- [x] Smoke: `go run ./cmd/partictl` prints usage and exits non-zero; `go run ./cmd/partictl validate -f provision/testdata/full.yaml` validates cleanly
- [ ] Reviewer: spot-check the CLI exit-code precedence table against the plan's "Exit code precedence" section (`docs/plans/provision-sdk-cli/00-implementation-plan.md`)
- [ ] Reviewer: scan `docs/plans/provision-sdk-cli/00-implementation-plan.md` "Non-Goals" and verify nothing in this PR violates them (especially "no partition record writes" — verified by grep: zero `kv.Put` calls in `provision/`)