### PR TITLE
feat(provision): add safe-update and adopt reconcile policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ checkpoints/
 /*.pprof
 
 /simulation
+/partictl
 failure_report.json
 DEADJOE

--- a/cmd/partictl/cmd_adopt.go
+++ b/cmd/partictl/cmd_adopt.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// adoptFlags holds flags specific to the adopt command.
+type adoptFlags struct {
+	common  commonFlags
+	file    string
+	dryRun  bool
+	jsonOut bool
+}
+
+// cmdAdopt is shorthand for "apply --policy=adopt [-dry-run]". With -dry-run it
+// emits the same PlanResult output as "plan --policy=adopt"; without it the
+// command performs a live Apply under PolicyAdopt.
+//
+// If cfg.policy in the YAML is non-empty and differs from "adopt" the conflict
+// check fires (exit 3). policy: "" or absent in YAML proceeds normally.
+func cmdAdopt(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("adopt", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var f adoptFlags
+	fs.StringVar(&f.file, "f", "", "YAML config path (required)")
+	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
+	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
+	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
+	fs.StringVar(&f.common.token, "token", "", "NATS token")
+	fs.StringVar(&f.common.timeout, "timeout", "30s", "operation timeout (e.g. 30s, 1m)")
+	fs.BoolVar(&f.dryRun, "dry-run", false, "plan only — emit the same output as plan --policy=adopt")
+	fs.BoolVar(&f.jsonOut, "json", false, "emit JSON output (PlanResult for -dry-run, Report otherwise)")
+
+	if err := fs.Parse(args); err != nil {
+		return ExitValidation
+	}
+
+	if f.file == "" {
+		fmt.Fprintln(stderr, "partictl adopt: -f is required")
+		fs.Usage()
+
+		return ExitValidation
+	}
+
+	return runReconcile(reconcileParams{
+		common:     f.common,
+		file:       f.file,
+		policyFlag: string(provision.PolicyAdopt),
+		subcmd:     "adopt",
+		dryRun:     f.dryRun,
+		jsonOut:    f.jsonOut,
+	}, stdout, stderr)
+}

--- a/cmd/partictl/cmd_apply.go
+++ b/cmd/partictl/cmd_apply.go
@@ -4,14 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
-
-	"github.com/arloliu/parti/v2/provision"
 )
 
 // applyFlags holds flags specific to the apply command.
 type applyFlags struct {
 	common      commonFlags
 	file        string
+	policy      string
 	dryRun      bool
 	jsonOut     bool
 	failOnDrift bool
@@ -23,6 +22,7 @@ func cmdApply(args []string, stdout, stderr io.Writer) int {
 
 	var f applyFlags
 	fs.StringVar(&f.file, "f", "", "YAML config path (required)")
+	fs.StringVar(&f.policy, "policy", "", "reconcile policy: warn, adopt, safe-update (default: warn or cfg.policy)")
 	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
 	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
 	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
@@ -36,11 +36,8 @@ func cmdApply(args []string, stdout, stderr io.Writer) int {
 		return ExitValidation
 	}
 
-	// Validate -timeout before any NATS connect so invalid values exit 3.
-	timeoutDur, err := parseTimeout(f.common.timeout)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-
+	// Reject unsupported --policy values before any I/O.
+	if !validatePolicyFlag(f.policy, "apply", stderr) {
 		return ExitValidation
 	}
 
@@ -51,85 +48,13 @@ func cmdApply(args []string, stdout, stderr io.Writer) int {
 		return ExitValidation
 	}
 
-	cfg, err := loadConfig(f.file)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-
-		return ExitValidation
-	}
-
-	// Static validation before any NATS connect.
-	if err := provision.Validate(cfg); err != nil {
-		fmt.Fprintln(stderr, err)
-
-		return ExitValidation
-	}
-
-	ctx, stop, exitIfTimeout := makeContext(timeoutDur, stderr)
-	defer stop()
-
-	conn, code, err := connectNATS(ctx, f.common)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		if exitIfTimeout(ctx) {
-			return ExitNATS
-		}
-
-		return code
-	}
-	defer conn.close()
-
-	// -dry-run: runs the same planning path as cmdPlan and emits identical output.
-	if f.dryRun {
-		planResult, err := provision.Plan(ctx, conn.js, cfg)
-		if err != nil {
-			if exitIfTimeout(ctx) {
-				return ExitNATS
-			}
-			fmt.Fprintln(stderr, "partictl apply -dry-run:", err)
-
-			return classifyError(err)
-		}
-
-		if f.jsonOut {
-			_ = jsonOutput(stdout, planResult)
-		} else {
-			renderPlanText(stdout, planResult)
-		}
-
-		if f.failOnDrift && hasDrift(planResult.Drift) {
-			return ExitDrift
-		}
-
-		return ExitOK
-	}
-
-	// Live apply.
-	report, err := provision.Apply(ctx, conn.js, cfg)
-	if err != nil {
-		if exitIfTimeout(ctx) {
-			if f.jsonOut {
-				_ = jsonOutput(stdout, report)
-			} else {
-				renderReportText(stdout, report)
-			}
-
-			return ExitNATS
-		}
-		if f.jsonOut {
-			_ = jsonOutput(stdout, report)
-		} else {
-			renderReportText(stdout, report)
-		}
-
-		return classifyError(err)
-	}
-
-	if f.jsonOut {
-		_ = jsonOutput(stdout, report)
-	} else {
-		renderReportText(stdout, report)
-	}
-
-	return ExitOK
+	return runReconcile(reconcileParams{
+		common:      f.common,
+		file:        f.file,
+		policyFlag:  f.policy,
+		subcmd:      "apply",
+		dryRun:      f.dryRun,
+		jsonOut:     f.jsonOut,
+		failOnDrift: f.failOnDrift,
+	}, stdout, stderr)
 }

--- a/cmd/partictl/cmd_plan.go
+++ b/cmd/partictl/cmd_plan.go
@@ -12,6 +12,7 @@ import (
 type planFlags struct {
 	common      commonFlags
 	file        string
+	policy      string
 	jsonOut     bool
 	failOnDrift bool
 }
@@ -22,6 +23,7 @@ func cmdPlan(args []string, stdout, stderr io.Writer) int {
 
 	var f planFlags
 	fs.StringVar(&f.file, "f", "", "YAML config path (required)")
+	fs.StringVar(&f.policy, "policy", "", "reconcile policy: warn, adopt, safe-update (default: warn or cfg.policy)")
 	fs.StringVar(&f.common.server, "server", defaultServer(), "NATS server URL")
 	fs.StringVar(&f.common.creds, "creds", "", "path to NATS credentials file")
 	fs.StringVar(&f.common.nkey, "nkey", "", "path to NATS nkey seed file")
@@ -31,6 +33,11 @@ func cmdPlan(args []string, stdout, stderr io.Writer) int {
 	fs.BoolVar(&f.failOnDrift, "fail-on-drift", false, "exit 2 if non-informational drift is detected")
 
 	if err := fs.Parse(args); err != nil {
+		return ExitValidation
+	}
+
+	// Reject unsupported --policy values before any I/O.
+	if !validatePolicyFlag(f.policy, "plan", stderr) {
 		return ExitValidation
 	}
 
@@ -53,6 +60,11 @@ func cmdPlan(args []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 
+		return ExitValidation
+	}
+
+	// Resolve flag vs YAML policy. policy: "" in YAML is treated as absent.
+	if !resolveAndStampPolicy(f.policy, "plan", f.file, &cfg, stderr) {
 		return ExitValidation
 	}
 
@@ -88,11 +100,7 @@ func cmdPlan(args []string, stdout, stderr io.Writer) int {
 		return classifyError(err)
 	}
 
-	if f.jsonOut {
-		_ = jsonOutput(stdout, planResult)
-	} else {
-		renderPlanText(stdout, planResult)
-	}
+	emitPlan(stdout, planResult, f.jsonOut)
 
 	if f.failOnDrift && hasDrift(planResult.Drift) {
 		return ExitDrift

--- a/cmd/partictl/doc.go
+++ b/cmd/partictl/doc.go
@@ -1,5 +1,5 @@
 // Package main is the cmd/partictl CLI for Parti environment provisioning.
 //
-// Commands: view, validate, plan, apply.
+// Commands: view, validate, plan, apply, adopt.
 // See partictl -help for full usage.
 package main

--- a/cmd/partictl/output.go
+++ b/cmd/partictl/output.go
@@ -108,6 +108,15 @@ func renderPlanText(w io.Writer, plan provision.PlanResult) {
 	}
 }
 
+// emitPlan writes plan to w as JSON or as the human-readable table.
+func emitPlan(w io.Writer, plan provision.PlanResult, jsonOut bool) {
+	if jsonOut {
+		_ = jsonOutput(w, plan)
+	} else {
+		renderPlanText(w, plan)
+	}
+}
+
 func fmtDriftDetail(detail map[string]any) string {
 	if len(detail) == 0 {
 		return ""
@@ -177,6 +186,15 @@ func renderReportText(w io.Writer, report provision.Report) {
 			fmt.Fprintf(tw, "  %s\t%s\t%s\n", e.Kind, e.Name, e.Error)
 		}
 		fmt.Fprintln(tw)
+	}
+}
+
+// emitReport writes report to w as JSON or as the human-readable table.
+func emitReport(w io.Writer, report provision.Report, jsonOut bool) {
+	if jsonOut {
+		_ = jsonOutput(w, report)
+	} else {
+		renderReportText(w, report)
 	}
 }
 

--- a/cmd/partictl/policy.go
+++ b/cmd/partictl/policy.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// policyForce is the reserved-but-unsupported policy value. It has no
+// provision.ReconcilePolicy constant because the SDK keeps it internal;
+// the CLI rejects it at flag-parse time with a clear message.
+const policyForce = "force"
+
+// resolveAndStampPolicy resolves the --policy flag against the YAML policy in
+// cfg, stamps the effective value onto cfg.Policy, and reports whether to
+// proceed. cfg.Policy is read (as the raw YAML value) before it is
+// overwritten. On a flag-vs-config conflict it writes the error to w and
+// returns false.
+func resolveAndStampPolicy(flagVal, subcmd, file string, cfg *provision.Config, w io.Writer) bool {
+	effective, ok := resolvePolicy(flagVal, cfg.Policy, subcmd, file, w)
+	if !ok {
+		return false
+	}
+	cfg.Policy = effective
+
+	return true
+}
+
+// resolvePolicy applies the flag-vs-config conflict-resolution rules:
+//
+//	flag absent + YAML absent  → warn
+//	flag absent + YAML X       → X
+//	flag X      + YAML absent  → X
+//	flag X      + YAML X       → X
+//	flag X      + YAML Y       → exit 3 with conflict message
+//
+// flagVal is the raw string from --policy ("" when the flag was not supplied).
+// rawCfgPolicy is cfg.Policy as unmarshalled from YAML, before provision.Validate
+// defaults it ("" when the YAML omits or explicitly sets policy: "").
+// subcmd is the command name used in the error message ("apply", "plan", "adopt").
+// file is the YAML file path used in the error message.
+//
+// Returns (effective, true) on success; ("", false) on conflict (the error has
+// already been written to w).
+func resolvePolicy(flagVal string, rawCfgPolicy provision.ReconcilePolicy, subcmd, file string, w io.Writer) (provision.ReconcilePolicy, bool) {
+	yamlAbsent := rawCfgPolicy == ""
+	flagAbsent := flagVal == ""
+
+	switch {
+	case flagAbsent && yamlAbsent:
+		return provision.PolicyWarn, true
+	case flagAbsent && !yamlAbsent:
+		return rawCfgPolicy, true
+	case !flagAbsent && yamlAbsent:
+		return provision.ReconcilePolicy(flagVal), true
+	default:
+		// Both flag and YAML are present (the two yamlAbsent cases above
+		// cover the empty string), so rawCfgPolicy is non-empty here.
+		if flagVal == string(rawCfgPolicy) {
+			return provision.ReconcilePolicy(flagVal), true
+		}
+		fmt.Fprintf(w, "partictl %s: --policy=%s conflicts with cfg.policy=%s in %s. Pick one or remove the cfg.policy field.\n",
+			subcmd, flagVal, rawCfgPolicy, file)
+
+		return "", false
+	}
+}
+
+// validatePolicyFlag checks that the --policy flag value is one of the accepted
+// values. "force" is rejected at flag-parse time (not via provision.Validate)
+// so it gets the right message. Returns true when valid.
+func validatePolicyFlag(flagVal string, subcmd string, w io.Writer) bool {
+	if flagVal == "" {
+		return true
+	}
+	switch flagVal {
+	case string(provision.PolicyWarn), string(provision.PolicyAdopt), string(provision.PolicySafeUpdate):
+		return true
+	case policyForce:
+		fmt.Fprintf(w, "partictl %s: --policy=force is not yet supported\n", subcmd)
+		return false
+	default:
+		fmt.Fprintf(w, "partictl %s: --policy=%q is not recognized (accepted: warn, adopt, safe-update)\n", subcmd, flagVal)
+		return false
+	}
+}

--- a/cmd/partictl/policy_test.go
+++ b/cmd/partictl/policy_test.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// --- resolvePolicy unit tests ---
+
+func TestResolvePolicy_BothAbsent(t *testing.T) {
+	t.Parallel()
+	got, ok := resolvePolicy("", "", "apply", "cfg.yaml", &bytes.Buffer{})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != provision.PolicyWarn {
+		t.Errorf("resolvePolicy both absent = %q, want %q", got, provision.PolicyWarn)
+	}
+}
+
+func TestResolvePolicy_FlagAbsentYAMLPresent(t *testing.T) {
+	t.Parallel()
+	got, ok := resolvePolicy("", "safe-update", "apply", "cfg.yaml", &bytes.Buffer{})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != provision.PolicySafeUpdate {
+		t.Errorf("resolvePolicy flag absent, yaml=safe-update = %q, want %q", got, provision.PolicySafeUpdate)
+	}
+}
+
+func TestResolvePolicy_FlagPresentYAMLAbsent(t *testing.T) {
+	t.Parallel()
+	got, ok := resolvePolicy("adopt", "", "apply", "cfg.yaml", &bytes.Buffer{})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != provision.PolicyAdopt {
+		t.Errorf("resolvePolicy flag=adopt, yaml absent = %q, want %q", got, provision.PolicyAdopt)
+	}
+}
+
+func TestResolvePolicy_BothPresentEqual(t *testing.T) {
+	t.Parallel()
+	got, ok := resolvePolicy("warn", "warn", "apply", "cfg.yaml", &bytes.Buffer{})
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != provision.PolicyWarn {
+		t.Errorf("resolvePolicy both=warn = %q, want %q", got, provision.PolicyWarn)
+	}
+}
+
+func TestResolvePolicy_Conflict(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	_, ok := resolvePolicy("safe-update", "warn", "apply", "mycfg.yaml", &buf)
+	if ok {
+		t.Fatal("expected ok=false on conflict")
+	}
+	msg := buf.String()
+	if !strings.Contains(msg, "--policy=safe-update") {
+		t.Errorf("conflict message missing flag value: %q", msg)
+	}
+	if !strings.Contains(msg, "cfg.policy=warn") {
+		t.Errorf("conflict message missing YAML value: %q", msg)
+	}
+	if !strings.Contains(msg, "mycfg.yaml") {
+		t.Errorf("conflict message missing file path: %q", msg)
+	}
+	if !strings.Contains(msg, "partictl apply:") {
+		t.Errorf("conflict message missing subcmd prefix: %q", msg)
+	}
+}
+
+func TestResolvePolicy_ConflictSubcmdPrefix(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	// plan subcmd
+	_, ok := resolvePolicy("adopt", "warn", "plan", "cfg.yaml", &buf)
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+	if !strings.Contains(buf.String(), "partictl plan:") {
+		t.Errorf("conflict message should use plan prefix: %q", buf.String())
+	}
+}
+
+// --- validatePolicyFlag unit tests ---
+
+func TestValidatePolicyFlag_Empty(t *testing.T) {
+	t.Parallel()
+	if !validatePolicyFlag("", "apply", &bytes.Buffer{}) {
+		t.Error("empty flag should be valid")
+	}
+}
+
+func TestValidatePolicyFlag_ValidValues(t *testing.T) {
+	t.Parallel()
+	for _, v := range []string{"warn", "adopt", "safe-update"} {
+		t.Run(v, func(t *testing.T) {
+			t.Parallel()
+			if !validatePolicyFlag(v, "apply", &bytes.Buffer{}) {
+				t.Errorf("--policy=%s should be valid", v)
+			}
+		})
+	}
+}
+
+func TestValidatePolicyFlag_ForceRejected(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if validatePolicyFlag("force", "apply", &buf) {
+		t.Error("--policy=force should be rejected")
+	}
+	if !strings.Contains(buf.String(), "not yet supported") {
+		t.Errorf("expected 'not yet supported' in message: %q", buf.String())
+	}
+}
+
+func TestValidatePolicyFlag_UnknownRejected(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if validatePolicyFlag("magic", "apply", &buf) {
+		t.Error("unknown policy should be rejected")
+	}
+	if !strings.Contains(buf.String(), "not recognized") {
+		t.Errorf("expected 'not recognized' in message: %q", buf.String())
+	}
+}
+
+// --- Static (no-NATS) CLI tests for --policy conflict paths ---
+
+// TestApply_PolicyConflict_Exit3: --policy=safe-update with cfg.policy=warn → exit 3.
+func TestApply_PolicyConflict_Exit3(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("apply",
+		"-f", "testdata/policy_warn.yaml",
+		"-policy", "safe-update",
+	)
+	if code != ExitValidation {
+		t.Errorf("apply policy conflict = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "conflicts with") {
+		t.Errorf("expected conflict message in stderr: %q", stderr)
+	}
+}
+
+// TestPlan_PolicyConflict_Exit3: --policy=adopt with cfg.policy=warn → exit 3.
+func TestPlan_PolicyConflict_Exit3(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("plan",
+		"-f", "testdata/policy_warn.yaml",
+		"-policy", "adopt",
+	)
+	if code != ExitValidation {
+		t.Errorf("plan policy conflict = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "conflicts with") {
+		t.Errorf("expected conflict message in stderr: %q", stderr)
+	}
+}
+
+// TestAdopt_PolicyConflict_Exit3: partictl adopt with cfg.policy=warn → exit 3.
+func TestAdopt_PolicyConflict_Exit3(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("adopt",
+		"-f", "testdata/policy_warn.yaml",
+	)
+	if code != ExitValidation {
+		t.Errorf("adopt with cfg.policy=warn = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "conflicts with") {
+		t.Errorf("expected conflict message in stderr: %q", stderr)
+	}
+	if !strings.Contains(stderr, "partictl adopt:") {
+		t.Errorf("expected 'partictl adopt:' prefix in stderr: %q", stderr)
+	}
+}
+
+// TestAdopt_PolicyAdoptInYAML_Proceeds: partictl adopt with cfg.policy=adopt → conflict-free.
+// This reaches NATS (which is unreachable), confirming conflict resolution passed and we
+// got to the NATS connect step.
+func TestAdopt_PolicyAdoptInYAML_Proceeds(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("adopt",
+		"-f", "testdata/policy_adopt.yaml",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	// Should get ExitNATS (conflict passed, NATS unreachable).
+	if code != ExitNATS {
+		t.Errorf("adopt policy_adopt.yaml = %d, want %d (ExitNATS — conflict-free, NATS unreachable)", code, ExitNATS)
+	}
+}
+
+// TestAdopt_NoFile: partictl adopt without -f → exit 3.
+func TestAdopt_NoFile(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("adopt")
+	if code != ExitValidation {
+		t.Errorf("adopt no -f = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "-f is required") {
+		t.Errorf("expected '-f is required' in stderr: %q", stderr)
+	}
+}
+
+// TestApply_ForceRejected_Exit3: --policy=force → exit 3 before NATS connect.
+func TestApply_ForceRejected_Exit3(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("apply",
+		"-f", "testdata/minimal.yaml",
+		"-policy", "force",
+	)
+	if code != ExitValidation {
+		t.Errorf("apply --policy=force = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "not yet supported") {
+		t.Errorf("expected 'not yet supported' in stderr: %q", stderr)
+	}
+}
+
+// TestPlan_ForceRejected_Exit3: plan --policy=force → exit 3 before NATS connect.
+func TestPlan_ForceRejected_Exit3(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("plan",
+		"-f", "testdata/minimal.yaml",
+		"-policy", "force",
+	)
+	if code != ExitValidation {
+		t.Errorf("plan --policy=force = %d, want %d (ExitValidation)", code, ExitValidation)
+	}
+	if !strings.Contains(stderr, "not yet supported") {
+		t.Errorf("expected 'not yet supported' in stderr: %q", stderr)
+	}
+}
+
+// TestPolicy_EmptyYAML_TreatedAsAbsent: policy: "" in YAML is treated as absent;
+// --policy=safe-update proceeds (no conflict) → reaches NATS unreachable.
+func TestPolicy_EmptyYAML_TreatedAsAbsent(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("apply",
+		"-f", "testdata/policy_empty.yaml",
+		"-policy", "safe-update",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("apply policy_empty.yaml --policy=safe-update = %d, want %d (ExitNATS — no conflict, NATS unreachable)", code, ExitNATS)
+	}
+}
+
+// TestPolicy_EmptyYAML_AdoptTreatedAsAbsent: policy: "" with adopt command — no conflict.
+func TestPolicy_EmptyYAML_AdoptTreatedAsAbsent(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("adopt",
+		"-f", "testdata/policy_empty.yaml",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("adopt policy_empty.yaml = %d, want %d (ExitNATS — no conflict, NATS unreachable)", code, ExitNATS)
+	}
+}
+
+// TestApply_SamePolicyFlag_NoConflict: --policy=warn with cfg.policy=warn → no conflict.
+func TestApply_SamePolicyFlag_NoConflict(t *testing.T) {
+	t.Parallel()
+	_, _, code := runArgs("apply",
+		"-f", "testdata/policy_warn.yaml",
+		"-policy", "warn",
+		"-server", "nats://127.0.0.1:1",
+		"-timeout", "500ms",
+	)
+	if code != ExitNATS {
+		t.Errorf("apply same policy = %d, want %d (ExitNATS — no conflict, NATS unreachable)", code, ExitNATS)
+	}
+}
+
+// TestAdopt_UnknownCommand_IsNowKnown: dispatcher recognizes "adopt".
+func TestAdopt_UnknownCommand_IsNowKnown(t *testing.T) {
+	t.Parallel()
+	_, stderr, code := runArgs("adopt")
+	// Should not emit "unknown command" — it should emit "-f is required" instead.
+	if strings.Contains(stderr, "unknown command") {
+		t.Errorf("adopt should be a known command, got: %q", stderr)
+	}
+	if code != ExitValidation {
+		t.Errorf("adopt no args = %d, want %d", code, ExitValidation)
+	}
+}
+
+// TestHelp_ContainsAdopt: top-level help output lists adopt command.
+func TestHelp_ContainsAdopt(t *testing.T) {
+	t.Parallel()
+	stdout, _, code := runArgs("help")
+	if code != ExitOK {
+		t.Errorf("help = %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "adopt") {
+		t.Errorf("help output should mention adopt: %q", stdout)
+	}
+	if !strings.Contains(stdout, "-policy") {
+		t.Errorf("help output should mention -policy flag: %q", stdout)
+	}
+	// adopt should no longer be in the "Deferred commands" line.
+	deferred := extractDeferredLine(stdout)
+	if strings.Contains(deferred, "adopt") {
+		t.Errorf("adopt should not appear in deferred commands: %q", deferred)
+	}
+}
+
+// extractDeferredLine returns the line containing "Deferred commands" from s.
+func extractDeferredLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, "Deferred") {
+			return line
+		}
+	}
+	return ""
+}
+
+// --- NATS-backed tests for policy behavior ---
+
+// TestApply_PolicySafeUpdate_EmitsUpdateKVWhereWarnDoesNot verifies the
+// observable difference between the two policies: against a Parti-marked
+// bucket whose TTL has drifted from config, --policy=safe-update emits an
+// update-kv action while the default warn policy reports the drift but
+// emits no action.
+func TestApply_PolicySafeUpdate_EmitsUpdateKVWhereWarnDoesNot(t *testing.T) {
+	t.Parallel()
+	url, js := startTestNATSWithJS(t)
+	ctx := context.Background()
+
+	// Pre-create the stableid bucket, Parti-marked, with a TTL that drifts
+	// from minimal.yaml's workerIdTtl (75s). The other control-plane buckets
+	// stay absent.
+	_, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   "parti-stableid",
+		Storage:  jetstream.FileStorage,
+		History:  1,
+		TTL:      99 * time.Second,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneID, ""),
+	})
+	if err != nil {
+		t.Fatalf("create drifted bucket: %v", err)
+	}
+
+	emitsUpdateKV := func(args ...string) bool {
+		t.Helper()
+		stdout, code := runWithNATS(t, url, args...)
+		if code != ExitOK {
+			t.Fatalf("%v = %d, want 0\nstdout: %s", args, code, stdout)
+		}
+		var plan provision.PlanResult
+		if err := json.Unmarshal([]byte(stdout), &plan); err != nil {
+			t.Fatalf("unmarshal plan: %v\nstdout: %s", err, stdout)
+		}
+		for _, a := range plan.Actions {
+			if a.Kind == provision.ActionUpdateKV {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if !emitsUpdateKV("apply", "-f", "testdata/minimal.yaml",
+		"-policy", "safe-update", "-dry-run", "-json") {
+		t.Error("--policy=safe-update should emit an update-kv action for the drifted bucket")
+	}
+	if emitsUpdateKV("apply", "-f", "testdata/minimal.yaml", "-dry-run", "-json") {
+		t.Error("default warn policy must not emit an update-kv action")
+	}
+}
+
+// TestAdopt_DryRun_ByteIdenticalToPlanAdopt verifies that
+// "adopt -dry-run -json" produces byte-identical output to "plan --policy=adopt -json".
+func TestAdopt_DryRun_ByteIdenticalToPlanAdopt(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+
+	planOut, planCode := runWithNATSBytes(t, url, "plan",
+		"-f", "testdata/minimal.yaml", "-policy", "adopt", "-json")
+	if planCode != ExitOK {
+		t.Fatalf("plan --policy=adopt -json = %d", planCode)
+	}
+
+	adoptOut, adoptCode := runWithNATSBytes(t, url, "adopt",
+		"-f", "testdata/minimal.yaml", "-dry-run", "-json")
+	if adoptCode != ExitOK {
+		t.Fatalf("adopt -dry-run -json = %d", adoptCode)
+	}
+
+	if !bytes.Equal(planOut, adoptOut) {
+		t.Errorf("plan --policy=adopt -json and adopt -dry-run -json are not byte-identical\nplan:\n%s\nadopt:\n%s",
+			planOut, adoptOut)
+	}
+}
+
+// TestAdopt_EmptyServer_NoActions verifies that adopt against an empty server
+// emits no actions (adopt only stamps markers on existing resources).
+func TestAdopt_EmptyServer_NoActions(t *testing.T) {
+	t.Parallel()
+	url := startTestNATS(t)
+
+	stdout, code := runWithNATS(t, url, "adopt",
+		"-f", "testdata/minimal.yaml", "-dry-run", "-json")
+	if code != ExitOK {
+		t.Fatalf("adopt -dry-run = %d, want 0\nstdout: %s", code, stdout)
+	}
+	var plan provision.PlanResult
+	if err := json.Unmarshal([]byte(stdout), &plan); err != nil {
+		t.Fatalf("unmarshal plan: %v", err)
+	}
+	// Adopt does NOT create missing buckets — empty server means no stamp-marker actions.
+	if len(plan.Actions) != 0 {
+		t.Errorf("adopt against empty server should emit no actions, got %d: %+v", len(plan.Actions), plan.Actions)
+	}
+}

--- a/cmd/partictl/reconcile.go
+++ b/cmd/partictl/reconcile.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/arloliu/parti/v2/provision"
+)
+
+// reconcileParams carries the resolved inputs for an apply-style run. Both
+// the apply and adopt commands parse their own flag sets and then delegate
+// to runReconcile — adopt is exactly "apply with policyFlag pinned to adopt".
+type reconcileParams struct {
+	common      commonFlags
+	file        string // already checked non-empty by the caller
+	policyFlag  string // the --policy value; adopt pins this to "adopt"
+	subcmd      string // "apply" or "adopt" — error-message prefix
+	dryRun      bool
+	jsonOut     bool
+	failOnDrift bool // dry-run only; adopt always false
+}
+
+// runReconcile loads the config, resolves the policy, validates, connects to
+// NATS, and runs either a dry-run plan or a live apply. It is the shared body
+// of the apply and adopt commands.
+func runReconcile(p reconcileParams, stdout, stderr io.Writer) int {
+	timeoutDur, err := parseTimeout(p.common.timeout)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	cfg, err := loadConfig(p.file)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	if !resolveAndStampPolicy(p.policyFlag, p.subcmd, p.file, &cfg, stderr) {
+		return ExitValidation
+	}
+
+	// Static validation before any NATS connect so bad config exits 3.
+	if err := provision.Validate(cfg); err != nil {
+		fmt.Fprintln(stderr, err)
+
+		return ExitValidation
+	}
+
+	ctx, stop, exitIfTimeout := makeContext(timeoutDur, stderr)
+	defer stop()
+
+	conn, code, err := connectNATS(ctx, p.common)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+
+		return code
+	}
+	defer conn.close()
+
+	if p.dryRun {
+		planResult, err := provision.Plan(ctx, conn.js, cfg)
+		if err != nil {
+			if exitIfTimeout(ctx) {
+				return ExitNATS
+			}
+			fmt.Fprintf(stderr, "partictl %s -dry-run: %v\n", p.subcmd, err)
+
+			return classifyError(err)
+		}
+
+		emitPlan(stdout, planResult, p.jsonOut)
+		if p.failOnDrift && hasDrift(planResult.Drift) {
+			return ExitDrift
+		}
+
+		return ExitOK
+	}
+
+	report, err := provision.Apply(ctx, conn.js, cfg)
+	emitReport(stdout, report, p.jsonOut)
+	if err != nil {
+		if exitIfTimeout(ctx) {
+			return ExitNATS
+		}
+
+		return classifyError(err)
+	}
+
+	return ExitOK
+}

--- a/cmd/partictl/run.go
+++ b/cmd/partictl/run.go
@@ -67,7 +67,7 @@ Common flags (accepted by all commands):
   -instance <name>      Filter by parti.io/instance (view without -f; validate)
   -policy   <policy>    Reconcile policy for plan/apply: warn, adopt, safe-update (default: warn)
 
-Deferred commands (not yet available in v1):
+Deferred commands (not yet supported):
   partitions plan/apply, stream view/plan/apply, init, emit
 
 Exit codes:

--- a/cmd/partictl/run.go
+++ b/cmd/partictl/run.go
@@ -30,6 +30,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cmdPlan(rest, stdout, stderr)
 	case "apply":
 		return cmdApply(rest, stdout, stderr)
+	case "adopt":
+		return cmdAdopt(rest, stdout, stderr)
 	case "help", "-help", "--help", "-h":
 		printUsage(stdout)
 		return ExitOK
@@ -52,6 +54,7 @@ Commands:
   validate  Validate a config file (static; -live adds NATS preflight)
   plan      Compute desired-vs-live drift and proposed actions (PlanResult)
   apply     Create missing resources; -dry-run emits the same output as plan
+  adopt     Stamp Parti ownership marker on unmarked resources (shorthand for apply --policy=adopt)
 
 Common flags (accepted by all commands):
   -server   <url>       NATS server URL (default: $NATS_URL or nats://127.0.0.1:4222)
@@ -59,12 +62,13 @@ Common flags (accepted by all commands):
   -nkey     <path>      Path to NATS nkey seed file
   -token    <string>    NATS token
   -timeout  <duration>  Operation timeout (default: 30s)
-  -f        <path>      YAML config file (required for validate/plan/apply; optional for view)
+  -f        <path>      YAML config file (required for validate/plan/apply/adopt; optional for view)
   -json                 Emit machine-readable JSON output
   -instance <name>      Filter by parti.io/instance (view without -f; validate)
+  -policy   <policy>    Reconcile policy for plan/apply: warn, adopt, safe-update (default: warn)
 
 Deferred commands (not yet available in v1):
-  partitions plan/apply, adopt, stream view/plan/apply, init, emit
+  partitions plan/apply, stream view/plan/apply, init, emit
 
 Exit codes:
   0  success

--- a/cmd/partictl/testdata/policy_adopt.yaml
+++ b/cmd/partictl/testdata/policy_adopt.yaml
@@ -1,0 +1,8 @@
+# Config with explicit policy: adopt — used to verify adopt command proceeds when YAML
+# policy matches, and to test plan --policy=adopt conflict-free paths.
+apiVersion: parti.io/v1
+policy: adopt
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s

--- a/cmd/partictl/testdata/policy_empty.yaml
+++ b/cmd/partictl/testdata/policy_empty.yaml
@@ -1,0 +1,7 @@
+# Config with explicit policy: "" — treated as absent for conflict resolution.
+apiVersion: parti.io/v1
+policy: ""
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s

--- a/cmd/partictl/testdata/policy_warn.yaml
+++ b/cmd/partictl/testdata/policy_warn.yaml
@@ -1,0 +1,8 @@
+# Config with explicit policy: warn — used to trigger conflict when combined
+# with --policy=safe-update or --policy=adopt flags.
+apiVersion: parti.io/v1
+policy: warn
+controlPlane:
+  workerIdTtl: 75s
+  electionTimeout: 10s
+  heartbeatTtl: 15s

--- a/docs/PROVISION.md
+++ b/docs/PROVISION.md
@@ -1,0 +1,393 @@
+# Parti Provision Guide
+
+> Manage the NATS resources Parti's runtime depends on using the `provision` SDK and `partictl` CLI.
+
+**Related Documentation:**
+- [Docs README](README.md) - Documentation map
+- [Operations Guide](OPERATIONS.md) - Deployment, monitoring, troubleshooting
+- [Configuration Guide](CONFIGURATION.md) - Runtime configuration options
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [The Ownership Marker](#the-ownership-marker)
+3. [Reconcile Policies](#reconcile-policies)
+4. [partictl Commands](#partictl-commands)
+5. [Brownfield Adoption Playbook](#brownfield-adoption-playbook)
+6. [Safety Contracts](#safety-contracts)
+7. [Example Configuration](#example-configuration)
+
+---
+
+## Overview
+
+The `provision` SDK and `partictl` CLI manage the NATS resources that
+Parti's runtime manager depends on:
+
+- **Control-plane KV buckets** — five buckets (`parti-stableid`,
+  `parti-election`, `parti-heartbeat`, `parti-assignment`,
+  `parti-handoff`) that the Parti manager uses for worker coordination.
+- **The partition-source bucket** — the KV bucket that holds the
+  partition definition record read by the runtime source.
+
+`provision` never manages application streams, dynamic consumers, or
+partition record contents directly. It provides:
+
+- **Read-only inspection** — `view` lists all Parti-marked resources
+  in the NATS account; `validate` checks a config file for static or
+  live errors.
+- **Drift detection and reconcile** — `plan` computes what is missing
+  or drifted from desired config; `apply` executes the plan.
+
+---
+
+## The Ownership Marker
+
+Parti stamps a set of metadata keys on every resource it manages.
+These keys live in `jetstream.KeyValueConfig.Metadata` (not the
+`Description` field):
+
+| Key                    | Example value           | Meaning                                    |
+|------------------------|-------------------------|--------------------------------------------|
+| `parti.io/managed`     | `v1`                    | Schema version; non-empty means managed    |
+| `parti.io/component`   | `control-plane:election`| Which Parti component owns this bucket     |
+| `parti.io/instance`    | `prod`                  | Logical environment label (optional)       |
+
+The marker is **informational only**. It never grants or revokes
+mutation rights. Plan and Apply look up every resource by its exact NATS
+bucket name; a bucket with no marker is not deleted or skipped — it is
+reported as `adopted` drift so the operator sees it.
+
+Non-Parti metadata keys (e.g. `Description: "owned by infra team"`, or
+any other key not in the `parti.io/*` namespace) are always preserved
+verbatim across all reconcile operations.
+
+---
+
+## Reconcile Policies
+
+The `policy` field in `parti-env.yaml` (or the `-policy` CLI flag)
+controls what actions `plan` and `apply` are allowed to take on existing
+resources.
+
+| Policy        | Create missing | Stamp marker | Update mutable fields | Destructive repair |
+|---------------|:--------------:|:------------:|:---------------------:|:------------------:|
+| `warn`        | yes            | no           | no                    | no                 |
+| `adopt`       | no             | yes          | no                    | no                 |
+| `safe-update` | yes            | no           | yes (marked only)     | no                 |
+| `force`       | —              | —            | —                     | not yet supported  |
+
+### `warn` (default)
+
+Creates any bucket named by config that does not exist live. Reports
+drift on existing buckets — `drift-mutable` for fields that could be
+reconciled in place, `drift-immutable` for fields that require
+delete/recreate, and `adopted` for buckets that exist without the Parti
+marker. Never mutates an existing resource.
+
+This is the safe default for greenfield environments and for read-only
+drift audits.
+
+### `adopt`
+
+Stamps the Parti ownership marker on every bucket named by config that
+exists live and is currently unmarked. Non-Parti metadata keys on the
+bucket are preserved. Creates no missing buckets and updates no
+non-marker fields.
+
+Use `adopt` as the first step when onboarding a pre-existing NATS
+environment into Parti management.
+
+### `safe-update`
+
+Creates missing buckets (same as `warn`) and also reconciles
+drift-mutable fields in place on **Parti-marked** buckets via
+`js.UpdateKeyValue`. Fields that `safe-update` can reconcile:
+
+| Field            | Applies to                   | Notes                                                   |
+|------------------|------------------------------|---------------------------------------------------------|
+| `Metadata`       | control-plane + partition-source | Parti marker keys updated; non-Parti keys preserved |
+| `TTL`            | control-plane + partition-source |                                                     |
+| `MaxValueSize`   | partition-source only        | `controlPlane` has no `maxValueSize` field              |
+| `Replicas`       | control-plane + partition-source | Server enforces cluster-peer feasibility at apply time |
+
+Fields `safe-update` **never** changes:
+
+- `History` and `Storage` — changing these requires delete/recreate
+  (destructive repair is not yet supported). Plan reports them as
+  `drift-immutable`.
+- `Description` and `MaxBytes` — no YAML field exists for these; they
+  are preserved verbatim from the live bucket regardless of any other
+  change in the same Apply.
+
+Unmarked (adopted) buckets are **not** updated under `safe-update`.
+Plan reports them as `adopted` drift; the operator must run `adopt`
+first, then re-run `apply --policy=safe-update`.
+
+### `force`
+
+Reserved. Not yet supported.
+
+---
+
+## partictl Commands
+
+All commands accept common connection flags:
+
+```
+  -server   <url>       NATS server URL (default: $NATS_URL or nats://127.0.0.1:4222)
+  -creds    <path>      NATS credentials file
+  -nkey     <path>      NATS nkey seed file
+  -token    <string>    NATS token
+  -timeout  <duration>  Operation timeout (default: 30s)
+  -json                 Emit machine-readable JSON output
+```
+
+### `partictl view`
+
+Lists every Parti-marked KV bucket visible to the NATS account.
+
+```
+partictl view [flags]
+  -f        <path>   YAML config (optional; scopes results to config-named buckets)
+  -instance <name>   Filter by parti.io/instance (only when -f is absent)
+```
+
+Output is a `Snapshot` struct (`apiVersion: parti.io/provision/v1`, `kind: Snapshot`).
+
+### `partictl validate`
+
+Validates a config file without connecting to NATS (static check), or
+with a live NATS preflight (reachability + per-bucket info probes).
+
+```
+partictl validate -f <path> [flags]
+  -live    Perform live NATS validation (requires connectivity)
+```
+
+Exits 0 on success, 3 on validation error.
+
+### `partictl plan`
+
+Computes the desired-vs-live diff and the actions Apply would take,
+without performing any mutations.
+
+```
+partictl plan -f <path> [flags]
+  -policy       <policy>  warn | adopt | safe-update (default: warn or cfg.policy)
+  -fail-on-drift           Exit 2 if non-informational drift is found
+```
+
+Output is a `PlanResult` struct (`kind: Plan`).
+
+### `partictl apply`
+
+Executes the plan actions against live NATS.
+
+```
+partictl apply -f <path> [flags]
+  -policy       <policy>  warn | adopt | safe-update (default: warn or cfg.policy)
+  -dry-run                Plan only — same output as plan
+  -fail-on-drift           Exit 2 if drift is detected (dry-run only)
+```
+
+Output is a `Report` struct (`kind: Report`).
+
+The `-policy` flag and the YAML `policy:` field must agree when both
+are present. If they conflict, `apply` exits 3 with:
+
+```
+partictl apply: --policy=X conflicts with cfg.policy=Y in <file>. Pick one or remove the cfg.policy field.
+```
+
+Writing `policy: ""` in YAML (or omitting the field) is treated as
+absent: no conflict with any `-policy` value.
+
+### `partictl adopt`
+
+Shorthand for `apply --policy=adopt`. Stamps the Parti marker on
+unmarked buckets named by config.
+
+```
+partictl adopt -f <path> [flags]
+  -dry-run   Plan only — emit the same output as plan --policy=adopt
+```
+
+`adopt` requires `-f`; there is no "adopt everything" mode. If
+`cfg.policy` in the YAML is non-empty and not `adopt`, the command
+exits 3 with the same conflict message as `apply`.
+
+### Exit codes
+
+| Code | Meaning                                                     |
+|------|-------------------------------------------------------------|
+| 0    | Success                                                     |
+| 1    | Runtime error (operation failed after preflight)            |
+| 2    | Drift detected with `-fail-on-drift`                        |
+| 3    | Config parse / validation error, or flag conflict           |
+| 4    | NATS connect / auth / context timeout failure               |
+
+---
+
+## Brownfield Adoption Playbook
+
+For environments with pre-existing NATS buckets that were created
+manually, by the NATS CLI, or by an older tool, every `plan` run reports
+those buckets as `adopted` drift and emits no actions to resolve them.
+The canonical two-step to take ownership is:
+
+**Step 1 — Preview what adopt will stamp (optional but recommended):**
+
+```bash
+partictl adopt -f parti-env.yaml -dry-run
+```
+
+Review the `stamp-marker` actions in the output. Each action lists
+`mergedMetadata` (the full metadata map that will be written) and
+`partiKeys` (the keys the action adds or changes). Confirm no
+unintended non-Parti key is being modified.
+
+**Step 2 — Stamp the marker:**
+
+```bash
+partictl adopt -f parti-env.yaml
+```
+
+Each unmarked bucket named by config now carries the Parti ownership
+marker. Non-Parti metadata keys on each bucket are preserved verbatim.
+
+**Step 3 — Preview field-level drift (optional but recommended):**
+
+```bash
+partictl plan -f parti-env.yaml --policy=safe-update
+```
+
+After adoption, `plan --policy=safe-update` sees marked buckets and
+reveals any field-level drift that was hidden under the `adopted`
+finding — including `drift-immutable` findings for History or Storage
+mismatches that require destructive repair (not yet supported).
+
+**Step 4 — Reconcile mutable drift:**
+
+```bash
+partictl apply -f parti-env.yaml --policy=safe-update
+```
+
+Reconciles TTL, Metadata, MaxValueSize, and Replicas in place on every
+marked bucket that differs from config. Immutable drift is reported but
+not acted on.
+
+### Why two steps?
+
+`adopt` and `safe-update` are deliberately separate:
+
+- **Adoption is an explicit ownership transition.** The operator who
+  runs `adopt` is declaring "Parti now manages these buckets." That
+  decision should be visible in the operator's runbook, not absorbed
+  silently into a broader reconcile pass.
+- **`safe-update` never silently takes ownership of an unmarked
+  bucket.** An unmarked bucket under `safe-update` continues to
+  appear as `adopted` drift with no action emitted. This prevents
+  accidental ownership of buckets that happen to share a name with
+  a config-declared bucket.
+- **Adoption reveals hidden drift.** After `adopt`, the next
+  `plan` run shows field-level drift on newly-marked buckets,
+  including immutable drift that needs operator attention. If
+  `safe-update` absorbed adoption, that drift would be partially
+  resolved while immutable findings surfaced with no clear
+  before-state to compare.
+
+---
+
+## Safety Contracts
+
+### Adoption is not approval of the bucket's config
+
+Running `partictl adopt` stamps the Parti marker only. It does not
+assert that the bucket's History, Storage, Replicas, TTL, or any other
+field matches the desired config. After adoption, run
+`plan --policy=safe-update` to reveal field-level drift —
+including any drift-immutable findings that require manual intervention.
+
+### `safe-update` preserves fields the YAML cannot express
+
+The `update-kv` Apply path constructs its write target by copying the
+just-re-read live snapshot and overwriting only the fields the YAML can
+express (`TTL`, `Metadata`, `MaxValueSize`, `Replicas`). `Description`
+and `MaxBytes` are **never** reset, even when other fields change in the
+same Apply. Operators who set those fields out-of-band keep them.
+
+### Per-field mutability: what safe-update reconciles and what it does not
+
+`safe-update` reconciles drift-mutable fields: `Metadata`, `TTL`,
+`MaxValueSize` (partition-source only), and `Replicas`. It does **not**
+attempt to change `History` or `Storage` — those fields require
+delete/recreate and are reported as `drift-immutable`. Destructive
+repair is not yet supported.
+
+### Replicas changes are conditional on cluster size
+
+A `safe-update` Apply that bumps `Replicas` against a NATS cluster with
+fewer peers than the requested value will fail-fast. Apply records a
+`ResourceError` with the underlying NATS error; remaining actions are
+skipped with reason `prior-error`. The NATS server enforces peer-count
+feasibility; the SDK does not pre-check it.
+
+### Last-writer-wins on concurrent operators
+
+NATS `UpdateStream` carries no compare-and-swap / expected-revision
+token. The `update-kv` Apply path re-reads live state and verifies it
+still matches the plan-time snapshot before writing (the stale-before
+check). However, the window between the re-read and the write remains
+open. Two operators running `safe-update` or `adopt` concurrently
+against the same bucket are last-writer-wins. Operators who care about
+cross-operator ordering serialize their own runs.
+
+The stale-before check closes the **plan→apply** window (the gap
+between when `plan` was run and when `apply` is run); it does not close
+the re-read→write window within a single `apply` invocation.
+
+---
+
+## Example Configuration
+
+```yaml
+# parti-env.yaml
+apiVersion: parti.io/v1
+instance: prod
+policy: warn          # the --policy flag must match this when both are given
+
+controlPlane:
+  workerIdTtl:       1h
+  electionTimeout:   10s
+  heartbeatTtl:      30s
+  assignmentTtl:     0s  # 0 = no expiration
+  replicas:          3   # 0 (default) lets NATS choose; 3 requires a 3-node cluster
+
+partitionSource:
+  bucket:       my-partitions
+  key:          partitions
+  storage:      file
+  history:      1
+  replicas:     3
+  maxValueSize: 0     # 0 = no limit
+  ttl:          0s    # 0 = no expiration
+```
+
+### Minimal configuration (control-plane only, defaults for everything)
+
+```yaml
+apiVersion: parti.io/v1
+
+controlPlane:
+  workerIdTtl:     1h
+  electionTimeout: 10s
+  heartbeatTtl:    30s
+```
+
+Bucket names default to `parti-stableid`, `parti-election`,
+`parti-heartbeat`, `parti-assignment`, and `parti-handoff`.
+`policy` defaults to `warn`. `controlPlane.replicas` defaults to `0`
+(NATS normalizes to 1 server-side).

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ mgr.Start(context.Background())
 | [Reference](REFERENCE.md)         | Hooks, error handling, best practices, glossary |
 | [API Reference](API_REFERENCE.md) | Detailed API documentation                      |
 | [Operations Guide](OPERATIONS.md) | Deployment, monitoring, troubleshooting         |
+| [Provision Guide](PROVISION.md)   | provision SDK and partictl CLI for NATS resource management |
 
 ---
 

--- a/docs/plans/provision-sdk-cli-v2/00-implementation-plan.md
+++ b/docs/plans/provision-sdk-cli-v2/00-implementation-plan.md
@@ -1,0 +1,1321 @@
+# Parti Provision SDK and CLI — Phase 2 Plan ("Safe Update + Adopt")
+
+## Problem Statement
+
+Phase 1 of the Parti provision SDK and `partictl` CLI shipped a `warn`
+reconcile policy: it creates missing control-plane and partition-source
+buckets, reports drift on existing resources, and refuses to mutate. Phase 1
+gives operators visibility into desired-vs-live state but offers no path to
+*resolve* drift without leaving the tool.
+
+Two real operator workflows are still painful after Phase 1:
+
+1. **Brownfield NATS.** Operators with pre-existing Parti control-plane or
+   partition-source buckets (created manually, by NATS CLI, or by an older
+   tool) see every such bucket reported as `adopted` drift on every `plan` /
+   `apply` run. Phase 1 emits no action to transition those resources into the
+   managed set; the operator's only option is to manually stamp the Parti
+   ownership marker via the NATS CLI, then re-run `plan`.
+
+2. **In-place reconcile.** Operators who tune a `parti-env.yaml` TTL,
+   metadata, or size limit see Phase 1 report `drift-mutable` findings but
+   refuse to act on them. Operators must drop down to the NATS CLI to do
+   the in-place update — and once they do, the next `partictl plan` run
+   reports the bucket as `informational` rather than crediting the operator's
+   tool with the change.
+
+The result is a tool that knows what should change but can't make it
+happen. Phase 2 closes that gap for the **non-destructive** half of the
+mutation surface — fields NATS can reconcile via `UpdateStream` without
+delete/recreate, plus the adoption transition for unmarked resources.
+
+Destructive repair (delete/recreate of immutable-drift buckets like a
+History change) remains a Phase 6 problem.
+
+## End-State Vision
+
+This plan is **Phase 2** of the
+[Phased Roadmap](../provision-sdk-cli/00-implementation-plan.md#phased-roadmap)
+in the master plan. After this phase ships:
+
+- Operators can run `partictl adopt -f parti-env.yaml` to stamp the Parti
+  ownership marker on every resource named by config that exists live but
+  lacks the marker. Adoption never touches data or config — only the
+  marker keys are added; non-Parti metadata keys are preserved.
+- Operators can run `partictl apply -f parti-env.yaml --policy=safe-update`
+  to create missing resources and reconcile in-place every drift-mutable
+  field on resources that already carry the Parti marker.
+- Operators can declare `controlPlane.replicas` to ask Parti's control-plane
+  KV buckets to run with a non-default replica count. Replicas changes are
+  carried through `safe-update`; the NATS server enforces cluster-peer
+  feasibility.
+
+Subsequent phases (3–7) still own their own surface: partition records
+(Phase 3), application streams (Phase 4), dynamic consumer precreation
+(Phase 5), destructive repair (Phase 6), Kubernetes controller (Phase 7).
+
+## Invariants Inherited from Phase 1
+
+Every invariant in the
+[Phase 1 "Invariants inherited by every phase"](../provision-sdk-cli/00-implementation-plan.md#invariants-inherited-by-every-phase)
+section continues to hold in Phase 2, with **one narrowing** called out
+below. The full list, restated for clarity:
+
+- Ownership marker shape (`parti.io/managed`, `parti.io/component`,
+  `parti.io/instance`) stays in `Metadata` and remains informational.
+- JSON envelope schema stays at `apiVersion: parti.io/provision/v1`. Phase 2
+  adds new `PlannedAction.Kind` string values (`update-kv`, `stamp-marker`)
+  and new `ReconcilePolicy` values (`adopt`, `safe-update`); all additive.
+  Operator CI that keys on `apiVersion` continues to work; tooling that
+  filters by `kind == "create-kv"` continues to ignore the new kinds.
+- Input config `apiVersion: parti.io/v1` accepts additive fields. Phase 2
+  adds `controlPlane.replicas`; YAML omitting the field continues to load
+  with no behavior change.
+- CLI exit codes 0–4 are stable. Phase 2 introduces no new codes.
+- `Plan` action ordering remains deterministic `(Kind, Name)`. New kinds
+  sort alphabetically against existing `create-kv`.
+- Resource lookup is always by exact NATS name first; the marker still
+  never authorizes mutation.
+
+### The one narrowing — control-plane byte-equivalence
+
+Phase 1 promised that the provisioned control-plane `KeyValueConfig` is
+byte-equivalent to `manager_setup.go:ensureKVBucket` via the shared
+`internal/kvbuckets.BuildKeyValueConfig` builder (`internal/kvbuckets/builder.go`).
+Phase 2 **narrows** this invariant to accommodate `controlPlane.replicas`:
+
+> When `ControlPlaneConfig.Replicas == 0` (the default, matching omitted
+> YAML), the produced `KeyValueConfig` remains byte-equivalent to the
+> Phase 1 builder output — including `Replicas` left zero, which nats.go
+> normalizes to 1 server-side. When `ControlPlaneConfig.Replicas > 0`, the
+> Phase 2 plan-emission code stamps that value onto the post-builder
+> `KeyValueConfig`. Byte-equivalence is intentionally broken for the
+> Replicas field only; every other field (Bucket, History, Storage, TTL,
+> Metadata) remains byte-equivalent.
+
+Practical consequence: the `internal/kvbuckets.BuildKeyValueConfig`
+function **behavior and signature** are not modified in Phase 2. It
+continues to return the historical literal. W0 updates only the
+**comment block** in `internal/kvbuckets/builder.go` to document the
+narrowed invariant and to note that the provision package stamps
+`Replicas` post-builder. The Phase 2 plan emitter calls the builder,
+then conditionally sets `Replicas` on the result before stamping the
+Parti marker. Runtime `Manager.Start` continues to call the builder
+with no Replicas concept.
+
+This split is deliberate: Phase 2 introduces a provision-only Replicas
+contract. The runtime manager does not gain a Replicas concept; operators
+that scale control-plane replicas do it via provision, not via the runtime.
+
+## Goals
+
+- Add a `safe-update` reconcile policy that performs in-place
+  `UpdateKeyValue` for the **operator-expressible** drift-mutable fields
+  on Parti-marked resources: `Metadata` (component / instance keys),
+  `TTL`, `MaxValueSize` (partition-source only), and `Replicas`. Per-field
+  integration test coverage is required. Fields that exist on the live
+  resource but are not represented in the v2 input config (`Description`,
+  `MaxBytes`) are **preserved verbatim** from the live `Before` snapshot
+  during `update-kv` — Phase 2 never resets a field the operator cannot
+  express in YAML.
+- Add an `adopt` reconcile policy that stamps the Parti ownership marker
+  on resources named by config that exist live but lack the marker, while
+  preserving every non-Parti metadata key already on the resource.
+- Add a `partictl adopt -f parti-env.yaml [-dry-run]` command that is
+  syntactic sugar for `partictl apply -f parti-env.yaml --policy=adopt`.
+- Add a `--policy` flag to `partictl apply` (and to `partictl plan` for
+  symmetric dry-run behavior). The flag and the YAML `policy:` field
+  must agree when both are present (see
+  [CLI Additions](#cli-additions)); the CLI does **not** silently
+  override a YAML policy. The flag is the canonical way to select a
+  policy when YAML omits `policy:`.
+- Add `controlPlane.replicas` to `ControlPlaneConfig`. Drift detection
+  treats `Replicas` as drift-mutable under `safe-update` (deviating from
+  Phase 1, which classified it as drift-immutable conservatively).
+- Specify a single **canonical KV equality** function used uniformly by
+  drift detection, `update-kv` action suppression, and stale-before
+  comparison. The function normalizes NATS server-side defaults
+  (`Replicas 0↔1`, `MaxBytes 0↔-1`, `MaxMsgSize 0↔-1`) so a clean
+  default install does not flap between desired and live.
+- Preserve every Phase 1 invariant (with the single narrowing above).
+
+## Non-Goals (Phase 2)
+
+The following stay out of scope for Phase 2; the target phase or follow-up
+is cited so deferred work has a clear home.
+
+- Do not delete or recreate buckets to repair immutable drift. **History**,
+  **Storage**, and **bucket rename** remain drift-immutable. Destructive
+  repair lands in **Phase 6 (Force + Repair)**.
+- Do not add an `--auto-adopt` convenience flag on `apply --policy=safe-update`
+  that would stamp the marker and run safe-update in one shot. Phase 2
+  enforces the explicit two-step (`adopt` then `safe-update`) for an
+  auditable ownership transition. The convenience flag may land in a Phase
+  2.x follow-up if real operator pain emerges.
+- Do not pre-check NATS cluster peer count to validate that a requested
+  `controlPlane.replicas` is feasible before calling `UpdateKeyValue`. The
+  server enforces feasibility and Apply fail-fasts on its rejection. A
+  cluster-size probe in `ValidateLive` is a Phase 2.x follow-up if needed.
+- Do not add `Description` or `MaxBytes` fields to `ControlPlaneConfig`
+  or `PartitionSourceConfig` in Phase 2. The v2 YAML schema has no way
+  to express either field, and Phase 2 does **not** invent one. The
+  `update-kv` Apply path back-fills both fields from the live `Before`
+  snapshot, so operator-set values placed via the NATS CLI or another
+  tool are preserved across `safe-update`. If real demand emerges,
+  adding them is a Phase 2.x scope item.
+- Do not solve concurrent-operator coordination beyond best-effort
+  stale-before detection (see [Safety Rules](#safety-rules)). NATS
+  `UpdateStream` provides no CAS / expected-revision token. Two
+  operators running any combination of `safe-update`, `adopt`, or
+  `force` against the same bucket are last-writer-wins on every field
+  in the written `StreamConfig`; the `update-kv` stale-before check is
+  best-effort only and closes the plan→apply window, not the
+  re-read→write window. Phase 2 documents this honestly rather than
+  introducing distributed locking.
+- Do not write partition records. Partition-source bucket creation and
+  drift-detection still ships; partition record management remains in
+  **Phase 3 (Partition Records)**.
+- Do not pre-create dynamic consumers or update existing ones. The Phase 1
+  alignment-check surface is unchanged. Phase 2 adds no consumer
+  mutation. **Phase 5 (Dynamic Precreate)** owns precreation; **Phase 6**
+  owns destructive repair.
+- Do not change the JSON envelope `apiVersion`. New `PlannedAction.Kind`
+  and `ReconcilePolicy` string values are additive within `parti.io/provision/v1`.
+- Do not bump the input config `apiVersion`. `controlPlane.replicas` is
+  additive within `parti.io/v1`.
+
+## Reconcile Policy Ladder
+
+Phase 2 introduces two new `ReconcilePolicy` values. The policy is a
+**set of allowed reconcile actions per resource**; the actions and drift
+shapes are unchanged across the ladder.
+
+| Policy        | Create missing | Stamp markers | Update mutable | Delete-immutable | Phase |
+|---------------|----------------|---------------|-----------------|-------------------|-------|
+| `warn`        | yes            | no            | no              | no                | 1     |
+| `adopt`       | **no**         | **yes**       | no              | no                | **2** |
+| `safe-update` | yes            | no            | **yes** (marked only) | no          | **2** |
+| `force`       | yes            | no            | yes             | yes               | 6     |
+
+Per-policy plan emission:
+
+- **`warn`** (default): emit `create-kv` for missing buckets; report drift
+  on existing buckets; emit no other actions. Unchanged from Phase 1.
+- **`adopt`**: emit `stamp-marker` for buckets named by config that exist
+  live and are unmarked. Emit no `create-kv` (missing buckets are out of
+  scope for adopt; operator must run `warn` or `safe-update` to create).
+  Emit no `update-kv` (adoption never touches non-marker fields).
+- **`safe-update`**: emit `create-kv` for missing buckets; emit `update-kv`
+  for **marked** buckets whose drift-mutable fields differ from desired;
+  emit no action for **unmarked** buckets (they remain `adopted` drift —
+  operator must run `adopt` first). Emit no `stamp-marker`.
+
+This separation enforces the rule that **safe-update never silently takes
+ownership of an unmarked bucket**. The operator's two-step is:
+
+```
+$ partictl adopt -f parti-env.yaml
+# ... reviews stamp-marker actions ...
+$ partictl apply -f parti-env.yaml --policy=safe-update
+```
+
+After `adopt`, every previously-unmarked bucket carries the Parti marker;
+the safe-update step then sees marked buckets and emits `update-kv` for
+any remaining drift-mutable fields.
+
+## Per-Field Mutability Matrix
+
+Phase 2 splits every field on `jetstream.KeyValueConfig` (the union of
+fields nats.go v1.50.0 lets a caller write via `UpdateKeyValue` —
+`jetstream/kv.go:242-274`) into **three categories**:
+
+1. **Operator-expressible (overwrite-on-update).** YAML can express
+   the desired value. `safe-update` reconciles live to desired.
+2. **Drift-detection-only (preserved-from-live but emits drift).**
+   YAML can express the desired value, but NATS rejects in-place
+   updates. Plan emits a `drift-immutable` finding when live and
+   desired disagree; `update-kv.After` still inherits the field from
+   the live `Before` snapshot so the actual `UpdateKeyValue` call
+   does not attempt the rejected mutation. Phase 6 force will own
+   the destructive repair.
+3. **Preserved-from-live (no drift detection).** YAML has no way to
+   express the desired value. Plan never emits drift for this
+   field. `update-kv.After` inherits it from the live snapshot.
+
+The **default category** for any `KeyValueConfig` field not enumerated
+below is **preserved-from-live (no drift detection)**. This is the
+forward-compat rule: when nats.go adds a new field, Phase 2 preserves
+it across update-kv and stamp-marker without changes to the plan or
+classifier. The implementation enforces this by **copying the entire
+re-read live config into `After`** before overwriting the
+operator-expressible fields (see [Apply Semantics for New Actions](#apply-semantics-for-new-actions)).
+
+| Field            | Stream-config location       | Phase 2 category               | Notes |
+|------------------|------------------------------|--------------------------------|-------|
+| `Metadata`       | `Config.Metadata`            | operator-expressible           | Merged map (Parti marker keys + live non-Parti keys). Also reachable via `stamp-marker`. |
+| `TTL`            | `Config.MaxAge`              | operator-expressible           | Both resource kinds. |
+| `MaxValueSize`   | `Config.MaxMsgSize`          | operator-expressible (PS only) | Partition-source only. Control-plane has no `MaxValueSize` field on `ControlPlaneConfig`; treated as preserved-from-live there. |
+| `Replicas`       | `Config.Replicas`            | operator-expressible           | Both resource kinds. Conditional on cluster peer count; NATS enforces. |
+| `History`        | `Config.MaxMsgsPerSubject`   | drift-detection-only           | Emits `drift-immutable`; Phase 6 owns repair. |
+| `Storage`        | `Config.Storage`             | drift-detection-only           | Emits `drift-immutable`; Phase 6 owns repair. |
+| `Bucket`         | resource identity            | identity-only (not drift)      | Bucket name is the resource lookup key. A YAML rename produces a missing target (handled by `create-kv`) and leaves the old bucket outside this config's scope; there is no in-place bucket-field drift path. Excluded from `kvConfigsEqual`. |
+| `Description`    | `Config.Description`         | preserved-from-live            | YAML cannot express; never drifted. |
+| `MaxBytes`       | `Config.MaxBytes`            | preserved-from-live            | YAML cannot express; never drifted. |
+| `Placement`      | `Config.Placement`           | preserved-from-live            | YAML cannot express; preserved verbatim. |
+| `RePublish`      | `Config.RePublish`           | preserved-from-live            | YAML cannot express; preserved verbatim. |
+| `Mirror`         | `Config.Mirror`              | preserved-from-live            | YAML cannot express; preserved verbatim. |
+| `Sources`        | `Config.Sources`             | preserved-from-live            | YAML cannot express; preserved verbatim. |
+| `Compression`    | `Config.Compression`         | preserved-from-live            | YAML cannot express; preserved verbatim. |
+| `LimitMarkerTTL` | `Config.LimitMarkerTTL`      | preserved-from-live            | YAML cannot express; preserved verbatim. |
+| _any future field_ | _whichever location_       | preserved-from-live (default)  | nats.go upgrades that add a `KeyValueConfig` field are automatically preserved without plan changes. |
+
+Notes:
+
+- The **preserved-from-live** category is the key safety property
+  Phase 2 adds. The `update-kv` and `stamp-marker` Apply paths
+  construct `After` by **copying the entire re-read live config**
+  and then overwriting **only** the operator-expressible fields. An
+  operator setting `Description: "owned by team X"` via the NATS CLI,
+  or a cluster admin setting `Placement` tags or `Compression`,
+  survives a Phase 2 `safe-update` Apply that changes only TTL.
+- The drift severity vocabulary is unchanged: `informational`,
+  `drift-mutable`, `drift-immutable`, `adopted`. **Preserved-from-live**
+  fields never produce drift findings. **Drift-detection-only** fields
+  produce `drift-immutable` findings when desired and live disagree;
+  Phase 6 force will resolve them by delete/recreate.
+- The current `classifyPartitionSourceDrift` code that emits
+  `drift-mutable` findings for `Description` and `MaxBytes`
+  (`provision/partition_source.go:149-170`) is a Phase 1 inheritance
+  that **W0 removes** (those fields are now preserved-from-live and
+  not classified at all).
+- The same Metadata field is reachable through two different actions
+  depending on policy: under `adopt`, the action is `stamp-marker`
+  and *only* the marker keys are merged into the re-read live
+  Metadata. Under `safe-update`, the action is `update-kv` and the
+  full target config (including merged Metadata) is written.
+- W0 changes the Replicas severity classification (drift-mutable
+  instead of drift-immutable) for both resource kinds. The current
+  `classifyPartitionSourceDrift` Replicas check
+  (`provision/partition_source.go:138-147`) moves from the
+  `immutable` branch to the `mutable` branch in W0.
+- `Replicas` conditional-mutability is enforced by the NATS server,
+  not by `provision`. A `safe-update` Apply that requests
+  `Replicas=3` against a single-node NATS cluster will see
+  `js.UpdateKeyValue` return an error; Apply records it as a
+  fail-fast `ResourceError` per the existing contract.
+
+### Canonical KV equality
+
+Drift detection, `update-kv` action suppression (the "no-op when
+desired == live" rule), and the stale-before check at Apply time all
+use a single canonical equality function. The function compares **only
+the operator-expressible and drift-detection-only fields** from the
+[Per-Field Mutability Matrix](#per-field-mutability-matrix);
+preserved-from-live fields are intentionally excluded from comparison
+because the operator cannot express them and they are always inherited
+from live state.
+
+Fields compared by `kvConfigsEqual`:
+
+- `Metadata`: nil-equal-to-empty-map; key-by-key string compare.
+- `TTL` (stream `MaxAge`): nanosecond-equal; no normalization.
+- `MaxValueSize` (stream `MaxMsgSize`): treat `0` and `-1` as equal
+  (server stores "no limit" as `-1`, `jetstream/kv.go:639-642`).
+- `Replicas`: treat `0` and `1` as equal (nats.go normalizes
+  config `Replicas == 0` to server `Replicas = 1`,
+  `jetstream/kv.go:628-631`).
+- `History` (stream `MaxMsgsPerSubject`): integer-equal.
+- `Storage`: byte-equal.
+
+`Bucket` is **not** compared by `kvConfigsEqual`. The bucket name is
+the resource identity used by exact-name lookup
+(`provision/plan.go:107-117`, `provision/partition_source.go:53-65`);
+a YAML rename produces a `create-kv` for the new name and leaves the
+old name outside this config's scope. There is no in-resource
+bucket-field drift to compare.
+
+Fields **not** compared by `kvConfigsEqual` (preserved-from-live;
+operator cannot express them in YAML, so a difference cannot be
+intentional drift):
+
+- `Description`, `MaxBytes`, `Placement`, `RePublish`, `Mirror`,
+  `Sources`, `Compression`, `LimitMarkerTTL`, and any future
+  `KeyValueConfig` field added by nats.go.
+
+The canonical equality function lives in a single helper
+(`provision/kvequal.go::kvConfigsEqual`) and is the **only** equality
+check the safe-update path uses. Existing Phase 1 drift classifiers
+that perform their own ad-hoc normalization
+(`provision/partition_source.go:135-147,160-185`) are refactored in
+**W0** to call the helper instead, so the normalization rules live
+in one place.
+
+### Snapshot construction (Before / After / target)
+
+`KeyValueConfig` carries pointer and slice fields — `Placement
+*Placement`, `RePublish *RePublish`, `Mirror *StreamSource`,
+`Sources []*StreamSource` (nats.go v1.50.0
+`jetstream/kv.go:242-260`). A plain Go struct assignment is a
+**shallow copy**: the pointer values are duplicated but the
+pointees are shared with the source. This matters because nats.go's
+`prepareKeyValueConfig` may mutate entries in `cfg.Sources` while
+building the stream config (`jetstream/kv.go:700-720`), and because
+the plan-time `Resource.Before` value must remain immutable for the
+audit / JSON output regardless of later Apply or nats.go behavior.
+
+Phase 2 specifies **deep clone** for every snapshot construction:
+
+- Building Plan-time `Resource.Before` (from `StreamInfo.Config`):
+  shallow-copy the struct, then deep-clone `Placement`, `RePublish`,
+  `Mirror`, and every element of `Sources`. Same rule for the
+  `Metadata` map (always cloned to a fresh `map[string]string`).
+- Building Plan-time `Resource.After`: deep-clone of Before, then
+  overwrite operator-expressible fields.
+- Building Apply-time rebuilt target: deep-clone of the re-read
+  live config, then overwrite operator-expressible fields. The
+  rebuilt target is passed to `js.UpdateKeyValue`; deep cloning
+  insulates `Resource.Before` (still in the Plan output) from any
+  mutation nats.go performs on the target.
+
+Implementation detail: a single helper
+(`provision/clone_kvconfig.go::cloneKVConfig(jetstream.KeyValueConfig) jetstream.KeyValueConfig`)
+covers all three call sites. The helper is responsible for the
+pointer/slice cloning rules and the forward-compat preservation
+unit test calls it directly; if nats.go adds a new pointer-bearing
+field, the test fails until `cloneKVConfig` is updated to deep-clone it.
+
+"Byte copy of Before" elsewhere in this plan is shorthand for
+"shallow copy + deep-clone of pointer/slice fields per
+`cloneKVConfig`."
+
+The forward-compat preservation unit test asserts equality with
+`reflect.DeepEqual`, not pointer-identity, on every
+non-operator-expressible field.
+
+### Stale-before check uses operator-expressible subset only
+
+The Apply-time stale-before check (see
+[`update-kv` Apply path](#update-kv-apply-path) step 2) calls
+`kvConfigsEqual(reread, Resource.Before)`. Because `kvConfigsEqual`
+ignores preserved-from-live fields, the check is **not** sensitive to
+a concurrent operator changing `Description`, `Placement`, or any
+other preserved field between plan and apply — Apply simply inherits
+the new value at re-read time. The check fires only when an
+operator-expressible field or a drift-detection-only field has
+changed, which is the exact race the check is designed to catch.
+
+## Proposed SDK Additions
+
+All additions are in the `provision` package.
+
+### Policy constants
+
+```go
+// PolicyAdopt stamps the Parti ownership marker on resources named by
+// config that exist live and are unmarked. Adopt creates no missing
+// resources and updates no non-marker fields.
+//
+// Validate rejected PolicyAdopt in v1; Phase 2 accepts it.
+const PolicyAdopt ReconcilePolicy = "adopt"
+
+// PolicySafeUpdate performs create-missing PLUS in-place UpdateKeyValue
+// for drift-mutable fields on Parti-marked resources. Unmarked resources
+// continue to surface as "adopted" drift and are not mutated under
+// safe-update. Operators run `partictl adopt` first to transition them.
+//
+// Validate rejected PolicySafeUpdate in v1; Phase 2 accepts it.
+const PolicySafeUpdate ReconcilePolicy = "safe-update"
+```
+
+The Phase 1 `reservedPolicySafeUpdate` and `reservedPolicyForce` string
+constants in `provision/policy.go` change behavior:
+
+- `safe-update` is now accepted by `Validate`; the reserved string is
+  removed.
+- `force` remains reserved (Phase 6).
+
+### Action kind constants
+
+```go
+const (
+    // ActionUpdateKV is emitted by Plan under PolicySafeUpdate when a
+    // Parti-marked resource has drift-mutable field differences. Apply
+    // calls js.UpdateKeyValue(ctx, after) after verifying the live state
+    // still matches before. Resource is *UpdateKVResource.
+    ActionUpdateKV = "update-kv"
+
+    // ActionStampMarker is emitted by Plan under PolicyAdopt when a
+    // resource named by config exists live and is unmarked. Apply reads
+    // live state, merges the Parti marker keys with any existing non-Parti
+    // metadata keys, and calls js.UpdateKeyValue to write the merged
+    // result. Resource is *StampMarkerResource.
+    ActionStampMarker = "stamp-marker"
+)
+```
+
+### Action resource shapes
+
+Both new actions carry richer resource payloads than Phase 1's
+`create-kv`, so operator JSON tooling and audit consumers see what is
+changing. **The shapes below ship as exported Go types in `provision`.**
+
+```go
+// UpdateKVResource is the Resource carried by an ActionUpdateKV action.
+// Before is the live KeyValueConfig as observed at plan time; After is
+// the target. Apply re-reads live state before mutating and fails fast
+// (without mutation) if the re-read does not match Before; this is a
+// best-effort guard against last-writer-wins races on UpdateStream
+// (which carries no expected-revision token in nats.go v1.50.0).
+//
+// The Before/After pair is also the audit surface: JSON consumers can
+// diff Before vs After to render exactly which fields will change.
+type UpdateKVResource struct {
+    Before jetstream.KeyValueConfig `json:"before"`
+    After  jetstream.KeyValueConfig `json:"after"`
+}
+
+// StampMarkerResource is the Resource carried by an ActionStampMarker
+// action. MergedMetadata is the full Metadata map that will be written:
+// it is the union of (a) any non-Parti keys present on the live
+// resource at plan time and (b) the Parti marker keys for the target
+// component and instance.
+//
+// PartiKeys lists exactly the keys the action will add (or change), so
+// operator review can verify no non-Parti key is being silently
+// modified.
+type StampMarkerResource struct {
+    Bucket          string            `json:"bucket"`
+    MergedMetadata  map[string]string `json:"mergedMetadata"`
+    PartiKeys       []string          `json:"partiKeys"`
+}
+```
+
+Both `ActionUpdateKV` and `ActionStampMarker` populate
+`PlannedAction.Resource` with a **pointer** to the corresponding struct
+(matching Phase 1's pattern of carrying a `jetstream.KeyValueConfig`
+value in `Resource any`). Apply asserts the concrete type and fail-fasts
+on a mismatch (`provision/apply.go:93-103` shows the existing pattern).
+
+### Config additions
+
+```go
+type ControlPlaneConfig struct {
+    // ... existing fields unchanged ...
+
+    // Replicas is the desired number of NATS stream replicas for every
+    // control-plane KV bucket. 0 (the default) means "leave the
+    // KeyValueConfig.Replicas field unset"; nats.go normalizes that to
+    // 1 server-side. Non-zero values trigger drift-mutable detection
+    // under safe-update; the NATS server enforces feasibility (cluster
+    // peer count) at apply time.
+    //
+    // Replicas applies uniformly to every control-plane bucket. v2
+    // does not support per-bucket replica overrides.
+    Replicas int `yaml:"replicas,omitempty" json:"replicas,omitempty"`
+}
+```
+
+`PartitionSourceConfig.Replicas` already exists in Phase 1 (treated as
+drift-immutable then). Phase 2 reclassifies it to drift-mutable under
+safe-update; the field is **unchanged** structurally — only the
+classifier changes (`classifyPartitionSourceDrift` in
+`provision/partition_source.go:93-250`).
+
+`Validate` extensions for the new field:
+
+- `controlPlane.replicas < 0` is rejected (`ErrInvalidConfig`).
+- Mirroring the existing partition-source validation
+  (`provision/validate.go:162-164`), no upper bound is enforced; the
+  server rejects infeasible values at apply time.
+
+## Plan-emission details
+
+### `partictl plan` and policy selection
+
+The SDK's `Plan(ctx, js, cfg)` reads `cfg.Policy` and emits actions per
+[Reconcile Policy Ladder](#reconcile-policy-ladder). The CLI accepts a
+`--policy` flag on `plan`, `apply`, and `adopt`; the flag and the YAML
+`policy:` field must **agree** when both are present. The CLI does not
+silently override YAML — see [CLI Additions](#cli-additions) for the
+conflict-rejection contract. When YAML omits `policy:`, the flag is
+the canonical selection mechanism. When both are present and equal,
+the flag is redundant but accepted.
+
+### Order of operations: adopted drift suppresses field drift
+
+When a marked bucket exists, the per-resource classifier reports its
+drift findings normally. When an **unmarked** bucket named by config
+exists, the existing Phase 1 classifier returns early with a single
+`adopted` finding (`provision/plan.go:155-166`,
+`provision/partition_source.go:96-107`). Phase 2 preserves that
+short-circuit:
+
+- Under `safe-update`, an adopted bucket emits **no** `update-kv`
+  action and no field-drift findings — only the `adopted` finding.
+  The operator must run `adopt` first.
+- Under `adopt`, an adopted bucket emits a `stamp-marker` action;
+  the field-drift comparison is skipped entirely (it would surface
+  on the next `safe-update` run).
+- Under `warn` (default), behavior is unchanged.
+
+This is the codex review's "adoption is not approval" rule: the
+operator who runs `adopt` is not signing off on the bucket's current
+configuration. After adoption, the *next* `safe-update` plan reveals
+the field-level drift that was hidden under the adopted finding —
+including any drift-immutable findings that route to Phase 6.
+
+### `update-kv` emission
+
+For each Parti-marked bucket where `kvConfigsEqual(desired, live)`
+is false (the canonical equality function defined in
+[Canonical KV equality](#canonical-kv-equality)):
+
+1. Build the **Before** value: convert the live `StreamInfo.Config`
+   into a `KeyValueConfig`-equivalent shape covering **every** field
+   the nats.go `KeyValueConfig` knows about, not just the comparison
+   subset. This is the entire live snapshot.
+2. Build the **After** value: start with a **byte copy of Before**,
+   then overwrite only the operator-expressible fields with their
+   desired values:
+   - `Metadata`: merged (live non-Parti keys + Parti marker keys
+     for the resolved component and `cfg.Instance`).
+   - `TTL`: `cfg.<resource>.TTL`.
+   - `MaxValueSize` (partition-source only): `cfg.PartitionSource.MaxValueSize`.
+   - `Replicas`: `cfg.ControlPlane.Replicas` (control-plane) or
+     `cfg.PartitionSource.Replicas` (partition-source).
+   Every field that is not operator-expressible — including
+   drift-detection-only fields (`History`, `Storage`, `Bucket`) and
+   every preserved-from-live field (`Description`, `MaxBytes`,
+   `Placement`, `RePublish`, `Mirror`, `Sources`, `Compression`,
+   `LimitMarkerTTL`, **and any future field**) — is inherited from
+   Before verbatim. The "copy Before, then overwrite operator-
+   expressible" algorithm enforces the [Per-Field Mutability
+   Matrix](#per-field-mutability-matrix) at the code level.
+3. If `kvConfigsEqual(Before, After)` is true, emit no action;
+   record the bucket as `informational` drift if it was a candidate
+   at all. (This branch is rare because step 2 only ran when an
+   operator-expressible field differed; but the post-merge equality
+   check guards against bugs where the merge produces an equivalent
+   value, e.g. metadata maps differing only by ordering of
+   non-Parti keys.)
+4. Otherwise emit a `PlannedAction` with `Kind: ActionUpdateKV` and
+   `Resource: &UpdateKVResource{Before: live, After: target}`.
+
+The After value **never** changes drift-detection-only fields. If
+the live bucket has `History=3` and config asks for `History=1`,
+`update-kv.After.History` stays at `3`; the `drift-immutable`
+finding is emitted separately as in Phase 1, and the operator is
+told to route through Phase 6 force when that ships.
+
+The After value **never** resets preserved-from-live fields either.
+If the live bucket has `Description="owned by team X"` set out-of-band
+or `Placement` tags configured by a cluster admin,
+`update-kv.After` carries those values verbatim regardless of any
+other change in the same Apply.
+
+### `stamp-marker` emission
+
+For each unmarked bucket named by config that exists live:
+
+1. Read live `Metadata` from `StreamInfo`.
+2. Build `MergedMetadata`: start with a copy of every key in live
+   metadata, then write the three Parti keys (`parti.io/managed=v1`,
+   `parti.io/component=<component>`, `parti.io/instance=<cfg.Instance>`
+   only when non-empty).
+3. Build `PartiKeys`: the list of keys whose value differs between
+   live metadata and `MergedMetadata` — i.e. exactly the keys the
+   action will add or change.
+4. Emit a `PlannedAction` with `Kind: ActionStampMarker` and
+   `Resource: &StampMarkerResource{Bucket, MergedMetadata, PartiKeys}`.
+
+`BuildMarker` (`provision/marker.go:83-93`) returns only Parti keys,
+so it is **not** used directly here. Phase 2 adds a thin helper:
+
+```go
+// mergeMarker returns the metadata map to write when stamping the
+// Parti marker onto an unmanaged bucket. Live non-Parti keys are
+// preserved; Parti marker keys are written/overwritten; the parti.io/
+// prefix is the only prefix authoritatively owned by Parti, so any
+// other parti.io/* key not in the marker set is left in place
+// (forward-compat with future Parti marker keys).
+func mergeMarker(live map[string]string, component, instance string) (merged map[string]string, partiKeys []string)
+```
+
+This helper is reachable from both the `stamp-marker` plan path and
+the `update-kv` plan path (which also writes a full Metadata map
+including the marker, merged with live non-Parti keys).
+
+## Apply Semantics for New Actions
+
+### `update-kv` Apply path
+
+For each `ActionUpdateKV` in the plan:
+
+1. **Re-read live state.** Call `js.Stream(ctx, kvStreamPrefix+bucket).Info(ctx)`
+   to get the current live `KeyValueConfig`-equivalent fields.
+   - **`ErrStreamNotFound`** at this step → fail-fast `ResourceError`
+     with message `"bucket-missing-before-update: KV_<bucket> no longer exists"`,
+     `Aborted=false`, remaining actions in
+     `Skipped{Reason: SkipReasonPriorError}` per the Phase 1
+     fail-fast contract (`provision/apply.go:120-130`). No
+     auto-create attempt — adopt and safe-update do not create
+     resources that disappeared mid-Apply.
+   - Other lookup errors → classified per Phase 1's
+     `classifyLiveError` pattern (`provision/validate_live.go:232-247`).
+2. **Stale-before check (canonical).** Use `kvConfigsEqual(reread, Resource.Before)`
+   from [Canonical KV equality](#canonical-kv-equality). If unequal,
+   fail-fast: `ResourceError` message
+   `"stale-before: live state changed since plan; re-run plan"`,
+   identifying the bucket. Remaining actions go to
+   `Skipped{Reason: SkipReasonPriorError}`. The canonical equality
+   means that NATS server normalization (e.g. live `Replicas=1` vs
+   plan `Replicas=0`) does **not** trip the check.
+3. **Rebuild After from re-read.** Apply the same Plan-side
+   algorithm but starting from the **just-re-read** live snapshot:
+   byte-copy the re-read config into the target, then overwrite only
+   the operator-expressible fields from `cfg`. This guarantees
+   every preserved-from-live field (`Description`, `MaxBytes`,
+   `Placement`, `RePublish`, `Mirror`, `Sources`, `Compression`,
+   `LimitMarkerTTL`, and any future field) carries the *current*
+   live value, not the stale plan-time value. The result is the
+   actual `KeyValueConfig` that will be written. **The plan-time
+   `Resource.After` is used for audit / JSON output only; the value
+   actually written is the just-rebuilt target.**
+4. **No-op short-circuit.** If `kvConfigsEqual(reread, rebuilt_after)`,
+   skip the mutation; record `ExecutedAction{Raced: true}` (a
+   concurrent operator already converged the bucket). Continue to
+   the next action.
+5. **Call `js.UpdateKeyValue(ctx, rebuilt_after)`.** The full target
+   is written.
+   - **`errors.Is(err, jetstream.ErrBucketNotFound)`** (the bucket
+     was deleted in the re-read→write window) → fail-fast
+     `ResourceError` reusing the same message class as the
+     re-read miss: `"bucket-missing-before-update: KV_<bucket> no
+     longer exists"`. This unifies the two missing-bucket exits
+     so operator tooling can pattern-match on a single class.
+     Remaining actions go to `Skipped{Reason: SkipReasonPriorError}`.
+   - NATS server rejects History/Storage mismatches; we never set
+     those fields differently from Before, so they pass through
+     unchanged.
+   - The server may reject Replicas changes when the cluster lacks
+     peers; that surfaces as a normal non-cancellation Apply error
+     per the existing fail-fast contract.
+   - Any other error → standard fail-fast per
+     `provision/apply.go:120-130`.
+6. **No success-side re-read.** Once `UpdateKeyValue` returns nil,
+   record an `ExecutedAction` and continue. The next `partictl plan`
+   run is the canonical post-apply verification surface.
+
+Phase 1's Plan→Apply race handling for `create-kv` uses
+`ErrBucketExists` / `ErrStreamNameAlreadyInUse` to mark
+`Raced=true` (`provision/apply.go:111-116`). The `update-kv` path has
+two race exits: (a) stale-before fail-fast when live drifted from
+the plan-time Before, and (b) no-op `Raced=true` when re-read shows
+the target state already converged. Both are deliberate — operators
+see whether their plan was overtaken (case a) or whether their
+intent was already realized by someone else (case b).
+
+### `stamp-marker` Apply path
+
+For each `ActionStampMarker` in the plan:
+
+1. **Re-read live state.** Call `Stream(...).Info(ctx)`.
+   - **`ErrStreamNotFound`** → fail-fast `ResourceError` with
+     `"bucket-missing-before-stamp: KV_<bucket> no longer exists"`,
+     same remaining-actions handling as `update-kv` step 1.
+2. **Re-merge.** Recompute `MergedMetadata` from the **live**
+   metadata at re-read time (not from the plan's snapshot).
+   Stamping the Parti marker is idempotent on the Parti keys; if a
+   non-Parti key has changed since plan time, the new value flows
+   into the merged map (this is the "non-Parti keys preserved"
+   safety property at re-read granularity).
+3. **No-op short-circuit.** If every key in the recomputed merged
+   map already matches live metadata, no mutation is needed;
+   record `ExecutedAction{Raced: true}` (the bucket was
+   concurrently adopted or never needed stamping at this point)
+   and continue.
+4. **Build target `KeyValueConfig`.** Byte-copy the re-read live
+   `KeyValueConfig` and overwrite **only** `Metadata` with the
+   recomputed merged map. **Every** other field — operator-
+   expressible (`TTL`, `MaxValueSize`, `Replicas`), drift-
+   detection-only (`Storage`, `History`, `Bucket`), and
+   preserved-from-live (`Description`, `MaxBytes`, `Placement`,
+   `RePublish`, `Mirror`, `Sources`, `Compression`,
+   `LimitMarkerTTL`, future fields) — is inherited from the
+   re-read snapshot verbatim. `stamp-marker` writes one and only
+   one field-class change: Metadata. This minimizes the
+   cross-policy race window — see
+   [Cross-policy race window](#cross-policy-race-window).
+5. **Call `js.UpdateKeyValue(ctx, target)`.**
+   - **`errors.Is(err, jetstream.ErrBucketNotFound)`** (deleted in
+     the re-read→write window) → fail-fast `ResourceError` reusing
+     the re-read miss class: `"bucket-missing-before-stamp:
+     KV_<bucket> no longer exists"`. Same remaining-actions
+     handling as `update-kv` step 5.
+   - Other server-side rejections (extremely unlikely for a
+     metadata-only delta) fail-fast per the existing contract.
+6. Record `ExecutedAction` on success.
+
+The `update-kv` and `stamp-marker` Apply paths share enough plumbing
+that they should live in one helper file
+(`provision/apply_update.go`); each kind has its own entry point
+called from the kind-switch in `applyPlan`.
+
+### Testability seam
+
+The Apply helper for `update-kv` and `stamp-marker` is built around
+two narrow interfaces that act as injection seams so tests can
+deterministically interleave the re-read and write steps:
+
+```go
+// streamReader is the read-side of the Apply helper. The production
+// implementation calls js.Stream(...).Info(ctx).
+type streamReader interface {
+    StreamInfo(ctx context.Context, bucket string) (*jetstream.StreamInfo, error)
+}
+
+// kvUpdater is the write-side. The production implementation calls
+// js.UpdateKeyValue(ctx, cfg).
+type kvUpdater interface {
+    UpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) error
+}
+```
+
+The Apply entry point accepts a single combined interface (production
+implementations wrap `jetstream.JetStream`). Tests inject a fake that
+blocks between the read and the write so the cross-policy race test
+(see [Test Plan](#test-plan)) can deterministically drive the
+interleaving and assert the *exact* written target.
+
+### Cross-policy race window
+
+`stamp-marker` re-reads live state immediately before calling
+`UpdateKeyValue` (step 1) and writes the full re-read config with
+the merged Metadata (step 4). The window between step 1 and step 5
+is short but not zero. If another operator successfully writes a
+new TTL / Replicas / MaxValueSize value into the same bucket during
+that window, `stamp-marker`'s `UpdateKeyValue` will overwrite that
+value with what step 1 read (the **stale** value the other operator
+just updated past).
+
+Phase 2 **does not close this window** because NATS `UpdateStream`
+exposes no expected-revision / CAS primitive
+(`/home/arlo/.vfox/sdks/golang/packages/pkg/mod/github.com/nats-io/nats.go@v1.50.0/jetstream/jetstream.go:138-740`).
+The honest contract is:
+
+- `stamp-marker` is **best-effort** with respect to concurrent
+  `safe-update` or `force` on the same bucket. The mutation
+  *intends* to touch only Metadata; in the presence of a concurrent
+  field-changing mutation, it *may* overwrite that mutation if it
+  loses the race between the re-read (step 1) and the write
+  (step 5).
+- Operators who care about cross-policy ordering must serialize
+  `adopt` and `safe-update` themselves — the documented two-step
+  is the contract Phase 2 ships (`adopt` first, then `safe-update`).
+- The race-detection test in [Test Plan](#test-plan) demonstrates
+  the window and the operator-visible outcome; the plan does not
+  promise this race is closed.
+
+This honesty supersedes the earlier "adopt never touches data or
+config" wording in the [End-State Vision](#end-state-vision): the
+*intent* of adopt is to touch only the marker, and under serial
+operation that intent holds; under concurrent operators the actual
+guarantee is "intends to touch only the marker, may lose a race
+with concurrent updaters."
+
+### Cancellation, fail-fast, and partial reports
+
+Phase 1's cancellation contract
+(`provision/apply.go:25-34`, `83-90`, `117-121`) and fail-fast
+contract (`provision/apply.go:33-34`, `122-130`) cover the new
+action kinds without modification. No new `Skipped.Reason`
+constants are introduced — failures surface as `ResourceError`
+entries with descriptive messages (`"stale-before: ..."`,
+`"bucket-missing-before-update: ..."`,
+`"bucket-missing-before-stamp: ..."`); downstream actions use the
+existing `SkipReasonPriorError`.
+
+## CLI Additions
+
+### `partictl apply --policy`
+
+Add a `--policy` flag accepting `warn`, `adopt`, `safe-update`,
+or `force` (the last rejected at flag-parse time with
+"not supported in v1/v2"). The flag is parsed but does **not**
+silently override `cfg.Policy`. Resolution rules:
+
+| `--policy` flag | YAML `policy:` | Effective policy | Outcome |
+|-----------------|----------------|------------------|---------|
+| absent          | absent         | `warn` (default) | proceed |
+| absent          | `X`            | `X`              | proceed |
+| `X`             | absent         | `X`              | proceed |
+| `X`             | `X` (same)     | `X`              | proceed |
+| `X`             | `Y` (different)| —                | **exit 3** with `partictl apply: --policy=X conflicts with cfg.policy=Y in <file>. Pick one or remove the cfg.policy field.` |
+
+The CLI never overrides the YAML silently. When the flag and the
+YAML disagree, the operator picks which source of truth wins by
+editing one of them.
+
+**`policy: ""` is treated as absent.** The conflict check inspects
+the **raw unmarshalled** `cfg.Policy` string before
+`provision.normalize` defaults the empty string to `PolicyWarn`
+(`provision/validate.go:61-64`). An operator who writes
+`policy: ""` (or omits the field entirely) sees the same behavior:
+no conflict with any `--policy=X`, and the effective policy is `X`
+(or `warn` if `--policy` is also absent). This matches operator
+intent — writing `policy: ""` typically means "I haven't decided",
+not "I specifically chose `warn`."
+
+Symmetric flag-vs-config conflict checks also apply to
+`partictl plan --policy=X` and `partictl adopt -f` (which forbids
+any non-empty `cfg.policy` other than `adopt`; `cfg.policy: warn`
+plus `partictl adopt -f` still exits 3 with the same message
+form; `cfg.policy: ""` proceeds because it is absent).
+
+### `partictl plan --policy`
+
+`partictl plan` also accepts `--policy`. Plan output reflects the
+chosen policy's action emission rules (no actions for `adopt` /
+`safe-update` against missing or unmarked resources when the
+policy excludes them, per
+[Reconcile Policy Ladder](#reconcile-policy-ladder)). `-fail-on-drift`
+behavior is unchanged.
+
+### `partictl adopt -f cfg.yaml [-dry-run]`
+
+A new top-level command. Shorthand for `partictl apply -f cfg.yaml --policy=adopt`,
+with one delta: `partictl adopt -dry-run` is symmetric with
+`partictl apply -dry-run` and emits the same `PlanResult` JSON the
+plan command would emit under `--policy=adopt`.
+
+Per codex review: `--dry-run` on `adopt` is free given the shared
+Plan / Apply infrastructure. It is required for parity with the
+`apply --dry-run` operator workflow.
+
+`partictl adopt` requires `-f`. There is no standalone "adopt
+everything Parti-shaped" mode — adoption is config-scoped, by
+exact NATS name, just like every other config-scoped action in
+the SDK.
+
+If `cfg.Policy` is `adopt` (operator already wrote it in YAML),
+`partictl adopt` runs normally. If `cfg.Policy` is anything else
+non-empty, the policy-conflict check above fires.
+
+## Safety Rules
+
+Building on the Phase 1 Safety Rules section
+(`docs/plans/provision-sdk-cli/00-implementation-plan.md:848-868`).
+The Phase 1 rules continue to apply. Phase 2 adds:
+
+- **Adoption is not approval of the bucket's config.** Running
+  `partictl adopt` stamps the Parti marker. It does not assert that
+  the bucket's History, Storage, Replicas, TTL, or any other field
+  matches the desired config. The next `partictl plan` run after
+  adoption reveals every field-level drift that was hidden under
+  the `adopted` finding — including any drift-immutable drift that
+  routes to Phase 6 force.
+- **`safe-update` preserves fields the YAML cannot express.** The
+  `update-kv` Apply path constructs `After` by copying the
+  just-re-read live snapshot and overwriting only the
+  operator-expressible fields. `Description` and `MaxBytes` are
+  **never** reset by Phase 2 even when other fields change in the
+  same Apply. Operators who set those fields out-of-band keep them.
+- **UpdateStream is last-writer-wins; the stale-before check is
+  best-effort only.** NATS `$JS.API.STREAM.UPDATE` carries no
+  expected-revision token. Two operators running any combination of
+  `safe-update`, `adopt`, or `force` against the same bucket can
+  race. The `update-kv` stale-before check (Apply step 2) closes
+  the plan→apply window, but the re-read→write window (between
+  Apply step 1 and step 5) remains open. A concurrent operator's
+  mutation that lands in that window will be overwritten if the
+  loser of the race finishes second. See
+  [Cross-policy race window](#cross-policy-race-window) for the
+  precise contract.
+- **`adopt` is intent-only on data and config.** The `stamp-marker`
+  Apply path *intends* to touch only the Parti marker keys; in the
+  presence of concurrent field-changing writers, the unavoidable
+  re-read→write window may overwrite a concurrent field update.
+  Operators who care about cross-policy ordering serialize their
+  own runs.
+- **`cfg.Instance` changes are an operator-expressible Metadata
+  mutation.** If an operator stamps `instance=A` via `adopt`, then
+  edits cfg to `instance=B` and runs `safe-update`, Plan emits
+  `update-kv` with a new Metadata map carrying `parti.io/instance=B`
+  (preserving live non-Parti keys). This is intentional —
+  `cfg.Instance` is operator-controlled and lives in the
+  `parti.io/instance` marker key, which is squarely in the
+  operator-expressible category. Operators who change instance
+  labels know they are renaming an environment's logical identity.
+- **Replicas changes are conditional on cluster size.** A
+  `safe-update` Apply that bumps `Replicas` against a NATS cluster
+  with fewer peers than the requested value will fail-fast. Apply
+  records a `ResourceError` with the underlying NATS error;
+  `Aborted` stays false; remaining actions go to
+  `Skipped{Reason: SkipReasonPriorError}` per the existing
+  fail-fast contract.
+- **`partictl adopt` never mutates non-Parti metadata keys.** The
+  `stamp-marker` Apply path's merged metadata starts from the live
+  Metadata map and only writes the Parti marker keys. Any
+  non-Parti key with the same name as a marker key (e.g., an
+  operator manually setting `parti.io/managed: malformed`) is
+  overwritten with the canonical value; everything else is
+  preserved verbatim, subject to the race window above.
+- **`partictl adopt` is config-scoped.** Adoption requires `-f`.
+  There is no "adopt everything you find" mode; adoption walks
+  the buckets named by config and stamps only those.
+- **Missing-on-reread is a fail-fast.** If a bucket existed at
+  plan time but is gone when Apply re-reads it, both `update-kv`
+  and `stamp-marker` fail-fast with a clear `ResourceError`. Apply
+  never auto-creates a deleted bucket; that would race with the
+  delete itself.
+
+The Phase 1 [Output schema versioning](../provision-sdk-cli/00-implementation-plan.md#output-schema-versioning)
+rule continues to hold: every JSON-emitting struct (`Snapshot`,
+`PlanResult`, `Report`) carries `apiVersion: parti.io/provision/v1`
+and a `Kind` field. New `PlannedAction.Kind` values are additive
+within the v1 envelope.
+
+## Work Items
+
+Each work item ships as its own PR. The standard per-PR loop matches
+[Phase 1's Implementation Workflow](../provision-sdk-cli/00-implementation-plan.md#implementation-workflow):
+
+```
+sub-spec (if needed) → impl → /simplify → /codex:review (or /post-impl-review)
+  → fix → re-review → squash on merge verdict
+```
+
+Phase 1 conventions for sub-specs, `/simplify`, codex effort levels, and
+squash-on-merge carry over. Sub-specs live under
+`docs/plans/provision-sdk-cli-v2/` named `<NN>-<wname>-spec.md` (e.g.,
+`02-w2-update-kv-apply-spec.md`).
+
+### Recommended model + effort per work item
+
+| W  | Title | Sub-spec needed? | Sub-spec planner | Implementer | Codex review effort |
+|----|-------|------------------|------------------|-------------|---------------------|
+| W0 | **Classifier + config shape + equality / clone helpers only** (no new action kinds). Accept `PolicyAdopt` + `PolicySafeUpdate` in `Validate`; remove the "rejected in v1" string for safe-update (keep force reserved); add `controlPlane.replicas` field. Add the canonical equality helper `kvConfigsEqual` covering the operator-expressible + drift-detection-only subset. Add the deep-clone helper `cloneKVConfig` covering every pointer / slice field (`Placement`, `RePublish`, `Mirror`, `Sources`, `Metadata`) plus the forward-compat preservation unit test that exercises it. Refactor `classifyControlPlaneDrift` and `classifyPartitionSourceDrift` to use `kvConfigsEqual`. Reclassify `Replicas` from drift-immutable to drift-mutable on both resource kinds. Remove `drift-mutable` emission for `Description` and `MaxBytes` from `classifyPartitionSourceDrift` (preserved-from-live). Update only the comment block in `internal/kvbuckets/builder.go` to document the narrowed invariant (function behavior unchanged). | No | — | **Sonnet 4.6** | `xhigh` |
+| W1 | **Plan-emission path for `update-kv` only**. New `UpdateKVResource` type. Per-policy emission gating (`update-kv` only under `safe-update`). The Before-build / After-build algorithm: Before = full live `KeyValueConfig`-equivalent extracted from `StreamInfo.Config` (every nats.go field, not just the comparison subset), constructed via the W0 `cloneKVConfig` helper so pointer/slice fields are deep-cloned and Plan output stays immutable across later mutations. After = `cloneKVConfig(Before)` with only operator-expressible fields overwritten. `kvConfigsEqual(Before, After)` drives the no-action short-circuit. W1 does **not** modify classifier code, the canonical equality helper, or the clone helper (those landed in W0); W1 only consumes them. | **Yes** | **Opus 4.7** | **Opus 4.7** | `xhigh` |
+| W2 | Apply path for `update-kv`: re-read live state with `ErrStreamNotFound` → fail-fast `bucket-missing-before-update`; stale-before canonical equality check; rebuild-After-from-reread; no-op short-circuit when re-read shows convergence; `js.UpdateKeyValue` call; fail-fast error wrapping. Per-field integration tests for every operator-expressible field (Metadata, TTL, MaxValueSize, Replicas including server-rejection on undersized cluster). Plan→Apply race tests (stale-before path AND no-op convergence path) | **Yes** (shared with W1 or its own — sub-spec author decides) | **Opus 4.7** | **Opus 4.7** | `xhigh` |
+| W3 | `stamp-marker` plan + apply for `adopt` policy: `StampMarkerResource` type, `mergeMarker` helper, Apply path re-reads live and writes the full re-read config with merged Metadata (preserves-from-live every non-Metadata field), missing-on-reread fail-fast. Integration tests asserting (a) Parti keys stamped, (b) non-Parti metadata keys preserved verbatim, (c) preserved-from-live fields (Description, MaxBytes, TTL, MaxValueSize, Replicas) unchanged by adopt, (d) idempotent on re-run, (e) **cross-policy race window** demonstrated with explicit timing comment | **Yes** | **Opus 4.7** | **Opus 4.7** | `xhigh` |
+| W4 | CLI plumbing: `partictl apply --policy`, `partictl plan --policy`, `partictl adopt -f [-dry-run]`, **flag-vs-config conflict detection** (exit 3 when both supplied and disagree; same-value or single-source proceeds), per-policy golden-test outputs, exit-code coverage | No | — | **Sonnet 4.6** | `high` |
+| W5 | Documentation: `docs/PROVISION.md` Phase 2 section updates plus a new operator playbook covering brownfield NATS adoption, the `adopt → safe-update` sequence, the Replicas server-rejection contract, **the cross-policy race window**, **the preserved-from-live contract**, and the last-writer-wins UpdateStream caveat | No | — | **Sonnet 4.6** | `high` (or run `/doc-sync` against the updated SDK first to derive deltas) |
+
+Rationale, in line with Phase 1's W0–W5 rationale section:
+
+- **W0** changes the policy-acceptance surface and adds a Config field.
+  The byte-equivalence invariant narrowing is documented in the W0 PR
+  via an updated comment block in `internal/kvbuckets/builder.go` and a
+  test in `provision/plan_test.go` asserting that `Replicas==0` still
+  produces the byte-equivalent `KeyValueConfig` for control-plane
+  buckets. **`xhigh`** review (not `medium`) because the policy-string
+  acceptance change is load-bearing for every later work item; getting
+  the surface wrong here would force every later PR to re-litigate.
+- **W1** is the new public-API surface for plan emission. A sub-spec
+  is required because the `update-kv` Resource shape (the
+  `UpdateKVResource` struct, the stamp-merge helper interaction, the
+  "drift-immutable fields stay in After" rule) needs to be pinned
+  before code is written. Opus 4.7 + `xhigh` to match the W1
+  precedent.
+- **W2** is the mutation path. The stale-before contract, the
+  re-read semantics, and the per-field test matrix justify a
+  sub-spec (it may be co-located with W1's if the author prefers a
+  single spec covering both, but the actions are
+  separable). `xhigh` because mutation.
+- **W3** is the second mutation path. Separate sub-spec because the
+  merge semantics (which keys live, which keys overwrite, idempotency
+  rules) are a distinct contract. `xhigh` because mutation + this is
+  the operator's first taste of "Parti takes ownership of pre-existing
+  resources" — surface mistakes here are very visible.
+- **W4** is CLI glue. No public-SDK reasoning beyond what W1–W3 already
+  established. `high` (not `xhigh`) per Phase 1's W5 precedent.
+- **W5** is docs. Phase 1's docs surface already includes a Phase 2
+  placeholder; W5 fills it in and adds the operator playbook the
+  brownfield workflow requires.
+
+### Final plan review before W0 starts
+
+Per Phase 1 precedent, this plan runs `/plan-review` against
+`/post-impl-review`'s sibling — an architectural pass — until the
+verdict is CLEAN. Then a single `/final-plan-review` pass before W0
+opens; the latter is the precision pass (effort `high`), not
+another architectural round.
+
+## Test Plan
+
+Static / unit:
+
+- `Validate` accepts `policy: adopt` and `policy: safe-update`; rejects
+  `policy: force` with the "lands in Phase 6" message; rejects unknown
+  policy values with the existing message.
+- `ControlPlaneConfig.Replicas < 0` is rejected; `0` accepts; positive
+  values accept.
+- `Plan` with `cfg.Policy = adopt` emits `stamp-marker` for unmarked
+  buckets and no other action; emits no action for missing buckets;
+  emits no action for already-marked buckets.
+- `Plan` with `cfg.Policy = safe-update` emits `create-kv` for
+  missing buckets, `update-kv` for marked buckets with drift on at
+  least one operator-expressible field, and reports `adopted` drift
+  (no action) for unmarked buckets named by config.
+- **`Plan` no-op against default install**: a freshly-created
+  control-plane bucket via Phase 1's `create-kv` (live `Replicas=1`,
+  `MaxBytes=-1`, `MaxMsgSize=-1`, no Description) against a config
+  with omitted `replicas` and no overrides produces **no**
+  `update-kv` action under `policy=safe-update`. The canonical
+  equality function suppresses the action despite the raw
+  difference in field representation.
+- `Plan` byte-equivalence for control-plane buckets when
+  `ControlPlane.Replicas == 0`: every `create-kv` and `update-kv`
+  After value strips Metadata and Replicas, then compares
+  byte-for-byte against the W0 builder output for the same inputs
+  (preserves the narrowed invariant).
+- `update-kv.After` preserves drift-immutable fields from `Before`
+  when the desired config disagrees: assert no `History` / `Storage`
+  divergence between After and Before.
+- **`update-kv.After` preserves preserved-from-live fields**: pre-set
+  `Description="owned by team X"` and `MaxBytes=1<<30` on a marked
+  bucket; build `update-kv` Plan for an unrelated TTL change;
+  assert `After.Description == "owned by team X"` and
+  `After.MaxBytes == 1<<30` (preserved verbatim from Before).
+- `kvConfigsEqual` normalization: explicit table-driven tests for
+  every normalization rule (`Replicas 0↔1`, `MaxBytes 0↔-1`,
+  `MaxMsgSize 0↔-1`, `Metadata nil↔{}`).
+- `mergeMarker` preserves non-Parti keys verbatim; writes the
+  three Parti keys when instance is set; writes two Parti keys
+  when instance is empty (no `parti.io/instance` key); returns
+  `partiKeys` listing only keys that differ between live and
+  merged.
+
+Embedded-NATS integration (per-field — these are the user prompt's
+"per-field test coverage required"):
+
+- For each **operator-expressible** field (Metadata, TTL,
+  MaxValueSize for partition-source, Replicas for both): pre-create
+  a Parti-marked bucket with the field differing from cfg →
+  `plan --policy=safe-update` reports `drift-mutable` and emits
+  `update-kv` → `apply --policy=safe-update` converges the live
+  state → re-`plan` reports `informational`.
+- `Replicas` field: above matrix plus a sub-test where the
+  embedded NATS server is single-node and the target Replicas is
+  3 → `apply` fail-fasts with the server error in `Report.Errors`,
+  `Aborted=false`, remaining actions in `Skipped{Reason:
+  SkipReasonPriorError}`.
+- **Preserved-from-live** fields the YAML can never express:
+  pre-create a Parti-marked bucket with operator-set
+  `Description="owned by team X"`, `MaxBytes=1<<30`, **and**
+  every other preserved-from-live field the embedded NATS test
+  harness supports (at minimum: `Compression=true`; `Placement`
+  with a tag set; `RePublish` with a destination subject;
+  `LimitMarkerTTL > 0` if supported) → cfg requests a different
+  TTL but does not (and cannot) mention any of the above →
+  `apply --policy=safe-update` → live `Description`, `MaxBytes`,
+  `Compression`, `Placement`, `RePublish`, `LimitMarkerTTL` are
+  **all unchanged**; only TTL converged. Test fails if any
+  preserved-from-live field changes value.
+- **Forward-compat preservation**: a unit test that builds a
+  synthetic `KeyValueConfig`-equivalent with every field nats.go
+  v1.50.0 exposes set to a non-zero value, runs the W1
+  After-build algorithm against it, and asserts that **every
+  field except the operator-expressible ones is byte-equal to
+  Before**. If nats.go adds a new field to `KeyValueConfig` and
+  the W1 algorithm fails to copy it, this test fails immediately
+  (rather than waiting for a brownfield operator to notice).
+- For each **drift-immutable** field (History, Storage): pre-create
+  a Parti-marked bucket with the field differing from cfg →
+  `plan --policy=safe-update` reports `drift-immutable` and emits
+  **no** `update-kv` action → `apply` is a no-op for that bucket.
+- **No-op against default install**: pre-create a Parti-marked
+  bucket via `apply --policy=warn` (live `Replicas=1`,
+  `MaxBytes=-1`, `MaxMsgSize=-1`) → call
+  `plan --policy=safe-update` with cfg omitting `replicas` →
+  expect **no** `update-kv` action (canonical equality suppression).
+- `adopt` plan/apply: pre-create an unmarked bucket with name
+  matching config → `plan --policy=adopt` emits `stamp-marker` →
+  `apply --policy=adopt` writes the merged metadata → re-`plan`
+  under `safe-update` reports `informational` (or further drift
+  on non-marker fields, which is the explicit "adoption is not
+  approval" test).
+- `adopt` preserves non-Parti metadata: pre-create an unmarked
+  bucket with `{"custom.io/foo": "bar"}` in Metadata → `apply
+  --policy=adopt` → live Metadata contains
+  `{custom.io/foo: bar, parti.io/managed: v1, parti.io/component:
+  <component>}`. Test fails if the non-Parti key is missing or
+  altered.
+- `adopt` preserves preserved-from-live fields: pre-create an
+  unmarked bucket with `Description`, `MaxBytes`, `TTL`,
+  `MaxValueSize`, and `Replicas` all explicitly set →
+  `apply --policy=adopt` → live values for all five fields are
+  unchanged; only Metadata is augmented.
+- Plan→Apply stale-before race for `update-kv`: pre-stage a marked
+  bucket with drift on TTL → call `provision.Plan` →
+  out-of-band update of live TTL to a third value (neither
+  Before nor After) → call `provision.Apply` with the original
+  plan → expect fail-fast `ResourceError` containing
+  `"stale-before"`; remaining actions are
+  `Skipped{Reason: SkipReasonPriorError}`.
+- Plan→Apply no-op convergence race for `update-kv`: pre-stage a
+  marked bucket with drift on TTL → call `provision.Plan` →
+  out-of-band update of live TTL to the desired (After) value →
+  call `provision.Apply` with the original plan → expect
+  `ExecutedAction{Raced: true}` and no mutation attempt.
+- Plan→Apply race for `stamp-marker` (re-merge against current
+  live): pre-stage an unmarked bucket with a non-Parti key
+  `{"custom.io/foo": "bar"}` → call `provision.Plan` → stamp
+  an additional non-Parti key out-of-band
+  (`{"custom.io/baz": "qux"}`) → call `provision.Apply` →
+  `ExecutedAction` records the merged metadata containing BOTH
+  non-Parti keys plus the Parti marker.
+- **Cross-policy race for `stamp-marker` (deterministic)**: uses
+  the [Testability seam](#testability-seam) to inject a fake
+  `streamReader` / `kvUpdater`. Setup: an unmarked bucket with
+  Metadata `{custom.io/foo: bar}` and TTL=10s. The fake reader
+  returns this snapshot on first call. Apply enters
+  `stamp-marker`, completes its re-read, then **blocks before
+  the write**. The test then mutates the fake "live" state to
+  TTL=20s (simulating a concurrent `safe-update` that landed
+  between stamp-marker's read and write). The test unblocks
+  stamp-marker. Assert:
+  1. The `UpdateKeyValue` call target carries the **re-read
+     snapshot's** values (TTL=10s, the stale value) plus the
+     merged Metadata (Parti keys + `custom.io/foo: bar`).
+  2. `ExecutedAction` is recorded with no error.
+  3. The test comment block cites this plan section and
+     documents that the deterministic outcome demonstrates the
+     race window's existence; the production NATS path has the
+     same algorithm and the same window.
+  This test is **deterministic** (exact assertion on the write
+  target) and **encodes the contract from
+  [Cross-policy race window](#cross-policy-race-window)**.
+  Without this seam, the test would be timing-dependent and
+  unreliable; with it, the test passes when the algorithm
+  matches the documented behavior and fails when the
+  implementation accidentally closes (or widens) the window.
+- **Missing-on-reread**: pre-stage an `update-kv` Plan → delete
+  the underlying `KV_<bucket>` stream out-of-band → call
+  `provision.Apply` → expect fail-fast `ResourceError` with
+  `"bucket-missing-before-update"`, `Aborted=false`, remaining
+  actions in `Skipped{Reason: SkipReasonPriorError}`. Same test
+  for `stamp-marker` → `"bucket-missing-before-stamp"`.
+- Order-of-operations: pre-stage an unmarked bucket whose other
+  fields ALSO disagree with cfg → `plan --policy=safe-update`
+  reports only `adopted` finding (no `update-kv`) → run `adopt`
+  flow → re-run `plan --policy=safe-update` and observe `update-kv`
+  emission for the previously-hidden field drift. If the hidden
+  drift is immutable, observe `drift-immutable` instead.
+
+CLI:
+
+- `partictl adopt -f cfg.yaml -dry-run` emits the same JSON as
+  `partictl plan -f cfg.yaml --policy=adopt`.
+- `partictl apply --policy=safe-update` and `partictl apply` (no
+  flag, default warn) produce different plans against the same
+  drifted environment; golden-test the two outputs.
+- Policy-vs-config conflict: cfg.policy=warn + `--policy=safe-update`
+  exits 3 with a message naming both sources. Symmetric for
+  `partictl adopt -f cfg.yaml` when cfg.policy=safe-update.
+- Exit-code precedence is unchanged: connection failure during
+  `safe-update` apply still maps to exit 4; static validation
+  failure of an unknown policy maps to exit 3; runtime failure
+  (server-rejected Replicas) maps to exit 1.
+
+## Acceptance Criteria
+
+- An operator with a brownfield NATS environment can run
+  `partictl adopt -f parti-env.yaml`, see exactly which buckets
+  are about to be stamped (via `-dry-run -json`), then commit the
+  stamp. After the run, every config-named bucket carries
+  `parti.io/managed=v1` plus the appropriate `parti.io/component`,
+  and **every** other live field (Description, MaxBytes, TTL,
+  MaxValueSize, Replicas, plus non-Parti metadata keys) is
+  unchanged.
+- An operator can edit `parti-env.yaml` to change any
+  operator-expressible field (TTL, MaxValueSize for
+  partition-source, Replicas, or cfg.Instance) on any marked
+  bucket, then run `partictl apply -f parti-env.yaml
+  --policy=safe-update` and see those fields reconciled in place
+  with a single Apply. **Fields the YAML cannot express
+  (`Description`, `MaxBytes`) are never modified by this run** —
+  operator-set values placed via the NATS CLI or another tool
+  survive Phase 2 safe-update.
+- Re-running `safe-update` after a successful run is a no-op:
+  drift reports `informational` for the affected buckets, no
+  `update-kv` action is emitted. This holds even when live values
+  carry NATS server-side normalized defaults (`Replicas=1` from
+  config `0`, `MaxBytes=-1` from default install).
+- An unmarked bucket named by config is NEVER mutated by
+  `--policy=safe-update`. Phase 2 surfaces it as `adopted` drift,
+  emits no action, and forces the operator into the adopt flow.
+- An immutable-drift bucket (History or Storage mismatch) is
+  NEVER mutated by `--policy=safe-update`. Phase 2 surfaces it as
+  `drift-immutable`, emits no action, and points operators at the
+  Phase 6 force path.
+- A Replicas bump against an undersized cluster fails fast with the
+  underlying NATS error wrapped into a `ResourceError`; the partial
+  `Report` carries `Aborted=false` and the surviving plan actions
+  in `Skipped{Reason: SkipReasonPriorError}`. CLI exits 1.
+- A `safe-update` Apply whose live state drifted from the plan-time
+  Before fails fast at the stale-before check with
+  `"stale-before"` in the `ResourceError` message; no mutation
+  occurs. A `safe-update` Apply whose live state already converged
+  to the desired After records `ExecutedAction{Raced: true}` and
+  no mutation occurs.
+- A bucket that existed at plan time but was deleted before Apply
+  reached it produces a fail-fast `ResourceError`
+  (`"bucket-missing-before-update"` or
+  `"bucket-missing-before-stamp"`); no auto-create.
+- An `adopt` Apply that races with a concurrent operator's adopt on
+  the same bucket is idempotent at the Metadata level: the live
+  Parti marker keys after both runs are the same regardless of
+  order. The plan documents (and a test demonstrates) that the
+  race window for non-Parti fields under cross-policy concurrent
+  writes is **not** closed; that contract is honest in the docs.
+- The CLI rejects `--policy=X` plus `cfg.policy=Y` (where `X != Y`)
+  with exit 3 and a message naming both sources. The CLI never
+  silently overrides YAML.
+- Every JSON output payload still carries
+  `apiVersion: parti.io/provision/v1` and a `kind` field. New
+  `PlannedAction.Kind` and `ReconcilePolicy` strings appear under
+  the same envelope.
+- Control-plane `KeyValueConfig` byte-equivalence to
+  `manager_setup.go:ensureKVBucket` still holds when
+  `ControlPlaneConfig.Replicas == 0`. When non-zero, only the
+  `Replicas` field deviates; all others remain byte-equivalent.
+  A unit test pins this contract.
+
+## Assumptions
+
+- `partictl` callers running Phase 2 are using NATS server 2.6 or
+  newer (live Replicas changes supported). Older NATS servers will
+  reject Replicas changes at apply time; Phase 2 treats that as a
+  normal server-rejection error and does not pre-detect server
+  version.
+- `nats.go` v1.50.0's `UpdateKeyValue` semantics are stable for
+  the duration of Phase 2. The implementation depends on
+  `UpdateKeyValue` routing to `UpdateStream`
+  (`jetstream/kv.go:572-590` in the cached module); a future
+  nats.go version that changes this routing would require
+  reassessment.
+- Concurrent operators running `safe-update` simultaneously
+  against the same Parti environment is a real-world scenario
+  for CI-driven deployments; the stale-before check is sufficient
+  best-effort protection. Tighter coordination (server-side CAS,
+  distributed lock) is out of scope.
+- Operators understand that `adopt` and `safe-update` are
+  intentionally separate steps. The plan's documentation (W5)
+  pins this in the operator playbook; the CLI does not offer a
+  `--auto-adopt` shortcut in Phase 2.
+- Replicas downscale (e.g., from 3 to 1) is a valid safe-update
+  operation and not specially handled. The NATS server may or may
+  not enforce a hold-down on quorum loss during downscale; that
+  is out of scope for Phase 2 — operators run replica downscales
+  during maintenance windows, same as any cluster size change.
+- Phase 2 changes the partition-source drift-classification surface
+  in two ways relative to Phase 1: (a) `Replicas` moves from
+  `drift-immutable` to `drift-mutable`; (b) `Description` and
+  `MaxBytes` **stop** producing drift findings entirely (they are
+  preserved-from-live). Phase 1 callers that key on those
+  severities for those fields must update; the change is
+  announced in the W5 docs and the Phase 2 release notes. The
+  partition-source `drift-mutable` severity is otherwise reserved
+  for the operator-expressible fields enumerated in the
+  [Per-Field Mutability Matrix](#per-field-mutability-matrix).

--- a/docs/plans/provision-sdk-cli-v2/01-update-kv-spec.md
+++ b/docs/plans/provision-sdk-cli-v2/01-update-kv-spec.md
@@ -22,8 +22,9 @@ In scope:
 - `mergeUpdateKVMetadata` helper (distinct from W0's `mergeMarkerMetadata`).
 - `update-kv` emission in `planControlPlane` / `planPartitionSource`,
   gated on `cfg.Policy == PolicySafeUpdate`.
-- `update-kv` execution in `applyPlan`: re-read, stale-before check,
-  rebuild-after-from-reread, `js.UpdateKeyValue`, fail-fast classes.
+- `update-kv` execution in `applyPlan`: re-read, rebuild-after-from-reread,
+  no-op short-circuit, stale-before check, `js.UpdateKeyValue`,
+  fail-fast classes.
 - Testability seam (`streamReader` / `kvUpdater`) for deterministic
   apply tests.
 

--- a/docs/plans/provision-sdk-cli-v2/01-update-kv-spec.md
+++ b/docs/plans/provision-sdk-cli-v2/01-update-kv-spec.md
@@ -1,0 +1,377 @@
+# Sub-spec: `update-kv` plan emission and apply execution
+
+Covers work items **W1** (Plan emission) and **W2** (Apply execution)
+from [`00-implementation-plan.md`](00-implementation-plan.md). The two
+ship as **one PR**: W1 alone would make `Plan` emit `update-kv` actions
+that `applyPlan`'s kind-switch rejects via its `default` case
+(`provision/apply.go:132-142`), leaving `provision.Apply` broken for
+`safe-update` between merges. The feature is plan-emit plus
+apply-execute; splitting it leaves an incoherent intermediate state.
+
+This sub-spec pins the contract details the master plan leaves open. It
+does not restate the master plan; read the master plan's "update-kv
+emission", "update-kv Apply path", "Canonical KV equality", and
+"Snapshot construction" sections first.
+
+## Scope
+
+In scope:
+
+- `UpdateKVResource` exported type.
+- `streamConfigToKVConfig` full-projection helper.
+- `mergeUpdateKVMetadata` helper (distinct from W0's `mergeMarkerMetadata`).
+- `update-kv` emission in `planControlPlane` / `planPartitionSource`,
+  gated on `cfg.Policy == PolicySafeUpdate`.
+- `update-kv` execution in `applyPlan`: re-read, stale-before check,
+  rebuild-after-from-reread, `js.UpdateKeyValue`, fail-fast classes.
+- Testability seam (`streamReader` / `kvUpdater`) for deterministic
+  apply tests.
+
+Out of scope (later work items):
+
+- `stamp-marker` / `adopt` policy — **W3**.
+- `partictl --policy` flag, `partictl adopt` command — **W4**.
+- Cross-policy race tests — **W3** owns the seam-based race test;
+  this PR only introduces the seam.
+
+## ReconcilePolicy threading
+
+`Plan` and `Apply` already receive `cfg.Policy`. No signature changes.
+`planControlPlane` / `planPartitionSource` branch on
+`cfg.Policy == PolicySafeUpdate` to decide whether to emit `update-kv`.
+`warn` (default) and `adopt` emit no `update-kv`.
+
+## Type: `UpdateKVResource`
+
+```go
+// UpdateKVResource is the Resource carried by an ActionUpdateKV
+// PlannedAction. Before is the live KeyValueConfig observed at plan
+// time; After is the desired target. Both are deep clones (see
+// cloneKVConfig) so the Plan output is immutable regardless of later
+// Apply or nats.go mutation.
+//
+// Apply does not write Resource.After verbatim — it re-reads live
+// state and rebuilds the target from the re-read snapshot (see Apply
+// algorithm). Resource.Before / Resource.After are the audit surface:
+// JSON consumers diff them to render exactly which fields change.
+type UpdateKVResource struct {
+    Before jetstream.KeyValueConfig `json:"before"`
+    After  jetstream.KeyValueConfig `json:"after"`
+}
+```
+
+`PlannedAction.Resource` holds a `*UpdateKVResource` (pointer, matching
+the master plan's stated convention). `ActionUpdateKV = "update-kv"` is
+added to the action-kind constants in `provision/types.go`.
+
+## Helper: `streamConfigToKVConfig`
+
+W0's `extractLiveKVConfig` (`provision/kvequal.go`) projects a
+`StreamConfig` onto only the `kvConfigsEqual` comparison subset. W1
+needs the **full** projection so the `update-kv` Before/After preserve
+every preserved-from-live field.
+
+W1 adds:
+
+```go
+// streamConfigToKVConfig projects a live jetstream.StreamConfig onto a
+// jetstream.KeyValueConfig covering every field nats.go's
+// KeyValueConfig exposes, so a round-trip through UpdateKeyValue
+// preserves preserved-from-live fields.
+func streamConfigToKVConfig(sc jetstream.StreamConfig) jetstream.KeyValueConfig
+```
+
+Field mapping (nats.go v1.50.0 `jetstream/kv.go:242-274` is the
+authority — verify against the cached module):
+
+| KeyValueConfig field | StreamConfig source |
+|----------------------|---------------------|
+| `Bucket`             | `strings.TrimPrefix(sc.Name, "KV_")` |
+| `Description`        | `sc.Description` |
+| `MaxValueSize`       | `sc.MaxMsgSize` |
+| `History`            | `historyFromStream(sc.MaxMsgsPerSubject)` (W0 clamp helper) |
+| `TTL`                | `sc.MaxAge` |
+| `MaxBytes`           | `sc.MaxBytes` |
+| `Storage`            | `sc.Storage` |
+| `Replicas`           | `sc.Replicas` |
+| `Placement`          | `sc.Placement` |
+| `RePublish`          | `sc.RePublish` |
+| `Mirror`             | `sc.Mirror` |
+| `Sources`            | `sc.Sources` |
+| `Compression`        | `sc.Compression != jetstream.NoCompression` |
+| `Metadata`           | `sc.Metadata` |
+| `LimitMarkerTTL`     | `sc.SubjectDeleteMarkerTTL` if that is the v1.50.0 backing field — **verify the exact field name in the cached module before wiring; if absent in v1.50.0, omit and note it** |
+
+`extractLiveKVConfig` is redefined to delegate:
+`return streamConfigToKVConfig(sc)`. This is a behavior-preserving
+change — the classifiers consume `extractLiveKVConfig` only to feed
+`kvConfigsEqual` and `wantedControlPlaneKV` / `wantedPartitionSourceKV`,
+all of which read only the comparison-subset fields; the additional
+fields populated by the full projection are inert for them. The
+delegation removes the duplicate projection rather than shipping two.
+**This is the only W0-file change W1 makes; call it out explicitly in
+the PR description so the reviewer expects it.**
+
+## Helper: `mergeUpdateKVMetadata`
+
+W0's `mergeMarkerMetadata` overlays the **full** Parti marker
+(`managed` + `component` + `instance`) so the classifier gate detects
+component drift. The `update-kv` After must NOT rewrite
+`parti.io/component`: a component-marker mismatch is drift-immutable
+(W0-correction commit `a46a5cc`), and silently re-labelling a bucket's
+role would mask a misconfiguration.
+
+W1 adds a distinct merge:
+
+```go
+// mergeUpdateKVMetadata returns the Metadata map for an update-kv
+// target. It clones live, forces parti.io/managed to the current
+// schema value, sets or removes parti.io/instance per the desired
+// instance, and PRESERVES parti.io/component verbatim from live —
+// component is drift-immutable and update-kv never re-labels a
+// bucket's role. Non-Parti keys are preserved.
+func mergeUpdateKVMetadata(live map[string]string, instance string) map[string]string
+```
+
+Algorithm:
+
+1. `merged := maps.Clone(live)`; if nil, `merged = map[string]string{}`.
+2. `merged[MarkerManagedKey] = MarkerManagedValue`.
+3. If `instance != ""`: `merged[MarkerInstanceKey] = instance`.
+   Else: `delete(merged, MarkerInstanceKey)`.
+4. `parti.io/component` is left exactly as cloned from live (step 1).
+5. Return `merged`.
+
+### The classifier-vs-update-kv asymmetry (do not consolidate)
+
+`mergeMarkerMetadata` (W0, classifier) and `mergeUpdateKVMetadata`
+(W1, apply target) are intentionally different:
+
+| | `mergeMarkerMetadata` | `mergeUpdateKVMetadata` |
+|---|---|---|
+| `parti.io/managed` | set to `v1` | set to `v1` |
+| `parti.io/instance` | set / deleted per instance | set / deleted per instance |
+| `parti.io/component` | **set to the desired component** | **preserved from live** |
+| purpose | make the gate detect component drift so the classifier emits a `drift-immutable` finding | build a target that never re-labels the bucket |
+
+A future reader who "consolidates" these two helpers will reintroduce
+the silent component-rewrite bug. Both functions carry a comment
+pointing at this table.
+
+## Plan emission algorithm
+
+For each desired bucket in `planControlPlane` / `planPartitionSource`,
+after the existing lookup + classify steps:
+
+1. If the stream was not found → existing `create-kv` path, unchanged.
+2. If found and `cfg.Policy != PolicySafeUpdate` → existing behavior
+   (classify, append drift findings), no `update-kv`.
+3. If found and `cfg.Policy == PolicySafeUpdate`:
+   a. If the bucket is **unmarked** (`!ParseMarker(info.Config.Metadata).IsManaged()`):
+      no `update-kv` (the classifier already emitted the `adopted`
+      finding; adoption is W3).
+   b. Else build:
+      - `before := cloneKVConfig(streamConfigToKVConfig(info.Config))`
+      - `after := buildUpdateKVTarget(<spec|ps>, cfg.Instance, before)`
+   c. If `kvConfigsEqual(before, after)` → no `update-kv` (no
+      operator-expressible field differs; any remaining drift is
+      drift-immutable and routes to Phase 6).
+   d. Else append a `PlannedAction{Kind: ActionUpdateKV, Name: bucket,
+      Resource: &UpdateKVResource{Before: before, After: after}}`.
+
+The classifier still runs in every branch; its drift findings still
+populate `PlanResult.Drift`. `update-kv` actions and drift findings
+coexist — a bucket with a drift-mutable TTL produces both a
+`drift-mutable` finding and an `update-kv` action under `safe-update`.
+
+### `buildUpdateKVTarget`
+
+```go
+// buildUpdateKVTarget returns the desired update-kv target: a deep
+// clone of before with only the operator-expressible fields
+// overwritten. Every other field — drift-detection-only (History,
+// Storage), preserved-from-live (Description, MaxBytes, Placement,
+// RePublish, Mirror, Sources, Compression, LimitMarkerTTL), and
+// Bucket — is inherited from before verbatim.
+```
+
+Control-plane operator-expressible overwrites: `TTL = spec.ttl`,
+`Replicas = spec.replicas`, `Metadata = mergeUpdateKVMetadata(before.Metadata, instance)`.
+Control-plane has no `MaxValueSize` config field — it is
+preserved-from-live (left as `before`'s value).
+
+Partition-source operator-expressible overwrites: `TTL = ps.TTL`,
+`Replicas = ps.Replicas`, `MaxValueSize = ps.MaxValueSize`,
+`Metadata = mergeUpdateKVMetadata(before.Metadata, instance)`.
+
+Because `after` is a clone of `before` with only operator-expressible
+fields overwritten, `kvConfigsEqual(before, after) == false` if and
+only if at least one operator-expressible field genuinely differs.
+That is the emission gate — no need to inspect classifier findings.
+
+`History` / `Storage` are NOT overwritten: if config disagrees with
+live on those, `after` keeps `before`'s value, so `UpdateKeyValue`
+never attempts the server-rejected mutation. The `drift-immutable`
+finding is emitted separately by the classifier.
+
+## Apply execution algorithm
+
+`applyPlan` gains a `case ActionUpdateKV` branch. The `update-kv` and
+existing `create-kv` paths share the Phase 1 cancellation
+(`provision/apply.go:84-89`) and fail-fast
+(`provision/apply.go:122-130`) contracts unchanged.
+
+For each `ActionUpdateKV` action, with `res := action.Resource.(*UpdateKVResource)`
+(type-assert; on failure, fail-fast `ResourceError` per the existing
+`create-kv` defensive guard at `provision/apply.go:93-103`):
+
+**Step order matters.** The no-op short-circuit MUST precede the
+stale-before check. For a genuinely emitted action `Before != After`,
+so when a concurrent operator converges the bucket to the desired
+state between Plan and Apply, the re-read `live` equals the target but
+differs from `res.Before`. If stale-before ran first it would misreport
+that convergence as a stale plan; the no-op check must claim it as a
+raced success first.
+
+1. **Re-read live state.** `js.Stream(ctx, "KV_"+name).Info(ctx)`.
+   - `errors.Is(err, jetstream.ErrStreamNotFound)` → fail-fast
+     `ResourceError{Error: "bucket-missing-before-update: KV_<name> no longer exists"}`,
+     remaining actions `Skipped{Reason: SkipReasonPriorError}`.
+   - context cancellation → existing cancellation contract.
+   - other errors → fail-fast wrapped per `provision/apply.go:122-130`.
+   - `live := streamConfigToKVConfig(info.Config)`.
+2. **Rebuild target from re-read.** `target := buildUpdateKVTarget(<spec|ps>, instance, cloneKVConfig(live))`.
+   This re-applies the emission algorithm to the just-re-read snapshot
+   so preserved-from-live fields carry the current live value.
+3. **No-op short-circuit.** If `kvConfigsEqual(live, target)` →
+   record `ExecutedAction{Kind, Name, Raced: true}` (the bucket already
+   matches the desired target — this plan or a concurrent one converged
+   it); continue. Reuses the existing `ExecutedAction.Raced` field.
+4. **Stale-before check.** The bucket is not yet converged. If
+   `!kvConfigsEqual(live, res.Before)` → a concurrent writer moved the
+   bucket to a third state; fail-fast
+   `ResourceError{Error: "stale-before: live state changed since plan; re-run plan"}`,
+   remaining actions `Skipped{Reason: SkipReasonPriorError}`.
+   Canonical equality means NATS server normalization
+   (live `Replicas=1` vs plan `Replicas=0`) does not trip the check.
+5. **Write.** `js.UpdateKeyValue(ctx, target)`.
+   - `errors.Is(err, jetstream.ErrBucketNotFound)` → fail-fast
+     `ResourceError{Error: "bucket-missing-before-update: ..."}` (same
+     class as step 1; nats.go maps a mid-write stream disappearance
+     to `ErrBucketNotFound`, `jetstream/kv.go:580-583`).
+   - context cancellation → existing cancellation contract.
+   - other errors (including server Replicas-feasibility rejection) →
+     fail-fast wrapped per `provision/apply.go:122-130`.
+   - nil → `ExecutedAction{Kind, Name}`.
+
+Apply needs the desired `spec` / `ps` to rebuild the target in step 2.
+The cleanest wiring: `applyPlan` already has the `PlanResult`, but the
+`PlanResult` does not carry the desired config. Two options — the
+implementer picks one and the post-impl review verifies it:
+
+- **Option A**: thread `cfg` into `applyPlan` and re-derive the spec
+  for the named bucket. `applyPlan` already runs after `Plan`, which
+  has `cfg`; passing `cfg` to `applyPlan` is a one-parameter change.
+- **Option B**: have `UpdateKVResource` carry enough to rebuild —
+  but `After` already IS the plan-time target, and step 2's whole
+  point is to rebuild from a fresh read. Option B cannot rebuild
+  preserved-from-live fields from a stale `After`.
+
+**Use Option A.** Step 2 must rebuild from the re-read snapshot; the
+desired config (spec/ps) is the only stable input, and `cfg` is the
+natural carrier.
+
+## Testability seam
+
+`applyPlan`'s `update-kv` path interacts with NATS through two narrow
+interfaces so a fake can deterministically interleave re-read and
+write (the master plan's "Testability seam" section):
+
+```go
+type streamReader interface {
+    StreamInfo(ctx context.Context, bucket string) (*jetstream.StreamInfo, error)
+}
+type kvUpdater interface {
+    UpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) error
+}
+```
+
+Production implementations wrap `jetstream.JetStream`. W1/W2 introduces
+the seam and uses it for the stale-before and no-op-convergence unit
+tests; W3 reuses it for the cross-policy race test.
+
+## Test plan
+
+Unit (`package provision`, synthetic `StreamInfo`):
+
+- `streamConfigToKVConfig` populates every field; round-trips a config
+  with `Placement` / `RePublish` / `Sources` set.
+- `extractLiveKVConfig` still returns a value `kvConfigsEqual` reads
+  identically after the delegation change (regression guard).
+- `mergeUpdateKVMetadata`: forces `managed=v1`; sets instance when
+  non-empty; deletes instance key when empty; **preserves a
+  mismatched `component` verbatim**; preserves non-Parti keys.
+- `buildUpdateKVTarget`: `after` equals `before` on every
+  preserved-from-live and drift-detection-only field
+  (`reflect.DeepEqual` per field); only operator-expressible fields
+  differ.
+- Plan emission: `safe-update` against a marked control-plane bucket
+  with a TTL diff emits one `update-kv`; with Replicas diff emits one;
+  with instance change emits one; with instance removal emits one;
+  with a `managed`-version diff emits one.
+- Plan emission negative cases: `safe-update` against an unmarked
+  bucket emits no `update-kv` (only the `adopted` finding); against a
+  bucket whose only drift is `History` / `Storage` / `component`
+  emits no `update-kv` (drift-immutable finding only); against an
+  in-sync bucket emits no `update-kv`.
+- Plan emission under `warn` and `adopt` emits no `update-kv`.
+- `update-kv.After` preserves `Description` / `MaxBytes` set on the
+  live bucket; preserves a mismatched live `component`.
+- Determinism: shuffled inputs produce identical sorted `Actions`
+  (`create-kv` sorts before `update-kv`).
+
+Apply, seam-based unit (fake `streamReader` / `kvUpdater`):
+
+- Stale-before: re-read returns a config differing from `Before` on an
+  operator-expressible field → fail-fast `ResourceError` containing
+  `"stale-before"`; remaining actions `Skipped{prior-error}`.
+- No-op convergence: re-read already equals the target → 
+  `ExecutedAction{Raced: true}`, no `UpdateKeyValue` call.
+- Missing-on-reread: re-read returns `ErrStreamNotFound` → fail-fast
+  `"bucket-missing-before-update"`.
+- Missing-on-write: `UpdateKeyValue` returns `ErrBucketNotFound` →
+  fail-fast `"bucket-missing-before-update"`.
+
+Apply, embedded-NATS integration:
+
+- Per operator-expressible field (control-plane TTL, control-plane
+  Replicas, partition-source TTL, partition-source MaxValueSize,
+  partition-source Replicas, instance change): pre-create a marked
+  bucket with the field drifted → `Apply` with `safe-update` →
+  re-`Plan` reports `informational` for that bucket.
+- Replicas server-rejection: single-node embedded server, target
+  `Replicas=3` → `Apply` fail-fasts with the server error in
+  `Report.Errors`, `Aborted=false`.
+- Preserved-from-live: pre-create a marked bucket with a non-empty
+  `Description` set out-of-band → `Apply` a TTL change with
+  `safe-update` → live `Description` unchanged.
+- Re-run no-op: a second `Apply` with `safe-update` after convergence
+  records `ExecutedAction{Raced: true}` (or emits no `update-kv` at
+  plan time) and mutates nothing.
+
+## Acceptance
+
+- `provision.Plan` with `PolicySafeUpdate` emits `update-kv` for marked
+  buckets with operator-expressible drift; nothing for unmarked,
+  immutable-only, or in-sync buckets.
+- `provision.Apply` with `PolicySafeUpdate` reconciles those buckets
+  in place, preserves preserved-from-live fields, fail-fasts on
+  stale-before / missing-bucket / server rejection.
+- `warn` and `adopt` behavior is unchanged.
+- `make lint` clean; `make test` green including the new integration
+  tests.
+
+## Recommended model + effort
+
+Implementer: **Opus 4.7** (matches the master plan W1/W2 rows — new
+public type, mutation path). Post-impl review: **codex `xhigh`**.

--- a/docs/plans/provision-sdk-cli-v2/02-stamp-marker-spec.md
+++ b/docs/plans/provision-sdk-cli-v2/02-stamp-marker-spec.md
@@ -1,0 +1,323 @@
+# Sub-spec: `stamp-marker` plan emission and apply execution (adopt policy)
+
+Covers work item **W3** from [`00-implementation-plan.md`](00-implementation-plan.md):
+the `adopt` reconcile policy's `stamp-marker` action — plan emission and
+apply execution.
+
+W3 ships as one PR. Unlike W1 (plan emission alone left `Apply` broken),
+W3 delivers both halves of `stamp-marker`, so `provision.Apply` with
+`PolicyAdopt` is fully functional after this PR. The CLI surface
+(`partictl adopt`, `--policy`) is **W4** and is out of scope here.
+
+Read the master plan's "stamp-marker emission", "stamp-marker Apply
+path", "Cross-policy race window", and "Reconcile Policy Ladder"
+sections first. This sub-spec pins the contract details those leave
+open and does not restate them.
+
+## Scope
+
+In scope:
+
+- `StampMarkerResource` exported type; `ActionStampMarker` constant.
+- `adopt` policy plan emission: `stamp-marker` for config-named
+  buckets that exist live and are unmarked; suppression of `create-kv`
+  and `update-kv` under `adopt`.
+- `stamp-marker` execution in `applyPlan`: re-read, recompute merged
+  metadata, no-op short-circuit, write, missing-on-reread/write
+  fail-fast.
+- Reuse of the W0 `mergeMarkerMetadata` helper and the W1
+  `streamReader` / `kvUpdater` seam.
+- The deterministic cross-policy race test.
+
+Out of scope:
+
+- `partictl adopt` command and `partictl --policy` flag — **W4**.
+- Any change to `update-kv` (W1/W2) or the drift classifiers (W0).
+- `force` policy — Phase 6.
+
+## Type: `StampMarkerResource`
+
+```go
+// StampMarkerResource is the Resource carried by an ActionStampMarker
+// PlannedAction. MergedMetadata is the full Metadata map the action
+// will write: the union of the live bucket's existing keys and the
+// Parti marker keys (parti.io/managed, parti.io/component, and
+// parti.io/instance when the instance is non-empty).
+//
+// PartiKeys lists exactly the metadata keys the action adds or
+// changes relative to the live bucket, so operator review can verify
+// that no non-Parti key is being modified.
+//
+// Apply does not write MergedMetadata verbatim — it re-reads live
+// state and recomputes the merge against the re-read metadata (see
+// the Apply algorithm). MergedMetadata / PartiKeys are the audit
+// surface for `plan` / `apply -dry-run` output.
+type StampMarkerResource struct {
+    Bucket         string            `json:"bucket"`
+    MergedMetadata map[string]string `json:"mergedMetadata"`
+    PartiKeys      []string          `json:"partiKeys"`
+}
+```
+
+`PlannedAction.Resource` holds a `*StampMarkerResource` (pointer,
+matching the `create-kv` value-type and `update-kv` pointer-type
+precedent — pointer because the struct carries a map and a slice).
+`ActionStampMarker = "stamp-marker"` is added to the action-kind
+constants in `provision/types.go`.
+
+## Metadata merge: reuse `mergeMarkerMetadata`
+
+`stamp-marker` operates only on **unmarked** buckets. An unmarked
+bucket has no `parti.io/managed` key (`MarkerInfo.IsManaged()` is
+false), so there is no live Parti `component` value to preserve — the
+action establishes the full marker from the config-derived component.
+
+This is exactly what the W0 `mergeMarkerMetadata(live, component, instance)`
+helper does: clone live metadata, overlay `parti.io/managed=v1`,
+`parti.io/component=<component>`, and `parti.io/instance=<instance>`
+(deleting the instance key when instance is empty), preserving every
+non-Parti key. **W3 reuses `mergeMarkerMetadata`; it adds no new merge
+helper.**
+
+This is *not* the same as `update-kv`'s `mergeUpdateKVMetadata`, which
+preserves the live component because `update-kv` operates on
+already-marked buckets where a component mismatch is drift-immutable.
+The distinction holds: `stamp-marker` adopts unmarked buckets and
+writes the component; `update-kv` reconciles marked buckets and never
+touches the component. The two helpers' existing
+"do not consolidate" comments already document the asymmetry.
+
+`PartiKeys` is computed as the keys whose value differs between the
+live metadata and the merged result, in **either direction** —
+additions, overwrites, **and removals**. The removal case is real: an
+unmarked bucket carrying a stray `parti.io/instance=old` adopted under
+an empty `cfg.Instance` has that key deleted by `mergeMarkerMetadata`,
+and that deletion is a change the operator should see in the audit
+output. For a cleanly unmarked bucket `PartiKeys` is
+`[parti.io/managed, parti.io/component]` plus `parti.io/instance` when
+the instance is set. Computed with a small local helper, not a new
+exported function. The helper compares the two maps key-by-key:
+a key present in one and absent in the other, or present in both with
+differing values, is included.
+
+## Plan emission
+
+The `adopt` policy's per-bucket emission rules, applied in
+`planControlPlane` and `planPartitionSource` after the existing
+lookup + classify steps:
+
+1. **Stream not found** — under `adopt`, emit **no action** but **do
+   emit an `informational` drift finding**. Adopt does not create
+   buckets (Reconcile Policy Ladder: adopt's "create missing" is
+   *no*), so the action list stays empty for this bucket. But the
+   bucket must not vanish silently from the plan: an operator running
+   `adopt` against a config naming five buckets, one of them missing,
+   would otherwise see four `stamp-marker` actions and conclude the
+   environment is fully adopted. Emit:
+
+   ```
+   DriftFinding{
+     Severity: SeverityInformational,
+     Kind:     <KindControlPlaneKV | KindPartitionSource>,
+     Name:     bucket,
+     Detail:   {"reason": "bucket missing; adopt does not create — run apply with warn or safe-update"},
+   }
+   ```
+
+   The severity vocabulary is unchanged (`informational` already
+   exists). `-fail-on-drift` treats `informational` as non-drift, so
+   exit codes are unaffected. (`warn` and `safe-update` keep their
+   existing `create-kv` emission for a missing bucket; only `adopt`
+   substitutes this finding.)
+2. **Stream found and marked** (`ParseMarker(...).IsManaged()`) —
+   emit no `stamp-marker` (already adopted). The classifier still
+   runs and its drift findings still populate `PlanResult.Drift`; an
+   operator who runs `adopt` against an already-marked but drifted
+   bucket sees the drift finding and is directed (W5 docs) to
+   `safe-update`. This is the master plan's "adoption is not
+   approval" rule.
+3. **Stream found and unmarked** — emit a `stamp-marker` action.
+   Build it from the live snapshot:
+   - `live := streamConfigToKVConfig(info.Config)` (the W1 full
+     projection).
+   - `merged := mergeMarkerMetadata(live.Metadata, <component>, cfg.Instance)`.
+   - `partiKeys := keysAddedOrChanged(live.Metadata, merged)`.
+   - emit `PlannedAction{Kind: ActionStampMarker, Name: bucket,
+     Resource: &StampMarkerResource{Bucket: bucket,
+     MergedMetadata: merged, PartiKeys: partiKeys}}`.
+
+The `<component>` is the config-derived component for that bucket:
+the control-plane component for each control-plane spec
+(`spec.component`), `ComponentPartitionSource` for the
+partition-source bucket.
+
+Under `adopt`, `update-kv` is never emitted (that is `safe-update`
+only). Under `warn` and `safe-update`, `stamp-marker` is never
+emitted. The three policies' action sets stay disjoint per the
+Reconcile Policy Ladder.
+
+Determinism: `ActionStampMarker = "stamp-marker"` sorts after both
+`create-kv` and `update-kv` alphabetically; `sortActions` keeps the
+output stable with no new sort code. (No single plan mixes
+`stamp-marker` with the other kinds — policies are disjoint — but the
+ordering is well-defined regardless.)
+
+## Apply execution
+
+`applyPlan` gains a `case ActionStampMarker` branch. It shares the
+Phase 1 cancellation and fail-fast contracts and the W1
+`streamReader` / `kvUpdater` seam unchanged.
+
+For each `ActionStampMarker` action, with
+`res := action.Resource.(*StampMarkerResource)` (type-assert; on
+failure, fail-fast `ResourceError` per the existing defensive guard):
+
+1. **Re-read live state.** `reader.StreamInfo(ctx, action.Name)`.
+   - `errors.Is(err, jetstream.ErrStreamNotFound)` → fail-fast
+     `ResourceError` `"bucket-missing-before-stamp: KV_<name> no longer exists"`,
+     remaining actions `Skipped{Reason: SkipReasonPriorError}`.
+   - context cancellation → existing cancellation contract.
+   - other errors → fail-fast wrapped.
+   - `live := streamConfigToKVConfig(info.Config)`.
+2. **Recompute the merge against the re-read metadata.**
+   `merged := mergeMarkerMetadata(live.Metadata, <component>, cfg.Instance)`.
+   Recomputing (rather than trusting `res.MergedMetadata`) means a
+   non-Parti key added between plan and apply flows into the written
+   map — `stamp-marker` preserves the *current* non-Parti keys.
+3. **No-op short-circuit.** Build the target: `target := cloneKVConfig(live)`
+   with `target.Metadata = merged`. If `kvConfigsEqual(live, target)`
+   → record `ExecutedAction{Kind, Name, Raced: true}` (the bucket was
+   concurrently adopted, or already carries an equivalent marker) and
+   continue. No write.
+4. **Write.** `updater.UpdateKeyValue(ctx, target)`.
+   - `errors.Is(err, jetstream.ErrBucketNotFound)` → fail-fast
+     `"bucket-missing-before-stamp: ..."` (same class as step 1).
+   - context cancellation → existing cancellation contract.
+   - other errors → fail-fast wrapped.
+   - nil → `ExecutedAction{Kind, Name}`.
+
+`stamp-marker` has **no stale-before check**. Unlike `update-kv` it
+carries no plan-time expectation of the bucket's non-metadata fields:
+it re-reads live and writes that snapshot back with the marker
+merged. A concurrent change to a non-metadata field between plan and
+apply is simply picked up by the re-read. The one race it cannot
+close is a concurrent change landing between *its own* re-read
+(step 1) and write (step 4) — see below.
+
+The `component` needed in step 2 is re-derived the same way the
+`update-kv` apply path re-derives its spec: via the `cfg` threaded
+into `applyPlan` (W1's "Option A") plus the `cpSpecs` map. The
+partition-source component is the constant `ComponentPartitionSource`.
+If `action.Name` matches neither a control-plane spec in `cpSpecs`
+nor `cfg.PartitionSource.Bucket`, fail-fast with a defensive
+`ResourceError` — `"stamp-marker target %q is not described by the
+resolved config"` — exactly parallel to `buildUpdateKVTargetForBucket`.
+Plan should never emit such an action; the guard catches a wiring bug
+rather than a runtime race.
+
+The `update-kv` and `stamp-marker` apply paths live together in
+`provision/apply_update.go`; `applyStampMarkerAction` is the new
+entry point called from the `applyPlan` kind-switch.
+
+## Cross-policy race window
+
+`stamp-marker` re-reads live state (step 1) and writes the re-read
+config plus merged metadata (step 4). The window between the two is
+short but not zero. If a concurrent operator runs `safe-update` and
+changes a field such as `TTL` on the same bucket inside that window,
+`stamp-marker`'s write carries the value it read in step 1 — the
+stale value — and reverts the concurrent change.
+
+Phase 2 does not close this window: NATS `UpdateStream` has no
+expected-revision / CAS token. The contract is the master plan's
+"Cross-policy race window" rule: `stamp-marker` *intends* to touch
+only the marker, and under serial operation it does; under concurrent
+operators it is best-effort and may lose a race with a field-changing
+writer. Operators serialize `adopt` and `safe-update` themselves (the
+documented `adopt` then `safe-update` two-step).
+
+This window is genuine and the test plan demonstrates it
+deterministically rather than papering over it.
+
+## Test plan
+
+Unit (`package provision`, synthetic `StreamInfo` / seam fakes):
+
+- `StampMarkerResource` shape; `ActionStampMarker` constant.
+- Plan emission: `adopt` against an unmarked control-plane bucket
+  emits one `stamp-marker`; against an unmarked partition-source
+  bucket emits one; against a marked bucket emits none.
+- Plan emission: `adopt` against a missing bucket emits no action and
+  one `informational` drift finding whose `Detail["reason"]` mentions
+  that adopt does not create.
+- Plan emission: `adopt` emits no `update-kv`; `warn` and
+  `safe-update` emit no `stamp-marker`.
+- `StampMarkerResource.MergedMetadata` carries the Parti marker keys
+  plus every pre-existing non-Parti key; `PartiKeys` lists exactly
+  the added/changed keys (`parti.io/managed`, `parti.io/component`,
+  and `parti.io/instance` when instance is set — and only those).
+- Plan emission with empty `cfg.Instance`: `MergedMetadata` has no
+  `parti.io/instance` key; `PartiKeys` is the two-element set.
+- `PartiKeys` removal case: an unmarked bucket carrying a stray
+  `parti.io/instance=old` adopted under empty `cfg.Instance` →
+  `MergedMetadata` omits `parti.io/instance` and `PartiKeys` includes
+  it (a removal counts as a change).
+- Apply, seam-based: `applyStampMarkerAction` against an unmarked
+  re-read writes a target whose Metadata is the merged map and whose
+  every non-metadata field equals the re-read snapshot; against an
+  already-marked re-read records `ExecutedAction{Raced: true}` with
+  no write; `ErrStreamNotFound` on re-read → fail-fast
+  `bucket-missing-before-stamp`; `ErrBucketNotFound` on write →
+  same class; wrong `Resource` type → fail-fast; cancelled re-read →
+  cancellation propagates.
+- **Cross-policy race (deterministic).** A fake `streamReader`
+  returns an unmarked bucket with `TTL=10s` and a non-Parti metadata
+  key. Run `applyStampMarkerAction`; the fake `kvUpdater` captures
+  the write target. Assert the captured target's `TTL` equals the
+  re-read `10s` (not any "desired" value — `stamp-marker` has no
+  desired non-metadata values) and its `Metadata` is the Parti
+  marker plus the non-Parti key. A comment block states: this
+  demonstrates the race window — a concurrent `safe-update` changing
+  `TTL` between this re-read and write would be reverted, the
+  documented best-effort cross-policy contract.
+
+Embedded-NATS integration:
+
+- `adopt` against an unmarked bucket named by config: after `Apply`,
+  the live bucket carries `parti.io/managed=v1`, the correct
+  `parti.io/component`, and `parti.io/instance` (when configured).
+- Non-Parti metadata preserved: pre-create an unmarked bucket with
+  `{"custom.io/team": "x"}` in Metadata → `Apply` under `adopt` →
+  live Metadata contains both `custom.io/team=x` and the Parti keys.
+- Preserved-from-live: pre-create an unmarked bucket with
+  `Description`, `MaxBytes`, `TTL`, `MaxValueSize`, and an explicit
+  `Replicas` set → `Apply` under `adopt` → all five live values are
+  unchanged; only Metadata gains the Parti keys.
+- Idempotent: a second `Apply` under `adopt` after the bucket is
+  adopted emits no `stamp-marker` (plan-time) / records a raced
+  no-op, and mutates nothing.
+- Adopt does not create: `adopt` against a config naming a missing
+  bucket produces no action, creates nothing, and surfaces one
+  `informational` drift finding for that bucket.
+- Adopt then safe-update: after `adopt` marks a bucket, a subsequent
+  `Plan` under `safe-update` classifies it normally (informational
+  when in sync, drift findings when not) — proving adoption made the
+  bucket visible to the safe-update path.
+
+## Acceptance
+
+- `provision.Plan` with `PolicyAdopt` emits `stamp-marker` for every
+  config-named bucket that exists live and is unmarked, and nothing
+  for marked or missing buckets.
+- `provision.Apply` with `PolicyAdopt` stamps the Parti marker on
+  those buckets, preserves every non-Parti metadata key and every
+  preserved-from-live field, is idempotent, and fails fast on a
+  missing bucket.
+- `warn` and `safe-update` behavior is unchanged.
+- `make lint` clean; `make test` green including the new integration
+  tests.
+
+## Recommended model + effort
+
+Implementer: **Opus 4.7** (new public type, mutation path). Post-impl
+review: **codex `xhigh`**.

--- a/internal/kvbuckets/builder.go
+++ b/internal/kvbuckets/builder.go
@@ -21,15 +21,16 @@ import (
 //	    // TTL set only when ttl > 0
 //	}
 //
-// This equivalence is a hard contract: the forthcoming provision package builds
-// its KeyValueConfig by calling this function and then appending metadata. Any
-// deviation from the historical literal would silently break the byte-equality
-// invariant between live Manager buckets and provision-managed buckets.
+// This equivalence is a hard contract: the runtime manager and the
+// provision plan emitter must produce the same KeyValueConfig from the
+// same inputs. The provision package may stamp a Replicas value on the
+// returned config when its operator-supplied control-plane Replicas is
+// non-zero; that is the only field permitted to deviate.
 //
 // Rules:
 //   - Bucket, History (always 1), and Storage are always set.
 //   - TTL is set only when ttl > 0; zero and negative values leave cfg.TTL unset.
-//   - Replicas is intentionally left zero — nats.go normalizes it to 1 server-side.
+//   - Replicas is left zero — nats.go normalizes it to 1 server-side.
 //   - This function performs no I/O.
 func BuildKeyValueConfig(bucket string, ttl time.Duration, storage jetstream.StorageType) jetstream.KeyValueConfig {
 	cfg := jetstream.KeyValueConfig{

--- a/provision/apply.go
+++ b/provision/apply.go
@@ -22,22 +22,22 @@ import (
 //  4. Iterate Plan.Actions and call js.CreateKeyValue for each create-kv,
 //     mapping the result onto Report.{Executed, Skipped, Errors, Aborted}.
 //
-// Cancellation semantics (see sub-spec §2.D):
+// Cancellation semantics:
 //   - Pre-mutation cancel → Report{Aborted: true, Skipped: every-action
 //     with reason "context-cancelled"}, error = ctx.Err(); CLI exit 4.
 //   - Mid-mutation cancel → partial Report with Aborted=true, Executed
-//     holds completed creates, current+remaining go to Skipped with
+//     holds completed actions, current+remaining go to Skipped with
 //     reason "context-cancelled"; error = ctx.Err(); CLI exit 4.
 //
-// Non-cancellation failure (sub-spec §2.C) is fail-fast: the failing
-// action goes to Errors once, remaining go to Skipped with reason
-// "prior-error", Aborted stays false; CLI exit 1.
+// Non-cancellation failure is fail-fast: the failing action goes to Errors
+// once, remaining go to Skipped with reason "prior-error", Aborted stays
+// false; CLI exit 1.
 //
-// Plan→Apply race (sub-spec §2.E): if js.CreateKeyValue returns
-// ErrBucketExists / ErrStreamNameAlreadyInUse, Apply treats the outcome
-// as success and marks the ExecutedAction with Raced=true. Apply does NOT
-// re-read live state to drift-check the racing bucket; the next `plan`
-// run reports any adopted drift.
+// Plan→Apply race: if js.CreateKeyValue returns ErrBucketExists /
+// ErrStreamNameAlreadyInUse, Apply treats the outcome as success and marks
+// the ExecutedAction with Raced=true. Apply does NOT re-read live state to
+// drift-check the racing bucket; the next `plan` run reports any adopted
+// drift.
 //
 // Apply does NOT echo Plan.Drift into the returned Report. Drift findings
 // are a Plan concern; the CLI reads plan.Drift separately from apply
@@ -55,7 +55,7 @@ func Apply(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, err
 
 	// Step 2: live validation. Return Report{} (zero value) on failure:
 	// no mutation has been attempted yet, so a populated Report would
-	// misleadingly resemble a mutation-outcome Report (sub-spec §2.A).
+	// misleadingly resemble a mutation-outcome Report.
 	if _, err := ValidateLive(ctx, js, resolved); err != nil {
 		return Report{}, err
 	}
@@ -69,8 +69,8 @@ func Apply(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, err
 	return applyPlan(ctx, js, resolved, planResult)
 }
 
-// applyPlan executes a pre-computed plan against js, applying the W2
-// semantics laid out in the package-level Apply docstring.
+// applyPlan executes a pre-computed plan against js per the semantics laid
+// out in the package-level Apply docstring.
 //
 // cfg is the resolved Config. The update-kv path needs it to re-derive
 // the desired spec for a named bucket and rebuild the write target from
@@ -129,7 +129,7 @@ func applyPlan(ctx context.Context, js jetstream.JetStream, cfg Config, plan Pla
 				})
 			case errors.Is(err, jetstream.ErrBucketExists),
 				errors.Is(err, jetstream.ErrStreamNameAlreadyInUse):
-				// Plan→Apply race (sub-spec §2.E): treat as success.
+				// Plan→Apply race: treat as success.
 				report.Executed = append(report.Executed, ExecutedAction{
 					Kind: action.Kind, Name: action.Name, Raced: true,
 				})

--- a/provision/apply.go
+++ b/provision/apply.go
@@ -139,7 +139,7 @@ func applyPlan(ctx context.Context, js jetstream.JetStream, cfg Config, plan Pla
 				appendSkipped(&report, plan.Actions[i:], SkipReasonContextCancelled)
 				return report, err
 			default:
-				// Non-cancellation failure: fail-fast (sub-spec §2.C).
+				// Non-cancellation failure: fail-fast.
 				report.Errors = append(report.Errors, ResourceError{
 					Kind: action.Kind, Name: action.Name, Error: err.Error(),
 				})
@@ -159,7 +159,27 @@ func applyPlan(ctx context.Context, js jetstream.JetStream, cfg Config, plan Pla
 				appendSkipped(&report, plan.Actions[i:], SkipReasonContextCancelled)
 				return report, err
 			default:
-				// Non-cancellation failure: fail-fast (sub-spec §2.C).
+				// Non-cancellation failure: fail-fast.
+				report.Errors = append(report.Errors, ResourceError{
+					Kind: action.Kind, Name: action.Name, Error: err.Error(),
+				})
+				appendSkipped(&report, plan.Actions[i+1:], SkipReasonPriorError)
+				return report, fmt.Errorf("provision: apply %s %q: %w",
+					action.Kind, action.Name, err)
+			}
+
+		case ActionStampMarker:
+			executed, err := applyStampMarkerAction(ctx, reader, updater, cfg, cpSpecs, action)
+			switch {
+			case err == nil:
+				report.Executed = append(report.Executed, executed)
+			case errors.Is(err, context.Canceled),
+				errors.Is(err, context.DeadlineExceeded):
+				report.Aborted = true
+				appendSkipped(&report, plan.Actions[i:], SkipReasonContextCancelled)
+				return report, err
+			default:
+				// Non-cancellation failure: fail-fast.
 				report.Errors = append(report.Errors, ResourceError{
 					Kind: action.Kind, Name: action.Name, Error: err.Error(),
 				})
@@ -169,8 +189,9 @@ func applyPlan(ctx context.Context, js jetstream.JetStream, cfg Config, plan Pla
 			}
 
 		default:
-			// v1 only emits "create-kv". Defensive: surface as a
-			// fail-fast resource error so operators see what was rejected.
+			// Plan emits only create-kv, update-kv, and stamp-marker.
+			// Defensive: surface an unknown kind as a fail-fast resource
+			// error so operators see what was rejected.
 			err := fmt.Errorf("provision: apply: unsupported action kind %q (resource %q)",
 				action.Kind, action.Name)
 			report.Errors = append(report.Errors, ResourceError{

--- a/provision/apply.go
+++ b/provision/apply.go
@@ -66,12 +66,16 @@ func Apply(ctx context.Context, js jetstream.JetStream, cfg Config) (Report, err
 		return Report{}, err
 	}
 
-	return applyPlan(ctx, js, planResult)
+	return applyPlan(ctx, js, resolved, planResult)
 }
 
 // applyPlan executes a pre-computed plan against js, applying the W2
 // semantics laid out in the package-level Apply docstring.
-func applyPlan(ctx context.Context, js jetstream.JetStream, plan PlanResult) (Report, error) {
+//
+// cfg is the resolved Config. The update-kv path needs it to re-derive
+// the desired spec for a named bucket and rebuild the write target from
+// a fresh re-read of live state (the create-kv path does not consult it).
+func applyPlan(ctx context.Context, js jetstream.JetStream, cfg Config, plan PlanResult) (Report, error) {
 	report := Report{
 		APIVersion: APIVersionProvisionV1,
 		Kind:       KindReport,
@@ -79,6 +83,21 @@ func applyPlan(ctx context.Context, js jetstream.JetStream, plan PlanResult) (Re
 		Skipped:    []SkippedAction{},
 		Errors:     []ResourceError{},
 	}
+
+	// Resolve bucket name -> desired control-plane spec once so the
+	// update-kv path can rebuild a write target from a fresh re-read.
+	// Built from the same buildControlPlaneSpecs helper Plan uses, so
+	// Plan and Apply stay in lockstep.
+	cpSpecs := map[string]controlPlaneSpec{}
+	if cfg.ControlPlane != nil {
+		for _, spec := range buildControlPlaneSpecs(*cfg.ControlPlane) {
+			cpSpecs[spec.bucket] = spec
+		}
+	}
+	// Production seam adapters wrap js; tests inject fakes directly into
+	// applyUpdateKVAction.
+	reader := jsStreamReader{js: js}
+	updater := jsKVUpdater{js: js}
 
 	for i, action := range plan.Actions {
 		// Pre-mutation / between-iteration cancellation check.
@@ -114,6 +133,26 @@ func applyPlan(ctx context.Context, js jetstream.JetStream, plan PlanResult) (Re
 				report.Executed = append(report.Executed, ExecutedAction{
 					Kind: action.Kind, Name: action.Name, Raced: true,
 				})
+			case errors.Is(err, context.Canceled),
+				errors.Is(err, context.DeadlineExceeded):
+				report.Aborted = true
+				appendSkipped(&report, plan.Actions[i:], SkipReasonContextCancelled)
+				return report, err
+			default:
+				// Non-cancellation failure: fail-fast (sub-spec §2.C).
+				report.Errors = append(report.Errors, ResourceError{
+					Kind: action.Kind, Name: action.Name, Error: err.Error(),
+				})
+				appendSkipped(&report, plan.Actions[i+1:], SkipReasonPriorError)
+				return report, fmt.Errorf("provision: apply %s %q: %w",
+					action.Kind, action.Name, err)
+			}
+
+		case ActionUpdateKV:
+			executed, err := applyUpdateKVAction(ctx, reader, updater, cfg, cpSpecs, action)
+			switch {
+			case err == nil:
+				report.Executed = append(report.Executed, executed)
 			case errors.Is(err, context.Canceled),
 				errors.Is(err, context.DeadlineExceeded):
 				report.Aborted = true

--- a/provision/apply_update.go
+++ b/provision/apply_update.go
@@ -1,0 +1,172 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// streamReader is the read side of the update-kv Apply path. The
+// production implementation calls js.Stream(...).Info(ctx); tests
+// inject a fake to deterministically interleave the re-read and write
+// steps.
+type streamReader interface {
+	StreamInfo(ctx context.Context, bucket string) (*jetstream.StreamInfo, error)
+}
+
+// kvUpdater is the write side of the update-kv Apply path. The
+// production implementation calls js.UpdateKeyValue(ctx, cfg).
+type kvUpdater interface {
+	UpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) error
+}
+
+// jsStreamReader adapts a jetstream.JetStream to streamReader.
+type jsStreamReader struct {
+	js jetstream.JetStream
+}
+
+func (r jsStreamReader) StreamInfo(ctx context.Context, bucket string) (*jetstream.StreamInfo, error) {
+	stream, err := r.js.Stream(ctx, kvStreamPrefix+bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	return stream.Info(ctx)
+}
+
+// jsKVUpdater adapts a jetstream.JetStream to kvUpdater.
+type jsKVUpdater struct {
+	js jetstream.JetStream
+}
+
+func (u jsKVUpdater) UpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) error {
+	_, err := u.js.UpdateKeyValue(ctx, cfg)
+
+	return err
+}
+
+// applyUpdateKVAction executes one ActionUpdateKV. It re-reads live
+// state, rebuilds the write target from the re-read snapshot,
+// short-circuits when the bucket already matches the target, verifies
+// the re-read still matches the plan-time Before, and otherwise calls
+// UpdateKeyValue.
+//
+// The no-op check precedes the stale-before check deliberately: a
+// bucket that already equals the desired target is a converged success
+// regardless of whether this operator's plan or a concurrent one got it
+// there. Checking stale-before first would misreport that convergence
+// as a stale plan.
+//
+// Return contract:
+//   - nil error → the returned ExecutedAction is recorded as-is. Raced
+//     is true when the bucket already matched the target on re-read.
+//   - context.Canceled / context.DeadlineExceeded (or an error that
+//     wraps one) → the caller treats it as a mid-mutation cancellation.
+//   - any other error → fail-fast resource error; the caller records
+//     err.Error() verbatim into ResourceError.Error, so the message is
+//     the operator-facing classification (e.g. "stale-before: ...").
+func applyUpdateKVAction(
+	ctx context.Context,
+	reader streamReader,
+	updater kvUpdater,
+	cfg Config,
+	cpSpecs map[string]controlPlaneSpec,
+	action PlannedAction,
+) (ExecutedAction, error) {
+	res, ok := action.Resource.(*UpdateKVResource)
+	if !ok {
+		// Defensive guard: Plan should never emit this.
+		return ExecutedAction{}, fmt.Errorf(
+			"update-kv action %q has wrong Resource type %T", action.Name, action.Resource)
+	}
+
+	// Step 1: re-read live state.
+	info, err := reader.StreamInfo(ctx, action.Name)
+	if errors.Is(err, jetstream.ErrStreamNotFound) {
+		return ExecutedAction{}, bucketMissingBeforeUpdate(action.Name)
+	}
+	if err != nil {
+		// Cancellation surfaces here too; the caller distinguishes it
+		// via errors.Is. Other errors fail-fast wrapped.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return ExecutedAction{}, err
+		}
+
+		return ExecutedAction{}, fmt.Errorf("re-read %s%s: %w", kvStreamPrefix, action.Name, err)
+	}
+	live := streamConfigToKVConfig(info.Config)
+
+	// Step 2: rebuild the write target from the just-re-read snapshot so
+	// every preserved-from-live field carries the current live value.
+	target, err := buildUpdateKVTargetForBucket(cfg, cpSpecs, action.Name, live)
+	if err != nil {
+		return ExecutedAction{}, err
+	}
+
+	// Step 3: no-op short-circuit. The bucket already matches the desired
+	// target — whether this plan or a concurrent operator converged it,
+	// the intent is realized. Recorded as a raced success.
+	if kvConfigsEqual(live, target) {
+		return ExecutedAction{Kind: action.Kind, Name: action.Name, Raced: true}, nil
+	}
+
+	// Step 4: stale-before check. The bucket is not yet converged; if live
+	// no longer matches the plan-time Before either, a concurrent writer
+	// moved it to a third state and the plan is stale. kvConfigsEqual
+	// ignores preserved-from-live fields and normalizes server defaults,
+	// so this fires only on a genuine operator-expressible or
+	// drift-detection-only change since plan time.
+	if !kvConfigsEqual(live, res.Before) {
+		return ExecutedAction{}, errors.New(
+			"stale-before: live state changed since plan; re-run plan")
+	}
+
+	// Step 5: write.
+	if err := updater.UpdateKeyValue(ctx, target); err != nil {
+		switch {
+		case errors.Is(err, jetstream.ErrBucketNotFound):
+			// nats.go maps a mid-write stream disappearance onto
+			// ErrBucketNotFound; treat it the same as a missing re-read.
+			return ExecutedAction{}, bucketMissingBeforeUpdate(action.Name)
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			return ExecutedAction{}, err
+		default:
+			return ExecutedAction{}, fmt.Errorf("update %s%s: %w", kvStreamPrefix, action.Name, err)
+		}
+	}
+
+	return ExecutedAction{Kind: action.Kind, Name: action.Name}, nil
+}
+
+// bucketMissingBeforeUpdate is the fail-fast error for a bucket that
+// existed at plan time but is gone when Apply re-reads or writes it.
+// Both the re-read miss and the write-time ErrBucketNotFound surface
+// the same operator-facing message class.
+func bucketMissingBeforeUpdate(bucket string) error {
+	return fmt.Errorf("bucket-missing-before-update: %s%s no longer exists", kvStreamPrefix, bucket)
+}
+
+// buildUpdateKVTargetForBucket re-derives the desired update-kv target
+// for the named bucket from the just-re-read live config. It looks the
+// bucket up among the control-plane specs first, then the
+// partition-source config. A bucket Plan emitted an update-kv for but
+// Config no longer describes is a defensive error, not a race.
+func buildUpdateKVTargetForBucket(
+	cfg Config,
+	cpSpecs map[string]controlPlaneSpec,
+	bucket string,
+	live jetstream.KeyValueConfig,
+) (jetstream.KeyValueConfig, error) {
+	before := cloneKVConfig(live)
+	if spec, ok := cpSpecs[bucket]; ok {
+		return buildControlPlaneUpdateTarget(spec, cfg.Instance, before), nil
+	}
+	if cfg.PartitionSource != nil && cfg.PartitionSource.Bucket == bucket {
+		return buildPartitionSourceUpdateTarget(cfg.PartitionSource, cfg.Instance, before), nil
+	}
+
+	return jetstream.KeyValueConfig{}, fmt.Errorf(
+		"update-kv target %q is not described by the resolved config", bucket)
+}

--- a/provision/apply_update.go
+++ b/provision/apply_update.go
@@ -148,6 +148,123 @@ func bucketMissingBeforeUpdate(bucket string) error {
 	return fmt.Errorf("bucket-missing-before-update: %s%s no longer exists", kvStreamPrefix, bucket)
 }
 
+// bucketMissingBeforeStamp is the fail-fast error for a bucket that
+// existed at plan time but is gone when Apply re-reads or writes it on
+// the stamp-marker path. Both the re-read miss and the write-time
+// ErrBucketNotFound surface the same operator-facing message class.
+func bucketMissingBeforeStamp(bucket string) error {
+	return fmt.Errorf("bucket-missing-before-stamp: %s%s no longer exists", kvStreamPrefix, bucket)
+}
+
+// applyStampMarkerAction executes one ActionStampMarker. It re-reads
+// live state, recomputes the merged metadata against the re-read
+// snapshot, short-circuits when the merge is already a no-op, and
+// otherwise writes the re-read snapshot back with only Metadata
+// changed.
+//
+// Unlike applyUpdateKVAction, stamp-marker has no stale-before check:
+// it carries no plan-time expectation of the bucket's non-metadata
+// fields. It re-reads live and writes that snapshot back with the
+// marker merged, so a concurrent change to a non-metadata field
+// between plan and apply is simply picked up by the re-read. The one
+// race it cannot close is a concurrent change landing between its own
+// re-read and write — a documented best-effort cross-policy contract.
+//
+// Return contract mirrors applyUpdateKVAction:
+//   - nil error → the returned ExecutedAction is recorded as-is. Raced
+//     is true when the bucket already carries an equivalent marker on
+//     re-read (concurrently adopted or never needed stamping).
+//   - context.Canceled / context.DeadlineExceeded (or an error that
+//     wraps one) → the caller treats it as a mid-mutation cancellation.
+//   - any other error → fail-fast resource error; the caller records
+//     err.Error() verbatim into ResourceError.Error.
+func applyStampMarkerAction(
+	ctx context.Context,
+	reader streamReader,
+	updater kvUpdater,
+	cfg Config,
+	cpSpecs map[string]controlPlaneSpec,
+	action PlannedAction,
+) (ExecutedAction, error) {
+	if _, ok := action.Resource.(*StampMarkerResource); !ok {
+		// Defensive guard: Plan should never emit this.
+		return ExecutedAction{}, fmt.Errorf(
+			"stamp-marker action %q has wrong Resource type %T", action.Name, action.Resource)
+	}
+
+	// Re-derive the component from the resolved config the same way the
+	// update-kv path re-derives its spec. A bucket Plan emitted a
+	// stamp-marker for but Config no longer describes is a defensive
+	// wiring error, not a runtime race.
+	component, err := stampMarkerComponent(cfg, cpSpecs, action.Name)
+	if err != nil {
+		return ExecutedAction{}, err
+	}
+
+	// Step 1: re-read live state.
+	info, err := reader.StreamInfo(ctx, action.Name)
+	if errors.Is(err, jetstream.ErrStreamNotFound) {
+		return ExecutedAction{}, bucketMissingBeforeStamp(action.Name)
+	}
+	if err != nil {
+		// Cancellation surfaces here too; the caller distinguishes it
+		// via errors.Is. Other errors fail-fast wrapped.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return ExecutedAction{}, err
+		}
+
+		return ExecutedAction{}, fmt.Errorf("re-read %s%s: %w", kvStreamPrefix, action.Name, err)
+	}
+	live := streamConfigToKVConfig(info.Config)
+
+	// Step 2: recompute the merge against the re-read metadata. A
+	// non-Parti key added between plan and apply flows into the written
+	// map — stamp-marker preserves the current non-Parti keys.
+	merged := mergeMarkerMetadata(live.Metadata, component, cfg.Instance)
+
+	// Step 3: no-op short-circuit. The target is the re-read snapshot
+	// with only Metadata replaced. If it already equals live, the
+	// bucket was concurrently adopted or already carries an equivalent
+	// marker — recorded as a raced success with no write.
+	target := cloneKVConfig(live)
+	target.Metadata = merged
+	if kvConfigsEqual(live, target) {
+		return ExecutedAction{Kind: action.Kind, Name: action.Name, Raced: true}, nil
+	}
+
+	// Step 4: write.
+	if err := updater.UpdateKeyValue(ctx, target); err != nil {
+		switch {
+		case errors.Is(err, jetstream.ErrBucketNotFound):
+			// nats.go maps a mid-write stream disappearance onto
+			// ErrBucketNotFound; treat it the same as a missing re-read.
+			return ExecutedAction{}, bucketMissingBeforeStamp(action.Name)
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			return ExecutedAction{}, err
+		default:
+			return ExecutedAction{}, fmt.Errorf("stamp %s%s: %w", kvStreamPrefix, action.Name, err)
+		}
+	}
+
+	return ExecutedAction{Kind: action.Kind, Name: action.Name}, nil
+}
+
+// stampMarkerComponent re-derives the Parti component for a stamp-marker
+// target from the resolved config: a control-plane spec when the bucket
+// is one, ComponentPartitionSource when it is the partition-source
+// bucket. A bucket described by neither is a defensive wiring error,
+// exactly parallel to buildUpdateKVTargetForBucket.
+func stampMarkerComponent(cfg Config, cpSpecs map[string]controlPlaneSpec, bucket string) (string, error) {
+	if spec, ok := cpSpecs[bucket]; ok {
+		return spec.component, nil
+	}
+	if cfg.PartitionSource != nil && cfg.PartitionSource.Bucket == bucket {
+		return ComponentPartitionSource, nil
+	}
+
+	return "", fmt.Errorf("stamp-marker target %q is not described by the resolved config", bucket)
+}
+
 // buildUpdateKVTargetForBucket re-derives the desired update-kv target
 // for the named bucket from the just-re-read live config. It looks the
 // bucket up among the control-plane specs first, then the

--- a/provision/classify_drift_test.go
+++ b/provision/classify_drift_test.go
@@ -1,0 +1,359 @@
+package provision
+
+// Same-package unit tests for classifyControlPlaneDrift and
+// classifyPartitionSourceDrift. These tests use synthetic *jetstream.StreamInfo
+// values so they run without a live NATS server and can exercise Replicas
+// mismatches that a single-server cluster always normalizes to 1.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// managedStreamConfig builds a jetstream.StreamConfig whose Metadata contains
+// the expected managed marker for the given component. Instance is always
+// "prod" across these unit tests. All unlisted fields default to zero.
+func managedStreamConfig(component string, extra ...func(*jetstream.StreamConfig)) jetstream.StreamConfig {
+	cfg := jetstream.StreamConfig{
+		Metadata: BuildMarker(component, "prod"),
+	}
+	for _, fn := range extra {
+		fn(&cfg)
+	}
+
+	return cfg
+}
+
+func TestClassifyControlPlaneDrift_ReplicasMismatch_DriftMutable(t *testing.T) {
+	t.Parallel()
+
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneAssignment,
+		bucket:    "parti-assignment",
+		ttl:       0,
+		storage:   jetstream.FileStorage,
+		replicas:  0,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneAssignment, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 3
+			cfg.Storage = jetstream.FileStorage
+			cfg.MaxMsgsPerSubject = 1
+		}),
+	}
+
+	findings := classifyControlPlaneDrift(spec, info, "prod")
+
+	var mutable []DriftFinding
+	for _, f := range findings {
+		if f.Severity == SeverityDriftMutable {
+			mutable = append(mutable, f)
+		}
+	}
+	require.Len(t, mutable, 1)
+	require.Contains(t, mutable[0].Detail, "replicas")
+
+	replicasDetail, ok := mutable[0].Detail["replicas"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, 1, replicasDetail["want"])
+	require.Equal(t, 3, replicasDetail["got"])
+
+	for _, f := range findings {
+		if f.Severity == SeverityDriftImmutable {
+			require.NotContains(t, f.Detail, "replicas")
+		}
+	}
+}
+
+func TestClassifyControlPlaneDrift_ReplicasNormalization_NoMutable(t *testing.T) {
+	t.Parallel()
+
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneAssignment,
+		bucket:    "parti-assignment",
+		ttl:       0,
+		storage:   jetstream.FileStorage,
+		replicas:  0,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneAssignment, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.FileStorage
+			cfg.MaxMsgsPerSubject = 1
+		}),
+	}
+
+	findings := classifyControlPlaneDrift(spec, info, "prod")
+
+	for _, f := range findings {
+		require.NotContains(t, f.Detail, "replicas")
+	}
+}
+
+func TestClassifyControlPlaneDrift_ReplicasExplicit_Match(t *testing.T) {
+	t.Parallel()
+
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneHeartbeat,
+		bucket:    "parti-heartbeat",
+		ttl:       15 * time.Second,
+		storage:   jetstream.MemoryStorage,
+		replicas:  2,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneHeartbeat, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 2
+			cfg.Storage = jetstream.MemoryStorage
+			cfg.MaxMsgsPerSubject = 1
+			cfg.MaxAge = 15 * time.Second
+		}),
+	}
+
+	findings := classifyControlPlaneDrift(spec, info, "prod")
+
+	for _, f := range findings {
+		require.NotContains(t, f.Detail, "replicas")
+	}
+}
+
+func TestClassifyControlPlaneDrift_ReplicasExplicit_Mismatch(t *testing.T) {
+	t.Parallel()
+
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneHeartbeat,
+		bucket:    "parti-heartbeat",
+		ttl:       15 * time.Second,
+		storage:   jetstream.MemoryStorage,
+		replicas:  2,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneHeartbeat, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.MemoryStorage
+			cfg.MaxMsgsPerSubject = 1
+			cfg.MaxAge = 15 * time.Second
+		}),
+	}
+
+	findings := classifyControlPlaneDrift(spec, info, "prod")
+
+	var mutable []DriftFinding
+	for _, f := range findings {
+		if f.Severity == SeverityDriftMutable {
+			mutable = append(mutable, f)
+		}
+	}
+	require.Len(t, mutable, 1, "expected exactly one drift-mutable finding")
+	require.Contains(t, mutable[0].Detail, "replicas")
+
+	replicasDetail, ok := mutable[0].Detail["replicas"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, 2, replicasDetail["want"])
+	require.Equal(t, 1, replicasDetail["got"])
+}
+
+func TestClassifyPartitionSourceDrift_ReplicasMismatch_DriftMutable(t *testing.T) {
+	t.Parallel()
+
+	ps := &PartitionSourceConfig{
+		Bucket:   "parti-partitions",
+		Key:      "partitions/v1",
+		Storage:  "file",
+		History:  2,
+		Replicas: 2,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentPartitionSource, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.FileStorage
+			cfg.MaxMsgsPerSubject = 2
+		}),
+	}
+
+	findings := classifyPartitionSourceDrift(ps, info, "prod")
+
+	var mutable []DriftFinding
+	var immutable []DriftFinding
+	for _, f := range findings {
+		switch f.Severity {
+		case SeverityDriftMutable:
+			mutable = append(mutable, f)
+		case SeverityDriftImmutable:
+			immutable = append(immutable, f)
+		}
+	}
+
+	hasMutableReplicas := false
+	for _, f := range mutable {
+		if _, ok := f.Detail["replicas"]; ok {
+			hasMutableReplicas = true
+
+			replicasDetail, ok := f.Detail["replicas"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, 2, replicasDetail["want"])
+			require.Equal(t, 1, replicasDetail["got"])
+		}
+	}
+	require.True(t, hasMutableReplicas, "findings: %+v", findings)
+
+	for _, f := range immutable {
+		require.NotContains(t, f.Detail, "replicas")
+	}
+}
+
+func TestClassifyPartitionSourceDrift_ReplicasNormalization_NoMutable(t *testing.T) {
+	t.Parallel()
+
+	ps := &PartitionSourceConfig{
+		Bucket:   "parti-partitions",
+		Key:      "partitions/v1",
+		Storage:  "file",
+		History:  1,
+		Replicas: 0,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentPartitionSource, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.FileStorage
+			cfg.MaxMsgsPerSubject = 1
+		}),
+	}
+
+	findings := classifyPartitionSourceDrift(ps, info, "prod")
+
+	for _, f := range findings {
+		require.NotContains(t, f.Detail, "replicas")
+	}
+}
+
+func TestClassifyPartitionSourceDrift_ReplicasMatch_NoDrift(t *testing.T) {
+	t.Parallel()
+
+	ps := &PartitionSourceConfig{
+		Bucket:   "parti-partitions",
+		Key:      "partitions/v1",
+		Storage:  "file",
+		History:  1,
+		Replicas: 3,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentPartitionSource, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 3
+			cfg.Storage = jetstream.FileStorage
+			cfg.MaxMsgsPerSubject = 1
+		}),
+	}
+
+	findings := classifyPartitionSourceDrift(ps, info, "prod")
+
+	for _, f := range findings {
+		require.NotContains(t, f.Detail, "replicas")
+	}
+}
+
+func TestClassifyControlPlaneDrift_ManagedVersionMismatch_DriftMutable(t *testing.T) {
+	t.Parallel()
+
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneHeartbeat,
+		bucket:    "parti-heartbeat",
+		ttl:       15 * time.Second,
+		storage:   jetstream.MemoryStorage,
+		replicas:  0,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneHeartbeat, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.MemoryStorage
+			cfg.MaxMsgsPerSubject = 1
+			cfg.MaxAge = 15 * time.Second
+			cfg.Metadata[MarkerManagedKey] = "v2"
+		}),
+	}
+
+	findings := classifyControlPlaneDrift(spec, info, "prod")
+
+	var mutable []DriftFinding
+	for _, f := range findings {
+		if f.Severity == SeverityDriftMutable {
+			mutable = append(mutable, f)
+		}
+	}
+	require.Len(t, mutable, 1)
+	require.Contains(t, mutable[0].Detail, "managed")
+}
+
+func TestClassifyControlPlaneDrift_InstanceRemoval_DriftMutable(t *testing.T) {
+	t.Parallel()
+
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneHeartbeat,
+		bucket:    "parti-heartbeat",
+		ttl:       15 * time.Second,
+		storage:   jetstream.MemoryStorage,
+		replicas:  0,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneHeartbeat, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.MemoryStorage
+			cfg.MaxMsgsPerSubject = 1
+			cfg.MaxAge = 15 * time.Second
+		}),
+	}
+
+	findings := classifyControlPlaneDrift(spec, info, "")
+
+	var mutable []DriftFinding
+	for _, f := range findings {
+		if f.Severity == SeverityDriftMutable {
+			mutable = append(mutable, f)
+		}
+	}
+	require.Len(t, mutable, 1)
+	require.Contains(t, mutable[0].Detail, "instance")
+
+	detail, ok := mutable[0].Detail["instance"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "", detail["want"])
+	require.Equal(t, "prod", detail["got"])
+}
+
+func TestClassifyPartitionSourceDrift_ComponentMismatch_DriftImmutable(t *testing.T) {
+	t.Parallel()
+
+	ps := &PartitionSourceConfig{
+		Bucket:   "parti-partitions",
+		Key:      "partitions/v1",
+		Storage:  "file",
+		History:  1,
+		Replicas: 0,
+	}
+	info := &jetstream.StreamInfo{
+		Config: managedStreamConfig(ComponentControlPlaneAssignment, func(cfg *jetstream.StreamConfig) {
+			cfg.Replicas = 1
+			cfg.Storage = jetstream.FileStorage
+			cfg.MaxMsgsPerSubject = 1
+		}),
+	}
+
+	findings := classifyPartitionSourceDrift(ps, info, "prod")
+
+	var immutable []DriftFinding
+	for _, f := range findings {
+		if f.Severity == SeverityDriftImmutable {
+			immutable = append(immutable, f)
+		}
+	}
+	require.Len(t, immutable, 1)
+	require.Contains(t, immutable[0].Detail, "component")
+
+	for _, f := range findings {
+		if f.Severity == SeverityDriftMutable {
+			require.NotContains(t, f.Detail, "component")
+		}
+	}
+}

--- a/provision/clone_kvconfig.go
+++ b/provision/clone_kvconfig.go
@@ -1,0 +1,66 @@
+package provision
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// cloneKVConfig returns a deep clone of src. Pointer fields (Placement,
+// RePublish, Mirror), the Sources slice and its pointees, and Metadata
+// are all reallocated so the result is safe to mutate without affecting
+// src — required because nats.go's prepareKeyValueConfig may mutate
+// entries in cfg.Sources while building the underlying stream config.
+func cloneKVConfig(src jetstream.KeyValueConfig) jetstream.KeyValueConfig {
+	dst := src // shallow copy of scalar fields
+
+	if src.Placement != nil {
+		p := *src.Placement
+		p.Tags = slices.Clone(src.Placement.Tags)
+		dst.Placement = &p
+	}
+
+	if src.RePublish != nil {
+		rp := *src.RePublish
+		dst.RePublish = &rp
+	}
+
+	if src.Mirror != nil {
+		dst.Mirror = cloneStreamSource(src.Mirror)
+	}
+
+	if src.Sources != nil {
+		dst.Sources = make([]*jetstream.StreamSource, len(src.Sources))
+		for i, ss := range src.Sources {
+			dst.Sources[i] = cloneStreamSource(ss)
+		}
+	}
+
+	dst.Metadata = maps.Clone(src.Metadata)
+
+	return dst
+}
+
+// cloneStreamSource deep-clones a *StreamSource, including its pointer and
+// slice fields (OptStartTime, External, SubjectTransforms).
+func cloneStreamSource(src *jetstream.StreamSource) *jetstream.StreamSource {
+	if src == nil {
+		return nil
+	}
+	dst := *src // shallow copy
+
+	if src.OptStartTime != nil {
+		t := *src.OptStartTime
+		dst.OptStartTime = &t
+	}
+
+	if src.External != nil {
+		e := *src.External
+		dst.External = &e
+	}
+
+	dst.SubjectTransforms = slices.Clone(src.SubjectTransforms)
+
+	return &dst
+}

--- a/provision/clone_kvconfig_test.go
+++ b/provision/clone_kvconfig_test.go
@@ -1,0 +1,154 @@
+package provision
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// fullKVConfig constructs a jetstream.KeyValueConfig with every field that
+// nats.go v1.50.0 exposes set to a non-zero / non-nil value. This is the
+// forward-compatibility anchor: if nats.go adds a new pointer-bearing field,
+// reflect.DeepEqual in the preservation test will detect it before cloneKVConfig
+// is updated to handle it.
+func fullKVConfig() jetstream.KeyValueConfig {
+	now := time.Now()
+	tags := []string{"region:us-east", "tier:prod"}
+
+	return jetstream.KeyValueConfig{
+		Bucket:         "test-bucket",
+		Description:    "test description",
+		MaxValueSize:   4096,
+		History:        3,
+		TTL:            10 * time.Minute,
+		MaxBytes:       1024 * 1024,
+		Storage:        jetstream.FileStorage,
+		Replicas:       2,
+		Compression:    true,
+		LimitMarkerTTL: 5 * time.Minute,
+		Placement: &jetstream.Placement{
+			Cluster: "us-east",
+			Tags:    tags,
+		},
+		RePublish: &jetstream.RePublish{
+			Source:      "src.>",
+			Destination: "dst.>",
+			HeadersOnly: true,
+		},
+		Mirror: &jetstream.StreamSource{
+			Name:          "mirror-stream",
+			OptStartSeq:   42,
+			OptStartTime:  &now,
+			FilterSubject: "foo.>",
+			SubjectTransforms: []jetstream.SubjectTransformConfig{
+				{Source: "foo.>", Destination: "bar.>"},
+			},
+			External: &jetstream.ExternalStream{
+				APIPrefix:     "ext-api",
+				DeliverPrefix: "ext-deliver",
+			},
+		},
+		Sources: []*jetstream.StreamSource{
+			{
+				Name:          "source-stream",
+				OptStartSeq:   100,
+				OptStartTime:  &now,
+				FilterSubject: "baz.>",
+				SubjectTransforms: []jetstream.SubjectTransformConfig{
+					{Source: "baz.>", Destination: "qux.>"},
+				},
+				External: &jetstream.ExternalStream{
+					APIPrefix:     "src-api",
+					DeliverPrefix: "src-deliver",
+				},
+			},
+		},
+		Metadata: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		},
+	}
+}
+
+// TestCloneKVConfig_ForwardCompatPreservation is the forward-compatibility anchor
+// test. It builds a KeyValueConfig with every field set to non-zero/non-nil values,
+// clones it, and asserts reflect.DeepEqual. If nats.go adds a new pointer-bearing
+// field, this test will fail until cloneKVConfig is updated to deep-clone it.
+func TestCloneKVConfig_ForwardCompatPreservation(t *testing.T) {
+	t.Parallel()
+
+	src := fullKVConfig()
+	clone := cloneKVConfig(src)
+
+	// Assert byte-equality between src and clone.
+	require.True(t, reflect.DeepEqual(src, clone),
+		"clone must be deeply equal to src\nsrc:   %#v\nclone: %#v", src, clone)
+
+	// Mutate every pointer and slice element on the clone; assert src is unchanged.
+	clone.Placement.Cluster = "mutated-cluster"
+	clone.Placement.Tags[0] = "mutated-tag"
+	clone.RePublish.Source = "mutated-src.>"
+	clone.Mirror.Name = "mutated-mirror"
+	clone.Mirror.SubjectTransforms[0].Source = "mutated.>"
+	clone.Mirror.External.APIPrefix = "mutated-api"
+	clone.Sources[0].Name = "mutated-source"
+	clone.Sources[0].SubjectTransforms[0].Destination = "mutated-dst.>"
+	clone.Sources[0].External.DeliverPrefix = "mutated-deliver"
+	clone.Metadata["key1"] = "mutated-val"
+
+	// src must be unchanged.
+	require.Equal(t, "us-east", src.Placement.Cluster, "src.Placement.Cluster must not be mutated")
+	require.Equal(t, "region:us-east", src.Placement.Tags[0], "src.Placement.Tags must not be mutated")
+	require.Equal(t, "src.>", src.RePublish.Source, "src.RePublish.Source must not be mutated")
+	require.Equal(t, "mirror-stream", src.Mirror.Name, "src.Mirror.Name must not be mutated")
+	require.Equal(t, "foo.>", src.Mirror.SubjectTransforms[0].Source, "src.Mirror.SubjectTransforms must not be mutated")
+	require.Equal(t, "ext-api", src.Mirror.External.APIPrefix, "src.Mirror.External must not be mutated")
+	require.Equal(t, "source-stream", src.Sources[0].Name, "src.Sources[0].Name must not be mutated")
+	require.Equal(t, "qux.>", src.Sources[0].SubjectTransforms[0].Destination, "src.Sources[0].SubjectTransforms must not be mutated")
+	require.Equal(t, "src-deliver", src.Sources[0].External.DeliverPrefix, "src.Sources[0].External must not be mutated")
+	require.Equal(t, "val1", src.Metadata["key1"], "src.Metadata must not be mutated")
+}
+
+// TestCloneKVConfig_NilPointers verifies that cloneKVConfig handles a config
+// with all pointer/slice fields nil without panicking and returns all nil.
+func TestCloneKVConfig_NilPointers(t *testing.T) {
+	t.Parallel()
+
+	src := jetstream.KeyValueConfig{
+		Bucket:  "simple",
+		History: 1,
+		Storage: jetstream.FileStorage,
+	}
+
+	require.NotPanics(t, func() {
+		clone := cloneKVConfig(src)
+		require.Nil(t, clone.Placement)
+		require.Nil(t, clone.RePublish)
+		require.Nil(t, clone.Mirror)
+		require.Nil(t, clone.Sources)
+		require.Nil(t, clone.Metadata)
+	})
+}
+
+// TestCloneKVConfig_MetadataIndependence verifies that mutating the clone's
+// Metadata map does not affect the source.
+func TestCloneKVConfig_MetadataIndependence(t *testing.T) {
+	t.Parallel()
+
+	src := jetstream.KeyValueConfig{
+		Bucket:   "test",
+		Metadata: map[string]string{"k": "v"},
+	}
+	clone := cloneKVConfig(src)
+	clone.Metadata["k"] = "mutated"
+	require.Equal(t, "v", src.Metadata["k"], "src.Metadata must be independent of clone.Metadata")
+}
+
+// TestCloneStreamSource_NilSrc verifies that cloneStreamSource(nil) returns nil.
+func TestCloneStreamSource_NilSrc(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, cloneStreamSource(nil))
+}

--- a/provision/config.go
+++ b/provision/config.go
@@ -50,6 +50,16 @@ type ControlPlaneConfig struct {
 	// EnableTwoPhaseHandoff gates the optional handoff KV bucket. When true,
 	// HandoffTTL must be > 0.
 	EnableTwoPhaseHandoff bool `yaml:"enableTwoPhaseHandoff" json:"enableTwoPhaseHandoff"`
+
+	// Replicas is the desired number of NATS stream replicas for every
+	// control-plane KV bucket. 0 (the default) leaves the underlying
+	// KeyValueConfig.Replicas field unset; nats.go normalizes that to 1
+	// server-side. Non-zero values are drift-mutable under safe-update;
+	// the NATS server enforces cluster-peer feasibility at apply time.
+	//
+	// Applies uniformly to every control-plane bucket; per-bucket
+	// replica overrides are not supported.
+	Replicas int `yaml:"replicas,omitempty" json:"replicas,omitempty"`
 }
 
 // PartitionSourceConfig declares the NATS KV bucket that holds the partition

--- a/provision/config.go
+++ b/provision/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	ControlPlane     *ControlPlaneConfig    `yaml:"controlPlane,omitempty"      json:"controlPlane,omitempty"`
 	PartitionSource  *PartitionSourceConfig `yaml:"partitionSource,omitempty"   json:"partitionSource,omitempty"`
 	DynamicConsumers []DynamicConsumerCfg   `yaml:"dynamicConsumers,omitempty"  json:"dynamicConsumers,omitempty"`
-	// Streams is intentionally absent in v1 (see Non-Goals in plan).
+	// Streams is intentionally absent; application stream management is not yet supported.
 }
 
 // ControlPlaneConfig mirrors the parti runtime fields that drive control-plane
@@ -63,8 +63,9 @@ type ControlPlaneConfig struct {
 }
 
 // PartitionSourceConfig declares the NATS KV bucket that holds the partition
-// definition record. v1 provisions the bucket only; partition record contents
-// are written by Phase 3 (Partition Records).
+// definition record. The SDK provisions the bucket; partition record contents
+// (the actual partition definitions) are managed separately and are not yet
+// part of this SDK.
 type PartitionSourceConfig struct {
 	Bucket   string `yaml:"bucket"                 json:"bucket"`
 	Key      string `yaml:"key"                    json:"key"`
@@ -80,8 +81,9 @@ type PartitionSourceConfig struct {
 	TTL          time.Duration `yaml:"ttl,omitempty"          json:"ttl,omitempty"`
 }
 
-// DynamicConsumerCfg describes one dynamic-consumer alignment target. v1
-// performs alignment-check only; consumer pre-creation lands in Phase 5.
+// DynamicConsumerCfg describes one dynamic-consumer alignment target.
+// The current implementation performs alignment-check only; consumer
+// precreation is not yet supported.
 type DynamicConsumerCfg struct {
 	StreamName      string `yaml:"streamName"              json:"streamName"`
 	ConsumerPrefix  string `yaml:"consumerPrefix"          json:"consumerPrefix"`

--- a/provision/doc.go
+++ b/provision/doc.go
@@ -1,26 +1,40 @@
-// Package provision provides a read-only SDK for viewing, validating, and
-// planning the NATS resources Parti's runtime depends on.
+// Package provision manages the NATS resources Parti's runtime depends on:
+// control-plane KV buckets and the partition-source bucket.
 //
-// Phase 1 (W1) of the provision-sdk-cli plan delivers:
+// The primary entry points are:
 //
 //   - Config — desired-state input loaded from YAML or constructed in Go.
 //   - Validate(cfg) — pure static validation with bucket-name defaulting.
 //   - View(ctx, js, scope) — read-only inventory of Parti-marked resources.
-//   - Plan(ctx, js, cfg) — deterministic drift report and create-kv actions
-//     for control-plane KV buckets. No mutation.
+//   - Plan(ctx, js, cfg) — deterministic drift report and proposed actions.
+//     Read-only; never mutates NATS.
+//   - Apply(ctx, js, cfg) — executes the Plan actions against live NATS.
 //
-// Plan emits at most one PlannedAction kind in v1 — "create-kv" — and only
-// for control-plane buckets. Partition-source create-kv actions, dynamic-
-// consumer alignment, and the Apply mutation path land in later work items
-// (W2–W4) of the same plan. See docs/plans/provision-sdk-cli for the full
-// design and roadmap.
+// Plan emits three action kinds depending on the reconcile policy:
+//
+//   - "create-kv": create a missing KV bucket (all policies except adopt).
+//   - "update-kv": reconcile drift-mutable fields in place on a Parti-marked
+//     bucket (safe-update policy only).
+//   - "stamp-marker": stamp the Parti ownership marker on an unmarked bucket
+//     that exists live, preserving all non-Parti metadata (adopt policy only).
+//
+// Reconcile policies (set via Config.Policy or the -policy CLI flag):
+//
+//   - "warn" (default): create missing buckets; report drift; never mutate
+//     existing resources.
+//   - "adopt": stamp the Parti marker on unmarked existing buckets named by
+//     config; create nothing; update no non-marker fields.
+//   - "safe-update": create missing buckets; reconcile drift-mutable fields
+//     (Metadata, TTL, MaxValueSize, Replicas) on Parti-marked buckets. Never
+//     mutates unmarked buckets; operators run adopt first.
+//   - "force": reserved, not yet supported.
 //
 // Byte-equivalence invariant: every "create-kv" action's KeyValueConfig is
 // built by calling github.com/arloliu/parti/v2/internal/kvbuckets.BuildKeyValueConfig
 // and then attaching the Parti ownership marker in Metadata. The same builder
 // is used by (*Manager).ensureKVBucket at runtime, so a provision-managed
-// bucket is byte-identical (modulo the Metadata marker) to one created by
-// Parti's manager.
+// bucket is byte-identical (modulo Metadata and an explicit Replicas override)
+// to one created by Parti's manager.
 //
 // ValidateLiveDynamicConsumers is best-effort: stream-info fetch failures
 // inside the underlying consumer.CheckWorkQueueRecoveryCompat helper are

--- a/provision/dynamic_consumers.go
+++ b/provision/dynamic_consumers.go
@@ -18,16 +18,16 @@ import (
 //
 // The builder produces the same per-subject jetstream.ConsumerConfig that
 // the runtime consumer.Dynamic would create (modulo runtime-tunable fields
-// supplied via Dynamic options — see the W4 sub-spec §2 for the enumerated
-// equality subset).
+// supplied via Dynamic options; the equality subset is documented in the
+// corresponding integration test).
 //
-// In v1 the builder hard-codes:
+// The builder hard-codes:
 //   - AckPolicy = jetstream.AckExplicitPolicy
 //   - DeliverPolicy = jetstream.DeliverAllPolicy
 //
 // All other ConsumerConfig fields are populated from the zero values of
 // dynamicbuild.Defaults; runtime equivalents are tunable through consumer
-// options that the v1 builder does not accept. The runtime-defaults
+// options that this builder does not accept. The runtime-defaults
 // roundtrip test (provision/dynamic_consumers_test.go) pins the equality
 // subset against durable.WorkerConsumerConfig.SetDefaults().
 //
@@ -86,8 +86,8 @@ func PlanDynamicConsumers(
 
 	defaults := dynamicbuild.Defaults{
 		AckPolicy: jetstream.AckExplicitPolicy,
-		// Remaining tunables left at their Go zero values; the v1 equality
-		// subset does not assert them. See sub-spec §2.
+		// Remaining tunables left at their Go zero values; the equality
+		// subset tested by the roundtrip test does not assert them.
 	}
 
 	out := make([]PlannedConsumer, 0, len(subjects))
@@ -109,12 +109,13 @@ func PlanDynamicConsumers(
 // check that runtime consumer.Dynamic.Update would perform on first update,
 // for each configured dynamic-consumer alignment target.
 //
-// v1 always passes consumer.RecoveryDisabled as the strategy, mirroring
-// what consumer.Dynamic would produce when no WithRecoveryStrategy option
-// is set. Both RecoveryDisabled and RecoverFromBeginning unconditionally
-// pass the check (see consumer.CheckWorkQueueRecoveryCompat), so v1
-// alignment never raises a false positive against a WorkQueuePolicy
-// stream. Phase 5 (precreation) reintroduces a configurable strategy.
+// ValidateLiveDynamicConsumers always passes consumer.RecoveryDisabled as
+// the strategy, mirroring what consumer.Dynamic would produce when no
+// WithRecoveryStrategy option is set. Both RecoveryDisabled and
+// RecoverFromBeginning unconditionally pass the check (see
+// consumer.CheckWorkQueueRecoveryCompat), so alignment never raises a
+// false positive against a WorkQueuePolicy stream. A configurable strategy
+// is not yet supported for this check.
 //
 // Errors:
 //   - Returns the first error encountered (fail-fast), wrapped with the

--- a/provision/kvequal.go
+++ b/provision/kvequal.go
@@ -1,0 +1,101 @@
+package provision
+
+import (
+	"maps"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// kvConfigsEqual reports whether two jetstream.KeyValueConfig values
+// agree on the comparison subset: operator-expressible fields
+// (Metadata, TTL, MaxValueSize, Replicas) and drift-detection-only
+// fields (History, Storage). Preserved-from-live fields (Description,
+// MaxBytes, Placement, RePublish, Mirror, Sources, Compression,
+// LimitMarkerTTL, plus any future field) are NOT compared.
+//
+// Normalizations applied to match nats.go server-side defaults:
+//   - Replicas: 0 == 1 (server default)
+//   - MaxValueSize: 0 == -1 ("no limit")
+//   - Metadata: nil == empty map
+//
+// Bucket is NOT compared — bucket name is the resource identity used
+// by exact-name lookup, not an in-resource drift field.
+func kvConfigsEqual(a, b jetstream.KeyValueConfig) bool {
+	if normalizeReplicas(a.Replicas) != normalizeReplicas(b.Replicas) {
+		return false
+	}
+	if normalizeMaxValueSize(a.MaxValueSize) != normalizeMaxValueSize(b.MaxValueSize) {
+		return false
+	}
+	if a.TTL != b.TTL {
+		return false
+	}
+	if !maps.Equal(a.Metadata, b.Metadata) {
+		return false
+	}
+	if a.History != b.History {
+		return false
+	}
+	if a.Storage != b.Storage {
+		return false
+	}
+
+	return true
+}
+
+// normalizeReplicas maps the desired Replicas value through the NATS
+// server-default rule: a zero (the KeyValueConfig zero value, meaning
+// "omit") is equivalent to 1, the server's default replica count.
+// Used by kvConfigsEqual and by every drift classifier that needs to
+// compare a config-side Replicas against a live stream's Replicas.
+func normalizeReplicas(r int) int {
+	if r == 0 {
+		return 1
+	}
+
+	return r
+}
+
+// normalizeMaxValueSize maps the desired MaxValueSize through the NATS
+// server-default rule: a zero (meaning "no limit" on the caller side)
+// is equivalent to -1, which is how the server stores "no limit".
+func normalizeMaxValueSize(s int32) int32 {
+	if s == 0 {
+		return -1
+	}
+
+	return s
+}
+
+// extractLiveKVConfig projects a live jetstream.StreamConfig onto the
+// subset of KeyValueConfig fields kvConfigsEqual compares. Fields outside
+// that subset (Bucket, Description, MaxBytes, Placement, RePublish,
+// Mirror, Sources, Compression, LimitMarkerTTL) are omitted because the
+// equality contract excludes them; the returned value is suitable as
+// input to kvConfigsEqual but not for round-tripping to UpdateKeyValue.
+func extractLiveKVConfig(sc *jetstream.StreamConfig) jetstream.KeyValueConfig {
+	return jetstream.KeyValueConfig{
+		TTL:          sc.MaxAge,
+		MaxValueSize: sc.MaxMsgSize,
+		Replicas:     sc.Replicas,
+		Storage:      sc.Storage,
+		History:      historyFromStream(sc.MaxMsgsPerSubject),
+		Metadata:     sc.Metadata,
+	}
+}
+
+// historyFromStream clamps the stream-side MaxMsgsPerSubject to the
+// uint8 range of jetstream.KeyValueConfig.History. NATS KV enforces
+// History <= 64 (KeyValueMaxHistory), so any live value above 255 is
+// non-KV data; the clamp keeps drift comparison deterministic without
+// pretending to round-trip arbitrary stream configurations.
+func historyFromStream(maxMsgsPerSubject int64) uint8 {
+	switch {
+	case maxMsgsPerSubject < 0:
+		return 0
+	case maxMsgsPerSubject > 255:
+		return 255
+	default:
+		return uint8(maxMsgsPerSubject)
+	}
+}

--- a/provision/kvequal.go
+++ b/provision/kvequal.go
@@ -2,6 +2,7 @@ package provision
 
 import (
 	"maps"
+	"strings"
 
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -67,21 +68,46 @@ func normalizeMaxValueSize(s int32) int32 {
 	return s
 }
 
-// extractLiveKVConfig projects a live jetstream.StreamConfig onto the
-// subset of KeyValueConfig fields kvConfigsEqual compares. Fields outside
-// that subset (Bucket, Description, MaxBytes, Placement, RePublish,
-// Mirror, Sources, Compression, LimitMarkerTTL) are omitted because the
-// equality contract excludes them; the returned value is suitable as
-// input to kvConfigsEqual but not for round-tripping to UpdateKeyValue.
-func extractLiveKVConfig(sc *jetstream.StreamConfig) jetstream.KeyValueConfig {
+// streamConfigToKVConfig projects a live jetstream.StreamConfig onto a
+// jetstream.KeyValueConfig covering every field nats.go's KeyValueConfig
+// exposes, so a round-trip through UpdateKeyValue preserves
+// preserved-from-live fields. This is the full projection; the
+// comparison-subset-only callers (drift classifiers) consume it through
+// extractLiveKVConfig, for which the extra fields are inert.
+//
+// LimitMarkerTTL is backed by StreamConfig.SubjectDeleteMarkerTTL in
+// nats.go v1.50.0 (confirmed via KeyValueBucketStatus.LimitMarkerTTL,
+// jetstream/kv.go:840). Compression is the StoreCompression enum on the
+// stream side and a bool on the KeyValueConfig side.
+func streamConfigToKVConfig(sc jetstream.StreamConfig) jetstream.KeyValueConfig {
 	return jetstream.KeyValueConfig{
-		TTL:          sc.MaxAge,
-		MaxValueSize: sc.MaxMsgSize,
-		Replicas:     sc.Replicas,
-		Storage:      sc.Storage,
-		History:      historyFromStream(sc.MaxMsgsPerSubject),
-		Metadata:     sc.Metadata,
+		Bucket:         strings.TrimPrefix(sc.Name, kvStreamPrefix),
+		Description:    sc.Description,
+		MaxValueSize:   sc.MaxMsgSize,
+		History:        historyFromStream(sc.MaxMsgsPerSubject),
+		TTL:            sc.MaxAge,
+		MaxBytes:       sc.MaxBytes,
+		Storage:        sc.Storage,
+		Replicas:       sc.Replicas,
+		Placement:      sc.Placement,
+		RePublish:      sc.RePublish,
+		Mirror:         sc.Mirror,
+		Sources:        sc.Sources,
+		Compression:    sc.Compression != jetstream.NoCompression,
+		LimitMarkerTTL: sc.SubjectDeleteMarkerTTL,
+		Metadata:       sc.Metadata,
 	}
+}
+
+// extractLiveKVConfig projects a live jetstream.StreamConfig onto a
+// jetstream.KeyValueConfig for drift comparison. It delegates to
+// streamConfigToKVConfig: the classifiers feed the result only to
+// kvConfigsEqual and the wantedControlPlaneKV / wantedPartitionSourceKV
+// builders, all of which read the comparison-subset fields only, so the
+// extra preserved-from-live fields the full projection populates are
+// inert here. The delegation removes a duplicate projection.
+func extractLiveKVConfig(sc *jetstream.StreamConfig) jetstream.KeyValueConfig {
+	return streamConfigToKVConfig(*sc)
 }
 
 // historyFromStream clamps the stream-side MaxMsgsPerSubject to the

--- a/provision/kvequal_test.go
+++ b/provision/kvequal_test.go
@@ -1,0 +1,221 @@
+package provision
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKVConfigsEqual(t *testing.T) {
+	t.Parallel()
+
+	base := jetstream.KeyValueConfig{
+		Bucket:       "test-bucket",
+		History:      1,
+		Storage:      jetstream.FileStorage,
+		Replicas:     1,
+		MaxValueSize: -1, // server "no limit"
+		TTL:          5 * time.Minute,
+		Metadata:     map[string]string{"k": "v"},
+	}
+
+	tests := []struct {
+		name  string
+		a     jetstream.KeyValueConfig
+		b     jetstream.KeyValueConfig
+		equal bool
+	}{
+		{
+			name:  "byte_equal",
+			a:     base,
+			b:     base,
+			equal: true,
+		},
+		{
+			// Replicas 0 and 1 are both "server default" — must be equal.
+			name:  "replicas_zero_equals_one",
+			a:     withReplicas(base, 0),
+			b:     withReplicas(base, 1),
+			equal: true,
+		},
+		{
+			name:  "replicas_one_equals_zero",
+			a:     withReplicas(base, 1),
+			b:     withReplicas(base, 0),
+			equal: true,
+		},
+		{
+			name:  "replicas_mismatch",
+			a:     withReplicas(base, 1),
+			b:     withReplicas(base, 3),
+			equal: false,
+		},
+		{
+			// MaxValueSize 0 and -1 are both "no limit" — must be equal.
+			name:  "max_value_size_zero_equals_minus_one",
+			a:     withMaxValueSize(base, 0),
+			b:     withMaxValueSize(base, -1),
+			equal: true,
+		},
+		{
+			name:  "max_value_size_minus_one_equals_zero",
+			a:     withMaxValueSize(base, -1),
+			b:     withMaxValueSize(base, 0),
+			equal: true,
+		},
+		{
+			name:  "max_value_size_mismatch",
+			a:     withMaxValueSize(base, 512),
+			b:     withMaxValueSize(base, 1024),
+			equal: false,
+		},
+		{
+			name:  "metadata_nil_equals_empty_map",
+			a:     withMetadata(base, nil),
+			b:     withMetadata(base, map[string]string{}),
+			equal: true,
+		},
+		{
+			name:  "metadata_empty_map_equals_nil",
+			a:     withMetadata(base, map[string]string{}),
+			b:     withMetadata(base, nil),
+			equal: true,
+		},
+		{
+			name:  "metadata_equal_maps",
+			a:     withMetadata(base, map[string]string{"k": "v", "x": "y"}),
+			b:     withMetadata(base, map[string]string{"x": "y", "k": "v"}),
+			equal: true,
+		},
+		{
+			name:  "metadata_value_mismatch",
+			a:     withMetadata(base, map[string]string{"k": "v1"}),
+			b:     withMetadata(base, map[string]string{"k": "v2"}),
+			equal: false,
+		},
+		{
+			name:  "metadata_key_missing",
+			a:     withMetadata(base, map[string]string{"k": "v"}),
+			b:     withMetadata(base, map[string]string{}),
+			equal: false,
+		},
+		{
+			name:  "ttl_equal",
+			a:     withTTL(base, 10*time.Minute),
+			b:     withTTL(base, 10*time.Minute),
+			equal: true,
+		},
+		{
+			name:  "ttl_mismatch",
+			a:     withTTL(base, 10*time.Minute),
+			b:     withTTL(base, 20*time.Minute),
+			equal: false,
+		},
+		{
+			name:  "history_equal",
+			a:     withHistory(base, 2),
+			b:     withHistory(base, 2),
+			equal: true,
+		},
+		{
+			name:  "history_mismatch",
+			a:     withHistory(base, 1),
+			b:     withHistory(base, 5),
+			equal: false,
+		},
+		{
+			name:  "storage_equal",
+			a:     withStorage(base, jetstream.MemoryStorage),
+			b:     withStorage(base, jetstream.MemoryStorage),
+			equal: true,
+		},
+		{
+			name:  "storage_mismatch",
+			a:     withStorage(base, jetstream.FileStorage),
+			b:     withStorage(base, jetstream.MemoryStorage),
+			equal: false,
+		},
+		{
+			// Bucket is NOT compared — it is the resource identity, not drift.
+			name:  "bucket_name_difference_ignored",
+			a:     withBucket(base, "bucket-a"),
+			b:     withBucket(base, "bucket-b"),
+			equal: true,
+		},
+		{
+			// Description is preserved-from-live — not compared.
+			name:  "description_difference_ignored",
+			a:     withDescription(base, "notes"),
+			b:     withDescription(base, ""),
+			equal: true,
+		},
+		{
+			// MaxBytes is preserved-from-live — not compared.
+			name:  "max_bytes_difference_ignored",
+			a:     withMaxBytes(base, 1024),
+			b:     withMaxBytes(base, 0),
+			equal: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := kvConfigsEqual(tc.a, tc.b)
+			if tc.equal {
+				require.True(t, got, "expected equal for %q", tc.name)
+			} else {
+				require.False(t, got, "expected not-equal for %q", tc.name)
+			}
+		})
+	}
+}
+
+// helpers to produce modified copies.
+
+func withReplicas(c jetstream.KeyValueConfig, r int) jetstream.KeyValueConfig {
+	c.Replicas = r
+	return c
+}
+
+func withMaxValueSize(c jetstream.KeyValueConfig, s int32) jetstream.KeyValueConfig {
+	c.MaxValueSize = s
+	return c
+}
+
+func withMetadata(c jetstream.KeyValueConfig, m map[string]string) jetstream.KeyValueConfig {
+	c.Metadata = m
+	return c
+}
+
+func withTTL(c jetstream.KeyValueConfig, d time.Duration) jetstream.KeyValueConfig {
+	c.TTL = d
+	return c
+}
+
+func withHistory(c jetstream.KeyValueConfig, h uint8) jetstream.KeyValueConfig {
+	c.History = h
+	return c
+}
+
+func withStorage(c jetstream.KeyValueConfig, s jetstream.StorageType) jetstream.KeyValueConfig {
+	c.Storage = s
+	return c
+}
+
+func withBucket(c jetstream.KeyValueConfig, b string) jetstream.KeyValueConfig {
+	c.Bucket = b
+	return c
+}
+
+func withDescription(c jetstream.KeyValueConfig, d string) jetstream.KeyValueConfig {
+	c.Description = d
+	return c
+}
+
+func withMaxBytes(c jetstream.KeyValueConfig, b int64) jetstream.KeyValueConfig {
+	c.MaxBytes = b
+	return c
+}

--- a/provision/partition_source.go
+++ b/provision/partition_source.go
@@ -71,7 +71,40 @@ func planPartitionSource(ctx context.Context, js jetstream.JetStream, cfg Config
 	findings := classifyPartitionSourceDrift(ps, info, cfg.Instance)
 	out.Drift = append(out.Drift, findings...)
 
+	// Under safe-update, a Parti-marked bucket with operator-
+	// expressible drift also gets an update-kv action. Drift findings
+	// and the action coexist; the classifier above still populates
+	// out.Drift in every policy.
+	if cfg.Policy == PolicySafeUpdate && ParseMarker(info.Config.Metadata).IsManaged() {
+		before := cloneKVConfig(streamConfigToKVConfig(info.Config))
+		after := buildPartitionSourceUpdateTarget(ps, cfg.Instance, before)
+		if !kvConfigsEqual(before, after) {
+			out.Actions = append(out.Actions, PlannedAction{
+				Kind:     ActionUpdateKV,
+				Name:     ps.Bucket,
+				Resource: &UpdateKVResource{Before: before, After: after},
+			})
+		}
+	}
+
 	return nil
+}
+
+// buildPartitionSourceUpdateTarget returns the desired update-kv target
+// for a partition-source bucket: a deep clone of before with only the
+// operator-expressible fields overwritten. Every other field —
+// drift-detection-only (History, Storage), preserved-from-live
+// (Description, MaxBytes, Placement, RePublish, Mirror, Sources,
+// Compression, LimitMarkerTTL), and Bucket — is inherited from before
+// verbatim.
+func buildPartitionSourceUpdateTarget(ps *PartitionSourceConfig, instance string, before jetstream.KeyValueConfig) jetstream.KeyValueConfig {
+	after := cloneKVConfig(before)
+	after.TTL = ps.TTL
+	after.Replicas = ps.Replicas
+	after.MaxValueSize = ps.MaxValueSize
+	after.Metadata = mergeUpdateKVMetadata(before.Metadata, instance)
+
+	return after
 }
 
 // classifyPartitionSourceDrift compares a live KV-bucket stream against the

--- a/provision/partition_source.go
+++ b/provision/partition_source.go
@@ -11,7 +11,7 @@ import (
 // buildPartitionSourceKVConfig returns a jetstream.KeyValueConfig for the
 // partition-source bucket described by ps.
 //
-// This builder is intentionally separate from the W0 control-plane builder
+// This builder is intentionally separate from the control-plane builder
 // (internal/kvbuckets.BuildKeyValueConfig) because partition-source has a
 // different shape: Storage, History, Replicas, and MaxValueSize are all
 // configurable by the operator, whereas control-plane buckets have fixed

--- a/provision/partition_source.go
+++ b/provision/partition_source.go
@@ -49,6 +49,15 @@ func planPartitionSource(ctx context.Context, js jetstream.JetStream, cfg Config
 
 	stream, err := js.Stream(ctx, streamName)
 	if errors.Is(err, jetstream.ErrStreamNotFound) {
+		// adopt does not create missing buckets: it emits no action but
+		// records an informational finding so the missing bucket is not
+		// silently absent from the plan. warn / safe-update keep their
+		// create-kv emission.
+		if cfg.Policy == PolicyAdopt {
+			out.Drift = append(out.Drift, missingUnderAdoptFinding(KindPartitionSource, ps.Bucket))
+
+			return nil
+		}
 		kv := buildPartitionSourceKVConfig(*ps)
 		kv.Metadata = BuildMarker(ComponentPartitionSource, cfg.Instance)
 		out.Actions = append(out.Actions, PlannedAction{
@@ -71,11 +80,13 @@ func planPartitionSource(ctx context.Context, js jetstream.JetStream, cfg Config
 	findings := classifyPartitionSourceDrift(ps, info, cfg.Instance)
 	out.Drift = append(out.Drift, findings...)
 
+	marked := ParseMarker(info.Config.Metadata).IsManaged()
+
 	// Under safe-update, a Parti-marked bucket with operator-
 	// expressible drift also gets an update-kv action. Drift findings
 	// and the action coexist; the classifier above still populates
 	// out.Drift in every policy.
-	if cfg.Policy == PolicySafeUpdate && ParseMarker(info.Config.Metadata).IsManaged() {
+	if cfg.Policy == PolicySafeUpdate && marked {
 		before := cloneKVConfig(streamConfigToKVConfig(info.Config))
 		after := buildPartitionSourceUpdateTarget(ps, cfg.Instance, before)
 		if !kvConfigsEqual(before, after) {
@@ -85,6 +96,15 @@ func planPartitionSource(ctx context.Context, js jetstream.JetStream, cfg Config
 				Resource: &UpdateKVResource{Before: before, After: after},
 			})
 		}
+	}
+
+	// Under adopt, an unmarked bucket gets a stamp-marker action. The
+	// classifier's "adopted" finding above still surfaces; the action
+	// and the finding coexist. A marked bucket is already adopted, so
+	// no stamp-marker is emitted.
+	if cfg.Policy == PolicyAdopt && !marked {
+		out.Actions = append(out.Actions,
+			newStampMarkerAction(ps.Bucket, ComponentPartitionSource, cfg.Instance, info.Config))
 	}
 
 	return nil

--- a/provision/partition_source.go
+++ b/provision/partition_source.go
@@ -25,17 +25,10 @@ import (
 //   - MaxValueSize: ps.MaxValueSize (0 = no limit)
 //   - TTL: set only when ps.TTL > 0 (matches control-plane convention)
 func buildPartitionSourceKVConfig(ps PartitionSourceConfig) jetstream.KeyValueConfig {
-	var storage jetstream.StorageType
-	if ps.Storage == "memory" {
-		storage = jetstream.MemoryStorage
-	} else {
-		storage = jetstream.FileStorage
-	}
-
 	cfg := jetstream.KeyValueConfig{
 		Bucket:       ps.Bucket,
 		History:      ps.History,
-		Storage:      storage,
+		Storage:      storageTypeFromString(ps.Storage),
 		Replicas:     ps.Replicas,
 		MaxValueSize: ps.MaxValueSize,
 	}
@@ -82,18 +75,18 @@ func planPartitionSource(ctx context.Context, js jetstream.JetStream, cfg Config
 }
 
 // classifyPartitionSourceDrift compares a live KV-bucket stream against the
-// desired partition-source config and returns one or more drift findings. v1
-// never emits update-* / delete-* actions, only findings.
+// desired partition-source config and returns drift findings.
 //
-// Mutability table (per KV field mutability rules in the plan):
-//   - Immutable: History, Storage. Replicas treated as drift-immutable
-//     conservatively in v1 (conditionally mutable; safe-update lands in Phase 2).
-//   - Mutable: Description, Metadata (managed, component, instance), MaxBytes,
-//     MaxValueSize, TTL.
+// Mutability:
+//   - Immutable: History, Storage, and the parti.io/component marker key.
+//   - Mutable: MaxValueSize, TTL, Replicas, and the parti.io/managed and
+//     parti.io/instance marker keys. The NATS server enforces cluster
+//     feasibility for Replicas changes at apply time.
+//   - Preserved-from-live (not reported as drift): Description, MaxBytes.
+//     These fields have no YAML representation and survive every update-kv
+//     unchanged.
 func classifyPartitionSourceDrift(ps *PartitionSourceConfig, info *jetstream.StreamInfo, instance string) []DriftFinding {
 	marker := ParseMarker(info.Config.Metadata)
-
-	// Unmarked bucket named by config → "adopted" drift, no action.
 	if !marker.IsManaged() {
 		return []DriftFinding{{
 			Severity: SeverityAdopted,
@@ -106,116 +99,81 @@ func classifyPartitionSourceDrift(ps *PartitionSourceConfig, info *jetstream.Str
 		}}
 	}
 
-	mutable := map[string]any{}
-	immutable := map[string]any{}
-
-	// Desired storage type.
-	var wantStorage jetstream.StorageType
-	if ps.Storage == "memory" {
-		wantStorage = jetstream.MemoryStorage
-	} else {
-		wantStorage = jetstream.FileStorage
+	live := extractLiveKVConfig(&info.Config)
+	wanted := wantedPartitionSourceKV(ps, instance, live)
+	if kvConfigsEqual(wanted, live) {
+		return []DriftFinding{{
+			Severity: SeverityInformational,
+			Kind:     KindPartitionSource,
+			Name:     ps.Bucket,
+			Detail:   map[string]any{"component": ComponentPartitionSource},
+		}}
 	}
-	if info.Config.Storage != wantStorage {
-		immutable["storage"] = map[string]any{
-			"want": storageName(wantStorage),
-			"got":  storageName(info.Config.Storage),
+
+	var mutable, immutable map[string]any
+	addImmutable := func(field string, detail map[string]any) {
+		if immutable == nil {
+			immutable = map[string]any{}
 		}
+		immutable[field] = detail
+	}
+	addMutable := func(field string, detail map[string]any) {
+		if mutable == nil {
+			mutable = map[string]any{}
+		}
+		mutable[field] = detail
 	}
 
-	// History is stored as MaxMsgsPerSubject on the underlying stream.
-	wantHistory := int64(ps.History) // already ≥ 1 after normalization
-	if info.Config.MaxMsgsPerSubject != wantHistory {
-		immutable["history"] = map[string]any{
-			"want": wantHistory,
+	if live.Storage != wanted.Storage {
+		addImmutable("storage", map[string]any{
+			"want": storageName(wanted.Storage),
+			"got":  storageName(live.Storage),
+		})
+	}
+	if live.History != wanted.History {
+		addImmutable("history", map[string]any{
+			"want": int64(wanted.History),
 			"got":  info.Config.MaxMsgsPerSubject,
-		}
+		})
 	}
-
-	// Replicas: 0 in config means "server default" which NATS normalizes to 1.
-	// Treat 0 and 1 as equivalent on the desired side to avoid spurious drift
-	// on every default-replica installation.
-	effectiveReplicas := ps.Replicas
-	if effectiveReplicas == 0 {
-		effectiveReplicas = 1
+	if normalizeReplicas(live.Replicas) != normalizeReplicas(wanted.Replicas) {
+		addMutable("replicas", map[string]any{
+			"want": normalizeReplicas(wanted.Replicas),
+			"got":  live.Replicas,
+		})
 	}
-	if info.Config.Replicas != effectiveReplicas {
-		immutable["replicas"] = map[string]any{
-			"want": effectiveReplicas,
-			"got":  info.Config.Replicas,
-		}
-	}
-
-	// Description is mutable in place (Phase 2). Desired is always empty string
-	// (we do not set a Description on partition-source buckets by default).
-	if info.Config.Description != "" {
-		mutable["description"] = map[string]any{
-			"want": "",
-			"got":  info.Config.Description,
-		}
-	}
-
-	// MaxBytes is mutable in place (Phase 2). Desired is always 0 ("no limit").
-	// NATS stores "no limit" as MaxBytes=-1 server-side; normalize -1→0 before
-	// comparing to avoid spurious drift on default installs.
-	liveMaxBytes := info.Config.MaxBytes
-	if liveMaxBytes == -1 {
-		liveMaxBytes = 0
-	}
-	if liveMaxBytes != 0 {
-		mutable["maxBytes"] = map[string]any{
-			"want": int64(0),
-			"got":  info.Config.MaxBytes,
-		}
-	}
-
-	// MaxValueSize is mutable in place (Phase 2).
-	// info.Config.MaxMsgSize is the stream-level field corresponding to KV MaxValueSize.
-	// NATS stores "no limit" as MaxMsgSize=-1 server-side; config uses 0 for the same
-	// semantic. Normalize -1→0 before comparing to avoid spurious drift on default installs.
-	liveMaxValueSize := info.Config.MaxMsgSize
-	if liveMaxValueSize == -1 {
-		liveMaxValueSize = 0
-	}
-	if liveMaxValueSize != ps.MaxValueSize {
-		mutable["maxValueSize"] = map[string]any{
-			"want": ps.MaxValueSize,
+	if normalizeMaxValueSize(live.MaxValueSize) != normalizeMaxValueSize(wanted.MaxValueSize) {
+		addMutable("maxValueSize", map[string]any{
+			"want": wanted.MaxValueSize,
 			"got":  info.Config.MaxMsgSize,
-		}
+		})
+	}
+	if live.TTL != wanted.TTL {
+		addMutable("ttl", map[string]any{
+			"want": wanted.TTL.String(),
+			"got":  live.TTL.String(),
+		})
 	}
 
-	// TTL is stored as MaxAge on the underlying stream. Mutable (Phase 2).
-	wantTTL := ps.TTL // 0 means "no expiration"
-	if info.Config.MaxAge != wantTTL {
-		mutable["ttl"] = map[string]any{
-			"want": wantTTL.String(),
-			"got":  info.Config.MaxAge.String(),
-		}
-	}
-
-	// Marker fields are mutable in place (Phase 2). Report any deviation from
-	// the expected v1 marker values as drift-mutable, including managed version
-	// and component mismatches.
 	if marker.Managed != MarkerManagedValue {
-		mutable["managed"] = map[string]any{
+		addMutable("managed", map[string]any{
 			"want": MarkerManagedValue,
 			"got":  marker.Managed,
-		}
+		})
 	}
+	// Component mismatch is immutable: a bucket stamped for a different
+	// role is a misconfiguration safe-update must not silently re-label.
 	if marker.Component != ComponentPartitionSource {
-		mutable["component"] = map[string]any{
+		addImmutable("component", map[string]any{
 			"want": ComponentPartitionSource,
 			"got":  marker.Component,
-		}
+		})
 	}
-
-	// Instance mismatch on a managed bucket is surfaced as drift-mutable
-	// since Metadata is live-editable in Phase 2.
 	if marker.Instance != instance {
-		mutable["instance"] = map[string]any{
+		addMutable("instance", map[string]any{
 			"want": instance,
 			"got":  marker.Instance,
-		}
+		})
 	}
 
 	findings := make([]DriftFinding, 0, 2)
@@ -235,16 +193,31 @@ func classifyPartitionSourceDrift(ps *PartitionSourceConfig, info *jetstream.Str
 			Detail:   mutable,
 		})
 	}
-	if len(findings) == 0 {
-		findings = append(findings, DriftFinding{
-			Severity: SeverityInformational,
-			Kind:     KindPartitionSource,
-			Name:     ps.Bucket,
-			Detail: map[string]any{
-				"component": ComponentPartitionSource,
-			},
-		})
-	}
 
 	return findings
+}
+
+// wantedPartitionSourceKV returns the KeyValueConfig the ps implies, with
+// preserved-from-live fields inherited from live.
+func wantedPartitionSourceKV(ps *PartitionSourceConfig, instance string, live jetstream.KeyValueConfig) jetstream.KeyValueConfig {
+	wanted := live
+	wanted.Storage = storageTypeFromString(ps.Storage)
+	wanted.History = ps.History
+	wanted.TTL = ps.TTL
+	wanted.Replicas = ps.Replicas
+	wanted.MaxValueSize = ps.MaxValueSize
+	wanted.Metadata = mergeMarkerMetadata(live.Metadata, ComponentPartitionSource, instance)
+
+	return wanted
+}
+
+// storageTypeFromString maps the YAML-side string ("file"/"memory") to a
+// jetstream.StorageType. Anything other than "memory" maps to FileStorage,
+// matching the runtime default for partition-source buckets.
+func storageTypeFromString(s string) jetstream.StorageType {
+	if s == "memory" {
+		return jetstream.MemoryStorage
+	}
+
+	return jetstream.FileStorage
 }

--- a/provision/partition_source_integration_test.go
+++ b/provision/partition_source_integration_test.go
@@ -384,10 +384,11 @@ func TestPlan_PartitionSource_ImmutableStorageDrift(t *testing.T) {
 	require.True(t, found, "expected drift-immutable for storage mismatch")
 }
 
-// TestPlan_PartitionSource_MutableDescriptionDrift verifies that Plan reports
-// drift-mutable when the live bucket has a non-empty Description (desired is
-// empty — we set no Description by default).
-func TestPlan_PartitionSource_MutableDescriptionDrift(t *testing.T) {
+// TestPlan_PartitionSource_DescriptionPreservedNoSrift verifies that Plan does
+// NOT report any drift when the live bucket has a non-empty Description. Description
+// is preserved-from-live: the v2 YAML schema cannot express it, so it is never
+// drifted.
+func TestPlan_PartitionSource_DescriptionPreservedNoDrift(t *testing.T) {
 	t.Parallel()
 	js := newJS(t)
 	cfg := partitionSourceCfg()
@@ -408,25 +409,23 @@ func TestPlan_PartitionSource_MutableDescriptionDrift(t *testing.T) {
 
 	// No create-kv action.
 	for _, a := range plan.Actions {
-		require.NotEqual(t, "parti-partitions", a.Name, "no action for mutable description drift")
+		require.NotEqual(t, "parti-partitions", a.Name, "no action for description (preserved-from-live)")
 	}
 
-	// A drift-mutable finding with "description" detail must be present.
-	var found bool
+	// Description must NOT appear in any drift finding — it is preserved-from-live.
 	for _, d := range plan.Drift {
-		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftMutable {
-			if _, ok := d.Detail["description"]; ok {
-				found = true
-			}
+		if d.Name == "parti-partitions" {
+			require.NotContains(t, d.Detail, "description",
+				"description is preserved-from-live and must not appear in drift findings")
 		}
 	}
-	require.True(t, found, "expected drift-mutable for description mismatch")
 }
 
-// TestPlan_PartitionSource_MutableMaxBytesDrift verifies that Plan reports
-// drift-mutable when the live bucket has a non-zero MaxBytes (desired is 0 —
-// no limit).
-func TestPlan_PartitionSource_MutableMaxBytesDrift(t *testing.T) {
+// TestPlan_PartitionSource_MaxBytesPreservedNoDrift verifies that Plan does NOT
+// report any drift when the live bucket has a non-zero MaxBytes. MaxBytes is
+// preserved-from-live: the v2 YAML schema cannot express it, so it is never
+// drifted.
+func TestPlan_PartitionSource_MaxBytesPreservedNoDrift(t *testing.T) {
 	t.Parallel()
 	js := newJS(t)
 	cfg := partitionSourceCfg()
@@ -447,19 +446,128 @@ func TestPlan_PartitionSource_MutableMaxBytesDrift(t *testing.T) {
 
 	// No create-kv action.
 	for _, a := range plan.Actions {
-		require.NotEqual(t, "parti-partitions", a.Name, "no action for mutable maxBytes drift")
+		require.NotEqual(t, "parti-partitions", a.Name, "no action for maxBytes (preserved-from-live)")
 	}
 
-	// A drift-mutable finding with "maxBytes" detail must be present.
-	var found bool
+	// MaxBytes must NOT appear in any drift finding — it is preserved-from-live.
 	for _, d := range plan.Drift {
-		if d.Name == "parti-partitions" && d.Severity == provision.SeverityDriftMutable {
-			if _, ok := d.Detail["maxBytes"]; ok {
-				found = true
-			}
+		if d.Name == "parti-partitions" {
+			require.NotContains(t, d.Detail, "maxBytes",
+				"maxBytes is preserved-from-live and must not appear in drift findings")
 		}
 	}
-	require.True(t, found, "expected drift-mutable for maxBytes mismatch")
+}
+
+// TestPlan_PartitionSource_MutableReplicasDrift verifies that Plan reports
+// drift-mutable (NOT drift-immutable) when the live bucket's Replicas count
+// differs from the desired count. Replicas is reclassified from drift-immutable
+// (Phase 1) to drift-mutable (Phase 2).
+func TestPlan_PartitionSource_ReplicasNormalization_NoDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:   "parti-partitions",
+			Key:      "partitions/v1",
+			Storage:  "file",
+			History:  1,
+			Replicas: 1, // desired
+		},
+	}
+
+	// Pre-create a marked bucket with default replicas (1 == desired).
+	// NATS single-server normalizes Replicas to 1 on creation; we can only
+	// verify the normalization equivalence (0↔1) path here.
+	// Positive Replicas drift-mutable classification is tested in the unit
+	// tests (classify_drift_test.go) using synthetic StreamInfo.
+	cfgZeroReplicas := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:   "parti-partitions",
+			Key:      "partitions/v1",
+			Storage:  "file",
+			History:  1,
+			Replicas: 0, // 0 normalizes to 1 — must not drift against live Replicas=1
+		},
+	}
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		History:  1,
+		Storage:  jetstream.FileStorage,
+		Replicas: 1,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Config Replicas=0 (== 1) vs live Replicas=1 → no replicas drift.
+	plan, err := provision.Plan(ctx, js, cfgZeroReplicas)
+	require.NoError(t, err)
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" {
+			require.NotContains(t, d.Detail, "replicas",
+				"Replicas=0 and live Replicas=1 are equivalent; no replicas drift expected")
+		}
+	}
+
+	// Config Replicas=1 vs live Replicas=1 → no replicas drift.
+	plan2, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	for _, d := range plan2.Drift {
+		if d.Name == "parti-partitions" {
+			require.NotContains(t, d.Detail, "replicas",
+				"Replicas=1 matches live; no replicas drift expected")
+		}
+	}
+}
+
+// TestPlan_PartitionSource_ReplicasDefaultMatch_Informational verifies that
+// when both config and live have the default replica count (1), Plan reports
+// no drift finding for replicas. The positive drift-mutable path is exercised
+// in classify_drift_test.go using synthetic StreamInfo (single-server NATS
+// always normalizes Replicas to 1, making positive-drift integration tests
+// impractical).
+func TestPlan_PartitionSource_ReplicasDefaultMatch_Informational(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:   "parti-partitions-r2",
+			Key:      "partitions/v1",
+			Storage:  "file",
+			History:  1,
+			Replicas: 0, // server default (1); live will also be 1
+		},
+	}
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions-r2",
+		History:  1,
+		Storage:  jetstream.FileStorage,
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// The key invariant: no drift-immutable finding with "replicas".
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions-r2" && d.Severity == provision.SeverityDriftImmutable {
+			require.NotContains(t, d.Detail, "replicas",
+				"Replicas must be classified as drift-mutable (not drift-immutable)")
+		}
+	}
 }
 
 // TestPlan_PartitionSource_MutableMarkerDrift verifies that Plan reports

--- a/provision/plan.go
+++ b/provision/plan.go
@@ -22,11 +22,11 @@ import (
 //   - Each desired bucket is looked up by exact NATS name (KV_<bucket>);
 //     marker presence is never used to authorize or skip the lookup.
 //   - The partition-source key is NOT probed in Plan (that is a ValidateLive
-//     concern, landing in W2).
+//     concern).
 //
-// Partition-source create-kv emission and drift classification are implemented
-// (W3). Dynamic-consumer alignment lands in W4. The PlanResult struct supports
-// those slots already.
+// Partition-source create-kv emission and drift classification are
+// implemented. Dynamic-consumer alignment entries are not yet populated
+// through Plan; use PlanDynamicConsumers directly.
 //
 // Cancellation: ctx cancellation returns a zero-value PlanResult plus
 // ctx.Err().
@@ -67,8 +67,8 @@ func Plan(ctx context.Context, js jetstream.JetStream, cfg Config) (PlanResult, 
 		}
 	}
 
-	// DynamicConsumers Plan output is intentionally empty in W1/W3. The
-	// slot exists so W4 inherits a stable shape.
+	// DynamicConsumers Plan output is intentionally empty. The slot exists
+	// so the PlanResult shape is stable for future use.
 
 	sortActions(out.Actions)
 	sortDrift(out.Drift)

--- a/provision/plan.go
+++ b/provision/plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -83,14 +84,15 @@ type controlPlaneSpec struct {
 	bucket    string
 	ttl       time.Duration
 	storage   jetstream.StorageType
+	replicas  int // 0 = server default (nats.go normalizes to 1)
 }
 
 func buildControlPlaneSpecs(cp ControlPlaneConfig) []controlPlaneSpec {
 	specs := []controlPlaneSpec{
-		{ComponentControlPlaneID, cp.StableIDBucket, cp.WorkerIDTTL, jetstream.FileStorage},
-		{ComponentControlPlaneElection, cp.ElectionBucket, cp.ElectionTimeout, jetstream.MemoryStorage},
-		{ComponentControlPlaneHeartbeat, cp.HeartbeatBucket, cp.HeartbeatTTL, jetstream.MemoryStorage},
-		{ComponentControlPlaneAssignment, cp.AssignmentBucket, cp.AssignmentTTL, jetstream.FileStorage},
+		{ComponentControlPlaneID, cp.StableIDBucket, cp.WorkerIDTTL, jetstream.FileStorage, cp.Replicas},
+		{ComponentControlPlaneElection, cp.ElectionBucket, cp.ElectionTimeout, jetstream.MemoryStorage, cp.Replicas},
+		{ComponentControlPlaneHeartbeat, cp.HeartbeatBucket, cp.HeartbeatTTL, jetstream.MemoryStorage, cp.Replicas},
+		{ComponentControlPlaneAssignment, cp.AssignmentBucket, cp.AssignmentTTL, jetstream.FileStorage, cp.Replicas},
 	}
 	if cp.EnableTwoPhaseHandoff {
 		// The handoff bucket is created with no MaxAge (ttl: 0). A bucket-level
@@ -102,6 +104,7 @@ func buildControlPlaneSpecs(cp ControlPlaneConfig) []controlPlaneSpec {
 			bucket:    cp.HandoffBucket,
 			ttl:       0,
 			storage:   jetstream.FileStorage,
+			replicas:  cp.Replicas,
 		})
 	}
 
@@ -137,11 +140,16 @@ func planControlPlane(ctx context.Context, js jetstream.JetStream, cfg Config, o
 }
 
 // newCreateKVAction builds the create-kv PlannedAction for one control-plane
-// bucket. The KeyValueConfig is built by the shared kvbuckets builder and
-// then stamped with the Parti ownership marker; nothing else may construct
-// the KeyValueConfig (this preserves the byte-equivalence invariant).
+// bucket. The KeyValueConfig is built by the shared kvbuckets builder
+// and then stamped with the Parti ownership marker; nothing else may
+// construct the KeyValueConfig (this preserves byte-equivalence with
+// the runtime manager). Replicas is the only field stamped on top of
+// the builder output, and only when explicitly set in config.
 func newCreateKVAction(spec controlPlaneSpec, instance string) PlannedAction {
 	kv := kvbuckets.BuildKeyValueConfig(spec.bucket, spec.ttl, spec.storage)
+	if spec.replicas > 0 {
+		kv.Replicas = spec.replicas
+	}
 	kv.Metadata = BuildMarker(spec.component, instance)
 	return PlannedAction{
 		Kind:     ActionCreateKV,
@@ -151,12 +159,10 @@ func newCreateKVAction(spec controlPlaneSpec, instance string) PlannedAction {
 }
 
 // classifyControlPlaneDrift compares a live KV-bucket stream against the
-// desired spec and returns one or more drift findings. v1 never emits
+// desired spec and returns one or more drift findings. Never emits
 // update-* / delete-* actions, only findings.
 func classifyControlPlaneDrift(spec controlPlaneSpec, info *jetstream.StreamInfo, instance string) []DriftFinding {
 	marker := ParseMarker(info.Config.Metadata)
-
-	// Unmarked bucket named by config → "adopted" drift, no action.
 	if !marker.IsManaged() {
 		return []DriftFinding{{
 			Severity: SeverityAdopted,
@@ -169,47 +175,73 @@ func classifyControlPlaneDrift(spec controlPlaneSpec, info *jetstream.StreamInfo
 		}}
 	}
 
-	mutable := map[string]any{}
-	immutable := map[string]any{}
+	live := extractLiveKVConfig(&info.Config)
+	wanted := wantedControlPlaneKV(spec, instance, live)
+	if kvConfigsEqual(wanted, live) {
+		return []DriftFinding{{
+			Severity: SeverityInformational,
+			Kind:     KindControlPlaneKV,
+			Name:     spec.bucket,
+			Detail:   map[string]any{"component": spec.component},
+		}}
+	}
 
-	if info.Config.Storage != spec.storage {
-		immutable["storage"] = map[string]any{
-			"want": storageName(spec.storage),
-			"got":  storageName(info.Config.Storage),
+	var mutable, immutable map[string]any
+	addImmutable := func(field string, detail map[string]any) {
+		if immutable == nil {
+			immutable = map[string]any{}
 		}
+		immutable[field] = detail
 	}
-	// KV History is stored on the underlying stream as MaxMsgsPerSubject.
-	// The shared builder always sets History=1, so any non-1 value is
-	// immutable drift.
-	if info.Config.MaxMsgsPerSubject != 1 {
-		immutable["history"] = map[string]any{
-			"want": int64(1),
+	addMutable := func(field string, detail map[string]any) {
+		if mutable == nil {
+			mutable = map[string]any{}
+		}
+		mutable[field] = detail
+	}
+
+	if live.Storage != wanted.Storage {
+		addImmutable("storage", map[string]any{
+			"want": storageName(wanted.Storage),
+			"got":  storageName(live.Storage),
+		})
+	}
+	if live.History != wanted.History {
+		addImmutable("history", map[string]any{
+			"want": int64(wanted.History),
 			"got":  info.Config.MaxMsgsPerSubject,
-		}
+		})
 	}
-	// KV TTL is stored on the underlying stream as MaxAge.
-	if info.Config.MaxAge != spec.ttl {
-		mutable["ttl"] = map[string]any{
-			"want": spec.ttl.String(),
-			"got":  info.Config.MaxAge.String(),
-		}
+	if live.TTL != wanted.TTL {
+		addMutable("ttl", map[string]any{
+			"want": wanted.TTL.String(),
+			"got":  live.TTL.String(),
+		})
 	}
-	// Instance mismatch on a managed bucket is surfaced as drift-mutable
-	// since Metadata is live-editable in Phase 2.
+	if normalizeReplicas(live.Replicas) != normalizeReplicas(wanted.Replicas) {
+		addMutable("replicas", map[string]any{
+			"want": normalizeReplicas(wanted.Replicas),
+			"got":  live.Replicas,
+		})
+	}
+	if marker.Managed != MarkerManagedValue {
+		addMutable("managed", map[string]any{
+			"want": MarkerManagedValue,
+			"got":  marker.Managed,
+		})
+	}
 	if marker.Instance != instance {
-		mutable["instance"] = map[string]any{
+		addMutable("instance", map[string]any{
 			"want": instance,
 			"got":  marker.Instance,
-		}
+		})
 	}
-	// Component mismatch: a bucket marked as one Parti component but named
-	// in config under a different role. Treat as immutable drift — the
-	// safe remediation is operator-driven.
+	// Component mismatch is immutable: the safe remediation is operator-driven.
 	if marker.Component != spec.component {
-		immutable["component"] = map[string]any{
+		addImmutable("component", map[string]any{
 			"want": spec.component,
 			"got":  marker.Component,
-		}
+		})
 	}
 
 	findings := make([]DriftFinding, 0, 2)
@@ -229,18 +261,42 @@ func classifyControlPlaneDrift(spec controlPlaneSpec, info *jetstream.StreamInfo
 			Detail:   mutable,
 		})
 	}
-	if len(findings) == 0 {
-		findings = append(findings, DriftFinding{
-			Severity: SeverityInformational,
-			Kind:     KindControlPlaneKV,
-			Name:     spec.bucket,
-			Detail: map[string]any{
-				"component": spec.component,
-			},
-		})
-	}
 
 	return findings
+}
+
+// wantedControlPlaneKV returns the KeyValueConfig the spec implies, with
+// preserved-from-live fields inherited from live. The returned value is
+// suitable as input to kvConfigsEqual against live.
+func wantedControlPlaneKV(spec controlPlaneSpec, instance string, live jetstream.KeyValueConfig) jetstream.KeyValueConfig {
+	wanted := live
+	wanted.Storage = spec.storage
+	wanted.History = 1
+	wanted.TTL = spec.ttl
+	wanted.Replicas = spec.replicas
+	wanted.Metadata = mergeMarkerMetadata(live.Metadata, spec.component, instance)
+
+	return wanted
+}
+
+// mergeMarkerMetadata returns a fresh metadata map with the Parti marker
+// keys overlaid on a clone of live so non-Parti keys are preserved. When
+// instance is empty the parti.io/instance key is removed, so a config
+// that clears the instance label produces metadata that genuinely
+// differs from a live bucket still carrying one.
+func mergeMarkerMetadata(live map[string]string, component, instance string) map[string]string {
+	merged := maps.Clone(live)
+	if merged == nil {
+		merged = map[string]string{}
+	}
+	for k, v := range BuildMarker(component, instance) {
+		merged[k] = v
+	}
+	if instance == "" {
+		delete(merged, MarkerInstanceKey)
+	}
+
+	return merged
 }
 
 func sortActions(s []PlannedAction) {

--- a/provision/plan.go
+++ b/provision/plan.go
@@ -134,6 +134,22 @@ func planControlPlane(ctx context.Context, js jetstream.JetStream, cfg Config, o
 
 		findings := classifyControlPlaneDrift(spec, info, cfg.Instance)
 		out.Drift = append(out.Drift, findings...)
+
+		// Under safe-update, a Parti-marked bucket with operator-
+		// expressible drift also gets an update-kv action. Drift
+		// findings and the action coexist; the classifier above still
+		// populates out.Drift in every policy.
+		if cfg.Policy == PolicySafeUpdate && ParseMarker(info.Config.Metadata).IsManaged() {
+			before := cloneKVConfig(streamConfigToKVConfig(info.Config))
+			after := buildControlPlaneUpdateTarget(spec, cfg.Instance, before)
+			if !kvConfigsEqual(before, after) {
+				out.Actions = append(out.Actions, PlannedAction{
+					Kind:     ActionUpdateKV,
+					Name:     spec.bucket,
+					Resource: &UpdateKVResource{Before: before, After: after},
+				})
+			}
+		}
 	}
 
 	return nil
@@ -284,6 +300,11 @@ func wantedControlPlaneKV(spec controlPlaneSpec, instance string, live jetstream
 // instance is empty the parti.io/instance key is removed, so a config
 // that clears the instance label produces metadata that genuinely
 // differs from a live bucket still carrying one.
+//
+// This helper sets parti.io/component to the desired value so the drift
+// classifier gate detects a component mismatch. It is intentionally
+// distinct from mergeUpdateKVMetadata, which PRESERVES the live
+// component — do not consolidate the two helpers.
 func mergeMarkerMetadata(live map[string]string, component, instance string) map[string]string {
 	merged := maps.Clone(live)
 	if merged == nil {
@@ -297,6 +318,51 @@ func mergeMarkerMetadata(live map[string]string, component, instance string) map
 	}
 
 	return merged
+}
+
+// mergeUpdateKVMetadata returns the Metadata map for an update-kv
+// target. It clones live, forces parti.io/managed to the current schema
+// value, sets or removes parti.io/instance per the desired instance,
+// and PRESERVES parti.io/component verbatim from live — component is
+// drift-immutable and update-kv never re-labels a bucket's role.
+// Non-Parti keys are preserved.
+//
+// This helper is intentionally distinct from mergeMarkerMetadata, which
+// rewrites parti.io/component to the desired value for classifier drift
+// detection. Do not consolidate the two helpers: doing so reintroduces
+// the silent component-rewrite bug, where safe-update would re-label a
+// bucket stamped for a different role instead of flagging it.
+func mergeUpdateKVMetadata(live map[string]string, instance string) map[string]string {
+	merged := maps.Clone(live)
+	if merged == nil {
+		merged = map[string]string{}
+	}
+	merged[MarkerManagedKey] = MarkerManagedValue
+	if instance != "" {
+		merged[MarkerInstanceKey] = instance
+	} else {
+		delete(merged, MarkerInstanceKey)
+	}
+	// parti.io/component is left exactly as cloned from live.
+
+	return merged
+}
+
+// buildControlPlaneUpdateTarget returns the desired update-kv target for
+// a control-plane bucket: a deep clone of before with only the
+// operator-expressible fields overwritten. Every other field —
+// drift-detection-only (History, Storage), preserved-from-live
+// (Description, MaxBytes, MaxValueSize, Placement, RePublish, Mirror,
+// Sources, Compression, LimitMarkerTTL), and Bucket — is inherited from
+// before verbatim. Control-plane has no MaxValueSize config field, so
+// that field is preserved-from-live here.
+func buildControlPlaneUpdateTarget(spec controlPlaneSpec, instance string, before jetstream.KeyValueConfig) jetstream.KeyValueConfig {
+	after := cloneKVConfig(before)
+	after.TTL = spec.ttl
+	after.Replicas = spec.replicas
+	after.Metadata = mergeUpdateKVMetadata(before.Metadata, instance)
+
+	return after
 }
 
 func sortActions(s []PlannedAction) {

--- a/provision/plan.go
+++ b/provision/plan.go
@@ -120,6 +120,14 @@ func planControlPlane(ctx context.Context, js jetstream.JetStream, cfg Config, o
 		streamName := kvStreamPrefix + spec.bucket
 		stream, err := js.Stream(ctx, streamName)
 		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			// adopt does not create missing buckets: it emits no action
+			// but records an informational finding so the missing bucket
+			// is not silently absent from the plan. warn / safe-update
+			// keep their create-kv emission.
+			if cfg.Policy == PolicyAdopt {
+				out.Drift = append(out.Drift, missingUnderAdoptFinding(KindControlPlaneKV, spec.bucket))
+				continue
+			}
 			out.Actions = append(out.Actions, newCreateKVAction(spec, cfg.Instance))
 			continue
 		}
@@ -135,11 +143,13 @@ func planControlPlane(ctx context.Context, js jetstream.JetStream, cfg Config, o
 		findings := classifyControlPlaneDrift(spec, info, cfg.Instance)
 		out.Drift = append(out.Drift, findings...)
 
+		marked := ParseMarker(info.Config.Metadata).IsManaged()
+
 		// Under safe-update, a Parti-marked bucket with operator-
 		// expressible drift also gets an update-kv action. Drift
 		// findings and the action coexist; the classifier above still
 		// populates out.Drift in every policy.
-		if cfg.Policy == PolicySafeUpdate && ParseMarker(info.Config.Metadata).IsManaged() {
+		if cfg.Policy == PolicySafeUpdate && marked {
 			before := cloneKVConfig(streamConfigToKVConfig(info.Config))
 			after := buildControlPlaneUpdateTarget(spec, cfg.Instance, before)
 			if !kvConfigsEqual(before, after) {
@@ -150,9 +160,80 @@ func planControlPlane(ctx context.Context, js jetstream.JetStream, cfg Config, o
 				})
 			}
 		}
+
+		// Under adopt, an unmarked bucket gets a stamp-marker action.
+		// The classifier's "adopted" finding above still surfaces; the
+		// action and the finding coexist. A marked bucket is already
+		// adopted, so no stamp-marker is emitted.
+		if cfg.Policy == PolicyAdopt && !marked {
+			out.Actions = append(out.Actions,
+				newStampMarkerAction(spec.bucket, spec.component, cfg.Instance, info.Config))
+		}
 	}
 
 	return nil
+}
+
+// missingUnderAdoptFinding builds the informational drift finding emitted
+// for a config-named bucket that does not exist live when the policy is
+// adopt. adopt does not create buckets, so the bucket would otherwise
+// vanish silently from the plan; this finding keeps it visible.
+func missingUnderAdoptFinding(kind, bucket string) DriftFinding {
+	return DriftFinding{
+		Severity: SeverityInformational,
+		Kind:     kind,
+		Name:     bucket,
+		Detail: map[string]any{
+			"reason": "bucket missing; adopt does not create — run apply with warn or safe-update",
+		},
+	}
+}
+
+// newStampMarkerAction builds the stamp-marker PlannedAction for one
+// unmarked bucket. The merged metadata is computed from the live
+// snapshot so non-Parti keys are preserved; PartiKeys lists exactly the
+// keys the action adds or changes for operator review.
+func newStampMarkerAction(bucket, component, instance string, live jetstream.StreamConfig) PlannedAction {
+	liveKV := streamConfigToKVConfig(live)
+	merged := mergeMarkerMetadata(liveKV.Metadata, component, instance)
+
+	return PlannedAction{
+		Kind: ActionStampMarker,
+		Name: bucket,
+		Resource: &StampMarkerResource{
+			Bucket:         bucket,
+			MergedMetadata: merged,
+			PartiKeys:      keysAddedOrChanged(liveKV.Metadata, merged),
+		},
+	}
+}
+
+// keysAddedOrChanged returns the sorted list of metadata keys whose value
+// differs between live and merged, in either direction: keys added to
+// merged, keys whose value changed, and keys removed from live (present
+// in live but absent from merged). A removal is a real change an
+// operator must see — an unmarked bucket carrying a stray
+// parti.io/instance adopted under an empty cfg.Instance has that key
+// deleted by mergeMarkerMetadata.
+func keysAddedOrChanged(live, merged map[string]string) []string {
+	changed := map[string]struct{}{}
+	for k, mv := range merged {
+		if lv, ok := live[k]; !ok || lv != mv {
+			changed[k] = struct{}{}
+		}
+	}
+	for k := range live {
+		if _, ok := merged[k]; !ok {
+			changed[k] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(changed))
+	for k := range changed {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	return keys
 }
 
 // newCreateKVAction builds the create-kv PlannedAction for one control-plane

--- a/provision/plan_integration_test.go
+++ b/provision/plan_integration_test.go
@@ -294,6 +294,48 @@ func TestPlan_CancelledContext(t *testing.T) {
 	require.Zero(t, plan)
 }
 
+// TestPlan_ControlPlane_ReplicasNormalization_NoDrift verifies that
+// Replicas=0 in config (normalized to 1) against a live bucket with
+// server-default Replicas=1 produces no replicas drift. The positive
+// drift-mutable path (mismatched Replicas) is covered in classify_drift_test.go
+// using synthetic StreamInfo; single-server NATS always normalizes to 1.
+func TestPlan_ControlPlane_ReplicasNormalization_NoDrift(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+
+	// Create a config with Replicas=0 (default) and a live bucket with
+	// Replicas=1 (server default). These must compare equal (0↔1 normalization).
+	cfg := planTestConfig()
+	cfg.ControlPlane.Replicas = 0
+
+	// Pre-create parti-election with correct config and marker.
+	liveElection := kvbuckets.BuildKeyValueConfig("parti-election", 10*time.Second, jetstream.MemoryStorage)
+	liveElection.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "prod")
+	createKV(t, js, liveElection)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+
+	// Replicas=0 (config) and Replicas=1 (live server default) are equivalent.
+	// No replicas drift expected.
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" {
+			require.NotContains(t, d.Detail, "replicas",
+				"Replicas=0 and live Replicas=1 must be treated as equivalent (no drift)")
+		}
+	}
+
+	// Replicas must NOT appear in a drift-immutable finding (it is mutable).
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" && d.Severity == provision.SeverityDriftImmutable {
+			require.NotContains(t, d.Detail, "replicas",
+				"Replicas must be classified as drift-mutable, not drift-immutable")
+		}
+	}
+}
+
 func TestPlan_DifferentNameBucketStillGetsCreateKV(t *testing.T) {
 	t.Parallel()
 	js := newJS(t)

--- a/provision/policy.go
+++ b/provision/policy.go
@@ -1,21 +1,31 @@
 package provision
 
-// ReconcilePolicy controls how Apply handles drift. v1 only supports
-// PolicyWarn; PolicySafeUpdate lands in Phase 2 and PolicyForce in Phase 6,
-// each with explicit field/test coverage. Validate rejects the future values
-// by string match so callers receive a clear error today.
+// ReconcilePolicy controls how Apply handles drift. Validate rejects
+// reserved future values by string match so callers receive a clear
+// error today rather than a generic "unrecognized" message.
 type ReconcilePolicy string
 
 const (
-	// PolicyWarn creates missing resources and reports drift, never mutating
-	// existing resources. This is the v1 default.
+	// PolicyWarn creates missing resources and reports drift, never
+	// mutating existing resources. This is the default.
 	PolicyWarn ReconcilePolicy = "warn"
+
+	// PolicyAdopt stamps the Parti ownership marker on resources named
+	// by config that exist live and are unmarked. Adopt creates no
+	// missing resources and updates no non-marker fields.
+	PolicyAdopt ReconcilePolicy = "adopt"
+
+	// PolicySafeUpdate performs create-missing plus in-place
+	// UpdateKeyValue for drift-mutable fields on Parti-marked resources.
+	// Unmarked resources continue to surface as "adopted" drift and are
+	// not mutated under safe-update; operators run partictl adopt first
+	// to transition them.
+	PolicySafeUpdate ReconcilePolicy = "safe-update"
 )
 
-// Reserved string values for future phases. They are documented here so
-// Validate can reject them with a clear "not supported in v1" message,
-// without forcing callers to type the literal strings themselves.
+// Reserved string values not yet supported. Listed here so Validate can
+// reject them with a clear "not supported yet" message without forcing
+// callers to type the literal strings.
 const (
-	reservedPolicySafeUpdate = "safe-update" // Phase 2 (Safe Update + Adopt)
-	reservedPolicyForce      = "force"       // Phase 6 (Force + Repair)
+	reservedPolicyForce = "force"
 )

--- a/provision/stamp_marker_integration_test.go
+++ b/provision/stamp_marker_integration_test.go
@@ -1,0 +1,275 @@
+package provision_test
+
+// Embedded-NATS integration tests for the stamp-marker apply path (the
+// adopt reconcile policy). Shared helpers (newJS, createKV,
+// safeUpdateCtx, controlPlaneOnlyCfg, liveStreamConfig,
+// driftSeverityFor) live in view_integration_test.go and
+// update_kv_integration_test.go.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply_Adopt_UnmarkedBucket_StampsMarker(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Pre-create an unmarked election bucket.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-election",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+		TTL:     10 * time.Second,
+	})
+
+	cfg := controlPlaneOnlyCfg(provision.PolicyAdopt)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+
+	var electionExec provision.ExecutedAction
+	for _, ex := range rep.Executed {
+		if ex.Name == "parti-election" {
+			electionExec = ex
+		}
+	}
+	require.Equal(t, provision.ActionStampMarker, electionExec.Kind)
+
+	live := liveStreamConfig(t, js, "parti-election")
+	marker := provision.ParseMarker(live.Metadata)
+	require.True(t, marker.IsManaged())
+	require.Equal(t, provision.ComponentControlPlaneElection, marker.Component)
+	require.Equal(t, "prod", marker.Instance)
+}
+
+func TestApply_Adopt_PreservesNonPartiMetadata(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-election",
+		Storage:  jetstream.MemoryStorage,
+		History:  1,
+		TTL:      10 * time.Second,
+		Metadata: map[string]string{"custom.io/team": "x"},
+	})
+
+	cfg := controlPlaneOnlyCfg(provision.PolicyAdopt)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-election")
+	require.Equal(t, "x", live.Metadata["custom.io/team"],
+		"non-Parti metadata key survives adoption")
+	require.Equal(t, provision.MarkerManagedValue, live.Metadata[provision.MarkerManagedKey])
+	require.Equal(t, provision.ComponentControlPlaneElection,
+		live.Metadata[provision.MarkerComponentKey])
+}
+
+func TestApply_Adopt_PreservesLiveFields(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Pre-create an unmarked bucket with Description, MaxBytes, TTL,
+	// MaxValueSize, and an explicit Replicas set.
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:              "KV_parti-election",
+		Description:       "owned by team X",
+		Subjects:          []string{"$KV.parti-election.>"},
+		Storage:           jetstream.MemoryStorage,
+		MaxMsgsPerSubject: 1,
+		MaxAge:            42 * time.Second,
+		MaxBytes:          1 << 20,
+		MaxMsgSize:        4096,
+		Replicas:          1,
+		AllowDirect:       true,
+	})
+	require.NoError(t, err)
+
+	cfg := controlPlaneOnlyCfg(provision.PolicyAdopt)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-election")
+	require.Equal(t, "owned by team X", live.Description, "Description preserved")
+	require.Equal(t, int64(1<<20), live.MaxBytes, "MaxBytes preserved")
+	require.Equal(t, 42*time.Second, live.MaxAge, "TTL preserved")
+	require.Equal(t, int32(4096), live.MaxMsgSize, "MaxValueSize preserved")
+	require.Equal(t, 1, live.Replicas, "Replicas preserved")
+	// Only Metadata gained the Parti keys.
+	require.True(t, provision.ParseMarker(live.Metadata).IsManaged())
+}
+
+func TestApply_Adopt_RerunIsNoOp(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-election",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+		TTL:     10 * time.Second,
+	})
+
+	cfg := controlPlaneOnlyCfg(provision.PolicyAdopt)
+
+	first, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, first.Errors)
+
+	// Second Apply: the bucket is now marked, so Plan emits no
+	// stamp-marker for it.
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	for _, a := range plan.Actions {
+		require.NotEqual(t, "parti-election", a.Name,
+			"an adopted bucket needs no second stamp-marker")
+	}
+
+	second, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, second.Errors)
+	for _, ex := range second.Executed {
+		require.NotEqual(t, "parti-election", ex.Name,
+			"converged election needs no second adoption")
+	}
+
+	// Metadata unchanged after the second run.
+	live := liveStreamConfig(t, js, "parti-election")
+	require.Equal(t, provision.ComponentControlPlaneElection,
+		provision.ParseMarker(live.Metadata).Component)
+}
+
+func TestApply_Adopt_MissingBucket_CreatesNothing(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// No buckets exist. adopt must create nothing and surface one
+	// informational finding per missing bucket.
+	cfg := controlPlaneOnlyCfg(provision.PolicyAdopt)
+
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, plan.Actions, "adopt creates nothing")
+	require.Contains(t, driftSeverityFor(plan, "parti-election"),
+		provision.SeverityInformational)
+
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Executed, "adopt executes nothing for missing buckets")
+	require.Empty(t, rep.Errors)
+
+	// The stream was not created.
+	_, err = js.Stream(ctx, "KV_parti-election")
+	require.ErrorIs(t, err, jetstream.ErrStreamNotFound)
+}
+
+func TestApply_Adopt_ThenSafeUpdate_BucketBecomesVisible(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Pre-create an unmarked bucket whose TTL matches the desired
+	// config (so after adoption a safe-update plan is in sync).
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-election",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+		TTL:     10 * time.Second,
+	})
+
+	adoptCfg := controlPlaneOnlyCfg(provision.PolicyAdopt)
+	_, err := provision.Apply(ctx, js, adoptCfg)
+	require.NoError(t, err)
+
+	// After adoption the safe-update path classifies the bucket
+	// normally — it is no longer "adopted" drift.
+	safeCfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+	plan, err := provision.Plan(ctx, js, safeCfg)
+	require.NoError(t, err)
+	sevs := driftSeverityFor(plan, "parti-election")
+	require.Contains(t, sevs, provision.SeverityInformational,
+		"adopted bucket is now in sync under safe-update")
+	require.NotContains(t, sevs, provision.SeverityAdopted,
+		"adoption made the bucket visible to the safe-update path")
+}
+
+func TestApply_Adopt_PartitionSource_StampsMarker(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-partitions",
+		Storage: jetstream.FileStorage,
+		History: 1,
+	})
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		Policy:     provision.PolicyAdopt,
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:  "parti-partitions",
+			Key:     "partitions/v1",
+			Storage: "file",
+			History: 1,
+		},
+	}
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-partitions")
+	marker := provision.ParseMarker(live.Metadata)
+	require.True(t, marker.IsManaged())
+	require.Equal(t, provision.ComponentPartitionSource, marker.Component)
+	require.Equal(t, "prod", marker.Instance)
+}
+
+// Note: the bucket-missing-before-stamp fail-fast path (a bucket
+// deleted between the plan-time lookup and the apply-time re-read)
+// cannot be triggered deterministically through the public Apply
+// surface — Apply re-plans internally, so a bucket deleted before
+// applyPlan simply produces no stamp-marker action. The fail-fast
+// path is covered deterministically by the seam-based unit tests
+// TestApplyStampMarker_MissingOnReread_FailsFast and
+// TestApplyStampMarker_MissingOnWrite_FailsFast in stamp_marker_test.go.
+
+// TestApply_Warn_Unchanged guards that warn behavior is byte-identical:
+// an unmarked drifted bucket is not mutated and surfaces adopted drift.
+func TestApply_Warn_Unchanged_ForUnmarkedBucket(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-election",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+		TTL:     99 * time.Second,
+	})
+
+	cfg := controlPlaneOnlyCfg(provision.PolicyWarn)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	// warn does not adopt: the unmarked bucket is untouched.
+	live := liveStreamConfig(t, js, "parti-election")
+	require.Equal(t, 99*time.Second, live.MaxAge)
+	require.False(t, provision.ParseMarker(live.Metadata).IsManaged())
+}

--- a/provision/stamp_marker_test.go
+++ b/provision/stamp_marker_test.go
@@ -1,0 +1,480 @@
+package provision
+
+// Same-package unit tests for the stamp-marker plan-emission and apply
+// helpers (the adopt reconcile policy). These use synthetic
+// *jetstream.StreamInfo / StreamConfig values so they run without a
+// live NATS server. Shared helpers (cpUpdateCfg, electionStream,
+// planWith, fakeStreamReader, fakeKVUpdater, cpSpecsFor) live in
+// update_kv_test.go.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// stampMarkerActions returns just the stamp-marker actions in a plan.
+func stampMarkerActions(p PlanResult) []PlannedAction {
+	var out []PlannedAction
+	for _, a := range p.Actions {
+		if a.Kind == ActionStampMarker {
+			out = append(out, a)
+		}
+	}
+
+	return out
+}
+
+// stampMarkerRes type-asserts a PlannedAction's Resource to
+// *StampMarkerResource, failing the test on a mismatch.
+func stampMarkerRes(t *testing.T, a PlannedAction) *StampMarkerResource {
+	t.Helper()
+	res, ok := a.Resource.(*StampMarkerResource)
+	require.True(t, ok, "Resource is *StampMarkerResource")
+
+	return res
+}
+
+// unmarkedElectionStream returns a synthetic KV_parti-election stream
+// with no Parti marker. mutate lets a test add stray keys.
+func unmarkedElectionStream(mutate ...func(*jetstream.StreamConfig)) jetstream.StreamConfig {
+	cfg := jetstream.StreamConfig{
+		Name:              "KV_parti-election",
+		Storage:           jetstream.MemoryStorage,
+		MaxMsgsPerSubject: 1,
+		MaxAge:            10 * time.Second,
+	}
+	for _, m := range mutate {
+		m(&cfg)
+	}
+
+	return cfg
+}
+
+// --- type shape --------------------------------------------------------------
+
+func TestStampMarkerResource_ShapeAndConstant(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "stamp-marker", ActionStampMarker)
+
+	res := StampMarkerResource{
+		Bucket:         "parti-election",
+		MergedMetadata: map[string]string{MarkerManagedKey: MarkerManagedValue},
+		PartiKeys:      []string{MarkerManagedKey},
+	}
+	require.Equal(t, "parti-election", res.Bucket)
+	require.Equal(t, MarkerManagedValue, res.MergedMetadata[MarkerManagedKey])
+	require.Equal(t, []string{MarkerManagedKey}, res.PartiKeys)
+}
+
+// --- keysAddedOrChanged ------------------------------------------------------
+
+func TestKeysAddedOrChanged_Additions(t *testing.T) {
+	t.Parallel()
+
+	live := map[string]string{"team": "infra"}
+	merged := map[string]string{
+		"team":             "infra",
+		MarkerManagedKey:   MarkerManagedValue,
+		MarkerComponentKey: ComponentControlPlaneElection,
+	}
+	require.Equal(t, []string{MarkerComponentKey, MarkerManagedKey},
+		keysAddedOrChanged(live, merged))
+}
+
+func TestKeysAddedOrChanged_Overwrite(t *testing.T) {
+	t.Parallel()
+
+	live := map[string]string{MarkerManagedKey: "v0"}
+	merged := map[string]string{MarkerManagedKey: MarkerManagedValue}
+	require.Equal(t, []string{MarkerManagedKey}, keysAddedOrChanged(live, merged))
+}
+
+func TestKeysAddedOrChanged_Removal(t *testing.T) {
+	t.Parallel()
+
+	// A stray parti.io/instance present live but deleted by the merge
+	// (adopted under an empty instance) is a real change.
+	live := map[string]string{MarkerInstanceKey: "old"}
+	merged := map[string]string{}
+	require.Equal(t, []string{MarkerInstanceKey}, keysAddedOrChanged(live, merged))
+}
+
+func TestKeysAddedOrChanged_NoChange(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]string{MarkerManagedKey: MarkerManagedValue, "team": "infra"}
+	require.Empty(t, keysAddedOrChanged(m, m))
+}
+
+// --- plan emission -----------------------------------------------------------
+
+func TestPlanEmission_Adopt_UnmarkedControlPlaneBucket_EmitsStampMarker(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": unmarkedElectionStream(),
+	}
+	actions := stampMarkerActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	require.Equal(t, "parti-election", actions[0].Name)
+
+	res := stampMarkerRes(t, actions[0])
+	require.Equal(t, "parti-election", res.Bucket)
+	require.Equal(t, MarkerManagedValue, res.MergedMetadata[MarkerManagedKey])
+	require.Equal(t, ComponentControlPlaneElection, res.MergedMetadata[MarkerComponentKey])
+	require.Equal(t, "prod", res.MergedMetadata[MarkerInstanceKey])
+	require.ElementsMatch(t,
+		[]string{MarkerManagedKey, MarkerComponentKey, MarkerInstanceKey}, res.PartiKeys)
+}
+
+func TestPlanEmission_Adopt_UnmarkedPartitionSourceBucket_EmitsStampMarker(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		APIVersion: APIVersionV1,
+		Instance:   "prod",
+		Policy:     PolicyAdopt,
+		PartitionSource: &PartitionSourceConfig{
+			Bucket:  "parti-partitions",
+			Key:     "partitions/v1",
+			Storage: "file",
+			History: 1,
+		},
+	}
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-partitions": {
+			Name:              "KV_parti-partitions",
+			Storage:           jetstream.FileStorage,
+			MaxMsgsPerSubject: 1,
+		},
+	}
+	actions := stampMarkerActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	require.Equal(t, "parti-partitions", actions[0].Name)
+	res := stampMarkerRes(t, actions[0])
+	require.Equal(t, ComponentPartitionSource, res.MergedMetadata[MarkerComponentKey])
+}
+
+func TestPlanEmission_Adopt_MarkedBucket_NoStampMarker(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(), // already marked
+	}
+	require.Empty(t, stampMarkerActions(planWith(t, cfg, streams)),
+		"a marked bucket is already adopted; no stamp-marker")
+}
+
+func TestPlanEmission_Adopt_MissingBucket_NoActionInformationalFinding(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	// No streams: every control-plane bucket is missing.
+	plan := planWith(t, cfg, map[string]jetstream.StreamConfig{})
+	require.Empty(t, plan.Actions, "adopt creates nothing for missing buckets")
+
+	var found DriftFinding
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" {
+			found = d
+		}
+	}
+	require.Equal(t, SeverityInformational, found.Severity)
+	require.Equal(t, KindControlPlaneKV, found.Kind)
+	reason, _ := found.Detail["reason"].(string)
+	require.Equal(t, "bucket missing; adopt does not create — run apply with warn or safe-update", reason)
+}
+
+func TestPlanEmission_Adopt_MissingPartitionSource_InformationalFinding(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		APIVersion: APIVersionV1,
+		Instance:   "prod",
+		Policy:     PolicyAdopt,
+		PartitionSource: &PartitionSourceConfig{
+			Bucket:  "parti-partitions",
+			Key:     "partitions/v1",
+			Storage: "file",
+			History: 1,
+		},
+	}
+	plan := planWith(t, cfg, map[string]jetstream.StreamConfig{})
+	require.Empty(t, plan.Actions)
+
+	var found DriftFinding
+	for _, d := range plan.Drift {
+		if d.Name == "parti-partitions" {
+			found = d
+		}
+	}
+	require.Equal(t, SeverityInformational, found.Severity)
+	require.Equal(t, KindPartitionSource, found.Kind)
+	reason, _ := found.Detail["reason"].(string)
+	require.Equal(t, "bucket missing; adopt does not create — run apply with warn or safe-update", reason)
+}
+
+// Note: adopt-emits-no-update-kv is covered by TestPlanEmission_Adopt_NoUpdateKV
+// in update_kv_test.go.
+
+func TestPlanEmission_WarnAndSafeUpdate_NoStampMarker(t *testing.T) {
+	t.Parallel()
+
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": unmarkedElectionStream(),
+	}
+	require.Empty(t, stampMarkerActions(planWith(t, cpUpdateCfg(PolicyWarn), streams)),
+		"warn never emits stamp-marker")
+	require.Empty(t, stampMarkerActions(planWith(t, cpUpdateCfg(PolicySafeUpdate), streams)),
+		"safe-update never emits stamp-marker")
+}
+
+func TestPlanEmission_Warn_MissingBucket_KeepsCreateKV(t *testing.T) {
+	t.Parallel()
+
+	// warn / safe-update keep their create-kv emission for a missing
+	// bucket — only adopt substitutes the informational finding.
+	for _, policy := range []ReconcilePolicy{PolicyWarn, PolicySafeUpdate} {
+		plan := planWith(t, cpUpdateCfg(policy), map[string]jetstream.StreamConfig{})
+		var sawCreate bool
+		for _, a := range plan.Actions {
+			if a.Kind == ActionCreateKV && a.Name == "parti-election" {
+				sawCreate = true
+			}
+		}
+		require.True(t, sawCreate, "%s still emits create-kv for a missing bucket", policy)
+	}
+}
+
+func TestPlanEmission_Adopt_EmptyInstance_NoInstanceKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	cfg.Instance = ""
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": unmarkedElectionStream(),
+	}
+	actions := stampMarkerActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	res := stampMarkerRes(t, actions[0])
+	_, ok := res.MergedMetadata[MarkerInstanceKey]
+	require.False(t, ok, "empty instance produces no parti.io/instance key")
+	require.ElementsMatch(t, []string{MarkerManagedKey, MarkerComponentKey}, res.PartiKeys)
+}
+
+func TestPlanEmission_Adopt_NonPartiKeysPreserved(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": unmarkedElectionStream(func(c *jetstream.StreamConfig) {
+			c.Metadata = map[string]string{"custom.io/team": "infra"}
+		}),
+	}
+	actions := stampMarkerActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	res := stampMarkerRes(t, actions[0])
+	require.Equal(t, "infra", res.MergedMetadata["custom.io/team"],
+		"non-Parti keys are preserved in MergedMetadata")
+	require.ElementsMatch(t,
+		[]string{MarkerManagedKey, MarkerComponentKey, MarkerInstanceKey}, res.PartiKeys,
+		"PartiKeys lists only the Parti keys added")
+}
+
+func TestPlanEmission_Adopt_StrayInstanceKey_RemovalInPartiKeys(t *testing.T) {
+	t.Parallel()
+
+	// An unmarked bucket carrying a stray parti.io/instance, adopted
+	// under an empty cfg.Instance: the key is deleted by the merge and
+	// the removal must surface in PartiKeys.
+	cfg := cpUpdateCfg(PolicyAdopt)
+	cfg.Instance = ""
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": unmarkedElectionStream(func(c *jetstream.StreamConfig) {
+			c.Metadata = map[string]string{MarkerInstanceKey: "old"}
+		}),
+	}
+	actions := stampMarkerActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	res := stampMarkerRes(t, actions[0])
+	_, ok := res.MergedMetadata[MarkerInstanceKey]
+	require.False(t, ok, "MergedMetadata omits the stray instance key")
+	require.Contains(t, res.PartiKeys, MarkerInstanceKey,
+		"PartiKeys includes the removed instance key")
+}
+
+func TestPlanEmission_Adopt_UnmarkedBucket_StillSurfacesAdoptedDrift(t *testing.T) {
+	t.Parallel()
+
+	// The classifier's adopted finding coexists with the stamp-marker
+	// action: adoption is not approval.
+	cfg := cpUpdateCfg(PolicyAdopt)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": unmarkedElectionStream(),
+	}
+	plan := planWith(t, cfg, streams)
+	require.Len(t, stampMarkerActions(plan), 1)
+	var adopted bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" && d.Severity == SeverityAdopted {
+			adopted = true
+		}
+	}
+	require.True(t, adopted, "unmarked bucket still surfaces adopted drift under adopt")
+}
+
+// --- apply, seam-based -------------------------------------------------------
+
+func stampMarkerAction(bucket string) PlannedAction {
+	return PlannedAction{
+		Kind:     ActionStampMarker,
+		Name:     bucket,
+		Resource: &StampMarkerResource{Bucket: bucket},
+	}
+}
+
+func TestApplyStampMarker_UnmarkedReread_WritesMergedMetadata(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	live := unmarkedElectionStream(func(c *jetstream.StreamConfig) {
+		c.MaxAge = 10 * time.Second
+		c.Metadata = map[string]string{"custom.io/team": "infra"}
+	})
+	reader := fakeStreamReader{cfg: live}
+	updater := &fakeKVUpdater{}
+
+	executed, err := applyStampMarkerAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), stampMarkerAction("parti-election"))
+	require.NoError(t, err)
+	require.False(t, executed.Raced)
+	require.True(t, updater.called)
+
+	// Metadata is the merged map.
+	require.Equal(t, MarkerManagedValue, updater.got.Metadata[MarkerManagedKey])
+	require.Equal(t, ComponentControlPlaneElection, updater.got.Metadata[MarkerComponentKey])
+	require.Equal(t, "prod", updater.got.Metadata[MarkerInstanceKey])
+	require.Equal(t, "infra", updater.got.Metadata["custom.io/team"])
+
+	// Every non-metadata field equals the re-read snapshot.
+	require.Equal(t, 10*time.Second, updater.got.TTL)
+	require.Equal(t, jetstream.MemoryStorage, updater.got.Storage)
+	require.Equal(t, "parti-election", updater.got.Bucket)
+}
+
+func TestApplyStampMarker_AlreadyMarkedReread_RacedNoWrite(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	// The bucket already carries an equivalent marker: merge is a no-op.
+	reader := fakeStreamReader{cfg: electionStream()}
+	updater := &fakeKVUpdater{}
+
+	executed, err := applyStampMarkerAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), stampMarkerAction("parti-election"))
+	require.NoError(t, err)
+	require.True(t, executed.Raced, "an already-marked bucket is a raced no-op")
+	require.False(t, updater.called, "no write when the marker is already present")
+}
+
+func TestApplyStampMarker_MissingOnReread_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	reader := fakeStreamReader{err: jetstream.ErrStreamNotFound}
+	updater := &fakeKVUpdater{}
+
+	_, err := applyStampMarkerAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), stampMarkerAction("parti-election"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bucket-missing-before-stamp")
+	require.False(t, updater.called)
+}
+
+func TestApplyStampMarker_MissingOnWrite_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	reader := fakeStreamReader{cfg: unmarkedElectionStream()}
+	updater := &fakeKVUpdater{err: jetstream.ErrBucketNotFound}
+
+	_, err := applyStampMarkerAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), stampMarkerAction("parti-election"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bucket-missing-before-stamp")
+	require.True(t, updater.called)
+}
+
+func TestApplyStampMarker_WrongResourceType_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	action := PlannedAction{Kind: ActionStampMarker, Name: "parti-election", Resource: "nope"}
+	_, err := applyStampMarkerAction(context.Background(), fakeStreamReader{cfg: unmarkedElectionStream()},
+		&fakeKVUpdater{}, cfg, cpSpecsFor(t, cfg), action)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong Resource type")
+}
+
+func TestApplyStampMarker_UnknownBucket_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	// A bucket the resolved config does not describe: defensive guard.
+	_, err := applyStampMarkerAction(context.Background(), fakeStreamReader{cfg: unmarkedElectionStream()},
+		&fakeKVUpdater{}, cfg, cpSpecsFor(t, cfg), stampMarkerAction("not-in-config"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not described by the resolved config")
+}
+
+func TestApplyStampMarker_CancelledReread_PropagatesCancellation(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	reader := fakeStreamReader{err: context.Canceled}
+	_, err := applyStampMarkerAction(context.Background(), reader, &fakeKVUpdater{}, cfg,
+		cpSpecsFor(t, cfg), stampMarkerAction("parti-election"))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestApplyStampMarker_CrossPolicyRaceWindow demonstrates the documented
+// best-effort cross-policy contract. stamp-marker re-reads live state
+// and writes that snapshot back with only Metadata merged — it has no
+// "desired" non-metadata values. If a concurrent safe-update changed a
+// field such as TTL between this re-read and the write, stamp-marker
+// would carry the value it read (the stale one) and revert the
+// concurrent change. NATS UpdateStream has no expected-revision token,
+// so this window cannot be closed; operators serialize adopt and
+// safe-update themselves.
+func TestApplyStampMarker_CrossPolicyRaceWindow(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	live := unmarkedElectionStream(func(c *jetstream.StreamConfig) {
+		c.MaxAge = 10 * time.Second // the value a concurrent writer might change
+		c.Metadata = map[string]string{"custom.io/team": "infra"}
+	})
+	reader := fakeStreamReader{cfg: live}
+	updater := &fakeKVUpdater{}
+
+	_, err := applyStampMarkerAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), stampMarkerAction("parti-election"))
+	require.NoError(t, err)
+	require.True(t, updater.called)
+
+	// The captured target's TTL equals the re-read 10s — not any
+	// "desired" value, because stamp-marker has none.
+	require.Equal(t, 10*time.Second, updater.got.TTL,
+		"the write carries the re-read TTL; a concurrent change would be reverted")
+	// Metadata is the Parti marker plus the preserved non-Parti key.
+	require.Equal(t, MarkerManagedValue, updater.got.Metadata[MarkerManagedKey])
+	require.Equal(t, ComponentControlPlaneElection, updater.got.Metadata[MarkerComponentKey])
+	require.Equal(t, "infra", updater.got.Metadata["custom.io/team"])
+}

--- a/provision/types.go
+++ b/provision/types.go
@@ -93,7 +93,31 @@ type PlannedAction struct {
 // Action kind constants.
 const (
 	ActionCreateKV = "create-kv"
+
+	// ActionUpdateKV is emitted by Plan under PolicySafeUpdate when a
+	// Parti-marked KV bucket has at least one operator-expressible field
+	// (Metadata, TTL, MaxValueSize, Replicas) that differs from the
+	// desired config. Apply re-reads live state, verifies it still
+	// matches the plan-time Before, rebuilds the target from the re-read
+	// snapshot, and calls js.UpdateKeyValue. Resource is *UpdateKVResource.
+	ActionUpdateKV = "update-kv"
 )
+
+// UpdateKVResource is the Resource carried by an ActionUpdateKV
+// PlannedAction. Before is the live KeyValueConfig observed at plan
+// time; After is the desired target. Both are deep clones (see
+// cloneKVConfig) so the Plan output is immutable regardless of later
+// Apply or nats.go mutation.
+//
+// Apply does not write Resource.After verbatim — it re-reads live
+// state and rebuilds the target from the re-read snapshot (see the
+// Apply algorithm). Resource.Before / Resource.After are the audit
+// surface: JSON consumers diff them to render exactly which fields
+// change.
+type UpdateKVResource struct {
+	Before jetstream.KeyValueConfig `json:"before"`
+	After  jetstream.KeyValueConfig `json:"after"`
+}
 
 // DriftFinding describes how a live resource differs from the desired state,
 // or that an existing resource is unmarked ("adopted"). v1 emits drift

--- a/provision/types.go
+++ b/provision/types.go
@@ -101,6 +101,15 @@ const (
 	// matches the plan-time Before, rebuilds the target from the re-read
 	// snapshot, and calls js.UpdateKeyValue. Resource is *UpdateKVResource.
 	ActionUpdateKV = "update-kv"
+
+	// ActionStampMarker is emitted by Plan under PolicyAdopt for a KV
+	// bucket named by config that exists live and carries no Parti
+	// ownership marker. Apply re-reads live state, recomputes the
+	// merged metadata (live keys plus the Parti marker keys),
+	// short-circuits when the merge is already a no-op, otherwise
+	// writes the re-read snapshot back with only Metadata changed.
+	// Resource is *StampMarkerResource.
+	ActionStampMarker = "stamp-marker"
 )
 
 // UpdateKVResource is the Resource carried by an ActionUpdateKV
@@ -117,6 +126,26 @@ const (
 type UpdateKVResource struct {
 	Before jetstream.KeyValueConfig `json:"before"`
 	After  jetstream.KeyValueConfig `json:"after"`
+}
+
+// StampMarkerResource is the Resource carried by an ActionStampMarker
+// PlannedAction. MergedMetadata is the full Metadata map the action
+// will write: the union of the live bucket's existing keys and the
+// Parti marker keys (parti.io/managed, parti.io/component, and
+// parti.io/instance when the instance is non-empty).
+//
+// PartiKeys lists exactly the metadata keys the action adds or
+// changes relative to the live bucket, so operator review can verify
+// that no non-Parti key is being modified.
+//
+// Apply does not write MergedMetadata verbatim — it re-reads live
+// state and recomputes the merge against the re-read metadata (see
+// the Apply algorithm). MergedMetadata / PartiKeys are the audit
+// surface for plan / apply -dry-run output.
+type StampMarkerResource struct {
+	Bucket         string            `json:"bucket"`
+	MergedMetadata map[string]string `json:"mergedMetadata"`
+	PartiKeys      []string          `json:"partiKeys"`
 }
 
 // DriftFinding describes how a live resource differs from the desired state,

--- a/provision/types.go
+++ b/provision/types.go
@@ -18,11 +18,11 @@ type Snapshot struct {
 	ObservedAt      time.Time       `json:"observedAt"`
 	ControlPlane    []KVBucketState `json:"controlPlane"`
 	PartitionSource []KVBucketState `json:"partitionSource"`
-	// DynamicConsumers is reserved for Phase 5 (dynamic-consumer
-	// precreation). In v1 it is always empty: alignment-check is the
-	// only dynamic-consumer surface and it does not produce ConsumerState
-	// entries because v1 does not stamp the ownership marker on
-	// dynamic consumers.
+	// DynamicConsumers is always empty in the current release: alignment-check
+	// is the only dynamic-consumer surface, and it does not produce
+	// ConsumerState entries because the SDK does not yet stamp the ownership
+	// marker on dynamic consumers. Dynamic consumer precreation is not yet
+	// supported.
 	DynamicConsumers []ConsumerState `json:"dynamicConsumers"`
 }
 
@@ -55,7 +55,9 @@ type KVBucketState struct {
 	MaxValueSize int32 `json:"maxValueSize,omitempty"`
 }
 
-// ConsumerState is a placeholder; populated in W4 (dynamic-consumer alignment).
+// ConsumerState is a placeholder. Dynamic-consumer alignment is not yet
+// populated in the current release; the struct exists so the Snapshot shape
+// is stable for future use.
 type ConsumerState struct {
 	StreamName string `json:"streamName,omitempty"`
 	Durable    string `json:"durable,omitempty"`
@@ -80,10 +82,14 @@ type PlanResult struct {
 	Drift      []DriftFinding  `json:"drift"`
 }
 
-// PlannedAction is one operation Apply would perform. In v1, Kind is always
-// "create-kv" (update-* lands in Phase 2; consumer-create in Phase 5;
-// delete-* in Phase 6). The Resource field carries the would-be NATS config
-// — for "create-kv" this is a jetstream.KeyValueConfig value.
+// PlannedAction is one operation Apply would perform. Kind is one of the
+// ActionCreateKV, ActionUpdateKV, or ActionStampMarker constants. The Resource
+// field carries the would-be NATS config: for "create-kv" this is a
+// jetstream.KeyValueConfig value; for "update-kv" it is *UpdateKVResource;
+// for "stamp-marker" it is *StampMarkerResource.
+//
+// Consumer precreation and destructive repair (delete/recreate) are not yet
+// supported.
 type PlannedAction struct {
 	Kind     string `json:"kind"`
 	Name     string `json:"name"`
@@ -149,14 +155,15 @@ type StampMarkerResource struct {
 }
 
 // DriftFinding describes how a live resource differs from the desired state,
-// or that an existing resource is unmarked ("adopted"). v1 emits drift
-// findings but never emits update-* / delete-* actions.
+// or that an existing resource is unmarked ("adopted").
 //
 // Severity values:
-//   - "informational": resource exists and matches; no action needed.
-//   - "drift-mutable": fields differ but would be safe to live-edit (v2).
-//   - "drift-immutable": fields differ and require delete/recreate (v6).
-//   - "adopted": resource exists without the Parti marker; reported only.
+//   - "informational": resource exists and matches desired state; no action needed.
+//   - "drift-mutable": fields differ but can be reconciled in place (see
+//     PolicySafeUpdate and the ActionUpdateKV action kind).
+//   - "drift-immutable": fields differ and require delete/recreate to repair;
+//     destructive repair is not yet supported.
+//   - "adopted": resource exists without the Parti marker; see PolicyAdopt.
 type DriftFinding struct {
 	Severity string         `json:"severity"`
 	Kind     string         `json:"kind"`
@@ -180,8 +187,6 @@ const (
 )
 
 // Report is the result of Apply: what executed, what was skipped, what failed.
-// v1 never emits Apply, but the type is part of the load-bearing W1 surface
-// so later phases inherit it verbatim.
 type Report struct {
 	APIVersion string           `json:"apiVersion"`
 	Kind       string           `json:"kind"`
@@ -209,7 +214,7 @@ type ExecutedAction struct {
 
 // SkippedAction is a PlannedAction Apply did not run.
 //
-// Reason values (W2+):
+// Reason values:
 //   - "context-cancelled": ctx was cancelled before this action started.
 //   - "prior-error": an earlier action errored; Apply is fail-fast.
 type SkippedAction struct {
@@ -232,9 +237,9 @@ type ResourceError struct {
 	Error string `json:"error"`
 }
 
-// PlannedConsumer is the W4 dynamic-consumer alignment output type. The
-// struct lives here so the Plan surface is stable across phases; v1 never
-// populates dynamic-consumer entries (alignment-check ships in W4).
+// PlannedConsumer is the dynamic-consumer alignment output type. The struct
+// exists so the Plan surface is stable; dynamic-consumer entries are not
+// yet populated through Plan (use PlanDynamicConsumers directly).
 type PlannedConsumer struct {
 	StreamName string                   `json:"streamName"`
 	Subject    string                   `json:"subject"`

--- a/provision/update_kv_integration_test.go
+++ b/provision/update_kv_integration_test.go
@@ -1,0 +1,359 @@
+package provision_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/provision"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// safeUpdateCtx returns a context bounded for an embedded-NATS apply test.
+func safeUpdateCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	return ctx
+}
+
+// markedElectionKV builds a KeyValueConfig for a Parti-marked
+// control-plane election bucket. mutate lets a test introduce drift.
+func markedElectionKV(mutate ...func(*jetstream.KeyValueConfig)) jetstream.KeyValueConfig {
+	kv := jetstream.KeyValueConfig{
+		Bucket:   "parti-election",
+		Storage:  jetstream.MemoryStorage,
+		History:  1,
+		TTL:      10 * time.Second,
+		Metadata: provision.BuildMarker(provision.ComponentControlPlaneElection, "prod"),
+	}
+	for _, m := range mutate {
+		m(&kv)
+	}
+
+	return kv
+}
+
+// controlPlaneOnlyCfg returns a Config provisioning a single control-plane
+// election bucket with the given policy. The other control-plane buckets
+// are still emitted, so tests assert per-bucket.
+func controlPlaneOnlyCfg(policy provision.ReconcilePolicy) provision.Config {
+	return provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		Policy:     policy,
+		ControlPlane: &provision.ControlPlaneConfig{
+			WorkerIDTTL:     75 * time.Second,
+			ElectionTimeout: 10 * time.Second,
+			HeartbeatTTL:    15 * time.Second,
+			AssignmentTTL:   0,
+		},
+	}
+}
+
+// liveStreamConfig fetches the current StreamConfig for a KV bucket.
+func liveStreamConfig(t *testing.T, js jetstream.JetStream, bucket string) jetstream.StreamConfig {
+	t.Helper()
+	stream, err := js.Stream(context.Background(), "KV_"+bucket)
+	require.NoError(t, err)
+	info, err := stream.Info(context.Background())
+	require.NoError(t, err)
+
+	return info.Config
+}
+
+// driftSeverityFor returns the severities reported for a named bucket.
+func driftSeverityFor(plan provision.PlanResult, name string) []string {
+	var out []string
+	for _, d := range plan.Drift {
+		if d.Name == name {
+			out = append(out, d.Severity)
+		}
+	}
+
+	return out
+}
+
+func TestApply_UpdateKV_ControlPlaneTTL_Converges(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Pre-create a marked election bucket with a drifted TTL.
+	createKV(t, js, markedElectionKV(func(kv *jetstream.KeyValueConfig) {
+		kv.TTL = 99 * time.Second
+	}))
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.False(t, rep.Aborted)
+	require.Empty(t, rep.Errors)
+
+	// election must have been reconciled in place (update-kv), not created.
+	var electionExec provision.ExecutedAction
+	for _, ex := range rep.Executed {
+		if ex.Name == "parti-election" {
+			electionExec = ex
+		}
+	}
+	require.Equal(t, provision.ActionUpdateKV, electionExec.Kind)
+
+	require.Equal(t, 10*time.Second, liveStreamConfig(t, js, "parti-election").MaxAge)
+
+	// Re-plan: election is now informational.
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Contains(t, driftSeverityFor(plan, "parti-election"), provision.SeverityInformational)
+}
+
+func TestApply_UpdateKV_ControlPlaneInstanceChange_Converges(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, markedElectionKV(func(kv *jetstream.KeyValueConfig) {
+		kv.Metadata = provision.BuildMarker(provision.ComponentControlPlaneElection, "staging")
+	}))
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate) // Instance "prod"
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-election")
+	require.Equal(t, "prod", provision.ParseMarker(live.Metadata).Instance)
+}
+
+func TestApply_UpdateKV_ControlPlaneReplicas_Converges(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Single-node embedded server: live Replicas is 1. Requesting an
+	// explicit Replicas=1 is feasible and exercises the operator-
+	// expressible Replicas path without server rejection.
+	createKV(t, js, markedElectionKV(func(kv *jetstream.KeyValueConfig) {
+		kv.TTL = 88 * time.Second // drift so an update-kv is emitted
+	}))
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+	cfg.ControlPlane.Replicas = 1
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+	require.Equal(t, 1, liveStreamConfig(t, js, "parti-election").Replicas)
+}
+
+func TestApply_UpdateKV_ReplicasServerRejection_FailsFast(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, markedElectionKV(func(kv *jetstream.KeyValueConfig) {
+		kv.TTL = 88 * time.Second
+	}))
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+	cfg.ControlPlane.Replicas = 3 // infeasible on a single-node server
+
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.Error(t, err)
+	require.False(t, rep.Aborted, "server rejection is a resource error, not an abort")
+	require.NotEmpty(t, rep.Errors)
+
+	// Fail-fast contract: the failing action appears in Errors, not Skipped.
+	for _, e := range rep.Errors {
+		require.NotContains(t, []string{e.Name}, "",
+			"resource error must name the failing bucket")
+	}
+	for _, s := range rep.Skipped {
+		require.Equal(t, provision.SkipReasonPriorError, s.Reason,
+			"actions after the failure are skipped with prior-error, not double-reported")
+	}
+}
+
+func TestApply_UpdateKV_PartitionSourceTTLAndMaxValueSize_Converge(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:       "parti-partitions",
+		Storage:      jetstream.FileStorage,
+		History:      2,
+		TTL:          time.Minute, // drifts
+		MaxValueSize: 256,         // drifts
+		Metadata:     provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		Policy:     provision.PolicySafeUpdate,
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:       "parti-partitions",
+			Key:          "partitions/v1",
+			Storage:      "file",
+			History:      2,
+			MaxValueSize: 4096,
+			TTL:          5 * time.Minute,
+		},
+	}
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-partitions")
+	require.Equal(t, 5*time.Minute, live.MaxAge)
+	require.Equal(t, int32(4096), live.MaxMsgSize)
+
+	plan, err := provision.Plan(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Contains(t, driftSeverityFor(plan, "parti-partitions"), provision.SeverityInformational)
+}
+
+func TestApply_UpdateKV_PartitionSourceReplicas_Converges(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Single-node embedded server: live Replicas is 1. An explicit
+	// Replicas=1 exercises the partition-source operator-expressible
+	// Replicas path without server rejection; the TTL drift triggers
+	// the update-kv.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:   "parti-partitions",
+		Storage:  jetstream.FileStorage,
+		History:  1,
+		TTL:      time.Minute, // drifts
+		Metadata: provision.BuildMarker(provision.ComponentPartitionSource, "prod"),
+	})
+
+	cfg := provision.Config{
+		APIVersion: provision.APIVersionV1,
+		Instance:   "prod",
+		Policy:     provision.PolicySafeUpdate,
+		PartitionSource: &provision.PartitionSourceConfig{
+			Bucket:   "parti-partitions",
+			Key:      "partitions/v1",
+			Storage:  "file",
+			History:  1,
+			Replicas: 1,
+			TTL:      5 * time.Minute,
+		},
+	}
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-partitions")
+	require.Equal(t, 1, live.Replicas)
+	require.Equal(t, 5*time.Minute, live.MaxAge,
+		"TTL reconciled alongside the explicit Replicas=1")
+}
+
+func TestApply_UpdateKV_PreservesLiveDescriptionAndMaxBytes(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Pre-create a marked bucket with Description and MaxBytes set
+	// out-of-band — neither has a YAML representation — plus a drifted TTL.
+	_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:              "KV_parti-election",
+		Description:       "owned by team X",
+		Subjects:          []string{"$KV.parti-election.>"},
+		Storage:           jetstream.MemoryStorage,
+		MaxMsgsPerSubject: 1,
+		MaxAge:            99 * time.Second,
+		MaxBytes:          1 << 20,
+		AllowDirect:       true,
+		Metadata:          provision.BuildMarker(provision.ComponentControlPlaneElection, "prod"),
+	})
+	require.NoError(t, err)
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	live := liveStreamConfig(t, js, "parti-election")
+	require.Equal(t, 10*time.Second, live.MaxAge, "TTL reconciled")
+	require.Equal(t, "owned by team X", live.Description,
+		"preserved-from-live Description survives a safe-update")
+	require.Equal(t, int64(1<<20), live.MaxBytes,
+		"preserved-from-live MaxBytes survives a safe-update")
+}
+
+func TestApply_UpdateKV_RerunIsNoOp(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, markedElectionKV(func(kv *jetstream.KeyValueConfig) {
+		kv.TTL = 99 * time.Second
+	}))
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+
+	first, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, first.Errors)
+
+	// Second Apply: election already converged. Plan emits no update-kv
+	// (canonical-equality suppression), so nothing is executed for it.
+	second, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, second.Errors)
+	require.Empty(t, second.Skipped)
+	for _, ex := range second.Executed {
+		require.NotEqual(t, "parti-election", ex.Name,
+			"converged election needs no second update")
+	}
+}
+
+func TestApply_UpdateKV_UnmarkedBucket_NotMutated(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	// Pre-create an UNMARKED election bucket with a drifted TTL.
+	createKV(t, js, jetstream.KeyValueConfig{
+		Bucket:  "parti-election",
+		Storage: jetstream.MemoryStorage,
+		History: 1,
+		TTL:     99 * time.Second,
+	})
+
+	cfg := controlPlaneOnlyCfg(provision.PolicySafeUpdate)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	// safe-update does not adopt: the unmarked bucket's TTL is untouched.
+	require.Equal(t, 99*time.Second, liveStreamConfig(t, js, "parti-election").MaxAge)
+	for _, ex := range rep.Executed {
+		require.NotEqual(t, "parti-election", ex.Name)
+	}
+}
+
+func TestApply_Warn_MarkedDriftedBucket_NotMutated(t *testing.T) {
+	t.Parallel()
+	js := newJS(t)
+	ctx := safeUpdateCtx(t)
+
+	createKV(t, js, markedElectionKV(func(kv *jetstream.KeyValueConfig) {
+		kv.TTL = 99 * time.Second
+	}))
+
+	cfg := controlPlaneOnlyCfg(provision.PolicyWarn)
+	rep, err := provision.Apply(ctx, js, cfg)
+	require.NoError(t, err)
+	require.Empty(t, rep.Errors)
+
+	// warn never mutates an existing bucket.
+	require.Equal(t, 99*time.Second, liveStreamConfig(t, js, "parti-election").MaxAge)
+}

--- a/provision/update_kv_test.go
+++ b/provision/update_kv_test.go
@@ -1,0 +1,690 @@
+package provision
+
+// Same-package unit tests for the update-kv plan-emission and apply
+// helpers. These use synthetic *jetstream.StreamInfo / StreamConfig
+// values so they run without a live NATS server.
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// --- streamConfigToKVConfig --------------------------------------------------
+
+func TestStreamConfigToKVConfig_PopulatesEveryField(t *testing.T) {
+	t.Parallel()
+
+	sc := jetstream.StreamConfig{
+		Name:                   "KV_my-bucket",
+		Description:            "owned by team X",
+		MaxMsgSize:             4096,
+		MaxMsgsPerSubject:      3,
+		MaxAge:                 7 * time.Minute,
+		MaxBytes:               1 << 20,
+		Storage:                jetstream.FileStorage,
+		Replicas:               3,
+		Placement:              &jetstream.Placement{Cluster: "c1", Tags: []string{"t1"}},
+		RePublish:              &jetstream.RePublish{Source: "a", Destination: "b"},
+		Mirror:                 &jetstream.StreamSource{Name: "src"},
+		Sources:                []*jetstream.StreamSource{{Name: "s1"}},
+		Compression:            jetstream.S2Compression,
+		SubjectDeleteMarkerTTL: 9 * time.Second,
+		Metadata:               map[string]string{"k": "v"},
+	}
+
+	kv := streamConfigToKVConfig(sc)
+
+	require.Equal(t, "my-bucket", kv.Bucket)
+	require.Equal(t, "owned by team X", kv.Description)
+	require.Equal(t, int32(4096), kv.MaxValueSize)
+	require.Equal(t, uint8(3), kv.History)
+	require.Equal(t, 7*time.Minute, kv.TTL)
+	require.Equal(t, int64(1<<20), kv.MaxBytes)
+	require.Equal(t, jetstream.FileStorage, kv.Storage)
+	require.Equal(t, 3, kv.Replicas)
+	require.Equal(t, sc.Placement, kv.Placement)
+	require.Equal(t, sc.RePublish, kv.RePublish)
+	require.Equal(t, sc.Mirror, kv.Mirror)
+	require.Equal(t, sc.Sources, kv.Sources)
+	require.True(t, kv.Compression)
+	require.Equal(t, 9*time.Second, kv.LimitMarkerTTL)
+	require.Equal(t, map[string]string{"k": "v"}, kv.Metadata)
+}
+
+func TestStreamConfigToKVConfig_NoCompression_MapsToFalse(t *testing.T) {
+	t.Parallel()
+
+	kv := streamConfigToKVConfig(jetstream.StreamConfig{Name: "KV_b", Compression: jetstream.NoCompression})
+	require.False(t, kv.Compression)
+}
+
+// TestExtractLiveKVConfig_DelegationIsBehaviorPreserving guards that
+// extractLiveKVConfig, now delegating to streamConfigToKVConfig, still
+// yields the same comparison-subset values kvConfigsEqual reads.
+func TestExtractLiveKVConfig_DelegationIsBehaviorPreserving(t *testing.T) {
+	t.Parallel()
+
+	sc := jetstream.StreamConfig{
+		Name:              "KV_b",
+		MaxMsgSize:        2048,
+		MaxMsgsPerSubject: 1,
+		MaxAge:            time.Minute,
+		Storage:           jetstream.MemoryStorage,
+		Replicas:          1,
+		Metadata:          map[string]string{"x": "y"},
+	}
+	live := extractLiveKVConfig(&sc)
+
+	require.True(t, kvConfigsEqual(live, jetstream.KeyValueConfig{
+		MaxValueSize: 2048,
+		History:      1,
+		TTL:          time.Minute,
+		Storage:      jetstream.MemoryStorage,
+		Replicas:     1,
+		Metadata:     map[string]string{"x": "y"},
+	}))
+}
+
+// --- mergeUpdateKVMetadata ---------------------------------------------------
+
+func TestMergeUpdateKVMetadata_ForcesManagedAndSetsInstance(t *testing.T) {
+	t.Parallel()
+
+	merged := mergeUpdateKVMetadata(map[string]string{MarkerManagedKey: "v0"}, "prod")
+	require.Equal(t, MarkerManagedValue, merged[MarkerManagedKey])
+	require.Equal(t, "prod", merged[MarkerInstanceKey])
+}
+
+func TestMergeUpdateKVMetadata_EmptyInstanceDeletesKey(t *testing.T) {
+	t.Parallel()
+
+	merged := mergeUpdateKVMetadata(map[string]string{MarkerInstanceKey: "old"}, "")
+	_, ok := merged[MarkerInstanceKey]
+	require.False(t, ok)
+}
+
+func TestMergeUpdateKVMetadata_PreservesMismatchedComponentVerbatim(t *testing.T) {
+	t.Parallel()
+
+	live := map[string]string{
+		MarkerManagedKey:   "v1",
+		MarkerComponentKey: ComponentPartitionSource, // mismatched on purpose
+		"team":             "infra",
+	}
+	merged := mergeUpdateKVMetadata(live, "prod")
+	require.Equal(t, ComponentPartitionSource, merged[MarkerComponentKey],
+		"update-kv must never re-label a bucket's component")
+	require.Equal(t, "infra", merged["team"], "non-Parti keys must be preserved")
+}
+
+func TestMergeUpdateKVMetadata_NilLiveDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	merged := mergeUpdateKVMetadata(nil, "prod")
+	require.Equal(t, MarkerManagedValue, merged[MarkerManagedKey])
+	require.Equal(t, "prod", merged[MarkerInstanceKey])
+}
+
+// --- buildUpdateKVTarget -----------------------------------------------------
+
+func TestBuildControlPlaneUpdateTarget_PreservesNonOperatorFields(t *testing.T) {
+	t.Parallel()
+
+	before := jetstream.KeyValueConfig{
+		Bucket:         "parti-election",
+		Description:    "out-of-band note",
+		MaxValueSize:   8192,
+		History:        3,
+		MaxBytes:       4096,
+		Storage:        jetstream.MemoryStorage,
+		Placement:      &jetstream.Placement{Cluster: "c"},
+		Compression:    true,
+		LimitMarkerTTL: 5 * time.Second,
+		TTL:            time.Minute,
+		Replicas:       1,
+		Metadata:       map[string]string{MarkerManagedKey: "v1", MarkerComponentKey: ComponentControlPlaneElection},
+	}
+	spec := controlPlaneSpec{
+		component: ComponentControlPlaneElection,
+		bucket:    "parti-election",
+		ttl:       2 * time.Minute,
+		storage:   jetstream.MemoryStorage,
+		replicas:  3,
+	}
+	after := buildControlPlaneUpdateTarget(spec, "prod", before)
+
+	// Operator-expressible fields change.
+	require.Equal(t, 2*time.Minute, after.TTL)
+	require.Equal(t, 3, after.Replicas)
+	require.Equal(t, "prod", after.Metadata[MarkerInstanceKey])
+
+	// Every other field is inherited verbatim.
+	require.Equal(t, before.Bucket, after.Bucket)
+	require.True(t, reflect.DeepEqual(before.Description, after.Description))
+	require.Equal(t, before.MaxValueSize, after.MaxValueSize) // CP: preserved-from-live
+	require.Equal(t, before.History, after.History)
+	require.Equal(t, before.MaxBytes, after.MaxBytes)
+	require.Equal(t, before.Storage, after.Storage)
+	require.True(t, reflect.DeepEqual(before.Placement, after.Placement))
+	require.Equal(t, before.Compression, after.Compression)
+	require.Equal(t, before.LimitMarkerTTL, after.LimitMarkerTTL)
+}
+
+func TestBuildPartitionSourceUpdateTarget_OverwritesMaxValueSize(t *testing.T) {
+	t.Parallel()
+
+	before := jetstream.KeyValueConfig{
+		Bucket:       "parti-source",
+		History:      2,
+		Storage:      jetstream.FileStorage,
+		MaxValueSize: 1024,
+		TTL:          time.Minute,
+		Replicas:     1,
+		Metadata:     map[string]string{MarkerManagedKey: "v1", MarkerComponentKey: ComponentPartitionSource},
+	}
+	ps := &PartitionSourceConfig{
+		Bucket:       "parti-source",
+		History:      2,
+		Storage:      "file",
+		MaxValueSize: 65536,
+		TTL:          3 * time.Minute,
+		Replicas:     2,
+	}
+	after := buildPartitionSourceUpdateTarget(ps, "prod", before)
+
+	require.Equal(t, int32(65536), after.MaxValueSize)
+	require.Equal(t, 3*time.Minute, after.TTL)
+	require.Equal(t, 2, after.Replicas)
+	require.Equal(t, before.History, after.History)
+	require.Equal(t, before.Storage, after.Storage)
+}
+
+// --- plan emission -----------------------------------------------------------
+
+func cpUpdateCfg(policy ReconcilePolicy) Config {
+	return Config{
+		APIVersion: APIVersionV1,
+		Instance:   "prod",
+		Policy:     policy,
+		ControlPlane: &ControlPlaneConfig{
+			StableIDBucket:   "parti-stableid",
+			ElectionBucket:   "parti-election",
+			HeartbeatBucket:  "parti-heartbeat",
+			AssignmentBucket: "parti-assignment",
+			HandoffBucket:    "parti-handoff",
+			ElectionTimeout:  10 * time.Second,
+			HeartbeatTTL:     15 * time.Second,
+			WorkerIDTTL:      75 * time.Second,
+			AssignmentTTL:    0,
+		},
+	}
+}
+
+// fakeJS lets plan-emission unit tests inject one synthetic stream.
+type fakeJS struct {
+	jetstream.JetStream
+	streams map[string]jetstream.StreamConfig // streamName -> config
+}
+
+func (f *fakeJS) Stream(_ context.Context, name string) (jetstream.Stream, error) {
+	cfg, ok := f.streams[name]
+	if !ok {
+		return nil, jetstream.ErrStreamNotFound
+	}
+
+	return &fakeStream{cfg: cfg}, nil
+}
+
+type fakeStream struct {
+	jetstream.Stream
+	cfg jetstream.StreamConfig
+}
+
+func (s *fakeStream) Info(_ context.Context, _ ...jetstream.StreamInfoOpt) (*jetstream.StreamInfo, error) {
+	return &jetstream.StreamInfo{Config: s.cfg}, nil
+}
+
+// electionStream returns a synthetic KV_parti-election stream config.
+func electionStream(mutate ...func(*jetstream.StreamConfig)) jetstream.StreamConfig {
+	cfg := jetstream.StreamConfig{
+		Name:              "KV_parti-election",
+		Storage:           jetstream.MemoryStorage,
+		MaxMsgsPerSubject: 1,
+		MaxAge:            10 * time.Second,
+		Metadata:          BuildMarker(ComponentControlPlaneElection, "prod"),
+	}
+	for _, m := range mutate {
+		m(&cfg)
+	}
+
+	return cfg
+}
+
+func planWith(t *testing.T, cfg Config, streams map[string]jetstream.StreamConfig) PlanResult {
+	t.Helper()
+	js := &fakeJS{streams: streams}
+	out, err := Plan(context.Background(), js, cfg)
+	require.NoError(t, err)
+
+	return out
+}
+
+func updateKVActions(p PlanResult) []PlannedAction {
+	var out []PlannedAction
+	for _, a := range p.Actions {
+		if a.Kind == ActionUpdateKV {
+			out = append(out, a)
+		}
+	}
+
+	return out
+}
+
+func TestPlanEmission_SafeUpdate_TTLDrift_EmitsUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) {
+			c.MaxAge = 99 * time.Second // drifts from cfg's 10s
+		}),
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	require.Equal(t, "parti-election", actions[0].Name)
+	res, ok := actions[0].Resource.(*UpdateKVResource)
+	require.True(t, ok)
+	require.Equal(t, 10*time.Second, res.After.TTL)
+}
+
+func TestPlanEmission_SafeUpdate_ReplicasDrift_EmitsUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	cfg.ControlPlane.Replicas = 3
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) { c.Replicas = 1 }),
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+}
+
+func TestPlanEmission_SafeUpdate_PartitionSourceReplicasDrift_EmitsUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		APIVersion: APIVersionV1,
+		Instance:   "prod",
+		Policy:     PolicySafeUpdate,
+		PartitionSource: &PartitionSourceConfig{
+			Bucket:   "parti-partitions",
+			Key:      "partitions/v1",
+			Storage:  "file",
+			History:  1,
+			Replicas: 3,
+		},
+	}
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-partitions": {
+			Name:              "KV_parti-partitions",
+			Storage:           jetstream.FileStorage,
+			MaxMsgsPerSubject: 1,
+			Replicas:          1, // drifts from cfg's 3
+			Metadata:          BuildMarker(ComponentPartitionSource, "prod"),
+		},
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	require.Equal(t, "parti-partitions", actions[0].Name)
+	res, ok := actions[0].Resource.(*UpdateKVResource)
+	require.True(t, ok)
+	require.Equal(t, 3, res.After.Replicas)
+}
+
+func TestPlanEmission_SafeUpdate_InstanceChange_EmitsUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	cfg.Instance = "staging"
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(), // marked instance=prod
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+}
+
+func TestPlanEmission_SafeUpdate_InstanceRemoval_EmitsUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	cfg.Instance = ""
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(), // marked instance=prod
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	res, ok := actions[0].Resource.(*UpdateKVResource)
+	require.True(t, ok)
+	_, ok = res.After.Metadata[MarkerInstanceKey]
+	require.False(t, ok)
+}
+
+func TestPlanEmission_SafeUpdate_ManagedVersionDrift_EmitsUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) {
+			c.Metadata[MarkerManagedKey] = "v0"
+		}),
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+}
+
+func TestPlanEmission_SafeUpdate_UnmarkedBucket_NoUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) {
+			c.Metadata = nil // unmarked
+			c.MaxAge = 99 * time.Second
+		}),
+	}
+	plan := planWith(t, cfg, streams)
+	require.Empty(t, updateKVActions(plan))
+	var adopted bool
+	for _, d := range plan.Drift {
+		if d.Severity == SeverityAdopted && d.Name == "parti-election" {
+			adopted = true
+		}
+	}
+	require.True(t, adopted, "unmarked bucket still surfaces adopted drift")
+}
+
+func TestPlanEmission_SafeUpdate_ImmutableOnlyDrift_NoUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) {
+			c.MaxMsgsPerSubject = 3 // History drift only — immutable
+		}),
+	}
+	plan := planWith(t, cfg, streams)
+	require.Empty(t, updateKVActions(plan), "History drift alone is immutable, no update-kv")
+}
+
+func TestPlanEmission_SafeUpdate_ComponentOnlyDrift_NoUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	// A bucket whose ONLY drift is a mismatched parti.io/component.
+	// Component is drift-immutable; update-kv never re-labels a bucket's
+	// role. This guards the mergeUpdateKVMetadata asymmetry: it preserves
+	// the live component, so before == after and no action is emitted.
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) {
+			c.Metadata[MarkerComponentKey] = ComponentPartitionSource // mismatched
+		}),
+	}
+	plan := planWith(t, cfg, streams)
+	require.Empty(t, updateKVActions(plan),
+		"component drift alone is immutable; update-kv must not re-label the bucket")
+	var immutable bool
+	for _, d := range plan.Drift {
+		if d.Name == "parti-election" && d.Severity == SeverityDriftImmutable {
+			immutable = true
+		}
+	}
+	require.True(t, immutable, "component drift still surfaces a drift-immutable finding")
+}
+
+func TestPlanEmission_SafeUpdate_InSyncBucket_NoUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(),
+	}
+	require.Empty(t, updateKVActions(planWith(t, cfg, streams)))
+}
+
+func TestPlanEmission_Warn_NoUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyWarn)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) { c.MaxAge = 99 * time.Second }),
+	}
+	require.Empty(t, updateKVActions(planWith(t, cfg, streams)))
+}
+
+func TestPlanEmission_Adopt_NoUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicyAdopt)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) { c.MaxAge = 99 * time.Second }),
+	}
+	require.Empty(t, updateKVActions(planWith(t, cfg, streams)))
+}
+
+func TestPlanEmission_SafeUpdate_BeforePreservesLiveDescriptionAndComponent(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) {
+			c.MaxAge = 99 * time.Second
+			c.Description = "owned by team X"
+			c.MaxBytes = 4096
+			c.Metadata[MarkerComponentKey] = ComponentPartitionSource // mismatched
+		}),
+	}
+	actions := updateKVActions(planWith(t, cfg, streams))
+	require.Len(t, actions, 1)
+	res, ok := actions[0].Resource.(*UpdateKVResource)
+	require.True(t, ok)
+	require.Equal(t, "owned by team X", res.After.Description)
+	require.Equal(t, int64(4096), res.After.MaxBytes)
+	require.Equal(t, ComponentPartitionSource, res.After.Metadata[MarkerComponentKey],
+		"update-kv preserves a mismatched live component verbatim")
+}
+
+func TestPlanEmission_Determinism_CreateKVSortsBeforeUpdateKV(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	// election exists with drift (-> update-kv); the rest are missing
+	// (-> create-kv). Sort is (Kind, Name); "create-kv" < "update-kv".
+	streams := map[string]jetstream.StreamConfig{
+		"KV_parti-election": electionStream(func(c *jetstream.StreamConfig) { c.MaxAge = 99 * time.Second }),
+	}
+	plan := planWith(t, cfg, streams)
+	require.NotEmpty(t, plan.Actions)
+	seenUpdate := false
+	for _, a := range plan.Actions {
+		if a.Kind == ActionUpdateKV {
+			seenUpdate = true
+		}
+		if a.Kind == ActionCreateKV {
+			require.False(t, seenUpdate, "all create-kv actions must sort before any update-kv")
+		}
+	}
+}
+
+// --- apply, seam-based -------------------------------------------------------
+
+// fakeStreamReader / fakeKVUpdater drive applyUpdateKVAction deterministically.
+type fakeStreamReader struct {
+	cfg jetstream.StreamConfig
+	err error
+}
+
+func (r fakeStreamReader) StreamInfo(_ context.Context, _ string) (*jetstream.StreamInfo, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return &jetstream.StreamInfo{Config: r.cfg}, nil
+}
+
+type fakeKVUpdater struct {
+	err    error
+	called bool
+	got    jetstream.KeyValueConfig
+}
+
+func (u *fakeKVUpdater) UpdateKeyValue(_ context.Context, cfg jetstream.KeyValueConfig) error {
+	u.called = true
+	u.got = cfg
+
+	return u.err
+}
+
+func electionUpdateAction(before jetstream.KeyValueConfig) PlannedAction {
+	return PlannedAction{
+		Kind:     ActionUpdateKV,
+		Name:     "parti-election",
+		Resource: &UpdateKVResource{Before: before, After: before},
+	}
+}
+
+func cpSpecsFor(t *testing.T, cfg Config) map[string]controlPlaneSpec {
+	t.Helper()
+	m := map[string]controlPlaneSpec{}
+	for _, s := range buildControlPlaneSpecs(*cfg.ControlPlane) {
+		m[s.bucket] = s
+	}
+
+	return m
+}
+
+func TestApplyUpdateKV_StaleBefore_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	before := streamConfigToKVConfig(electionStream())
+	// Re-read returns a TTL differing from Before -> stale.
+	reader := fakeStreamReader{cfg: electionStream(func(c *jetstream.StreamConfig) {
+		c.MaxAge = 999 * time.Second
+	})}
+	updater := &fakeKVUpdater{}
+
+	_, err := applyUpdateKVAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), electionUpdateAction(before))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stale-before")
+	require.False(t, updater.called, "no write on stale-before")
+}
+
+func TestApplyUpdateKV_NoOpConvergence_RacedTrueNoWrite(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	// A genuinely emitted action: Before carries the stale plan-time TTL,
+	// After the desired one. Before != After is what the plan gate
+	// guarantees for any emitted update-kv.
+	before := streamConfigToKVConfig(electionStream(func(c *jetstream.StreamConfig) {
+		c.MaxAge = 99 * time.Second
+	}))
+	after := streamConfigToKVConfig(electionStream())
+	require.False(t, kvConfigsEqual(before, after), "test needs a genuine Before != After")
+
+	// A concurrent operator converged the bucket to the desired state
+	// between Plan and Apply: the re-read live equals the target but
+	// differs from Before. This must be a raced success, not stale-before.
+	reader := fakeStreamReader{cfg: electionStream()}
+	updater := &fakeKVUpdater{}
+	action := PlannedAction{
+		Kind:     ActionUpdateKV,
+		Name:     "parti-election",
+		Resource: &UpdateKVResource{Before: before, After: after},
+	}
+
+	executed, err := applyUpdateKVAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), action)
+	require.NoError(t, err)
+	require.True(t, executed.Raced, "bucket already at the target is a raced success")
+	require.False(t, updater.called, "no write when already converged")
+}
+
+func TestApplyUpdateKV_MissingOnReread_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	before := streamConfigToKVConfig(electionStream())
+	reader := fakeStreamReader{err: jetstream.ErrStreamNotFound}
+	updater := &fakeKVUpdater{}
+
+	_, err := applyUpdateKVAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), electionUpdateAction(before))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bucket-missing-before-update")
+	require.False(t, updater.called)
+}
+
+func TestApplyUpdateKV_MissingOnWrite_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	// Live drifts on TTL (so a write is needed) but matches Before.
+	live := electionStream(func(c *jetstream.StreamConfig) { c.MaxAge = 99 * time.Second })
+	before := streamConfigToKVConfig(live)
+	reader := fakeStreamReader{cfg: live}
+	updater := &fakeKVUpdater{err: jetstream.ErrBucketNotFound}
+
+	_, err := applyUpdateKVAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), electionUpdateAction(before))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bucket-missing-before-update")
+	require.True(t, updater.called)
+}
+
+func TestApplyUpdateKV_HappyPath_WritesTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	live := electionStream(func(c *jetstream.StreamConfig) { c.MaxAge = 99 * time.Second })
+	before := streamConfigToKVConfig(live)
+	reader := fakeStreamReader{cfg: live}
+	updater := &fakeKVUpdater{}
+
+	executed, err := applyUpdateKVAction(context.Background(), reader, updater, cfg,
+		cpSpecsFor(t, cfg), electionUpdateAction(before))
+	require.NoError(t, err)
+	require.False(t, executed.Raced)
+	require.True(t, updater.called)
+	require.Equal(t, 10*time.Second, updater.got.TTL, "write target carries the desired TTL")
+}
+
+func TestApplyUpdateKV_WrongResourceType_FailsFast(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	action := PlannedAction{Kind: ActionUpdateKV, Name: "parti-election", Resource: "not-a-resource"}
+	_, err := applyUpdateKVAction(context.Background(), fakeStreamReader{cfg: electionStream()},
+		&fakeKVUpdater{}, cfg, cpSpecsFor(t, cfg), action)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong Resource type")
+}
+
+func TestApplyUpdateKV_CancelledReread_PropagatesCancellation(t *testing.T) {
+	t.Parallel()
+
+	cfg := cpUpdateCfg(PolicySafeUpdate)
+	before := streamConfigToKVConfig(electionStream())
+	reader := fakeStreamReader{err: context.Canceled}
+
+	_, err := applyUpdateKVAction(context.Background(), reader, &fakeKVUpdater{}, cfg,
+		cpSpecsFor(t, cfg), electionUpdateAction(before))
+	require.True(t, errors.Is(err, context.Canceled))
+}

--- a/provision/validate.go
+++ b/provision/validate.go
@@ -17,8 +17,9 @@ var ErrInvalidConfig = errors.New("provision: invalid config")
 // spec):
 //
 //   - APIVersion must equal APIVersionV1.
-//   - Policy defaults to PolicyWarn when empty; "safe-update" and "force"
-//     are rejected as not-supported-in-v1.
+//   - Policy defaults to PolicyWarn when empty; PolicyWarn, PolicyAdopt,
+//     and PolicySafeUpdate are accepted. "force" is rejected as not yet
+//     supported.
 //   - ControlPlane bucket name fields default to runtime defaults; any
 //     bucket name still empty after defaulting is rejected.
 //   - ControlPlane.WorkerIDTTL, .ElectionTimeout, .HeartbeatTTL must be > 0.
@@ -26,6 +27,9 @@ var ErrInvalidConfig = errors.New("provision: invalid config")
 //   - When ControlPlane.EnableTwoPhaseHandoff is true, HandoffTTL must be > 0.
 //     This keeps the coordinator's advisory sweep TTL positive; it does NOT set
 //     the handoff bucket's MaxAge (the handoff bucket is provisioned with none).
+//   - ControlPlane.Replicas must be >= 0. Zero means server default;
+//     non-zero values are drift-mutable under safe-update and the server
+//     enforces feasibility at apply time.
 //
 // PartitionSource static validation is active (W3): Bucket, Key, Storage,
 // Replicas, MaxValueSize, and TTL are all validated. DynamicConsumers deeper
@@ -111,20 +115,15 @@ func normalize(cfg Config) (Config, error) {
 }
 
 func validateResolved(cfg Config) error {
-	// Policy: reject reserved-future values by string match; anything else
-	// not PolicyWarn is also rejected.
 	switch string(cfg.Policy) {
-	case string(PolicyWarn):
+	case string(PolicyWarn), string(PolicyAdopt), string(PolicySafeUpdate):
 		// ok
-	case reservedPolicySafeUpdate:
-		return fmt.Errorf("%w: policy %q is not supported in v1 (lands in Phase 2)",
-			ErrInvalidConfig, reservedPolicySafeUpdate)
 	case reservedPolicyForce:
-		return fmt.Errorf("%w: policy %q is not supported in v1 (lands in Phase 6)",
+		return fmt.Errorf("%w: policy %q is not yet supported",
 			ErrInvalidConfig, reservedPolicyForce)
 	default:
-		return fmt.Errorf("%w: policy %q is not recognized (v1 supports only %q)",
-			ErrInvalidConfig, cfg.Policy, PolicyWarn)
+		return fmt.Errorf("%w: policy %q is not recognized (supported: %q, %q, %q)",
+			ErrInvalidConfig, cfg.Policy, PolicyWarn, PolicyAdopt, PolicySafeUpdate)
 	}
 
 	if cfg.ControlPlane != nil {
@@ -210,6 +209,11 @@ func validateControlPlane(cp ControlPlaneConfig) error {
 	if cp.EnableTwoPhaseHandoff && cp.HandoffTTL <= 0 {
 		return fmt.Errorf("%w: controlPlane.handoffTtl must be > 0 when enableTwoPhaseHandoff is true",
 			ErrInvalidConfig)
+	}
+	// Replicas: 0 means "server default" (nats.go normalizes to 1); negative
+	// values are rejected. No upper bound here — the server enforces feasibility.
+	if cp.Replicas < 0 {
+		return fmt.Errorf("%w: controlPlane.replicas must be >= 0", ErrInvalidConfig)
 	}
 
 	return nil

--- a/provision/validate.go
+++ b/provision/validate.go
@@ -31,9 +31,9 @@ var ErrInvalidConfig = errors.New("provision: invalid config")
 //     non-zero values are drift-mutable under safe-update and the server
 //     enforces feasibility at apply time.
 //
-// PartitionSource static validation is active (W3): Bucket, Key, Storage,
-// Replicas, MaxValueSize, and TTL are all validated. DynamicConsumers deeper
-// validation lands in W4.
+// PartitionSource static validation covers Bucket, Key, Storage, Replicas,
+// MaxValueSize, and TTL. DynamicConsumers deeper static validation is not yet
+// implemented.
 func Validate(cfg Config) error {
 	resolved, err := normalize(cfg)
 	if err != nil {
@@ -138,7 +138,7 @@ func validateResolved(cfg Config) error {
 		}
 	}
 
-	// DynamicConsumers: deeper validation lands in W4.
+	// DynamicConsumers: deeper static validation is not yet implemented.
 	return nil
 }
 

--- a/provision/validate_live.go
+++ b/provision/validate_live.go
@@ -71,8 +71,7 @@ func ValidateLive(ctx context.Context, js jetstream.JetStream, cfg Config) (Repo
 		return liveErrorReport("reachability", "$JS.API.INFO", err), fmt.Errorf("provision: validatelive: reachability: %w", err)
 	}
 
-	// Step 1.C: per-bucket info probes (control-plane block; W3 adds
-	// partition-source bucket info probe in this slot).
+	// Step 1.C: per-bucket info probes (control-plane and partition-source).
 	if cfg.ControlPlane != nil {
 		specs := buildControlPlaneSpecs(*cfg.ControlPlane)
 		for _, spec := range specs {
@@ -98,9 +97,9 @@ func ValidateLive(ctx context.Context, js jetstream.JetStream, cfg Config) (Repo
 		}
 	}
 
-	// Step 4 (W4) — dynamic-consumer live checks. Only runs when the caller
-	// declared one or more dynamic-consumer alignment targets. A failure here
-	// is a config-mismatch (WorkQueuePolicy + incompatible recovery strategy),
+	// Dynamic-consumer live checks. Only runs when the caller declared one or
+	// more dynamic-consumer alignment targets. A failure here is a
+	// config-mismatch (WorkQueuePolicy + incompatible recovery strategy),
 	// so it's surfaced under ErrLiveValidation (CLI exit code 3).
 	if len(cfg.DynamicConsumers) > 0 {
 		if err := ValidateLiveDynamicConsumers(ctx, js, cfg.DynamicConsumers); err != nil {
@@ -121,9 +120,9 @@ func ValidateLive(ctx context.Context, js jetstream.JetStream, cfg Config) (Repo
 	}, nil
 }
 
-// probeBucketInfo runs the per-bucket info probe described in sub-spec §1.C.
-// Returns nil on success or on ErrStreamNotFound (the bucket is creatable);
-// otherwise classifies the error per §1.E.
+// probeBucketInfo probes live stream info for the named KV bucket.
+// Returns nil on success or on ErrStreamNotFound (bucket is creatable);
+// otherwise classifies the error via classifyLiveError.
 func probeBucketInfo(ctx context.Context, js jetstream.JetStream, bucket string) error {
 	stream, err := js.Stream(ctx, kvStreamPrefix+bucket)
 	if err != nil {
@@ -151,7 +150,7 @@ func probePartitionSourceKey(ctx context.Context, js jetstream.JetStream, ps Par
 	if err != nil {
 		if errors.Is(err, jetstream.ErrStreamNotFound) {
 			// Bucket does not exist live; the key probe is vacuously OK.
-			// (Apply or W3 will create the bucket.)
+			// Apply will create the bucket.
 			return nil
 		}
 		return classifyLiveError(ctx, err)

--- a/provision/validate_test.go
+++ b/provision/validate_test.go
@@ -60,12 +60,18 @@ func TestValidate_TableDriven(t *testing.T) {
 			errSubstr: "apiVersion",
 		},
 		{
-			name: "policy_safe_update_rejected",
+			name: "policy_safe_update_accepted",
 			mutate: func(c *provision.Config) {
-				c.Policy = "safe-update"
+				c.Policy = provision.PolicySafeUpdate
 			},
-			wantErr:   true,
-			errSubstr: "safe-update",
+			wantErr: false,
+		},
+		{
+			name: "policy_adopt_accepted",
+			mutate: func(c *provision.Config) {
+				c.Policy = provision.PolicyAdopt
+			},
+			wantErr: false,
 		},
 		{
 			name: "policy_force_rejected",
@@ -89,6 +95,28 @@ func TestValidate_TableDriven(t *testing.T) {
 				c.Policy = provision.PolicyWarn
 			},
 			wantErr: false,
+		},
+		{
+			name: "control_plane_replicas_zero_accepted",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.Replicas = 0
+			},
+			wantErr: false,
+		},
+		{
+			name: "control_plane_replicas_positive_accepted",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.Replicas = 3
+			},
+			wantErr: false,
+		},
+		{
+			name: "control_plane_replicas_negative_rejected",
+			mutate: func(c *provision.Config) {
+				c.ControlPlane.Replicas = -1
+			},
+			wantErr:   true,
+			errSubstr: "controlPlane.replicas",
 		},
 		{
 			name: "zero_workerid_ttl_rejected",

--- a/provision/view.go
+++ b/provision/view.go
@@ -15,7 +15,7 @@ const kvStreamPrefix = "KV_"
 // View returns a Snapshot of every Parti-marked NATS resource visible to js,
 // filtered by scope.
 //
-// In v1 the implementation walks $JS.API.STREAM.LIST (via jetstream.ListStreams)
+// The implementation walks $JS.API.STREAM.LIST (via jetstream.ListStreams)
 // once, filters for KV streams (Name starts with "KV_"), and reads
 // stream.Config.Metadata to decide which buckets are Parti-managed. Unmarked
 // buckets are excluded from default View output.
@@ -35,8 +35,8 @@ func View(ctx context.Context, js jetstream.JetStream, scope Scope) (Snapshot, e
 		DynamicConsumers: []ConsumerState{},
 	}
 
-	// Short-circuit: nothing to do if no KV kinds are requested. (The
-	// W1 scope never has DynamicConsumers populated; that lands in W4.)
+	// Short-circuit: nothing to do if no KV kinds are requested.
+	// DynamicConsumers is not yet populated by View.
 	if !scope.ControlPlane && !scope.PartitionSource {
 		return snap, nil
 	}
@@ -67,8 +67,7 @@ func View(ctx context.Context, js jetstream.JetStream, scope Scope) (Snapshot, e
 		// and unknown forward-compat values both surface under
 		// ControlPlane (operators don't lose visibility of new
 		// components). PartitionSource has its own slot. Anything else
-		// (dynamic-consumer, future categories) is dropped in W1 and
-		// will land in its own switch case in W4.
+		// (dynamic-consumer, future categories) is silently dropped.
 		switch state.Component {
 		case ComponentPartitionSource:
 			if scope.PartitionSource {


### PR DESCRIPTION
## Summary

Phase 2 of the provision SDK and `partictl` CLI ("Safe Update + Adopt").
It adds the non-destructive half of the reconcile surface: in-place
field updates and ownership adoption. Destructive repair stays out of
scope (a future `force` policy).

- **`safe-update` policy** — creates missing buckets and reconciles
  drift-mutable fields in place on Parti-marked buckets via
  `UpdateKeyValue`: `Metadata`, `TTL`, `MaxValueSize` (partition-source),
  and `Replicas`. `History`/`Storage` stay drift-immutable;
  `Description`/`MaxBytes` are preserved-from-live.
- **`adopt` policy + `partictl adopt`** — stamps the Parti ownership
  marker on config-named buckets that exist live but are unmarked,
  preserving every non-Parti metadata key and every non-metadata field.
  A missing bucket surfaces as an informational finding (adopt never
  creates).
- **`controlPlane.replicas`** — declare a non-default replica count for
  control-plane KV buckets; the NATS server enforces cluster-peer
  feasibility at apply time.
- **CLI** — `--policy` flag on `apply`/`plan` with strict flag-vs-config
  conflict rejection (no silent override); `partictl adopt -f [-dry-run]`.
- New additive action kinds `update-kv` / `stamp-marker` (JSON envelope
  stays `parti.io/provision/v1`); new operator guide `docs/PROVISION.md`.

### Notable scope decision

The original brief listed `Description`/`MaxBytes` as safe-update
targets, but neither has a YAML field — a "safe" update that wiped an
operator-set value would be destructive. They are now preserved-from-live:
inherited verbatim from the live bucket on every `update-kv`. Adding YAML
fields for them is a possible future increment.

### Safety contracts

- Adoption is not approval of the bucket's config — the next `plan`
  reveals field drift, including immutable drift.
- `UpdateStream` has no compare-and-swap; `update-kv` does a best-effort
  stale-before check, but concurrent operators are last-writer-wins.
  Documented in `docs/PROVISION.md`.
- Control-plane byte-equivalence to `manager_setup.go` is preserved when
  `controlPlane.replicas == 0`; only that field deviates when set.

The design plan and three sub-specs cleared external architectural
review (multiple rounds) and each work item cleared an external
post-implementation review.

## Test plan

- [ ] `make lint` — 0 issues
- [ ] `make test` — full suite green (provision 86.7%, partictl 80.1% coverage)
- [ ] Per-field `safe-update` reconcile (TTL, Metadata, MaxValueSize, Replicas) converges; re-plan reports `informational`
- [ ] `Description`/`MaxBytes` set out-of-band survive a `safe-update`
- [ ] `adopt` stamps the marker; non-Parti metadata and non-metadata fields unchanged; idempotent on re-run
- [ ] `update-kv` stale-before fail-fast, no-op convergence, and missing-bucket fail-fast
- [ ] Replicas bump against an undersized cluster fails fast
- [ ] CLI `--policy` vs `cfg.policy` conflict exits 3; `adopt -dry-run` byte-identical to `plan --policy=adopt`
- [ ] `warn`-policy behavior unchanged from v1