### PR TITLE
self-healing: phases 0–1 + 4 of 6 Phase-2 fixes (10 PRs + 1 follow-up)

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,44 @@ type KVBucketConfig struct {
 	// retries). Recommended: 2-5 minutes in production; fast tests may use
 	// seconds.
 	HandoffTTL time.Duration `yaml:"handoffTtl" default:"2m"`
+
+	// Replicas is the JetStream stream-replication factor applied to
+	// Parti-owned KV buckets when the library creates them fresh. Zero
+	// (the default) leaves the field unset, which nats.go normalizes to 1
+	// server-side — equivalent to no replication, the legacy behavior.
+	//
+	// Not to be confused with worker-pod replicas: Parti does not
+	// configure pod counts (that is the orchestrator's concern). This
+	// setting controls JetStream-level data replication only.
+	//
+	// Applies uniformly to every Parti-owned bucket the library creates
+	// (stableID, election, heartbeat, assignment, handoff). Per-bucket
+	// precision requires pre-creating buckets with explicit configs (the
+	// provision package supports this) — pre-created buckets keep their
+	// existing replica count regardless of this setting, because the
+	// library's ensure path is get-first.
+	//
+	// Post-create modification: NATS JetStream DOES support changing the
+	// replica count on an existing bucket via `UpdateStream`, but Parti
+	// does NOT auto-reconcile Replicas. Unlike MaxAge (which is reconciled
+	// because it carries a correctness invariant), Replicas is a
+	// per-deployment HA-quality decision; silently rewriting an existing
+	// bucket's Replicas could trigger expensive cross-node replication
+	// the operator did not ask for, or mask a deliberate downsize. When
+	// Manager.Start observes a pre-existing bucket whose Replicas differs
+	// from this setting, it emits a WARN log line naming the divergence
+	// and pointing at the `nats stream update KV_<bucket> --replicas=<N>`
+	// command operators can run to apply the change themselves.
+	//
+	// Cluster topology must support the value at create time or bucket
+	// creation fails loudly at Manager.Start (e.g. Replicas=3 against a
+	// single-node NATS server returns a stream-creation error).
+	//
+	// Recommended values:
+	//   - 0 / 1 — single-node NATS or test environments (default)
+	//   - 3   — production multi-node cluster (minimum for quorum)
+	//   - 5   — high-availability tier
+	Replicas int `yaml:"replicas,omitempty" default:"0" validate:"gte=0"`
 }
 
 // HandoffConfig controls two-phase handoff coordinator behavior.

--- a/doc.go
+++ b/doc.go
@@ -27,6 +27,10 @@
 //
 //	partitions := []parti.Partition{{Keys: []string{"0"}}, {Keys: []string{"1"}}, {Keys: []string{"2"}}}
 //	src := source.NewStatic(partitions)
+//	// Connect with MaxReconnects(-1) so the client rides through transient
+//	// NATS outages instead of going CLOSED. See docs/OPERATIONS.md
+//	// "NATS Client Connection" for the full posture.
+//	natsConn, _ := nats.Connect(natsURL, nats.MaxReconnects(-1), nats.RetryOnFailedConnect(true))
 //	js, _ := jetstream.New(natsConn)
 //	assignmentStrategy := strategy.NewConsistentHash()
 //	mgr, _ := parti.NewManager(&cfg, js, src, assignmentStrategy)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -69,6 +69,49 @@ cluster {
 }
 ```
 
+### NATS Client Connection
+
+Parti expects the caller-owned `*nats.Conn` to be configured to ride
+through transient NATS outages. The library's recovery design assumes
+the connection eventually reconnects; a connection that gives up turns
+a transient outage into a permanent `CLOSED` zombie that the manager's
+connection monitor then escalates into degraded mode and pod rotation.
+
+**Recommended posture:**
+
+```go
+nc, err := nats.Connect(natsURL,
+    // Unlimited reconnect budget — required for the library's
+    // recovery design. A finite cap will WARN at Manager.Start
+    // and, on a sustained outage, force degraded mode + pod
+    // rotation.
+    nats.MaxReconnects(-1),
+
+    // Spread reconnect attempts and add jitter so a NATS outage
+    // does not produce a thundering herd of synchronized reconnects
+    // when service is restored.
+    nats.ReconnectWait(2*time.Second),
+    nats.ReconnectJitter(500*time.Millisecond, 2*time.Second),
+
+    // Tolerate NATS startup races — return success once the client
+    // is connected, even if the first dial attempt failed.
+    nats.RetryOnFailedConnect(true),
+)
+```
+
+**Why `MaxReconnects(-1)` is required.** With a finite cap, the
+`*nats.Conn` exhausts its reconnect budget on a sustained outage and
+goes `CLOSED`. The Parti manager's connection monitor detects this
+and enters degraded mode (`OnDegraded` fires; readiness probe trips
+on the next health check) — the pod then rotates, which is more
+disruptive than letting the client reconnect. The library emits a
+`Warn`-level log line at `Manager.Start` if `MaxReconnect` is not
+negative; the warning is informational only, not blocking.
+
+**Other knobs.** `nats.Name(...)`, `nats.UserCredentials(...)`,
+`nats.RootCAs(...)`, etc. are orthogonal to the recovery posture —
+configure as your environment requires.
+
 ### KV Bucket Pre-Creation (Optional)
 
 Parti auto-creates KV buckets, but you can pre-create them for custom settings:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -578,6 +578,70 @@ Automatic process:
 
 **Recovery time:** ~2-3 heartbeat intervals (10-15s default)
 
+### Election Bucket Storage Migration
+
+The election bucket's storage type changed from `MemoryStorage` to
+`FileStorage` so the leadership lease key survives a NATS node
+restart. Previously, every NATS node restart lost the lease and
+triggered fleet-wide leadership churn.
+
+**Existing clusters need a one-time bucket replacement** because
+`EnsureKVBucketWithRetry` is get-first — it does not upgrade an
+existing `MemoryStorage` bucket to `FileStorage`.
+
+Pre-flight: confirm the F1 epoch fence is in your build (look in
+release notes, or check operational logs for `bucket-recreated`
+warn entries — any prior occurrence confirms the fence is wired).
+The fence is the migration's safety net.
+
+Migration steps, during a planned maintenance window:
+
+```bash
+# 1. Delete the bucket (this also removes the backing KV_<bucket> stream).
+nats kv rm parti-<cluster>-election
+
+# 2. Paranoia check — confirm the backing stream is gone.
+nats stream ls | grep KV_parti-<cluster>-election  # expect no output
+
+# 3. Recreate with the desired replica count (recommended: 3 in a
+#    multi-node cluster). The new bucket MUST be FileStorage; this
+#    matches what the runtime creates on a fresh deploy.
+nats kv add parti-<cluster>-election --replicas=3 --storage=file
+
+# 4. Rolling restart of Parti workers (any order is fine).
+```
+
+Workers that observed the deletion before their own restart enter
+degraded mode via the F1 epoch fence (reason
+`bucket-recreated:parti-<cluster>-election`); the existing
+`OnDegraded → readiness probe → pod rotation` path completes the
+migration automatically.
+
+Post-migration verification:
+
+```bash
+nats kv info parti-<cluster>-election | grep -i storage  # expect "File"
+```
+
+After the migration a single-node restart in a 3-replica cluster
+no longer causes leadership churn.
+
+### Tuning OperationTimeout vs ElectionTimeout
+
+The leader's renew loop has three attempts within `ElectionTimeout`
+to refresh the lease; each attempt's timeout is `OperationTimeout`.
+If `OperationTimeout > ElectionTimeout / 3`, a single slow renew
+can consume the entire lease budget and produce a false leadership
+flip. The library logs a one-shot WARN at `Manager.Start` when this
+ratio is exceeded. The recommended posture:
+
+```
+OperationTimeout <= ElectionTimeout / 3
+```
+
+At the default pair (both 10s) the warning fires; in production
+prefer something like `OperationTimeout=3s, ElectionTimeout=10s`.
+
 ### NATS Cluster Maintenance
 
 When performing NATS maintenance:

--- a/docs/plans/self-healing/00-fix-plan.md
+++ b/docs/plans/self-healing/00-fix-plan.md
@@ -1,0 +1,1695 @@
+# Self-Healing Hardening — Phased Implementation Plan
+
+Derived from [`findings.md`](./findings.md) (reviewed clean across 9 rounds;
+trail in [`review-trail.md`](./review-trail.md); do not re-investigate). This
+document turns the ten findings into a sequenced per-PR plan organized by the
+phases recorded in the findings doc's §8.
+
+## Organizing invariant
+
+**Every unrecoverable failure must trip the Kubernetes readiness probe.**
+
+Deployment is k8s with `OnDegraded → readiness probe → pod rotation`
+(review §2). A finding's danger is its readiness blindness — a worker that stays
+`Ready` while silently broken defeats the recovery design. Each per-PR section
+states *how this trips readiness* in one line so the engineer can lose neither
+sight of the invariant nor of the deployment context that justifies it.
+
+## Resolved decisions (do not re-litigate)
+
+1. **Plan shape** — phased; one finding per PR; F2 split further to one PR per
+   retry loop. Per-PR specs are written **lazily**, only when the prior PR is
+   merge-clean (mirrors `docs/plans/worker-state-hardening/README.md` — avoids
+   speculative spec drift).
+2. **F4 stays optional, off by default** — likely dropped given F9-A subsumes
+   the election-bucket case.
+3. **F9 split** — F9-A primary (one-line `MemoryStorage → FileStorage R≥3`),
+   F9-B deferred. F9-A depends on F1.
+4. **Public hooks added** — `OnStreamMissing` (F5) and `OnSourceUnavailable`
+   (F6-A); plus the F6-B behavioural requirement (leader retains cached
+   partition list; no fleet-wide reassignment on empty / shrunk non-erroring
+   source observation).
+5. **F6-B implementation location** — **calculator-layer** (see F6-B §Design
+   for the trade-off vs source-layer).
+6. **F10-A is gated on a chaos reproducer first**. Truncated `Keys()` ordered
+   consumer drop scenario must be empirically reproduced before any fix lands.
+7. **F2 envelope** lands with the first call-site wiring (emerging-helper
+   convention); subsequent F2 PRs reuse.
+
+## Implementation discipline (applies to every PR)
+
+The discipline below is stated once and assumed in every per-PR section.
+
+1. **One finding per PR.** Bundle nothing. F2 is itself split — one PR per
+   retry loop.
+2. **Reproducer-first.** For every finding marked *reproducer required*, write
+   the failing test, confirm it fails on the parent commit, then implement.
+   Memory pin: `feedback_verify_first_with_reproducer`. For F10-A specifically,
+   the chaos reproducer is a hard gate — no fix until the truncated `Keys()`
+   read is empirically observed.
+3. **Validation loop per PR.** Spec → impl → `/simplify` → `/post-impl-review`
+   loop → squash on merge verdict (memory pin:
+   `feedback_post_impl_review_workflow`). External-reviewer dispatch via
+   `/codex:review` first; fall back to `copilot` only on codex failure
+   (memory pin: `feedback_codex_review_preferred`).
+4. **Lint + build + test must be green before the next PR begins.** No
+   "I'll fix this in the next PR" cross-PR carry-overs. The plan tolerates the
+   per-PR cost; it does not tolerate compounding debt.
+5. **No drive-by refactors.** Each PR touches only what its finding requires.
+   A recovery-controller consolidation is a separate, future effort — do not
+   fold it in here.
+6. **Commit-message hygiene.** Plan body uses `F1 / F9-A / Phase 2` labels
+   freely; **derived commits and PR titles MUST NOT** (memory pin:
+   `feedback_no_plan_jargon_in_commits`). A reader of `git log` lacks this
+   plan's context.
+7. **Implementation-agent + review-effort tuning.** Model recommendations
+   are stated in version-neutral terms so the guidance survives model
+   renames:
+   - **Use the strongest available Claude model** (today: Opus-tier) for
+     any PR that (a) carries a `MED–HIGH` or `HIGH` change-risk rating in
+     the table below, (b) introduces new state on the `Calculator` struct,
+     (c) introduces new ordering or sentinel contracts in the recovery
+     controller, OR (d) requires a chaos reproducer. The escalation
+     list this produces for this plan: **P1.3 (F1), P2.1 (F9-A),
+     P2.2 (F6-B), P2.4a (F2 envelope), P2.4d (F2 partition_consumer),
+     P2.3 (F5), P2.5 (F10-A)**. P2.1 escalates not for code complexity
+     but because the migration runbook is operator-facing and ships
+     with the PR.
+   - **Use the standard tier** (today: Sonnet-tier) on `LOW`/`MED`
+     change-risk PRs that are mechanically bounded: P0.1, P0.2, P0.3,
+     P1.1, P1.2, P2.4b, P2.4c.
+   - **Post-impl review effort** follows the AGENTS.md convention plus
+     the change-risk column: every PR in the escalation list above runs
+     `/codex:review` at `xhigh`; every other in-scope PR runs at
+     `high`. F2 PRs after P2.4a (the envelope-introduction PR) run at
+     `high` once P2.4a has locked the envelope shape at `xhigh`.
+
+## Phased PR sequence
+
+Numbers (e.g. `P0.1`) are stable identifiers used in the per-finding sections
+below. They are **not** commit-message labels.
+
+The `Tier` column is a version-neutral model recommendation per the
+heuristic in discipline rule 7 above: **strong** = use the strongest
+available Claude model (today Opus-tier); **standard** = standard tier
+(today Sonnet-tier). The `Review` column is the `/codex:review` effort
+for that PR's post-impl review.
+
+| Order | ID | Finding | Impact | Change risk | Reproducer required | Tier | Review | Notes |
+|---|---|---|---|---|---|---|---|---|
+| P0.1 | F7 | Connection-config docs + startup warning | LOW–MED | **LOW** | no | standard | `high` | Warm-up; docs + read-only warning |
+| P0.2 | F8 | `source.WithReconcileInterval(0)` guard | LOW | **LOW** | no | standard | `high` | Godoc + optional config warning |
+| P0.3 | F10-B | Two-phase config diagnostic warning | MED | **LOW** | no | standard | `high` | Warning at first two-phase apply (NOT at `Start`) |
+| P1.1 | F6-A | Source-bucket escalation hook | MED | LOW–MED | yes | standard | `high` | `OnSourceUnavailable` hook + metric |
+| P1.2 | F3 | stableID NotFound classification | MED–HIGH | **MED** | yes | standard | `high` | Small surface; changes self-stop trigger |
+| P1.3 | F1 | Epoch fence (bucket re-create detection) | **HIGH** | **MED** | yes | **strong** | `xhigh` | **Prerequisite for F9-A migration** |
+| P2.1 | F9-A | Election bucket → `FileStorage` R≥3 + `OperationTimeout` warning | MED–HIGH | **LOW** | yes | **strong** | `xhigh` | Depends on F1; operator-facing migration runbook |
+| P2.2 | F6-B | Calculator-layer "minimum credible partition input" guard | **HIGH** | **MED** | yes | **strong** | `xhigh` | New `Calculator` state; symmetric with F10-A |
+| P2.4a | F2 | Bounded-retry envelope + `restartWatcher` wiring | MED–HIGH | **MED–HIGH** | yes | **strong** | `xhigh` | Envelope crystallises; locks shape for 3 reuse PRs |
+| P2.4b | F2 | Apply envelope to `claim_resolver.go` handoff watcher | MED–HIGH | **MED–HIGH** | yes | standard | `high` | Reuses envelope from P2.4a |
+| P2.4c | F2 | Apply envelope to `monitorAssignmentChanges` | MED–HIGH | **MED–HIGH** | yes | standard | `high` | Reuses envelope from P2.4a |
+| P2.4d | F2 | Apply envelope to `partition_consumer.go` recovery | MED–HIGH | **MED–HIGH** | yes | **strong** | `xhigh` | Larger surface; **prerequisite for P2.3** |
+| P2.3 | F5 | Stream-gone hook + checkpoint reset | **HIGH** | **MED** | yes | **strong** | `xhigh` | Three coordinated mechanisms; depends on P2.4d |
+| P2.5 | F10-A | Truncated-`Keys()` defense + worker-set floor | **HIGH** | **MED** | **yes — chaos test FIRST** | **strong** | `xhigh` | Hard gate — no fix until reproducer reproduces |
+| P3.1 | F9-B | Lease-aware leader (DEFERRED) | LOW–MED post-F9-A | **HIGH** | yes | tbd | tbd | Gated; re-evaluate at re-promotion |
+| P3.2 | F4 | In-process re-provision of coordination buckets (OPTIONAL) | LOW–MED on k8s | **HIGH** | yes | tbd | tbd | Gated; likely dropped |
+
+13 in-scope PRs (P0–P2). 2 deferred (P3). After P2 every unrecoverable failure
+trips the readiness probe and the dominant leadership-churn source is gone.
+
+---
+
+## Phase 0 — Low-risk warm-ups
+
+Three additive, behavior-neutral PRs that establish the per-PR rhythm. No
+behavior change; just observability and configuration safety.
+
+### P0.1 (F7) — Connection-config docs + startup warning
+
+**Anchors** (verified against the review doc; re-verify at PR start):
+- `manager.go:258, 410-414` — conn is caller-injected; no callbacks registered
+- `doc.go:30`, `examples/basic/main.go:34` — examples use bare `nats.Connect`
+- `manager_setup.go:387-406` — `warnOnShortAuditGrace` pattern to mirror
+
+**Scope.** Add documentation for the required nats.go connection posture
+(`MaxReconnects = -1`, sane `ReconnectWait`/`ReconnectJitter`,
+`RetryOnFailedConnect`) and, at `Manager.Start`, emit a read-only warning if
+`conn.Opts.MaxReconnects` is finite. No behavior change.
+
+**Design.**
+- Docs: edit `doc.go` package comment, `docs/OPERATIONS.md` (connection
+  section), and the basic example. Document the zombie outcome that finite
+  `MaxReconnects` produces (review §F7).
+- Warning: in `manager_setup.go`, after the existing `warnOnShortAuditGrace`,
+  add a parallel `warnOnFiniteMaxReconnects(m.conn.Opts, m.logger)`. Read-only;
+  emits a `Warn`-level log line; does not block `Start`.
+
+**Reproducer test list.** No reproducer required (no behavior change). One
+unit test for the warning emission (table-driven across `MaxReconnects = -1`,
+0, finite-positive).
+
+**Verification gates.**
+- `make lint && make test` green.
+- Manual: spin a manager with `MaxReconnects = 5` and confirm the warning
+  appears once at `Start`; spin with `-1` and confirm silence.
+- Godoc review: `go doc github.com/arloliu/parti/v2` shows the updated
+  guidance.
+
+**How this trips readiness.** It doesn't directly — but documents the
+posture so finite `MaxReconnects` (which today turns an outage into a stuck
+`CLOSED` zombie that *does* enter degraded mode and rotate the pod) is
+operator-visible and avoidable up front.
+
+**Dependencies & sequencing.** Independent. First PR of Phase 0 because
+it is the smallest no-behavior-change change.
+
+**Out of scope.** Programmatic enforcement (rejecting finite `MaxReconnects`)
+— warning only, per review §F7. Caller's responsibility to fix.
+
+---
+
+### P0.2 (F8) — `source.WithReconcileInterval(0)` guard
+
+**Anchors.**
+- `source/nats_kv.go:50-63, 807-814` — `reconcileLoop` exits on non-positive
+  interval with no leadership probe; only documents "disables polling"
+- `consumer/resolver_config.go:61-63`, `internal/durable/config.go:89` — the
+  **safe** consumer path; do not touch
+- `manager_setup.go:387-406` — `warnOnShortAuditGrace` pattern
+
+**Scope.** Source-only. Either clamp `0` to a minimum + warn, or update Godoc
+to state plainly that disabling the reconciler disables server-restart
+recovery for the source watcher.
+
+**Design — locked.** **Godoc + optional config warning, no rejection.** The
+review doc allows both options; rejection is more disruptive (existing users
+who explicitly disable polling break on upgrade), and the safer route is to
+make the foot-gun loud:
+- Update `WithReconcileInterval`'s Godoc to add a paragraph naming the
+  consequence: "Setting this to zero disables the reconciler, which is the
+  load-bearing recovery path for silently-stalled KV watchers after a NATS
+  server restart (see `test/integration/failure/claim_resolver_nats_restart_test.go`
+  and review §3 'load-bearing reconciler'). Disable only with full awareness."
+- At source `Start`, if `s.reconcileInterval <= 0` AND no leadership probe is
+  set, emit a warn-level log line ("source reconciler disabled; server-restart
+  recovery will not work").
+
+**Reproducer test list.** No correctness reproducer. One unit test for the
+warning (interval=0 emits, interval>0 silent).
+
+**Verification gates.**
+- `make lint && make test` green.
+- Godoc lint: `go doc github.com/arloliu/parti/v2/source.WithReconcileInterval`
+  shows the new paragraph.
+
+**How this trips readiness.** Indirect: documents that the foot-gun creates a
+readiness-blind silent stall so operators avoid it.
+
+**Dependencies & sequencing.** Independent. Sequenced after P0.1 only
+because the warning helper pattern (mirrors P0.1's) is more familiar
+once P0.1 has landed.
+
+**Out of scope.** Touching `consumer.ResolverConfig` or
+`internal/durable/config.go` — both are already safe (review §F8).
+
+---
+
+### P0.3 (F10-B) — Two-phase config diagnostic warning
+
+**Anchors.**
+- `config.go:412` — `EnableTwoPhaseHandoff` default false
+- `internal/durable/processing_gate.go:19, 135-139` — `ProcessingGate.Enabled`
+  default false
+- `internal/durable/worker_consumer.go:386-398, 604-623` — `CapProcessingGate`
+  set after gate-wrapped handler creation
+- `manager_assignment.go:851-859` → `manager.go:815-832` —
+  `reportConsumerCapabilities` after first non-empty two-phase apply
+- `internal/durable/config.go:295-305` — gate-config → pull-gating auto-enable
+
+**Scope.** Add a warn-level log when `EnableTwoPhaseHandoff == true` and after
+the first non-empty two-phase apply the manager has still **not** seen
+`CapProcessingGate` in the consumer's reported capabilities. **Not** a
+`Start`-time check (would false-positive on every correctly-configured gated
+consumer before its first assignment).
+
+**Design — locked.** Place the check inside `reportConsumerCapabilities`
+(`manager.go:815-832`), after the existing capability merge. Single log line;
+no behavior change.
+
+```go
+// In reportConsumerCapabilities, after merging caps:
+if m.cfg.EnableTwoPhaseHandoff &&
+    !m.capProcessingGateWarned &&
+    !caps.Has(types.CapProcessingGate) {
+    m.logger.Warn("two-phase handoff is enabled but the consumer reports no processing gate; partition claims are written and never consulted",
+        "remedy", "wire a processing gate on the consumer (e.g. consumer.Dynamic) so claims fence delivery")
+    m.capProcessingGateWarned = true
+}
+```
+
+The `capProcessingGateWarned` field guards against repeated warnings on each
+re-apply.
+
+**Reproducer test list.**
+- *T1 (must fail on parent).* Set `EnableTwoPhaseHandoff = true` on a manager
+  whose consumer does not wire a processing gate. Trigger an apply that
+  reports capabilities with no `CapProcessingGate` bit. Assert the warning is
+  emitted exactly once. On parent (no warning logic), the assertion fails.
+- *T2 (positive case).* Same setup but with a gated consumer. Assert **no**
+  warning is emitted. Confirms no false-positive on the happy path.
+
+**Verification gates.**
+- `make lint && make test && make test-race` green.
+- Code-review checklist: warning fires exactly once across N applies (the
+  guard field is the design's load-bearing element).
+
+**How this trips readiness.** It doesn't directly. The warning makes a
+misconfiguration that today produces an unfenced two-phase claim flow
+**operator-visible** — they can re-deploy with the gate enabled, which is
+the actual fix.
+
+**Dependencies & sequencing.** Independent. Last of Phase 0 — the
+behavior the test exercises (capability sampling after a real
+two-phase apply) is the most integration-shaped of the Phase 0
+tests, so landing P0.1/P0.2 first keeps the per-PR test-shape
+gradient gentle.
+
+**Out of scope.**
+- Rejecting the misconfiguration at `Start` (cannot — capability bit is
+  set at runtime, not at construction; review explicitly forbids this).
+- Adding a construction-time "gate-capable" predicate (mentioned as a
+  follow-up in the review; not in scope here).
+
+---
+
+## Phase 1 — Additive correctness (make readiness-blind failures visible)
+
+Three PRs that add detection and escalation paths so the readiness-probe
+recovery can actually engage. F1 specifically must ship here because F9-A's
+migration depends on it.
+
+### P1.1 (F6-A) — Source-bucket escalation hook
+
+**Anchors.**
+- `source/nats_kv.go:178` — handle is injected; library never creates it
+- `source/nats_kv.go:772-805` — `restartWatcher` retries forever
+- `source/nats_kv.go:864-878` — `reconcileOnce` treats `ErrBucketNotFound` as
+  generic logged error
+
+**Scope.** Add an `OnSourceUnavailable(err error)` hook and a
+`parti_source_bucket_missing` metric. When `restartWatcher` or `reconcileOnce`
+sees `jetstream.ErrBucketNotFound`, the hook fires (rate-limited) and the
+metric is set. Wiring the hook to readiness is the **caller's** responsibility
+(documented).
+
+**Design — locked.**
+- New public type:
+  ```go
+  // SourceUnavailableHook fires when the partition-source bucket is observed
+  // to be missing on the live connection. Wire into your readiness logic to
+  // rotate the pod if the source vanishes (the library cannot recreate a
+  // user-owned bucket; review §5 category A).
+  type SourceUnavailableHook func(err error)
+  ```
+- `source.NatsKV` accepts the hook via a new option `WithUnavailableHook`.
+- Hook firing: at the first observation of `ErrBucketNotFound` in either
+  `restartWatcher` or `reconcileOnce`. Subsequent observations within
+  a `cooldown` (default 30 s, matching the reconcile interval) suppress the
+  hook to avoid log-spam; the metric stays set until a successful operation
+  clears it.
+- Metric: `parti_source_bucket_missing` (gauge 0/1) registered through the
+  existing metrics interface (see other `parti_*` metrics for the registration
+  site).
+
+**Reproducer test list.**
+- *T1 (must fail on parent).* Integration test under
+  `test/integration/failure/`: create a source bucket, start the manager,
+  delete the bucket, assert `OnSourceUnavailable` fires within 30 s and the
+  metric reads 1. On parent, the hook is absent — test fails at compile time
+  (or, after introducing the hook field via testing helper, at the
+  `firedWithin` assertion).
+- *T2.* The recreate-bucket case: after T1, re-create the bucket; assert
+  the metric returns to 0 within one reconcile interval.
+
+**Verification gates.**
+- `make lint && make test && make test-race && make test-integration` green.
+- Confirm hook signature is reflected in `docs/OPERATIONS.md` (responsibility
+  split between library and operator restated).
+- New exported symbol audit: only `SourceUnavailableHook` and `WithUnavailableHook`
+  added; no existing exported API changed.
+
+**How this trips readiness.** The k8s operator wires `OnSourceUnavailable`
+into a readiness-probe flag (mirroring the existing `OnDegraded` pattern); a
+silent source loss now fails readiness and rotates the pod.
+
+**Dependencies & sequencing.** Independent. Ships first in Phase 1 because
+it is the smallest additive change in the phase.
+
+**Out of scope.**
+- Library auto-recreating the source bucket (category A — forbidden).
+- The retry-bounding loop on `restartWatcher` — that is F2's territory
+  (PR P2.4a).
+
+---
+
+### P1.2 (F3) — stableID NotFound classification
+
+**Anchors.**
+- `internal/stableid/claimer.go:364-368` — renew translates only
+  `jetstream.ErrKeyExists` to `ErrClaimLost`
+- `internal/stableid/claimer.go:369` — every other error returns the generic
+  `"failed to renew ID"`
+- `internal/stableid/claimer.go:329` — `claimLostShutdown` path
+- `manager_election.go:91-98` — self-stop wiring
+- `docs/OPERATIONS.md:649-659` — documented contract
+
+**Scope.** In `Claimer.renew`, classify `jetstream.ErrBucketNotFound` and
+`jetstream.ErrStreamNotFound` as claim-loss (return `ErrClaimLost`) so the
+existing self-stop machinery runs. Matches the documented contract.
+
+**Design — locked.** Single error-classification branch in `renew`:
+
+```go
+// Inside Claimer.renew, replacing the existing single-case classification:
+switch {
+case errors.Is(err, jetstream.ErrKeyExists):
+    return ErrClaimLost
+case errors.Is(err, jetstream.ErrBucketNotFound),
+     errors.Is(err, jetstream.ErrStreamNotFound):
+    return ErrClaimLost
+default:
+    return fmt.Errorf("failed to renew ID: %w", err)
+}
+```
+
+The downstream self-stop (`claimLostShutdown` → `OnError` → pod rotation) is
+unchanged.
+
+**Reproducer test list.**
+- *T1 (must fail on parent).* Unit test in `internal/stableid/claimer_test.go`:
+  inject a KV stub whose `Update`-during-renew returns
+  `jetstream.ErrBucketNotFound`; call `renew`; assert
+  `errors.Is(err, ErrClaimLost)`. On parent the test fails (gets generic
+  wrapped error).
+- *T2 (must fail on parent).* Same with `jetstream.ErrStreamNotFound`.
+- *T3 (regression-guard).* The existing `ErrKeyExists` case still classifies
+  as `ErrClaimLost` (regression test for the pre-existing branch).
+- *T4 (negative).* Some other NATS error (e.g. a context timeout) does **not**
+  classify as `ErrClaimLost` — must keep the generic wrap. Prevents
+  over-classification.
+
+**Verification gates.**
+- `make lint && make test && make test-race` green.
+- Manual: confirm `claimLostShutdown` actually runs on T1/T2 by also adding
+  a small integration-style test that wires the real shutdown path.
+
+**How this trips readiness.** A vanished stableID bucket now triggers
+`claimLostShutdown` → `OnError` → existing readiness flip → pod restart →
+re-claim into the (presumably re-provisioned) bucket cleanly.
+
+**Dependencies & sequencing.** Independent. After P1.1 because P1.1 is
+smaller; before P1.3 because F1 is the riskier landing.
+
+**Out of scope.**
+- Preventing the brief duplicate-ID window during a wipe — closed by
+  F1 (epoch fence). R3 ensures the worker fails *safe*.
+
+---
+
+### P1.3 (F1) — Epoch fence (bucket re-create detection)
+
+**Anchors.**
+- `manager.go:455-456` — cached `m.assignmentKV` / `m.heartbeatKV` handles
+- `manager_degraded.go:33-55` — `monitorNATSConnection` (only checks
+  `conn.Status()`)
+- `manager_degraded.go:80-132` — `recordKVError` (only fires on
+  connectivity/NotFound)
+- `manager_setup.go:158-186` — KV bucket creation in `Start`
+- `provision/marker.go` — alternative epoch source (mentioned in review)
+
+**Scope.** Cache an immutable per-bucket identity at `Start` and verify it in
+the reconcilers. Detect wipe-and-recreate under the same names; enter degraded
+/ fire `OnDegraded` with a distinct reason. **This is the highest-impact
+readiness-blind gap** and the prerequisite for F9-A's migration.
+
+**Design — locked.** **Use the JetStream stream `Created` timestamp** as the
+epoch source. Rationale:
+- It is an immutable server value, available via `StreamInfo` on any KV bucket
+  (each bucket is backed by a `KV_<name>` JetStream stream).
+- It changes precisely when the stream backing the bucket is recreated — the
+  exact event F1 must detect.
+- It is independent of the `provision/marker` mechanism (which is provisioning
+  state and could itself be wiped in the F1 scenario).
+
+Mechanism:
+1. At `Start`, after `EnsureKVBucket` for each Parti-owned bucket
+   (`parti-assignment`, `parti-heartbeat`, `parti-election`, `parti-handoff`,
+   `parti-stableid`), call `kvutil.StreamInfoForBucket(ctx, js, bucketName)`
+   (new helper) and cache `Created`/`StreamName` into a `bucketEpoch` map on
+   the manager.
+2. Each KV-watcher reconciler (assignment, commit, claim-resolver, source —
+   per review §3 inventory) gains a single new step after its existing
+   reconcile pass: re-read `StreamInfo`; if the cached `Created` does not
+   match the live `Created`, call `m.enterDegraded("bucket-recreated:<name>")`
+   (new degraded reason constant).
+3. `OnDegraded` receives the new reason verbatim. The existing
+   `OnDegraded` → readiness probe wiring then rotates the pod.
+
+New error / sentinel:
+```go
+// In manager_degraded.go:
+const degradedReasonBucketRecreated = "bucket-recreated"
+```
+
+No recovery is attempted in-process. F1 is detection-only; rotation is the
+recovery.
+
+**Reproducer test list.**
+- *T1 (must fail on parent — primary).* Integration test under
+  `test/integration/failure/`: start manager → record stream `Created` →
+  shut down → delete bucket + stream → re-create bucket under the same name
+  → re-start the watchers (or use a fresh manager instance per test isolation
+  rules). Assert: within one reconcile interval, `OnDegraded` fires with
+  `reason == "bucket-recreated:<bucket>"`. On parent, the assertion times out.
+- *T2.* The happy-path case: same bucket, no recreate. Reconcilers fire
+  normally; no `OnDegraded`. Prevents false-positive on a healthy bucket.
+- *T3.* A NATS server restart with state intact (per the load-bearing
+  reconciler empirical finding) does **not** trip the epoch fence —
+  `Created` is preserved across the restart because the stream is the same.
+- *T4 (per-bucket coverage).* T1 must run against each of the five Parti
+  buckets (assignment / heartbeat / election / handoff / stableid) since they
+  each have an independent reconciler call site. Parameterize T1.
+
+**Verification gates.**
+- `make lint && make test && make test-race && make test-integration` green.
+- Manual: confirm the new `kvutil` helper does not regress existing
+  `EnsureKVBucket` callers (zero touch — it's a read-only addition).
+- Confirm the degraded reason string is exposed in metrics (`parti_degraded_total`
+  or equivalent counter) tagged by reason.
+
+**How this trips readiness.** Direct: detection enters degraded → `OnDegraded`
+→ readiness flip → pod rotation → restart re-provisions every missing bucket
+via get-first `EnsureKVBucket`. The previously-silent wipe-and-recreate path
+now triggers the *standard* recovery loop (findings.md §3 "load-bearing
+reconciler" baseline).
+
+**Dependencies & sequencing.** Independent of P1.1 and P1.2. **Must merge
+before P2.1 (F9-A)** — F9-A's operator migration runbook deletes the
+election bucket on existing clusters, and without F1 in place the migration
+itself can leave workers in a stuck-stale `lastSeenLeaderRevision` state
+until pod rotation. The plan therefore makes F1 a hard prerequisite for F9-A.
+
+**Out of scope.**
+- Healing the corruption in-process. F1 is fail-loud only.
+- The `provision/marker` alternative — mentioned in the review but not chosen
+  here (see Design rationale).
+
+---
+
+## Phase 2 — Dominant fixes
+
+Five findings (P2.1–P2.5), one of which is itself split into four PRs
+(P2.4a–d for F2). After this phase, every unrecoverable failure trips the
+readiness probe and the dominant leadership-churn source is gone.
+
+### P2.1 (F9-A) — Election bucket → `FileStorage` R≥3 + companion warning
+
+**Anchors.**
+- `manager_setup.go:89` — the one-line change (`MemoryStorage` →
+  `FileStorage` R≥3)
+- `internal/election/nats_election.go:140, 176-218, 351-390` — election
+  semantics (TTL-driven; identical on either storage)
+- `manager_election.go:191-275` — `monitorLeadership`; the renew loop and
+  `OperationTimeout` clamp
+- `config.go:360, 366` — `OperationTimeout` and `ElectionTimeout` defaults
+  (both 10 s)
+- `manager_setup.go:387-406` — `warnOnShortAuditGrace` pattern (mirrored
+  by the companion warning)
+- `kvutil/bucket.go:50-64` — `EnsureKVBucket` is get-then-create; does **not**
+  upgrade an existing bucket's storage type (the migration constraint)
+- `docs/plans/iops-investigation/findings.md` §2 cell M1.9 — IOPS evidence:
+  −2 % / −1 % at N=1000 / N=3000 (within noise) → the switch is
+  **effectively free** on the IOPS dimension
+
+**Scope.** Two things in one PR (review §F9-A explicitly bundles the warning
+companion with the storage switch because both touch the election machinery):
+1. Change the election bucket storage from `MemoryStorage` to `FileStorage`,
+   `Replicas: 3` (or whatever R≥3 the cluster is configured for; current
+   cluster defaults already use the manager's `Replicas` config field for
+   other buckets — apply that same value).
+2. Add a `Start`-time validation warning: if `OperationTimeout >
+   ElectionTimeout/3`, emit a `Warn`-level log.
+
+**Design — locked.**
+
+*Storage switch:* edit `manager_setup.go:89`'s `jetstream.KeyValueConfig` to
+replace
+```go
+Storage: jetstream.MemoryStorage,
+```
+with
+```go
+Storage:  jetstream.FileStorage,
+Replicas: m.cfg.Replicas, // or the package-level default if Replicas is unset
+```
+matching the storage block used by the other Parti buckets.
+
+*Companion warning* (read-only; no behavior change):
+```go
+// In manager_setup.go, alongside warnOnShortAuditGrace:
+func warnOnOperationTimeoutVsElection(cfg Config, logger types.Logger) {
+    if cfg.OperationTimeout > cfg.ElectionTimeout/3 {
+        logger.Warn("OperationTimeout exceeds ElectionTimeout/3; a single slow renew can consume the lease's three-attempt budget",
+            "OperationTimeout", cfg.OperationTimeout,
+            "ElectionTimeout", cfg.ElectionTimeout,
+            "remedy", "set OperationTimeout <= ElectionTimeout/3 (both default to 10s — at the default pair a single slow renew can consume the lease window)")
+    }
+}
+```
+Call from `Manager.Start` alongside the existing warning helpers.
+
+**F1 dependency check.** The PR description and the spec MUST state plainly:
+*Do not merge this PR before P1.3 (F1) is on `main`*. CI cannot enforce it,
+so the gate is human discipline + the README PR-sequencing table. The plan
+reviewer should reject this PR if the F1 epoch-fence commit is not present
+in the base.
+
+**Operator migration runbook.** Because `EnsureKVBucket` is get-then-create,
+a live `MemoryStorage` election bucket is *not* transparently upgraded by the
+new code. Operators must explicitly delete the bucket. **F1's epoch fence is
+exactly what detects the resulting recreate event**, so the runbook is safe
+once F1 has shipped. Add to `docs/OPERATIONS.md`:
+
+> #### Election bucket storage migration (after upgrading to the release that includes this fix)
+>
+> The election bucket's storage type changes from `MemoryStorage` to
+> `FileStorage` with this release. Because Parti's `EnsureKVBucket` is
+> get-then-create (`kvutil/bucket.go:50-64`), an existing `MemoryStorage`
+> bucket is **not** upgraded automatically. Existing clusters must perform
+> a one-time bucket replacement:
+>
+> 1. **Pre-flight: confirm F1 (epoch fence) is in the running build.**
+>    F1 is the migration's safety net — it detects the bucket-recreate
+>    event and routes affected workers through the standard degraded path.
+>    Verify by either (a) confirming the deployed release tag is at or past
+>    the release that landed F1 (release notes name the F1 commit
+>    explicitly), or (b) grepping the manager's structured logs for
+>    `bucket-recreated` or `degraded_reason="bucket-recreated"` in the
+>    operational record — any prior occurrence confirms the fence is wired.
+>    If F1 is not present, **abort** and upgrade further first.
+> 2. During a planned maintenance window, with no live leadership churn
+>    expected, remove the bucket from the live cluster. Use the bucket
+>    removal command (not the key-delete command):
+>    ```
+>    nats kv rm parti-<cluster>-election
+>    ```
+>    Then confirm the underlying JetStream stream is also gone:
+>    ```
+>    nats stream ls | grep KV_parti-<cluster>-election   # expect no output
+>    ```
+>    (`nats kv rm` removes both the bucket and its backing stream; the
+>    grep is a paranoia check before workers reconnect.)
+> 3. Restart each Parti worker (rolling restart is acceptable). Each restart
+>    re-runs `EnsureKVBucket`, which now creates the bucket with
+>    `FileStorage` R≥3.
+> 4. Workers that observed the deletion *before* their own restart enter
+>    degraded mode via the F1 epoch fence (reason
+>    `bucket-recreated:parti-<cluster>-election`); the existing
+>    `OnDegraded → readiness probe → pod rotation` path completes the
+>    migration automatically. The runbook does not need to handle this
+>    case manually.
+> 5. Verify post-migration: a NATS node restart no longer causes leadership
+>    churn across the worker fleet. Specifically:
+>    ```
+>    nats kv info parti-<cluster>-election | grep "Storage:"   # expect "File"
+>    ```
+
+Add a SOP cross-reference in `docs/OPERATIONS.md` from the existing degraded
+mode section.
+
+**Reproducer test list.**
+- *T1 (must fail on parent — IOPS regression guard).* Microbenchmark that
+  confirms the `FileStorage` switch does not regress IOPS beyond the noise
+  band recorded in M1.9. Run a 60 s capture window at N = 1000 partitions.
+  Assert mean IOPS ≤ M1.2 baseline + 2 %. On the *parent* commit, this test
+  is trivially green; the value of the test is forward — it pins the IOPS
+  invariant for future work that might touch the election bucket. (This is
+  the only forward-looking test in the plan; documented as such.)
+- *T2 (must fail on parent — bucket-loss survival).* Integration test:
+  start manager → confirm leadership → restart a single NATS node (out of
+  R≥3) → assert leadership is **preserved** (no churn, no
+  `OnLeadershipChanged(false)` then `(true)` ping-pong). On parent
+  (`MemoryStorage`), leadership flips on the node-restart; on the fix it
+  rides through. This is the actual correctness assertion.
+- *T3 (companion warning).* Unit test: construct a `Config` with
+  `OperationTimeout = 30s` and `ElectionTimeout = 30s`. Call `Start`. Assert
+  the warning is emitted. Construct again with `OperationTimeout = 5s`
+  and `ElectionTimeout = 30s`; assert no warning.
+- *T4 (migration safety).* Integration: simulate the migration runbook
+  (delete bucket while workers are running, assert `OnDegraded` fires with
+  `reason == "bucket-recreated:parti-election"` per F1; restart workers;
+  confirm new bucket is `FileStorage`). Validates the runbook end-to-end.
+
+**Verification gates.**
+- `make lint && make test && make test-race && make test-integration` green.
+- M1.9-style IOPS smoke (T1) within ±2 % of baseline.
+- Docs review: `docs/OPERATIONS.md` migration runbook section reads
+  unambiguously; operator can execute without questions.
+
+**How this trips readiness.** Indirectly: the change **eliminates** the
+dominant readiness-trip cause (election bucket loss on routine NATS node
+restart). After the switch, an R≥3 cluster survives single-node restarts
+without leader churn. Readiness still trips for the genuine cluster-rebuild
+case (F1 epoch fence + cached-bucket-handle failure), as designed.
+
+**Dependencies & sequencing.** **Hard dependency on P1.3 (F1).** First of
+Phase 2 because it is the lowest change-risk item in the phase and removes
+the dominant operational pain.
+
+**Out of scope.**
+- F9-B (lease-aware leader) — deferred to Phase 3.
+- Other bucket storage changes — **this PR changes only the election
+  bucket**. The `heartbeat` bucket is also currently `MemoryStorage`
+  (`manager_setup.go:93`) by design (workers re-publish every
+  `HeartbeatInterval`, per the comment at `manager_setup.go:57-62`);
+  changing it is **not** in scope here. The `assignment` bucket is
+  already `FileStorage` (`manager_setup.go:97`). If the operational
+  data later supports switching `heartbeat` too, that is a separate
+  PR with its own IOPS justification.
+
+---
+
+### P2.2 (F6-B) — Calculator-layer "minimum credible partition input" guard
+
+**Anchors.**
+- `internal/assignment/calculator.go:1071-1102` — `getActiveWorkers` worker-set
+  read; the symmetric path for workers
+- `internal/assignment/calculator.go:1238-1383` — `rebalance` entry and the
+  decision surface
+- `internal/assignment/calculator.go:1280-1283` — existing snapshot-error
+  abort (the **erroring** path is already correctly handled)
+- `internal/assignment/calculator.go:1290-1296` — existing `len(workers) == 0`
+  floor; the analogue for partitions does not exist
+- `internal/assignment/emergency.go:89-133` — `EmergencyDetector`
+  grace-window pattern; mirrors the across-polls confirmation we need for
+  shrunk-but-non-empty observations
+- `source/nats_kv.go:704` — `applyEmptyPreservingKnown` (the source-layer
+  pattern; intentionally NOT extended — see Design)
+- `types/partition_source.go:13-15` — `Snapshot` contract that distinguishes
+  "never-written" from "written-then-deleted" (the reason source-layer
+  suppression is wrong)
+
+**Scope.** Behavioral contract: an **empty** or **sharply shrunk
+(but non-empty)** partition-source observation MUST NOT propagate into a
+fleet-wide reassignment. The erroring path is already correctly aborted
+(`calculator.go:1280-1283`) — this PR closes the *suspicious-but-non-erroring*
+gap.
+
+**Design — locked. Calculator-layer.** Source-layer was considered (review
+§F6-B "likely the smaller change") and rejected because:
+1. `Snapshot()`'s documented contract explicitly distinguishes
+   "never-written" (`known=false, revision=0`) from "written-then-deleted"
+   (`known=true, revision=deleteRev, empty`). Suppressing empty/shrunk
+   observations at the source-layer would mutate the snapshot to lie
+   about what is in KV, breaking that contract for every other consumer
+   of the source.
+2. Third-party `WatchablePartitionSource` implementations would not be
+   covered — the contract would be source-implementation-specific.
+3. The calculator already owns the symmetric `len(workers) == 0` floor
+   (`calculator.go:1290-1296`) and the cross-poll confirmation pattern
+   (`EmergencyDetector`). Locating F6-B's mechanism alongside its
+   symmetric F10-A counterpart keeps "minimum credible inputs" as a
+   single calculator-side doctrine.
+
+Cost surfaced honestly: **the calculator gains new inter-poll state**
+(last-known partition count + shrunk-confirmation counter). It does not
+have this state today (review §F6-B explicitly flags this). That cost is
+the price of the contract preservation and third-party coverage above.
+
+*Mechanism:*
+1. Add to `Calculator`:
+   ```go
+   // lastKnownPartitionCount is the most recent non-suspicious
+   // partition count the calculator has acted on. Suspicious observations
+   // (empty, or sharply shrunk) do not advance it.
+   lastKnownPartitionCount int
+   // partitionShrunkObservations counts consecutive suspicious
+   // PARTITION observations. Confirmed (=> trusted) once it reaches
+   // PartitionShrinkConfirmationCount. Named distinctly from F10-A's
+   // workerShrunkObservations to avoid the cross-feature collision
+   // both fields would otherwise create on the Calculator struct.
+   partitionShrunkObservations int
+   ```
+2. New config field on `Calculator` config:
+   ```go
+   // PartitionShrinkConfirmationCount is the number of consecutive
+   // suspicious partition-source observations required before the
+   // calculator trusts the shrink. Default 3.
+   PartitionShrinkConfirmationCount int
+   // PartitionShrinkConfirmationThresholdPct gates the "sharply shrunk"
+   // definition. A new count below this percentage of
+   // lastKnownPartitionCount is suspicious. Default 50 (i.e. >=50%
+   // shrink in one poll is suspicious).
+   PartitionShrinkConfirmationThresholdPct int
+   ```
+3. New guard inside `rebalance`, placed *immediately after* the existing
+   `len(workers) == 0` floor at `calculator.go:1290-1296`:
+   ```go
+   if c.lastKnownPartitionCount > 0 {
+       if len(partitions) == 0 {
+           // Empty observation; never trust without confirmation.
+           c.partitionShrunkObservations++
+           if c.partitionShrunkObservations < c.cfg.PartitionShrinkConfirmationCount {
+               c.logger.Warn("ignoring empty partition observation pending confirmation",
+                   "lastKnown", c.lastKnownPartitionCount,
+                   "observation", c.partitionShrunkObservations,
+                   "needed", c.cfg.PartitionShrinkConfirmationCount)
+               return errSuspiciousPartitionObservation // existing-style sentinel; calculator caller treats like errEmptyWorkers
+           }
+       } else if len(partitions)*100 < c.lastKnownPartitionCount*c.cfg.PartitionShrinkConfirmationThresholdPct {
+           // Sharply shrunk but non-empty.
+           c.partitionShrunkObservations++
+           if c.partitionShrunkObservations < c.cfg.PartitionShrinkConfirmationCount {
+               c.logger.Warn("ignoring sharply-shrunk partition observation pending confirmation",
+                   "lastKnown", c.lastKnownPartitionCount,
+                   "observation", len(partitions),
+                   "thresholdPct", c.cfg.PartitionShrinkConfirmationThresholdPct,
+                   "consecutive", c.partitionShrunkObservations)
+               return errSuspiciousPartitionObservation
+           }
+       } else {
+           c.partitionShrunkObservations = 0 // observation healed; reset
+       }
+   }
+   c.lastKnownPartitionCount = len(partitions)
+   ```
+4. Surface the sentinel cleanly: `errSuspiciousPartitionObservation`
+   should NOT escalate (it is a "skip this rebalance, keep cached
+   assignment" — exactly mirrors the existing `errSuspiciousWorkerSet`
+   that F10-A will introduce). It is a non-erroring "do nothing" path
+   from the caller's POV.
+
+**Reproducer test list.**
+- *T1 (must fail on parent — empty observation).* Calculator unit test:
+  prime with N=100 partitions, run one rebalance to set
+  `lastKnownPartitionCount=100`. Inject a source whose next `Snapshot`
+  returns `[]`. Call `rebalance` for the **first
+  `PartitionShrinkConfirmationCount-1` polls in total** (i.e. inject
+  empty, call rebalance; then if `PartitionShrinkConfirmationCount > 2`,
+  inject empty and call rebalance `PartitionShrinkConfirmationCount-2`
+  more times). Across all of those, assert no commit is published and
+  `lastKnownPartitionCount` still equals 100. Do **not** call rebalance
+  a `PartitionShrinkConfirmationCount`-th time — that one is T3's
+  territory (the design proceeds on the Nth observation, per the
+  pseudocode `if c.partitionShrunkObservations <
+  PartitionShrinkConfirmationCount`). On parent, the test fails on the
+  very first empty observation — a zero-partition assignment commit
+  fires.
+- *T2 (must fail on parent — sharply shrunk).* Same setup; inject N=10
+  (90 % shrink, well below threshold). Assert suppression across
+  `PartitionShrinkConfirmationCount-1` polls (same off-by-one
+  arithmetic as T1).
+- *T3 (confirmation honoured — boundary).* Same setup; inject the
+  suspicious observation across `PartitionShrinkConfirmationCount`
+  consecutive polls. Assert: polls 1..(N-1) suppress (no commit);
+  poll N proceeds (commit fires). Confirms the boundary
+  (legitimate shrink is delayed by the confirmation window — accepted
+  trade per review §F6-B "design tension").
+- *T4 (legitimate growth not gated).* Inject N=200 after N=100. Assert
+  rebalance proceeds immediately (growth is never suspicious).
+- *T5 (counter reset on heal).* Inject N=5 once (below threshold),
+  then N=100. Assert `partitionShrunkObservations` resets to 0 on the
+  healing observation.
+- *T6 (suspicious-forever policy — locks the explicit stance).* Inject
+  N=0 across `PartitionShrinkConfirmationCount + 5` consecutive polls
+  (i.e. the source returns `[]` forever, non-erroring). Assert: (a)
+  during the first `PartitionShrinkConfirmationCount-1` polls, no
+  commit is published and the suspicious-observation counter advances;
+  (b) at the confirmation-completing poll, the rebalance proceeds with
+  N=0 — confirmed shrink is honored as legitimate operator intent;
+  (c) the `Warn` log line and the
+  `parti_partition_observation_suspicious_total` counter document the
+  acceptance. This test is **not** a failure-mode assertion — it pins
+  the explicit policy so a future change cannot silently re-introduce
+  fleet-wide reassign-to-zero on a transient blip nor silently change
+  the post-confirmation policy.
+
+**Verification gates.**
+- `make lint && make test && make test-race` green.
+- Code-review attention to interplay with the existing
+  `EmergencyDetector` worker-side path: confirm they do not duplicate or
+  cancel each other (they operate on different inputs — workers vs
+  partitions — so they should compose cleanly, but document that
+  explicitly).
+- Manual: simulate a partition-source flake (operator runbook for one
+  test cluster) — confirm the warning logs fire and the cached
+  assignment is preserved.
+
+**How this trips readiness.** It doesn't, by design — and this is a
+deliberate policy call surfaced explicitly. The contract is two-layer:
+
+1. *During the confirmation window:* hold cached assignment; emit a
+   `Warn` log each time the suppression fires. Readiness stays green.
+   This is the load-bearing safety on a transient blip — F6-B's main
+   value.
+2. *After the confirmation count is met:* the calculator trusts the
+   shrink and rebalances. This may be (a) legitimate operator intent
+   (e.g. the operator removed partitions in the source bucket), or
+   (b) a sustained source-side bug returning `[]` with no error. The
+   library **cannot distinguish (a) from (b) without operator input**;
+   F6-A (`OnSourceUnavailable`) does NOT fire here because the source
+   returns no error.
+
+The explicit policy: **F6-B treats post-confirmation shrink as
+legitimate operator intent.** The safety F6-B provides is the
+*confirmation window* itself — confirmed across multiple polls is
+strong enough evidence to act on. For the residual case (sustained
+non-erroring `[]` from a buggy source), the documented mitigation
+is operator vigilance via the per-suppression `Warn` log lines and
+the `parti_partition_observation_suspicious_total` counter (new
+metric introduced by this PR). `docs/OPERATIONS.md` must be updated
+in this PR's deliverable list to name the limit explicitly: "a
+sustained non-erroring empty/shrunk source observation will, after
+`PartitionShrinkConfirmationCount` consecutive polls, be honored as
+legitimate; operators must monitor the suspicious-observation
+counter for unexpected sustained shrinks."
+
+This is consistent with the organizing invariant — the invariant
+governs *unrecoverable* failures, and a non-erroring source
+observation is, by the library's contract with `PartitionSource`,
+recoverable (the next poll may heal). The doctrine is "minimum
+credible inputs"; once the input is confirmed across N polls it is
+credible.
+
+If post-merge operational evidence shows this policy is wrong (e.g.
+recurring incidents where a buggy source caused fleet-wide
+reassign-to-zero after N confirmations), revisit by adding an
+explicit suspicious-source hook (`OnSourcePartitionsSuspicious`)
+that fires at the confirmation boundary. That extension is **not**
+in scope here; it is a follow-up gated on evidence.
+
+**Dependencies & sequencing.** **Soft dependency on P1.1 (F6-A)** — both
+fixes the same problem from complementary angles, but each is independent
+and would work standalone. Sequencing P2.2 after P2.1 in Phase 2 because
+P2.1 is lower-risk; P2.2 then lands against a stable election baseline.
+
+**Out of scope.**
+- Touching the source layer (`source.NatsKV`). The design explicitly
+  keeps the source contract intact.
+- Generalising to other inputs beyond workers and partitions. The
+  doctrine is "minimum credible inputs" for the two inputs we have;
+  future inputs would extend the pattern when added.
+
+---
+
+### P2.3 (F5) — Stream-gone hook + checkpoint reset for recreated stream
+
+**Anchors.**
+- `internal/durable/partition_consumer.go:195-199, 372-439, 442-474,
+  457-460, 508-512` — `recreateFn`, legacy escalation, the bailing
+  point on stream-not-found
+- `internal/recovery/controller.go:206-225, 237, 294-302` —
+  `SeedCheckpoint` (monotonic; only seeds when `AckFloor.Stream > 0`);
+  `recover` path; log-and-fail path
+- `internal/recovery/checkpoint.go:30-40` — `Checkpoint.Seed` is
+  monotonic — **cannot lower** a stale checkpoint from a deleted stream
+- `internal/recovery/config.go:22-28` — `BuildConfig`'s
+  `FromLastProcessed`-with-`checkpoint==0` fallback to
+  `DeliverNewPolicy` (the reason a naive seed-to-zero would skip
+  every fresh-stream message)
+- `consumer/dynamic.go:309-316, 319-327` — `CheckWorkQueueRecoveryCompat`
+  under `sync.Once` only in `Update`; `UpdateWorkerConsumer` bypasses it
+
+**Scope.** Three things in one PR:
+1. Add a public `OnStreamMissing(streamName string) error` hook so
+   provisioning-owning callers can re-create the stream.
+2. Re-arm `CheckWorkQueueRecoveryCompat` on **both** consumer-update
+   paths (`Update` AND `UpdateWorkerConsumer`) — the manager-facing
+   path currently bypasses the check.
+3. **Reset (not seed) the checkpoint for a recreated stream** AND
+   pick a deliver policy that does not silently skip the fresh
+   stream's contents. The current monotonic `Checkpoint.Seed` cannot
+   lower a stale checkpoint, and `BuildConfig`'s `checkpoint==0` path
+   degrades to `DeliverNewPolicy`. Both must be addressed.
+
+**Design — locked.** Streams remain category B (the library does **not**
+auto-recreate). The hook is the escalation path; the consumer-side
+machinery hardens against a stream that *has* been recreated.
+
+*New public type:*
+```go
+// StreamMissingHook fires when a dynamic consumer cannot create a
+// consumer because the underlying JetStream stream is absent. The hook
+// is the escalation path — the library does not recreate streams.
+// Returning a nil error indicates the caller has re-created the stream
+// (e.g. via parti.Provision); the consumer loop will retry. A non-nil
+// error or no hook configured surfaces the loss via OnError so the
+// readiness probe can rotate the pod.
+type StreamMissingHook func(streamName string) error
+```
+
+Wire into `WorkerConsumerConfig` and the manager (`Manager.Config`).
+`partition_consumer.go:457-460` invokes the hook on `ErrStreamNotFound`
+instead of bailing silently.
+
+*Re-arm path:* introduce a small `resetCompatCheckOnce()` helper on
+`consumer.Dynamic` and call it from both `Update` and
+`UpdateWorkerConsumer` on stream-recreate (signalled by the hook
+returning nil). The `sync.Once` is replaced with an atomic flag the
+helper resets.
+
+*Checkpoint reset for a recreated stream.* Three coordinated
+additions in `internal/recovery/`, with **explicit control-flow
+ordering** and a **stream-epoch generation fence** to defend against
+late acks from the old stream.
+
+**Ordering — pinned.** Current `Controller.recover`
+(`internal/recovery/controller.go:237-316`) reads the checkpoint
+(`:273`) and calls `BuildConfig` (`:274`) *before* `recreate` runs
+(`:294`). The naive "hook fires inside `recreate`" placement would
+let the *pre-reset* checkpoint be used to build the *first
+post-recreate* consumer — exactly the T2 skip case. The spec
+mandates this ordering for the stream-missing recovery path:
+
+1. Recovery loop detects stream-missing (either the upstream
+   error classifies to a new `recovery.errStreamMissing` sentinel
+   OR `recreate` returns a wrapped `jetstream.ErrStreamNotFound`).
+2. The loop **bails out of the current `recover` attempt without
+   advancing** and invokes the `OnStreamMissing` hook.
+3. If the hook returns nil (recreate succeeded), the loop calls
+   `Controller.HandleStreamRecreated(ctx, infoFn)` (defined below)
+   which performs the reset + epoch bump + re-seed.
+4. The loop then **re-enters `recover` from the top.** The fresh
+   `recover` call reads the now-reset checkpoint and builds the
+   replacement consumer config with `DeliverAllPolicy` (or
+   `AckFloor + 1` for the restored-from-backup case).
+
+The spec adds a new `RecreateFunc` return contract: if `recreate`
+returns `(nil, errStreamMissing)`, `recover` MUST NOT update the
+checkpoint or burst state — it returns control to the caller (the
+partition-consumer run loop) which performs steps 2–4 and re-invokes
+`recover`. This makes the ordering explicit at the function-contract
+level, not implicit in call-site discipline.
+
+**Stream-epoch generation fence — non-negotiable.** Manual-ack mode
+(`Controller.Dispatch` with `manualAck=true`,
+`internal/recovery/controller.go:185-188`, and
+`trackingMsg.Ack`/`DoubleAck`,
+`internal/recovery/tracking_msg.go:19-37`) hands a `trackingMsg` to
+the handler and returns without waiting for the ack. A late ack from
+an OLD-stream handler — arriving AFTER `ResetForStreamRecreate` has
+zeroed the checkpoint — would call `AdvanceCheckpoint` and re-raise
+the checkpoint to an old-stream sequence, defeating the entire
+reset. The fence:
+
+```go
+// In Controller, alongside the checkpoint:
+streamEpoch atomic.Uint64   // bumped exactly once per HandleStreamRecreated
+```
+
+```go
+// trackingMsg captures the epoch at wrap-time:
+type trackingMsg struct {
+    jetstream.Msg
+    controller *Controller
+    epoch      uint64  // captured from controller.streamEpoch at WrapForTracking
+}
+
+// AdvanceCheckpoint ignores acks from a prior epoch.
+func (c *Controller) AdvanceCheckpoint(msg jetstream.Msg, epoch uint64) {
+    if c == nil { return }
+    if epoch != c.streamEpoch.Load() {
+        // Late ack from a prior stream generation. Drop silently.
+        return
+    }
+    c.checkpoint.Advance(msg)
+}
+```
+
+The non-manual-ack path (`Dispatch` with `manualAck=false`,
+`controller.go:190-194`) is implicitly fenced: the dispatch loop's
+`Ack → AdvanceCheckpoint` chain runs synchronously on the same
+goroutine that consumed the message, so it cannot outlive a
+`HandleStreamRecreated` that ran on the recovery goroutine — but the
+fence still applies (it captures the current epoch at dispatch
+time and the comparison protects against any future async-dispatch
+addition). Document the invariant: **`AdvanceCheckpoint` MUST be
+called with the epoch captured at message dispatch time, never at
+ack time.**
+
+**The three coordinated additions.**
+
+1. Non-monotonic reset on `Checkpoint`:
+   ```go
+   // ResetForStreamRecreate clears the checkpoint to zero. Unlike Seed,
+   // this is NON-monotonic and is only legal after the caller has
+   // confirmed (via StreamInfo) that the stream is a new identity
+   // (different Created timestamp / different stream-state lineage).
+   // The Controller's recreated-stream path is the only legitimate
+   // caller — direct use elsewhere will silently drop progress.
+   func (cp *Checkpoint) ResetForStreamRecreate() {
+       cp.maxAckedStreamSeq.Store(0)
+   }
+   ```
+2. `Controller.HandleStreamRecreated(ctx, infoFn)` — runs **after**
+   the hook returns nil and **before** the recovery loop re-enters
+   `recover`. Three steps in this exact order:
+   - Bump `streamEpoch` (`c.streamEpoch.Add(1)`). Any in-flight
+     `trackingMsg` from before this point is now from a prior
+     epoch; late acks will no-op via the fence.
+   - `cp.ResetForStreamRecreate()` — drop the stale checkpoint.
+   - `SeedCheckpoint(ctx, infoFn)` against the new stream. If the
+     new stream's `AckFloor.Stream > 0` (operator restored from a
+     backup with non-zero ack floor), the seed picks it up; if it
+     is 0 (fresh stream), the checkpoint stays at 0.
+   - Set `recreatedSinceLastBuild atomic.Bool` so the next
+     `BuildConfig` knows to choose `DeliverAllPolicy`.
+3. New deliver-policy rule in `BuildConfig`: when
+   `recreatedSinceLastBuild` is true AND strategy is `FromLastProcessed`
+   AND checkpoint is 0, override to **`DeliverAllPolicy`** (replay
+   everything in the fresh stream from sequence 1) instead of falling
+   back to `DeliverNewPolicy`. The flag is one-shot; the next normal
+   recovery rebuilds use the existing rules.
+   ```go
+   case FromLastProcessed:
+       switch {
+       case checkpoint > 0:
+           cfg.DeliverPolicy = jetstream.DeliverByStartSequencePolicy
+           cfg.OptStartSeq = checkpoint + 1
+       case recreatedSinceLastBuild:
+           cfg.DeliverPolicy = jetstream.DeliverAllPolicy
+           return cfg, "stream_recreated_replay_from_start"
+       default:
+           cfg.DeliverPolicy = jetstream.DeliverNewPolicy
+           return cfg, "fallback_no_checkpoint"
+       }
+   ```
+
+`BuildConfig`'s signature widens to accept the
+`recreatedSinceLastBuild` flag (or the existing `Controller.recover`
+reads-and-clears the flag before calling `BuildConfig` and passes the
+choice explicitly). Implementation may pick whichever shape is least
+invasive; the spec-level contract is "after stream recreate, the
+first build uses DeliverAllPolicy when checkpoint is 0, not
+DeliverNewPolicy."
+
+**Reproducer test list.**
+- *T1 (must fail on parent — hook fires).* Integration test under
+  `test/integration/failure/`: start manager with a non-nil
+  `OnStreamMissing` hook that records its invocation; delete the
+  dynamic-consumer stream; assert the hook fires within
+  one recovery-controller cycle, with the correct stream name. On
+  parent: hook field absent; test fails at compile or, after
+  introducing the field, at the firedWithin assertion.
+- *T2 (must fail on parent — fresh-stream delivery).* Set up the
+  recovery controller with strategy `FromLastProcessed` and an
+  in-memory checkpoint advanced to value 100 (simulates progress
+  in the original stream). Hook re-creates the stream with
+  `AckFloor.Stream == 0` (fresh stream). Publish 5 messages **after
+  the recreate but before the replacement consumer is bound** — this
+  is the load-bearing detail. Assert **two** things: (a) the
+  `jetstream.ConsumerConfig` passed to the first post-hook
+  `CreateOrUpdateConsumer` call has `DeliverPolicy == DeliverAllPolicy`
+  (capture via a spy `RecreateFunc`), and (b) all 5 messages are
+  delivered on resume with stream sequences 1..5. On parent: the
+  monotonic `Checkpoint.Seed` cannot lower from 100, `BuildConfig`
+  falls through to `DeliverByStartSequencePolicy` with
+  `OptStartSeq = 101` (or to `DeliverNewPolicy` if it had been 0),
+  and the consumer skips the five messages.
+- *T2b (restored-from-backup variant).* Same as T2 but the hook
+  restores from a snapshot with `AckFloor.Stream == 50`. Assert: (a)
+  the spy `RecreateFunc` captures `DeliverPolicy == DeliverByStartSequencePolicy`
+  with `OptStartSeq == 51`, and (b) the consumer resumes at sequence
+  51. Confirms the re-seed path picks up a non-zero ack floor when
+  present (NOT `DeliverAllPolicy` in this case — the flag drops out
+  because checkpoint > 0 after re-seed).
+- *T2c (must fail on parent — late-ack epoch fence).* Set up with
+  manual-ack mode AND `FromLastProcessed`. Prime the checkpoint to
+  value 100. Receive a tracking message at stream sequence 80; do
+  NOT ack it yet. Trigger `HandleStreamRecreated` (which bumps the
+  epoch, resets the checkpoint to 0, and seeds from a fresh stream).
+  THEN call `Ack` on the held tracking message. Assert: the
+  checkpoint stays at 0 — the late ack from the prior epoch is
+  silently dropped. On parent: the checkpoint advances to 80, which
+  causes the subsequent recreated-stream consumer to skip messages
+  1..80 of the new stream. **Forward-pin: this test exercises the
+  generation fence; without it, T2 would still pass but a real
+  manual-ack workload would silently lose messages.**
+- *T3 (compat re-arm).* Re-create the stream with a *different*
+  retention policy (e.g. `LimitsPolicy` → `WorkQueuePolicy`); assert
+  the compat check fires on the next `UpdateWorkerConsumer` call — on
+  parent, the check is `sync.Once`-gated and never re-runs.
+- *T4 (no hook = OnError + readiness flip).* Same setup with hook
+  unset. Delete the stream. Assert `OnError` fires with a stream-gone
+  error class; assert the existing degraded-mode wiring takes the
+  worker out of `Ready`. *Note:* this assertion depends on the
+  envelope being wired into `partition_consumer.go` — landed in P2.4d
+  before this PR (see Dependencies & sequencing below).
+- *T5 (hook returns error = no retry storm).* Hook returns a non-nil
+  error. Assert the consumer enters the permanent-failure state (per
+  the F2 envelope this PR depends on) and does NOT generate further
+  retry traffic. *Note:* same envelope dependency as T4.
+- *T6 (one-shot recreated-flag clears).* Trigger the recreate path
+  once; let the consumer process N messages cleanly; trigger an
+  unrelated transient consumer-delete recovery (no stream recreate).
+  Assert that second recovery uses the normal `FromLastProcessed`
+  path with the advanced checkpoint, *not* `DeliverAllPolicy`. Proves
+  the `recreatedSinceLastBuild` flag is single-shot.
+
+**Verification gates.**
+- `make lint && make test && make test-race && make test-integration` green.
+- Docs: `docs/CONSUMERS.md` documents `StreamMissingHook` with a
+  worked `provision`-based recreate example.
+- New exported symbol audit: only `StreamMissingHook` and the wiring
+  fields added.
+
+**How this trips readiness.** Two paths:
+1. Hook present, re-creates successfully → no readiness trip; consumer
+   resumes from `AckFloor` of the fresh stream.
+2. Hook absent or returns error → after F2's envelope-bounded retries
+   the consumer enters permanent failure → `OnError` fires → existing
+   degraded-mode wiring trips readiness → pod rotation. **Note:** a
+   pod restart alone does NOT restore the stream (`Manager.Start`
+   ensures only KV buckets, not message streams; review §F5 names this
+   precisely). The restart only stops the silently-wedged worker and
+   alerts orchestration; restoring the stream is the operator's
+   responsibility.
+
+**Dependencies & sequencing.** **Depends on P2.4d** — the F2 envelope
+applied to the `partition_consumer.go` dynamic-consumer recovery loop
+is what turns "no hook = `OnError` + readiness flip" and "hook returns
+error = no retry storm" into observable behavior. Today the loop
+backs-off-and-retries forever (`partition_consumer.go:195-227`,
+`recovery/controller.go:294-302`), so P2.3's T4/T5 tests would fail
+on parent + P2.4a alone (which wires only the source watcher).
+Sequenced in Phase 2 as: P2.1 → P2.2 → P2.4a → P2.4b → P2.4c →
+**P2.4d → P2.3** → P2.5. P2.4d MUST land before P2.3.
+
+**Out of scope.**
+- Library auto-recreating the stream (category B forbidden).
+- The retry envelope itself (F2's territory).
+- The recovery-controller consolidation (separate, future effort).
+
+---
+
+### P2.4 (F2) — Bounded-retry envelope across four loops
+
+**Anchors.**
+- `internal/durable/partition_consumer.go:195-199, 508-512` — dynamic
+  consumer recovery
+- `source/nats_kv.go:772-805` — `restartWatcher`
+- `internal/durable/claim_resolver.go:558-571` — handoff watcher
+- `manager_assignment.go:339` — `monitorAssignmentChanges`
+- `test/integration/failure/claim_resolver_nats_restart_test.go` — the
+  test pattern to mirror for restart-driven reproducers
+
+**Scope.** Apply the F2 envelope to four retry loops, one PR per loop.
+Each loop today retries forever on a genuinely-gone resource with no
+attempt cap, no permanent-failure state, no escalation. The envelope
+adds: exponential backoff with a hard ceiling; a bounded attempt
+budget per failure episode (reset on success); on exhaustion, an
+explicit permanent-failure state; on entering that state, fire
+`OnError` and a metric; stop generating API load until connectivity
+is re-confirmed.
+
+**Design — locked.** **Emerging-helper convention.** The envelope's
+shape only crystallises once one site is wired. PR P2.4a introduces
+the envelope **alongside** its first call-site wiring at
+`restartWatcher` (smallest, best-isolated site; reproducer pattern is
+"delete the bucket / restart the server" which the
+`claim_resolver_nats_restart_test.go` pattern already supports). PRs
+P2.4b–d then reuse.
+
+Envelope sketch (the engineer crystallises in PR P2.4a):
+```go
+// retryEnvelope is a bounded-retry loop with permanent-failure
+// state and one-shot escalation. Reset on a successful operation
+// returning from the work func; exhausted budget transitions to
+// permanent failure and stops calling work until ResetOnConnect is
+// signalled.
+type retryEnvelope struct {
+    work             func(ctx context.Context) error
+    classify         func(err error) retryClass  // transient / give-up / fatal
+    onPermanent      func(err error)             // fires once at exhaustion
+    onProgress       func(attempt int, err error)
+    baseBackoff      time.Duration
+    maxBackoff       time.Duration
+    maxAttempts      int                          // budget per episode
+    jitter           float64
+}
+
+// classify maps an error to:
+//   transient: schedule retry, bump attempts
+//   giveUp:    transition to permanent-failure immediately
+//   fatal:     return error to caller without retry
+type retryClass int
+const (
+    retryTransient retryClass = iota
+    retryGiveUp
+    retryFatal
+)
+```
+
+Live location: `internal/retry/envelope.go` (new package), exported only
+within the module — not part of the public API surface.
+
+**Configuration:** each call site exposes its own `MaxAttempts` /
+`BaseBackoff` / `MaxBackoff` knobs through the existing config layer
+(`Config` for manager-owned loops, `WorkerConsumerConfig` for the
+consumer loop, `NatsKVOption` for the source watcher). Sane defaults
+mirror the current per-site values where present.
+
+**PR-by-PR scope.**
+
+#### P2.4a (F2) — Envelope + `source/nats_kv.go:restartWatcher`
+
+Smallest, best-isolated site. Introduces `internal/retry/envelope.go`
+alongside the wiring. After exhaustion, `restartWatcher` fires
+`OnSourceUnavailable` (P1.1's hook) and stops retrying until the
+source reconciler successfully re-reads via `kv.Get` (the "connectivity
+re-confirmed" signal).
+
+*Reproducer (must fail on parent).*
+- *T1.* Delete the source bucket; assert `restartWatcher` retries
+  bounded times (`MaxAttempts`); after exhaustion, assert
+  `OnSourceUnavailable` fires AND `restartWatcher` stops generating
+  watcher-create traffic. On parent: retries continue indefinitely.
+- *T2.* Bucket re-created mid-retry; assert the envelope resets
+  the attempt counter on the next success and resumes normal
+  operation.
+
+#### P2.4b (F2) — Apply envelope to `claim_resolver.go` handoff watcher
+
+Smallest reuse; same shape as P2.4a. On exhaustion, fires `OnError`
+via the resolver's existing error surface (resolver does not have a
+dedicated public hook; review §F2 names this).
+
+*Reproducer.*
+- *T1.* Delete the handoff bucket; assert bounded retries; assert
+  `OnError` fires once at exhaustion.
+
+#### P2.4c (F2) — Apply envelope to `monitorAssignmentChanges`
+
+The comment at `manager_assignment.go:339` already names "wiped
+assignment bucket" as the expected case. On exhaustion, this loop's
+escalation feeds `enterDegraded` (the assignment bucket is a hard
+correctness dependency).
+
+*Reproducer.*
+- *T1.* Delete the assignment bucket while the manager runs; assert
+  bounded retries; assert degraded mode is entered after exhaustion
+  (not by `recordKVError` — which today handles only
+  connectivity/NotFound — but by the envelope's permanent-failure
+  path explicitly calling `enterDegraded("assignment-watcher-exhausted")`).
+
+#### P2.4d (F2) — Apply envelope to `partition_consumer.go` recovery
+
+Final loop and the larger surface. P2.4d lands **before** P2.3 (F5)
+in Phase 2's sequence, so this PR wires the envelope and the
+permanent-failure → `OnError` path without depending on the
+`OnStreamMissing` hook (which P2.3 layers on top later). On
+exhaustion at this stage:
+- Permanent failure fires `OnError` with the recovery-exhausted
+  reason; the existing degraded-mode wiring trips readiness.
+- The `OnStreamMissing` hook is **not** wired in P2.4d. P2.3 wires
+  it as an additional "yield once to the hook before transitioning
+  to permanent failure" step; that interaction is verified by
+  P2.3's T4/T5 reproducers, not here.
+
+*Reproducer.*
+- *T1.* Delete the dynamic-consumer stream; assert bounded retries
+  (per the envelope's `MaxAttempts`); assert permanent failure fires
+  `OnError` exactly once at exhaustion; assert no further consumer-
+  create traffic after the permanent-failure transition.
+
+**Verification gates (every F2 PR).**
+- `make lint && make test && make test-race && make test-integration`
+  green.
+- Manual review of the configured `MaxAttempts` per site — too aggressive
+  turns a recoverable blip into a premature permanent failure; too lax
+  defeats the bound. Defaults must be justified in the spec.
+- The `internal/retry/envelope.go` package introduced in P2.4a stays
+  internal — no public-API surface added.
+
+**How this trips readiness.** Each loop's exhaustion path eventually
+trips readiness (P2.4a via `OnSourceUnavailable`; P2.4b/c via degraded
+mode; P2.4d via `OnError` after the hook fails). Without F2 the loop
+generates infinite retry pressure and **never** trips readiness.
+
+**Dependencies & sequencing.**
+- P2.4a is the envelope introduction PR.
+- P2.4b/c/d reuse the envelope; each is independent of the others
+  *except* that P2.3 (F5) depends specifically on P2.4d (envelope
+  wired into `partition_consumer.go`).
+- Sequencing within Phase 2: P2.1 → P2.2 → P2.4a → P2.4b → P2.4c →
+  P2.4d → P2.3 → P2.5. P2.4d **must land before** P2.3 because P2.3's
+  readiness behavior is observable only after the dynamic-consumer
+  recovery loop is bounded.
+
+**Out of scope.**
+- The recovery-controller consolidation (separate, future effort).
+- Public-API extensions beyond the per-site config knobs.
+
+---
+
+### P2.5 (F10-A) — Truncated-`Keys()` defense + worker-set floor
+
+**Anchors.**
+- `internal/assignment/worker_monitor.go:162-194, 229-231` — `GetActiveWorkers`
+  → `heartbeatKV.Keys()` path
+- `internal/assignment/calculator.go:1071-1102` — `getActiveWorkers`;
+  connectivity-error path correctly handles cache fallback
+- `internal/assignment/calculator.go:1290-1296` — the existing
+  `len(workers) == 0` floor; the analogue we extend
+- `internal/assignment/calculator.go:1271-1277` — the existing log-only
+  "drop from N to 1" path; needs hardening
+- `internal/assignment/emergency.go:89-133` — `EmergencyDetector` grace
+  window — must compose, not duplicate
+- nats.go `jetstream/kv.go:1335-1393` (v1.50.0) — empirical source of
+  the truncation hypothesis
+
+**Scope.** Two-part defense:
+1. **Truncated-`Keys()` defense.** Make `GetActiveWorkers` defend
+   against a silently truncated `Keys()` result: cross-check the
+   result count against the last-known worker count; treat a large
+   unexplained single-poll shrink as non-fresh (degraded) OR require
+   two consecutive shrunk reads before trusting it.
+2. **"Minimum credible worker set" floor.** Refuse to reassign on a
+   suspiciously large worker-set shrink without emergency confirmation
+   across the full grace window.
+
+**Hard gate.** **The chaos reproducer is the first step. No fix is
+written until the bug is empirically observed**, per review §6 F10-A
+verification status and user constraint. The reproducer goes in
+`test/integration/failure/heartbeat_truncated_keys_test.go` (new
+file) and exercises an ordered-consumer drop mid-`Keys()` scan via
+NATS chaos (terminate the ordered consumer while a scan is in flight,
+or use the nats.go test hooks if available).
+
+*Gate semantics (precise).*
+- **T0 (the gate itself)** is a *diagnostic reproducer* that
+  demonstrates `KeyValue.Keys()` can return a truncated slice with
+  `err == nil` under ordered-consumer drop. T0 **passes on the parent
+  commit** — its passing IS the empirical observation that justifies
+  the fix. The PR is gated by T0 existing and being green on the
+  parent commit before any defense is written. T0 may remain in the
+  tree as a regression check (the truncation is a nats.go behavior,
+  not a Parti bug, so the diagnostic is a forward observation pin).
+- **T1/T2 below** are the *fixed-behavior* tests: they fail on the
+  parent + T0 combination (because the defense is not in place) and
+  pass after the fix lands.
+
+**Design — locked.** Reproducer-gated. Below is the *proposed* design
+to ship once T0 reproduces; the engineer revises if the empirical
+observation contradicts the source-analysis prediction.
+
+*Truncated-`Keys()` defense — placed in `Calculator.getActiveWorkers`,
+NOT `WorkerMonitor.GetActiveWorkers`.* `WorkerMonitor.GetActiveWorkers`
+returns `([]string, error)` only (`internal/assignment/worker_monitor.go:162`);
+the `fresh` flag lives one layer up at `calculator.go:1071-1102` where
+connectivity errors already become cached-with-`fresh=false`. The new
+defense reuses that same shape:
+```go
+// In Calculator.getActiveWorkers, after monitor.GetActiveWorkers returns:
+workers, err := c.monitor.GetActiveWorkers(ctx)
+if err != nil {
+    // ... existing connectivity-error path (cache fallback, fresh=false) ...
+}
+// New: cross-check against last-known count.
+if c.lastKnownWorkerCount > 0 {
+    thresholdCount := c.lastKnownWorkerCount * c.cfg.WorkerShrinkConfirmationThresholdPct / 100
+    if len(workers) < thresholdCount {
+        c.workerShrunkObservations++
+        if c.workerShrunkObservations < c.cfg.WorkerShrinkConfirmationCount {
+            c.Logger.Warn("ignoring suspiciously-shrunk worker observation pending confirmation",
+                "lastKnown", c.lastKnownWorkerCount,
+                "observation", len(workers),
+                "thresholdPct", c.cfg.WorkerShrinkConfirmationThresholdPct,
+                "consecutive", c.workerShrunkObservations)
+            // Same shape as the connectivity-error path: cached + fresh=false.
+            // Critically: do NOT update c.lastKnownWorkerCount on a
+            // suspicious observation — keep the cached baseline.
+            if cached, age, ok := c.getCachedWorkers(); ok {
+                c.Metrics.RecordCacheUsage("workers", age.Seconds())
+                c.Metrics.IncrementCacheFallback("suspicious_shrink")
+                return cached, false, nil
+            }
+            // No cache: degrade explicitly so the caller does not act on
+            // a suspicious observation.
+            return nil, false, fmt.Errorf("%w: %w", types.ErrDegraded, errSuspiciousWorkerSet)
+        }
+    } else {
+        c.workerShrunkObservations = 0
+    }
+}
+c.lastKnownWorkerCount = len(workers)
+c.updateCachedWorkers(workers)
+return workers, true, nil
+```
+
+*Worker-set floor in `rebalance` — compose with the existing emergency
+buffer.* The existing emergency lifecycle assigns confirmed-dead
+workers into `c.disappearedWorkers` (`calculator.go:52, 1008`) and
+consumes that buffer only on the emergency-rebalance branch
+(`calculator.go:1193-1219`). Use that buffer as the "confirmed deaths"
+signal — there is no need to add a new `HasConfirmedDeaths()` method:
+```go
+// Inside rebalance, immediately after the existing
+// len(workers) == 0 guard at calculator.go:1290-1296:
+if c.lastKnownWorkerCount > 0 {
+    thresholdCount := c.lastKnownWorkerCount * c.cfg.WorkerShrinkConfirmationThresholdPct / 100
+    if len(workers) < thresholdCount && len(c.disappearedWorkers) == 0 {
+        // Suspicious aggregate shrink with no emergency-confirmed deaths.
+        // The next poll will re-check once EmergencyDetector has had
+        // the grace window to confirm.
+        c.Logger.Warn("ignoring rebalance on suspiciously-shrunk worker set; no emergency-confirmed deaths",
+            "currentCount", len(workers),
+            "lastKnownCount", c.lastKnownWorkerCount)
+        return errSuspiciousWorkerSet
+    }
+}
+```
+Note: `c.disappearedWorkers` is the existing buffer; reading
+`len(...) == 0` here does NOT mutate it. The emergency-rebalance
+branch is unaffected — if EmergencyDetector has confirmed deaths,
+`c.disappearedWorkers` is non-empty and the floor releases.
+
+**Interaction with EmergencyDetector.** Crucial: the floor
+**composes** with the existing grace window, not duplicates or fights
+it. `EmergencyDetector` confirms *individual* worker deaths across the
+grace window (`internal/assignment/emergency.go:89-132`); the calculator
+captures confirmed deaths into `c.disappearedWorkers` (calculator.go:1000-1015).
+The F10-A floor refuses to act on a suspicious *aggregate* until
+`c.disappearedWorkers` is non-empty. The floor surfaces a sentinel
+that does not escalate; the next poll re-checks against the
+now-updated emergency state.
+
+*Config additions on `CalculatorConfig`:*
+- `WorkerShrinkConfirmationCount` (default 2)
+- `WorkerShrinkConfirmationThresholdPct` (default 50)
+
+*Calculator state additions:*
+- `lastKnownWorkerCount int`
+- `workerShrunkObservations int` (named distinctly from P2.2's
+  `partitionShrunkObservations` to avoid the cross-feature collision
+  both fields would create on the same `Calculator` struct).
+
+Neither field is exposed publicly; both are guarded by the existing
+`pollMu` (so the floor reads them under the same lock the emergency
+buffer already uses).
+
+**Reproducer test list (T0 chaos test FIRST is the gate).**
+- *T0 (diagnostic reproducer; the gate).* New integration test that
+  drops the heartbeat-bucket ordered consumer mid-`Keys()` scan.
+  Assert the truncated read is empirically observable — `Keys()`
+  returns `(partial-slice, nil)`. **T0 must PASS on the parent
+  commit** (its passing is the empirical observation that justifies
+  the fix). No defense is written until T0 reproduces. T0 stays in
+  the tree as a forward-observation pin against the nats.go behavior
+  (`jetstream/kv.go:1335-1393`).
+- *T1 (must fail on parent + T0; pass after fix).* Calculator unit
+  test: prime `c.lastKnownWorkerCount = 10`; inject a `WorkerMonitor`
+  stub that returns a 3-worker slice with `err == nil` (simulating
+  the truncated read T0 demonstrates). Call `Calculator.getActiveWorkers`.
+  Assert: returns the cached 10-worker set with `fresh=false` AND
+  `c.lastKnownWorkerCount` still equals 10 (suspicious observation
+  did not advance the baseline). On parent: returns 3 workers with
+  `fresh=true` — buggy behavior.
+- *T2 (must fail on parent + T0; pass after fix — the floor).* Same
+  prime; inject a monitor that returns a 3-worker slice (70 % shrink
+  past the 50 % threshold) AND `c.disappearedWorkers` is empty
+  (EmergencyDetector has not confirmed deaths). Call `rebalance`.
+  Assert: returns `errSuspiciousWorkerSet`; no commit published. On
+  parent: commit fires; partitions reassigned to the 3-worker set.
+- *T3 (confirmation honoured — released by emergency).* Same as T2
+  but set `c.disappearedWorkers = []string{"w1","w2","w3","w4","w5","w6","w7"}`
+  (EmergencyDetector confirmed seven deaths). Call `rebalance`.
+  Assert: the rebalance proceeds normally and a commit fires. Confirms
+  the floor releases when the emergency lifecycle has run.
+- *T4 (composition with degraded mode — the double-ownership case).*
+  Combine T1's setup with a separate worker in degraded mode (cached
+  assignment, still processing). Assert: across `WorkerShrinkConfirmationCount`
+  polls of truncated reads, no commit reassigns the degraded worker's
+  partitions to another worker — proves the realistic
+  double-ownership path is closed (review §F10-A "severity is
+  conditional").
+- *T5 (counter reset).* Inject one shrunk read followed by a healed
+  read (returns the full 10 workers); assert
+  `c.workerShrunkObservations` resets to 0 and `c.lastKnownWorkerCount`
+  advances to the healed count.
+- *T6 (confirmation budget allows real mass-death).* Prime with
+  10 workers; inject the same 3-worker observation across
+  `WorkerShrinkConfirmationCount + 2` polls AND simultaneously run
+  EmergencyDetector with confirmations of the missing 7 (so
+  `c.disappearedWorkers` populates after the grace window). Assert
+  the rebalance proceeds on the confirmation-completing poll and
+  partitions are correctly redistributed. Proves the floor does
+  not suppress a legitimate mass-death scenario.
+- *T7 (cross-feature counter isolation — landed once both P2.2 and
+  P2.5 are present).* Calculator unit test exercising both counters
+  in the same `Calculator` instance: inject a partition-suspicious
+  observation (P2.2 path); assert `partitionShrunkObservations++` but
+  `workerShrunkObservations == 0`. Then inject a worker-suspicious
+  observation (P2.5 path); assert `workerShrunkObservations++` but
+  `partitionShrunkObservations` is unchanged. Proves the two
+  cross-feature counters do not leak into each other (the bug the
+  v2 plan-review flagged would have manifested as a shared single
+  counter corrupting both confirmation windows).
+
+**Verification gates.**
+- `make lint && make test && make test-race && make test-integration`
+  green.
+- Confirm **T0 passes on the parent commit** before any defense is
+  written. This is the empirical-observation gate.
+- Confirm T1, T2 **fail on parent + T0** and pass after the fix lands.
+- Confirm T6 — the floor MUST NOT suppress a *legitimate* mass-death
+  rebalance once `c.disappearedWorkers` is populated by the emergency
+  lifecycle.
+- Audit: every call site that reads `Calculator.getActiveWorkers`
+  continues to handle `fresh=false` correctly (review §F10-A says the
+  connectivity-error path "is correctly handled (cache fallback,
+  fresh=false)" — the new path reuses that exact shape, so all
+  existing callers MUST already tolerate the case). Pre-implementation
+  grep verifies the claim.
+
+**How this trips readiness.** Indirectly: the *kept* leader on a
+truncated read does not act, so no wrong reassignment happens. If
+the underlying heartbeat bucket is genuinely broken (vs. a transient
+truncated read), the F1 epoch fence + F2 envelope wiring eventually
+trip readiness. F10-A is the **prevention of double ownership during
+the window** — a correctness fix, not a recovery fix.
+
+**Dependencies & sequencing.** Independent of F1/F9-A but composes
+with EmergencyDetector. Sequenced **last in Phase 2** because:
+- The chaos reproducer is the hardest test to build; deferring it
+  to the end of the phase amortises the risk against the rest of
+  the phase already being merge-clean.
+- The floor's tuning interacts with the grace-window discipline
+  established by P2.2 (F6-B) — handling P2.2 first makes the
+  "minimum credible inputs" doctrine already-live, which clarifies
+  the F10-A design.
+
+**Out of scope.**
+- F10-B (already in P0.3).
+- F10-C (partition-fencing — separate plan
+  [`docs/plans/partition-fencing/`](../partition-fencing/)).
+- F10-D (bounded overlap during normal moves — by design, not a
+  gap).
+
+---
+
+## Phase 3 — Deferred and optional
+
+These items do **not** ship with the rest. Their entries below are
+**deferred sketches, not implementation-ready specs.** The value of
+including them in this plan is naming the **specific operational
+signal** that would re-promote them. If either item is re-promoted,
+its sketch must be expanded into the full five-field per-PR spec
+(scope / design / reproducer list / verification gates / dependencies)
+before any code is written, following the same shape as the Phase 0–2
+entries.
+
+### P3.1 (F9-B) — Lease-aware leader (DEFERRED)
+
+**Scope sketch.** Hold leadership through transient bucket
+unavailability; step down at the lease deadline. Implements the
+"do not flip `m.isLeader` on context-timeout renew errors" lenience
+in `monitorLeadership`, tracking the *initiation timestamp of the
+last successful renew* and force-self-demoting at
+`now − lastSuccessfulRenew >= ElectionTimeout − margin`. Follower
+side unchanged. Lease invariant:
+`leader_local_stepdown_deadline + clock_skew ≤
+follower_earliest_acquire` (= bucket TTL since last write).
+
+**Re-promotion signal.** Ship F9-B only if **after F9-A is in
+production**, telemetry shows residual leadership churn caused by
+*transient bucket unavailability* (not bucket loss — that's already
+closed by F9-A). Concretely: collect `OnLeadershipChanged(false →
+true)` flip pairs per worker per hour; threshold ≥ 1 per hour
+sustained across a non-trivial fraction of workers, with the
+underlying NATS election bucket showing context-timeout renew errors
+in the same window. If churn stays under that, the HIGH change risk
+of touching election code is **not justified**.
+
+**Hard prerequisite.** F9-A must be in production for at least one
+release cycle's worth of observation. F1 must also be present.
+
+**Audit prerequisite.** `CheckLeadership` is currently the only
+non-test `LeaderCheck` call site (`manager_assignment.go:123`).
+Before relying on "hold the leader longer," audit that no other
+leader-exclusive write exists unfenced. The audit is part of F9-B
+when it activates.
+
+**Coupling with F10-A / F6-B.** A kept leader must not act on bad
+inputs. F10-A's worker-set floor and F6-B's partition-input floor
+are the load-bearing safety on the kept-leader window. Both must
+have been in production stably before F9-B activates. (This is
+already true in Phase 2's sequencing.)
+
+---
+
+### P3.2 (F4) — In-process re-provision of coordination buckets (OPTIONAL)
+
+**Scope sketch.** Gated, opt-in, in-process re-create for the
+regenerable coordination buckets (`parti-assignment`,
+`parti-heartbeat`, `parti-handoff`), off by default, only after the
+bucket is confirmed absent on a healthy connection for a sustained
+window (`RecreateGracePeriod`). Excludes the source bucket
+(category A) and message streams (category B). `parti-election` is
+**not** an F4 target because F9-A subsumes it. `parti-stableid` is
+**not** an in-process target — F3 handles it via restart.
+
+**Re-promotion signal.** Ship F4 only if pod-rotation cost on
+cluster-rebuild scenarios proves operationally significant after
+Phase 2 has been stable. Concretely: measure the average wall-clock
+gap between an `OnDegraded` event and the worker resuming `Ready`
+post-rotation; threshold ≥ 60 s sustained across multiple incidents
+for the case where the rebuild is "buckets gone but cluster
+otherwise healthy." Below that threshold, the HIGH change risk is
+not justified.
+
+**Hard prerequisite.** F1 + F2 must be present (review §F4 names
+both). F4 reuses F1's bucket-identity detection (the bucket-recreate
+event is the *opposite* of the bucket-absent event, but the
+mechanism is the same), and the F2 envelope provides the bounded
+confirmation-window machinery.
+
+---
+
+## Appendix — Cross-references
+
+- Authoritative source: [`findings.md`](./findings.md)
+- Review trail (consolidated, 9 rounds): [`review-trail.md`](./review-trail.md)
+- IOPS justification for F9-A:
+  [`docs/plans/iops-investigation/findings.md`](../iops-investigation/findings.md) §2 cell M1.9
+- Plan-shape mirror: [`docs/plans/worker-state-hardening/README.md`](../worker-state-hardening/README.md)
+  (lazy per-PR specs)
+- Reproducer-first discipline: `.agents/rules/300-testing.md`,
+  memory `feedback_verify_first_with_reproducer`
+- Post-impl-review workflow: memory `feedback_post_impl_review_workflow`,
+  preferred dispatch via `/codex:review`
+  (memory `feedback_codex_review_preferred`)
+- Commit-message hygiene: `.agents/rules/550-git-conventions.md`,
+  memory `feedback_no_plan_jargon_in_commits`
+- Partition-fencing roadmap (F10-C scope cross-reference):
+  [`docs/plans/partition-fencing/README.md`](../partition-fencing/README.md)

--- a/docs/plans/self-healing/01-pr1-spec.md
+++ b/docs/plans/self-healing/01-pr1-spec.md
@@ -1,0 +1,172 @@
+# P0.1 (F7) — Connection-config docs + `MaxReconnects` startup warning
+
+Per-PR spec for the first PR in the self-healing phased plan
+(`00-fix-plan.md` §P0.1). Lazy-written now per the plan's convention
+("specs are written only when the prior PR is merge-clean"; this is the
+first PR, so the gate is trivially satisfied).
+
+## Background
+
+`Manager` does not hold a `*nats.Conn` directly; it holds a
+`jetstream.JetStream`. The underlying connection is reachable via
+`m.js.Conn()` (returns `*nats.Conn`; verified against nats.go v1.50.0
+`jetstream/jetstream.go:571`). The `Opts` field on `*nats.Conn` exposes
+the reconnect-budget knob. The plan anchor "manager.go:258, 410-414 —
+conn is caller-injected" is correct in spirit (the connection IS
+caller-owned, constructed externally and threaded in via
+`jetstream.New(nc)`); the warning reaches the conn through
+`js.Conn().Opts`.
+
+**Field-name note (discovered during implementation, not in the plan).**
+The setter is `nats.MaxReconnects(...)` (plural — `nats.go:1108`) but
+the field on `nats.Options` is `MaxReconnect` (singular —
+`nats.go:374`). The helper, test, and log message all use the singular
+field name when referring to the field, and the plural name when
+referring to the setter. The user-visible docs use the plural setter
+form since that is what callers invoke. This naming asymmetry is a
+nats.go quirk, not a Parti quirk.
+
+## Scope (read-only / docs-only — no behavior change)
+
+1. **Docs.** Add a new "NATS Client Connection" subsection to
+   `docs/OPERATIONS.md` (after the existing "NATS Server Configuration"
+   subsection) documenting the required connection posture for a Parti
+   manager: `MaxReconnects = -1` (unlimited), reasonable
+   `ReconnectWait`/`ReconnectJitter`, `RetryOnFailedConnect = true`.
+   Name the failure mode finite `MaxReconnects` produces (the
+   `CLOSED` zombie connection that today eventually trips degraded
+   mode via connection monitoring; review §F7).
+2. **Godoc.** Update the `doc.go` package-comment example to call out
+   the connection posture in a one-line comment above the
+   `nats.Connect` call. The example body stays compact.
+3. **Example.** Update `examples/basic/main.go` to use the documented
+   connection options. The example is the public entry point — must
+   not teach the foot-gun.
+4. **Runtime warning.** Add `(m *Manager) warnOnFiniteMaxReconnects()`
+   alongside `warnOnShortAuditGrace` in `manager_setup.go`. Invoke
+   from `Manager.Start` after the existing `warnOnShortAuditGrace`
+   call (`manager.go:394`). The warning is **read-only** — it
+   inspects `m.js.Conn().Opts.MaxReconnects` and emits a single
+   `Warn`-level log line if the value is finite (i.e. `>= 0`).
+   `-1` (unlimited) is silent. `m.js.Conn()` returning `nil` is
+   defensively silent (test-double safety).
+
+## Design
+
+```go
+// In manager_setup.go, alongside warnOnShortAuditGrace:
+
+// warnOnFiniteMaxReconnects emits a one-shot WARN when the caller-owned
+// nats.Conn is configured with a finite MaxReconnects. A finite
+// MaxReconnects turns a transient NATS outage into a permanently CLOSED
+// zombie connection — the manager's connection monitor then enters
+// degraded mode and the readiness probe rotates the pod. This is the
+// documented posture (see docs/OPERATIONS.md "NATS Client Connection"),
+// but the warning surfaces the misconfiguration at Start so operators
+// catch it during smoke test rather than during the first outage.
+//
+// MaxReconnects == -1 (unlimited) is the recommended posture and is
+// silent here. Anything else (0 disables reconnect entirely; positive
+// finite caps) warns.
+func (m *Manager) warnOnFiniteMaxReconnects() {
+    if m.js == nil {
+        return
+    }
+    conn := m.js.Conn()
+    if conn == nil {
+        return // defensive (test doubles that bypass the real conn)
+    }
+    max := conn.Opts.MaxReconnects
+    if max < 0 {
+        return // -1 = unlimited, the recommended posture
+    }
+    m.logger.Warn(
+        "nats.Conn is configured with a finite MaxReconnects; on a sustained "+
+            "NATS outage the connection will exhaust its budget and stay CLOSED, "+
+            "forcing degraded mode and pod rotation. Configure the connection "+
+            "with nats.MaxReconnects(-1) and a reasonable nats.ReconnectWait/"+
+            "ReconnectJitter (see docs/OPERATIONS.md \"NATS Client Connection\").",
+        "max_reconnects", max,
+    )
+}
+```
+
+Call site in `Manager.Start` (after the existing
+`m.warnOnShortAuditGrace()` at `manager.go:394`):
+
+```go
+m.warnOnShortAuditGrace()
+m.warnOnFiniteMaxReconnects()
+```
+
+## Reproducer test list
+
+No correctness reproducer is required (no behavior change). One unit
+test for the warning emission, table-driven over the three relevant
+inputs:
+
+- *T1.* `MaxReconnects = -1` → no warning.
+- *T2.* `MaxReconnects = 0` → warning emitted exactly once.
+- *T3.* `MaxReconnects = 5` (finite positive) → warning emitted
+  exactly once.
+- *T4.* `js == nil` → silent (defensive); no panic.
+- *T5.* `js.Conn() == nil` → silent (defensive); no panic.
+
+The test uses the existing `captureLogger` pattern from
+`pull_gating_repro_test.go:23-71` (move to a shared test helper if
+needed; preferred: keep local since one other call site already uses
+it and the helper is tiny). The test does **not** spin up a real
+NATS server — it constructs the `Manager` directly with a real
+`*nats.Conn` whose `Opts.MaxReconnects` is set to each table value.
+Connect to an embedded NATS server (existing
+`internal/testutil/nats.StartEmbeddedNATS`) so `js.Conn()` returns a
+real conn whose `Opts` are populated.
+
+## Verification gates
+
+- `make lint && make test && make test-race` green.
+- New exported symbols: **none** (the helper is unexported).
+- Docs spot check: `go doc github.com/arloliu/parti/v2` shows the
+  updated package-comment example.
+- `examples/basic/main.go` builds (`go build ./examples/basic`).
+- Manual: construct a `Manager` against an embedded NATS with
+  `nats.MaxReconnects(5)` and confirm the warning appears once at
+  `Start`; switch to `nats.MaxReconnects(-1)` and confirm silence.
+
+## How this trips readiness
+
+Indirect. The warning itself does not flip readiness. It documents
+the posture so finite `MaxReconnects` (which today turns an outage
+into a `CLOSED` zombie that *does* enter degraded mode and rotate the
+pod) is operator-visible at first deploy rather than during an
+outage.
+
+## Test-helper alignment (in scope, ancillary)
+
+`partitest.StartEmbeddedNATS` connects with `nats.MaxReconnects(3)`
+(`partitest/nats.go:78`). Once the warning is wired, every integration
+test using this helper (354 call sites) would emit the warning — the
+helper itself models the foot-gun this PR documents away. Change the
+helper to `nats.MaxReconnects(-1)` to (a) silence the spurious
+warning noise in tests, and (b) make the test infrastructure model the
+recommended posture. This is a single-line change and is congruent
+with this PR's teaching.
+
+Also reviewed: `test/simulation/internal/natsutil/embedded.go:19`
+(`StartEmbeddedNATS` — separate simulation helper). Check whether it
+sets `MaxReconnects` and align if so.
+
+## Out of scope
+
+- Programmatic enforcement (rejecting finite `MaxReconnects` outright).
+  The plan explicitly rules this out (review §F7); the warning is the
+  agreed-upon mitigation.
+- Touching `cmd/partictl/natsconn.go` — that is an operator tool with
+  different lifecycle assumptions. Not in scope.
+- Any other connection posture knob (TLS, auth). Only the
+  reconnect-budget knob produces the silent-zombie outcome.
+
+## Dependencies & sequencing
+
+Independent. First PR of Phase 0 because it is the smallest
+no-behavior-change change in the plan.

--- a/docs/plans/self-healing/02-pr2-spec.md
+++ b/docs/plans/self-healing/02-pr2-spec.md
@@ -1,0 +1,137 @@
+# P0.2 (F8) — `source.WithReconcileInterval(0)` guard
+
+Per-PR spec for the second PR in Phase 0
+(`00-fix-plan.md` §P0.2). Lazy-written now per the plan's convention.
+Gates: P0.1 is merge-clean (branch `self-healing-p01-f7-conn-config`
+committed and surfaced to user).
+
+## Background
+
+`NatsKV.reconcileLoop` (`source/nats_kv.go:807-814`) exits immediately
+when `s.reconcileInterval <= 0` AND `s.leadershipProbe == nil`. The
+reconciler is the **load-bearing recovery path** for KV watchers after
+a NATS server restart — the empirical finding pinned in memory
+`project_nats_watcher_empirical_finding` notes that the nats.go KV
+watcher's `Updates()` channel does NOT close on server restart, so the
+reconciler is the only mechanism that re-syncs the source after a
+silently-stalled watcher.
+
+A user who passes `source.WithReconcileInterval(0)` therefore disables
+server-restart recovery without any visible signal. The current Godoc
+documents the cadence behavior but does not name the **silent-stall
+consequence**.
+
+The consumer-resolver counterpart (`consumer/resolver_config.go:61-63`,
+`internal/durable/config.go:89`) is already safe — both clamp
+non-positive intervals to a sane minimum. The source layer is the
+only outstanding gap.
+
+## Scope (source-only — no behavior change)
+
+1. **Godoc.** Update `source.WithReconcileInterval`'s comment to add a
+   paragraph naming the silent-stall consequence and pointing to the
+   load-bearing reconciler finding (memory pin reference). Keep the
+   existing parameter/return notation.
+2. **Runtime warning.** At `NatsKV.Start`, emit a `Warn`-level log
+   when **both** of the following hold:
+   - `s.reconcileInterval <= 0`
+   - `s.leadershipProbe == nil`
+   This is precisely the condition `reconcileLoop` uses to exit
+   immediately. With a leadership probe wired, the reconciler still
+   runs (driven by the probe), so the warning would be a false
+   positive — guard against it.
+
+The warning is **read-only**; the configuration is not rejected. Per
+the plan: "rejection is more disruptive (existing users who explicitly
+disable polling break on upgrade); the safer route is to make the
+foot-gun loud."
+
+## Design
+
+```go
+// In source/nats_kv.go, modify WithReconcileInterval's Godoc:
+
+// WithReconcileInterval sets the periodic-reconcile ticker cadence. A value of
+// 0 disables polling entirely. The default is 30s. When WithLeadershipProbe is
+// also set the fixed interval is ignored in favour of the leadership-driven
+// cadence (leader=30s / follower=5min).
+//
+// Disabling the reconciler (setting d <= 0 with no leadership probe)
+// disables the load-bearing recovery path for the source watcher: after
+// a NATS server restart, the nats.go KV watcher's Updates() channel does
+// NOT close, and the reconciler is the only mechanism that re-syncs the
+// source state. Disable polling only with full awareness that
+// server-restart recovery will not work — Start emits a one-shot WARN
+// log line when this state is detected so the choice is visible.
+//
+// Parameters:
+//   - d: Reconcile interval (0 disables; default 30s)
+//
+// Returns:
+//   - NatsKVOption: Option function
+func WithReconcileInterval(d time.Duration) NatsKVOption { ... }
+```
+
+And in `Start` (after the existing watcher seed, before launching
+the loops — the logical place is between the lifecycle context
+setup at `nats_kv.go:244` and the `go reconcileLoop` launch at
+`nats_kv.go:256`):
+
+```go
+// Warn when the reconciler is disabled with no leadership probe.
+// The reconcileLoop exits immediately on this condition (see
+// reconcileLoop at L812-815); without it, a silent NATS server
+// restart can leave the source watcher stalled with no recovery
+// path. See memory pin project_nats_watcher_empirical_finding.
+if s.reconcileInterval <= 0 && s.leadershipProbe == nil {
+    s.logger.Warn("source reconciler disabled; server-restart recovery will not work — call source.WithReconcileInterval with a positive duration (or wire a leadership probe via source.WithLeadershipProbe)")
+}
+```
+
+## Reproducer test list
+
+No correctness reproducer required (no behavior change). Unit tests:
+
+- *T1.* `WithReconcileInterval(0)` + no leadership probe → warning
+  emitted exactly once at `Start`.
+- *T2.* `WithReconcileInterval(0)` + leadership probe set → silent
+  (the probe makes the reconciler still run).
+- *T3.* Default reconciler interval (omit `WithReconcileInterval`) →
+  silent. The default is 30s (`nats_kv.go`); the warning must not
+  fire on the happy path.
+- *T4.* Negative interval (`-1s`) + no leadership probe → warning
+  emitted (matches the `<= 0` guard).
+
+Use a capture-style logger fixture (reuse `captureLogger` if cleanly
+accessible from the source package's test, otherwise write a small
+local one — the source package does not import `parti.captureLogger`,
+so a local helper is the pragmatic choice).
+
+## Verification gates
+
+- `make lint && make test && make test-race` green.
+- Godoc check: `go doc github.com/arloliu/parti/v2/source.WithReconcileInterval`
+  shows the new paragraph.
+- No exported API change.
+
+## How this trips readiness
+
+Indirect. The warning makes a configuration that produces a
+readiness-blind silent stall **operator-visible** at first deploy
+rather than during an actual NATS restart event. The actual recovery
+mechanism still depends on the reconciler being enabled; this PR
+just refuses to let the operator disable it accidentally.
+
+## Out of scope
+
+- `consumer.ResolverConfig` and `internal/durable/config.go` are
+  already safe (both clamp non-positive intervals). Do not touch.
+- Programmatic rejection (returning an error from
+  `WithReconcileInterval` or `Start`). The plan explicitly chooses
+  warning over rejection.
+
+## Dependencies & sequencing
+
+Independent. Second of Phase 0 because the warning-helper pattern
+this PR mirrors (P0.1's `warnOnFiniteMaxReconnects`) is now familiar
+to the codebase.

--- a/docs/plans/self-healing/03-pr3-spec.md
+++ b/docs/plans/self-healing/03-pr3-spec.md
@@ -1,0 +1,167 @@
+# P0.3 (F10-B) — Two-phase handoff misconfiguration warning
+
+Per-PR spec for the third PR in Phase 0
+(`00-fix-plan.md` §P0.3). Lazy-written per the plan's convention; prior
+PR (P0.2, branch `self-healing-p02-f8-reconcile-guard`) is committed
+and surfaced.
+
+## Background
+
+`Config.EnableTwoPhaseHandoff` (`config.go:412`, default false) gates
+the manager-side two-phase handoff coordinator. When true, the
+coordinator publishes per-partition claims into the handoff bucket and
+relies on the consumer wiring a **processing gate** that consults
+those claims before delivering messages. If the consumer does NOT
+wire a gate (`internal/durable/processing_gate.go`'s
+`ProcessingGate.Enabled` is false), the claims are written and
+**never consulted** — two-phase handoff is effectively disabled even
+though the manager-side flag is on. The result is a misconfigured
+deployment that silently behaves as if the flag were false.
+
+The manager already has the signal it needs: `consumerUpdater`'s
+optional `CapabilityReporter.Capabilities()` returns a bitmask
+including `CapProcessingGate` when the consumer's handler is
+gate-wrapped (`internal/durable/worker_consumer.go:386-398,
+604-623`). `Manager.reportConsumerCapabilities` (`manager.go:822`)
+samples this after every `handoffCoordinator.Apply`. Today, if the
+bit never appears, nothing surfaces the discrepancy.
+
+A `Start`-time check is not viable — the gate bit is set when the
+consumer wraps the handler, which happens **during** an apply (not
+during construction). The check must fire on or after the first
+apply.
+
+## Scope (read-only — no behavior change)
+
+Add a one-shot WARN inside `reportConsumerCapabilities` that fires
+when **all** of the following hold (after the existing capability
+merge):
+
+1. `m.cfg.EnableTwoPhaseHandoff == true`
+2. `m.capProcessingGateWarned` has not been set yet
+3. `m.capabilities.Load() & uint32(types.CapProcessingGate) == 0`
+
+Setting the warned guard is one-shot for the lifetime of the manager.
+A subsequent apply that DOES wire the gate (operator rolled the
+consumer config and re-deployed) will not re-trigger the warning —
+that is the plan's intended behavior; a single noisy log line at the
+first apply is enough to surface the issue.
+
+## Design
+
+Add an `atomic.Bool` guard field on `Manager`:
+
+```go
+// capProcessingGateWarned guards the one-shot warning that fires
+// when EnableTwoPhaseHandoff is true and the consumer has not
+// reported CapProcessingGate after the first sampling opportunity.
+// One-shot per Manager lifetime (matches the plan's design).
+capProcessingGateWarned atomic.Bool
+```
+
+Modify `reportConsumerCapabilities` to call a new
+`maybeWarnMissingProcessingGate` at the end (after the existing
+short-circuit + Or-in-newBits logic). When `capReporter == nil` or
+when `missing == 0` (gate already in `m.capabilities`), the function
+returns early as today and the warning is correctly silent.
+
+```go
+func (m *Manager) reportConsumerCapabilities() {
+    if m.capReporter == nil {
+        return
+    }
+    missing := reportableCapBits &^ m.capabilities.Load()
+    if missing == 0 {
+        return // already includes CapProcessingGate; nothing to warn about
+    }
+    newBits := m.capReporter.Capabilities() & missing
+    if newBits != 0 {
+        m.capabilities.Or(newBits)
+    }
+    m.maybeWarnMissingProcessingGate()
+}
+
+func (m *Manager) maybeWarnMissingProcessingGate() {
+    if !m.cfg.EnableTwoPhaseHandoff {
+        return
+    }
+    if m.capProcessingGateWarned.Load() {
+        return
+    }
+    if m.capabilities.Load()&uint32(types.CapProcessingGate) != 0 {
+        return // gate is present post-merge; silent
+    }
+    if !m.capProcessingGateWarned.CompareAndSwap(false, true) {
+        return // raced with another goroutine
+    }
+    m.logger.Warn(
+        "two-phase handoff is enabled but the consumer reports no processing gate; "+
+            "partition claims are written and never consulted",
+        "remedy", "wire a processing gate on the consumer (e.g. consumer.Dynamic) so claims fence delivery",
+    )
+}
+```
+
+**Limitation acknowledged in code comments.** If the consumer
+updater does NOT implement `CapabilityReporter`
+(`m.capReporter == nil`), no `Capabilities()` call ever happens; the
+warning cannot fire because the signal is unavailable. This is
+intentional and documented — the warning depends on capability
+reporting. Consumers that bypass capability reporting are responsible
+for their own gate wiring verification.
+
+## Reproducer test list
+
+- *T1 (must fail on parent — primary).* Construct a `Manager` with
+  `EnableTwoPhaseHandoff = true`, a `CapabilityReporter` stub that
+  returns `0` (no gate bit). Drive one `applyAssignmentWithPrev`
+  call. Assert the warning is emitted exactly once. On parent (no
+  warning logic), the assertion fails (zero warnings).
+- *T2.* Same setup but the stub returns `CapProcessingGate`. Drive
+  apply. Assert **no** warning is emitted. Prevents false-positive
+  on the happy path.
+- *T3 (idempotency).* Same as T1 (gate absent). Drive apply twice in
+  succession. Assert the warning is emitted exactly **once**
+  (the `capProcessingGateWarned` guard's load-bearing property).
+- *T4 (flag-off silence).* `EnableTwoPhaseHandoff = false`. Stub
+  returns 0. Drive apply. Assert no warning. Confirms the warning
+  is gated by the flag.
+- *T5 (nil reporter silence).* `EnableTwoPhaseHandoff = true`,
+  `m.capReporter = nil`. Drive apply. Assert no warning fires —
+  the documented limitation. (No `Capabilities()` call happens, so
+  the gate signal is undetectable.)
+
+## Verification gates
+
+- `make lint && make test && make test-race` green.
+- No exported API change.
+- New manager struct field is unexported.
+- Code-review attention: the guard is single-shot per Manager
+  lifetime; subsequent applies with a wired gate do NOT reset it
+  (documented in the field's Godoc).
+
+## How this trips readiness
+
+It doesn't directly. The warning makes a misconfiguration that today
+silently neutralises two-phase handoff **operator-visible**. The
+operator's remedy is a deployment-time fix (enable the gate on the
+consumer); readiness rotation cannot recover this on its own because
+the misconfiguration is in the consumer's wiring, not in the
+manager's runtime state.
+
+## Out of scope
+
+- Rejecting the misconfiguration at `Start` — explicitly forbidden by
+  the plan (the gate bit is set at runtime, not at construction).
+- Adding a construction-time "gate-capable" predicate — listed as a
+  future follow-up in the plan, not in scope here.
+- Synthesising the warning for consumers that don't implement
+  `CapabilityReporter` — out of scope per the design rationale
+  (signal undetectable).
+
+## Dependencies & sequencing
+
+Independent. Last of Phase 0 because the test (driving apply with a
+stub updater) is the most integration-shaped of the Phase 0 tests;
+landing P0.1/P0.2 first establishes the warning-helper rhythm at the
+mechanical end.

--- a/docs/plans/self-healing/04-pr4-spec.md
+++ b/docs/plans/self-healing/04-pr4-spec.md
@@ -1,0 +1,299 @@
+# P1.1 (F6-A) — Source-bucket escalation hook + metric
+
+Per-PR spec for the fourth PR (first of Phase 1)
+(`00-fix-plan.md` §P1.1). Lazy-written. Prior PRs P0.1/P0.2/P0.3
+committed on their branches.
+
+## Empirical correction to the plan (discovered during implementation)
+
+The plan (`00-fix-plan.md` §P1.1 Anchors) says: detection fires on
+`jetstream.ErrBucketNotFound` in `restartWatcher` and `reconcileOnce`.
+Empirically, against nats.go v1.50.0:
+
+- `js.KeyValue(ctx, bucket)` after `js.DeleteKeyValue` → returns
+  `jetstream.ErrBucketNotFound` ✓ (the lookup path).
+- **`kv.Get(ctx, key)` on a cached KV handle after delete → returns
+  `nats.ErrNoResponders`** ✗ (the reconcile path; no JetStream
+  responder is bound to the subject anymore).
+- **`kv.Watch(ctx, key)` on a cached watcher after delete → returns
+  `jetstream.ErrStreamNotFound`** ✗ (the restartWatcher path; the
+  KV bucket is backed by a stream named `KV_<bucket>` and that
+  stream is gone).
+
+Neither call site that the plan names actually surfaces
+`ErrBucketNotFound`. The implementation therefore classifies all
+three errors as "bucket unavailable" via an `isBucketUnavailableErr`
+helper. `nats.ErrNoResponders` is broader than "bucket deleted" (it
+also fires during transient NATS reconnect), but the cooldown +
+gauge-clears-on-success design tolerates the false positive: the
+hook fires once, the gauge clears on the next successful op, and
+the operator's readiness probe sees only a brief blip. This is
+preferable to missing the genuine bucket-loss case.
+
+This finding deserves a memory pin (`project_nats_kv_delete_surface`)
+in the same family as `project_nats_watcher_empirical_finding`.
+
+## Background
+
+`source.NatsKV` accepts a `jetstream.KeyValue` handle from the caller
+(`source/nats_kv.go:178`) — the library never creates the bucket. If
+the bucket is deleted on the live connection, two read sites surface
+the loss:
+
+- `restartWatcher` (`source/nats_kv.go:772-805`) retries forever on
+  `watchFn` error. With the bucket gone, every retry produces
+  `jetstream.ErrBucketNotFound` and a logError line.
+- `reconcileOnce` (`source/nats_kv.go:864-878`) treats anything other
+  than `ErrKeyNotFound` as a generic log line.
+
+Neither path escalates. The Manager continues running with a stale
+in-memory partition list and the operator has no readiness signal.
+
+## Scope (additive — new public API)
+
+1. New exported callback type `SourceUnavailableHook func(err error)`.
+2. New option `source.WithUnavailableHook(SourceUnavailableHook)`.
+3. New metric interface `types.SourceMetrics` (single method:
+   `SetSourceBucketMissing(missing bool)`) + `NopSourceMetrics`
+   default, mirroring `HandoffMetricsRecorder`'s pattern. New
+   `source.WithMetrics(types.SourceMetrics)` option.
+4. Detection in `restartWatcher` and `reconcileOnce`: at the first
+   observation of `jetstream.ErrBucketNotFound`, fire the hook
+   (rate-limited, default 30s cooldown) and set the metric to
+   `missing=true`. On a successful subsequent watcher restart or
+   `kv.Get`, set the metric back to `missing=false`.
+
+No public API on the existing types is changed; only additions. The
+existing `WithReconcileInterval` / `WithLeadershipProbe` /
+`WithUpdateRetries` options keep their current signatures.
+
+## Design
+
+### Public type and options
+
+```go
+// SourceUnavailableHook fires when the partition-source bucket is
+// observed to be missing on the live connection. The library does not
+// recreate the bucket (user-owned; review §5 category A). Wire this
+// into your readiness logic — e.g. flip a readiness flag and let the
+// pod rotate — so the orchestrator can rebuild the bucket and let
+// startup re-provision cleanly.
+//
+// The hook is invoked synchronously from the source's reconciler /
+// restart goroutine. Implementations MUST be non-blocking and MUST
+// NOT call back into the source (recursive Get / Update will deadlock
+// against the watcher's restart path).
+type SourceUnavailableHook func(err error)
+
+// WithUnavailableHook registers a hook that fires when the partition-
+// source bucket is observed to be missing. See SourceUnavailableHook
+// for the deadlock contract.
+//
+// Without a hook, the loss is still logged and the metric is set, but
+// no escalation path runs — the library cannot recreate a user-owned
+// bucket on its own.
+func WithUnavailableHook(h SourceUnavailableHook) NatsKVOption
+```
+
+### Metric interface (new file `types/source_metrics.go`)
+
+```go
+// SourceMetrics captures source-layer health metrics.
+//
+// Implementations must be non-blocking and thread-safe. A no-op
+// implementation (NopSourceMetrics) is provided for callers that do
+// not need source metrics.
+//
+// This interface is intentionally separate from MetricsCollector
+// because the source layer is independent of the Manager runtime and
+// is constructed independently (a source can run without a Manager).
+type SourceMetrics interface {
+    // SetSourceBucketMissing sets the parti_source_bucket_missing
+    // gauge (0 = available, 1 = missing). Called from the source
+    // reconciler at the first ErrBucketNotFound observation and
+    // again when a subsequent operation succeeds.
+    SetSourceBucketMissing(missing bool)
+}
+
+type NopSourceMetrics struct{}
+
+func (NopSourceMetrics) SetSourceBucketMissing(bool) {}
+```
+
+### NatsKV state additions
+
+```go
+type NatsKV struct {
+    // ... existing fields ...
+
+    // F6-A: bucket-unavailability escalation
+    unavailableHook   SourceUnavailableHook
+    metrics           types.SourceMetrics
+    unavailableMu     sync.Mutex  // serialises lastHookAt / bucketMissing transitions
+    lastUnavailableAt time.Time   // most-recent hook invocation; zero == not fired
+    unavailableCooldown time.Duration // default 30s; mirrors defaultReconcileInterval
+    bucketMissing     bool        // current gauge state (under unavailableMu)
+}
+```
+
+Defaults applied in `NewNatsKV`:
+- `metrics = types.NopSourceMetrics{}`
+- `unavailableCooldown = 30 * time.Second` (matches the default
+  reconcile cadence; one cooldown ≈ one reconcile cycle)
+
+### Detection sites
+
+Both `restartWatcher` (after each `watchFn(ctx)` error) and
+`reconcileOnce` (the generic-error branch) gain a call to a new
+helper:
+
+```go
+// noteBucketUnavailable inspects err for jetstream.ErrBucketNotFound
+// and, when matched, fires the hook (rate-limited) and sets the
+// metric gauge. Returns true iff the error matched, so the caller
+// can keep its existing log line distinct.
+func (s *NatsKV) noteBucketUnavailable(err error) bool {
+    if !errors.Is(err, jetstream.ErrBucketNotFound) {
+        return false
+    }
+    s.unavailableMu.Lock()
+    fire := s.unavailableHook != nil &&
+        time.Since(s.lastUnavailableAt) >= s.unavailableCooldown
+    if fire {
+        s.lastUnavailableAt = time.Now()
+    }
+    if !s.bucketMissing {
+        s.bucketMissing = true
+        s.metrics.SetSourceBucketMissing(true)
+    }
+    s.unavailableMu.Unlock()
+
+    if fire {
+        s.unavailableHook(err)
+    }
+
+    return true
+}
+
+// noteBucketAvailable is called from the success paths of
+// restartWatcher (watcher created) and reconcileOnce (kv.Get OK)
+// to clear the gauge once the source is reachable again. The hook
+// is NOT fired on recovery — only on degradation.
+func (s *NatsKV) noteBucketAvailable() {
+    s.unavailableMu.Lock()
+    if s.bucketMissing {
+        s.bucketMissing = false
+        s.metrics.SetSourceBucketMissing(false)
+    }
+    s.unavailableMu.Unlock()
+}
+```
+
+Call-site changes (minimal):
+
+```go
+// In restartWatcher, replacing the existing error log:
+watcher, err := s.watchFn(ctx)
+if err == nil {
+    // ... existing success path ...
+    s.noteBucketAvailable()
+    return
+}
+if !s.noteBucketUnavailable(err) {
+    s.logError("failed to restart watcher, will retry", "error", err, "backoff", backoff)
+} else {
+    s.logError("source bucket missing; will retry", "error", err, "backoff", backoff)
+}
+```
+
+```go
+// In reconcileOnce, replacing the generic-error branch:
+entry, err := s.kv.Get(ctx, s.key)
+if err != nil {
+    if errors.Is(err, jetstream.ErrKeyNotFound) {
+        s.applyEmptyPreservingKnown()
+        s.noteBucketAvailable() // KeyNotFound implies bucket exists
+        return
+    }
+    if s.noteBucketUnavailable(err) {
+        s.logError("reconcile: source bucket missing", "error", err)
+        return
+    }
+    s.logError("reconcile: failed to fetch partitions", "error", err)
+    return
+}
+// ... existing success path; before applyLocal:
+s.noteBucketAvailable()
+```
+
+## Reproducer test list
+
+- *T1 (must fail on parent — hook fires).* Integration test under
+  `test/integration/failure/`: start an embedded NATS, create a
+  source bucket, wire `NatsKV` with `WithUnavailableHook` (records
+  invocations) and `WithReconcileInterval(200ms)` for a fast tick,
+  start it, then delete the bucket. Assert the hook fires within
+  one reconcile interval (≤ ~500 ms allowing for tick alignment)
+  with an error matching `jetstream.ErrBucketNotFound`. On parent:
+  hook field absent (compile error) OR, after introducing the
+  option scaffolding with no detection, the hook never fires (the
+  loss is silent).
+- *T2 (metric gauge set on loss).* Same setup; assert the metric
+  stub's gauge reads `true` after detection.
+- *T3 (cooldown — hook fired at most once per cooldown window).*
+  With cooldown overridden to 100ms via a test seam, delete the
+  bucket and let reconcile tick several times (3-5 ticks within
+  the cooldown). Assert the hook fires exactly once. Then advance
+  past the cooldown and trigger one more tick: assert the hook
+  fires a second time. The metric gauge stays `true` throughout.
+- *T4 (recovery clears the gauge).* After T1 fires the hook,
+  re-create the bucket (same name). On the next reconcile tick the
+  source recovers; assert the metric gauge reads `false`. The hook
+  is **not** re-fired on recovery (one-way escalation; the gauge
+  carries the recovery signal).
+- *T5 (no hook configured — silent path).* Same setup without
+  `WithUnavailableHook`. Delete the bucket. Assert no panic, the
+  reconcile loop keeps running, the metric gauge reads `true`.
+- *T6 (no metrics configured — silent path).* Same setup with the
+  hook but no `WithMetrics` (default Nop). Delete the bucket.
+  Assert no panic; the hook still fires.
+- *T7 (default 30s cooldown).* Unit test (no NATS): construct a
+  `NatsKV`, default cooldown applies; call `noteBucketUnavailable`
+  three times in rapid succession; assert hook fired exactly once.
+  The metric is set on every call (because the gauge tracks the
+  state, not the events).
+
+## Verification gates
+
+- `make lint && make test && make test-race && make test-integration`
+  green.
+- New exported symbols audited: `SourceUnavailableHook`,
+  `WithUnavailableHook`, `WithMetrics`, `types.SourceMetrics`,
+  `types.NopSourceMetrics`. No existing exported API changed.
+- `docs/OPERATIONS.md` updated under the existing degraded-mode
+  section to name the hook as the primary signal for source-bucket
+  loss; remind the operator that the library does not recreate the
+  bucket.
+
+## How this trips readiness
+
+The k8s operator wires `OnSourceUnavailable` into a
+readiness-probe flag (mirroring the existing `OnDegraded` pattern).
+A silent source loss now fails readiness → pod rotation → on
+restart, the source bucket is presumably re-provisioned by the
+operator's startup flow (or the failure surfaces consistently and
+the operator intervenes).
+
+## Out of scope
+
+- Library auto-recreating the source bucket — category A; forbidden.
+- The retry-bounding loop on `restartWatcher` — F2's territory
+  (PR P2.4a). This PR keeps `restartWatcher`'s forever-retry
+  behavior; it just adds escalation on bucket-loss.
+- Wiring the hook into Manager's degraded-mode machinery (the hook
+  is caller-owned; the Manager doesn't need to consume it).
+
+## Dependencies & sequencing
+
+Independent. First PR of Phase 1 because it is the smallest
+additive change in the phase.

--- a/docs/plans/self-healing/05-pr5-spec.md
+++ b/docs/plans/self-healing/05-pr5-spec.md
@@ -1,0 +1,156 @@
+# P1.2 (F3) — stableID NotFound classification → ErrClaimLost
+
+Per-PR spec for the fifth PR (second of Phase 1)
+(`00-fix-plan.md` §P1.2). Lazy-written; prior PR P1.1
+(`self-healing-p11-f6a-source-unavailable-hook`) committed.
+
+## Empirical correction to the plan (discovered during implementation)
+
+The plan says: "classify `jetstream.ErrBucketNotFound` and
+`jetstream.ErrStreamNotFound` as claim-loss in `Claimer.renew`."
+
+Empirical surface, against nats.go v1.50.0, of every KV op on a
+**cached KV handle** after `js.DeleteKeyValue(bucket)`:
+
+| Operation | Error returned |
+|---|---|
+| `kv.Update(...)` | `jetstream.ErrNoStreamResponse` |
+| `kv.Create(...)` | `jetstream.ErrNoStreamResponse` |
+| `kv.Delete(key)` | `jetstream.ErrNoStreamResponse` |
+| `kv.Get(...)`    | `nats.ErrNoResponders` |
+| `js.KeyValue(...)` lookup | `jetstream.ErrBucketNotFound` |
+| `kv.Watch(...)`  | `jetstream.ErrStreamNotFound` |
+
+**Crucially: `kv.Update` returns NEITHER of the plan's named errors.**
+The classifier must include `ErrNoStreamResponse` to detect the
+bucket-loss case that `Claimer.renew` actually encounters in
+production. The plan's named errors are kept for defense-in-depth
+(future nats.go versions could change behavior, and certain retry
+paths inside nats.go may surface them).
+
+Memory pin: [[project-nats-kv-delete-surface]]
+(also relevant for P1.3 F1 and the F2 envelope work).
+
+## Background
+
+`Claimer.renew` (`internal/stableid/claimer.go:362-370`) issues a
+CAS `kv.Update` on the claim key to re-stamp the timestamp. Today
+only `jetstream.ErrKeyExists` (the revision-mismatch case) is
+classified as `ErrClaimLost`; everything else is wrapped in a
+generic `"failed to renew ID %s"`.
+
+If the stableID bucket is deleted under a running worker, every
+subsequent renew tick returns `ErrNoStreamResponse`. The worker
+treats this as a generic error, logs it, keeps running — holding
+a stale claim that the bucket no longer recognizes. The
+documented contract (`docs/OPERATIONS.md`) says claim-loss
+triggers `claimLostShutdown` and pod rotation; this PR makes that
+contract actually hold.
+
+## Scope (small surface — classifier-only)
+
+Replace the single-case switch in `Claimer.renew` with a multi-arm
+classifier:
+
+- `jetstream.ErrKeyExists` → `ErrClaimLost` (existing; CAS conflict)
+- `jetstream.ErrNoStreamResponse` → `ErrClaimLost` (the empirical
+  bucket-loss surface for `Update`)
+- `jetstream.ErrBucketNotFound` → `ErrClaimLost` (defense-in-depth)
+- `jetstream.ErrStreamNotFound` → `ErrClaimLost` (defense-in-depth)
+- everything else → existing generic wrap
+
+The downstream `claimLostShutdown` → `OnError` → readiness flip →
+pod rotation path is unchanged.
+
+## Design
+
+```go
+// Inside Claimer.renew, replacing the existing two-arm conditional:
+newRev, err := c.kv.Update(ctx, key, []byte(value), c.lastRevision.Load())
+if err != nil {
+    switch {
+    case errors.Is(err, jetstream.ErrKeyExists):
+        // Revision mismatch: another worker took this ID over (or it
+        // expired and was re-created under us). The claim is lost.
+        return fmt.Errorf("%w: ID %s", ErrClaimLost, wid)
+    case errors.Is(err, jetstream.ErrNoStreamResponse),
+        errors.Is(err, jetstream.ErrBucketNotFound),
+        errors.Is(err, jetstream.ErrStreamNotFound):
+        // Bucket vanished from under us. We cannot renew, so the
+        // claim is effectively lost regardless of what's in our
+        // in-memory revision cache. See [[project-nats-kv-delete-surface]]
+        // for which error each surface actually returns.
+        return fmt.Errorf("%w: ID %s (bucket missing): %w", ErrClaimLost, wid, err)
+    default:
+        return fmt.Errorf("failed to renew ID %s: %w", wid, err)
+    }
+}
+```
+
+## Reproducer test list
+
+- *T1 (must fail on parent — primary).* Unit test in
+  `internal/stableid/claimer_test.go`: claim an ID against an embedded
+  NATS, then `js.DeleteKeyValue(bucket)`. Call `renew`. Assert
+  `errors.Is(err, ErrClaimLost)`. On parent the test fails (generic
+  wrapped error containing `"no response from stream"`).
+- *T2 (regression-guard for the existing case).* Inject a synthetic
+  KV stub whose `Update` returns `jetstream.ErrKeyExists`. Assert
+  `errors.Is(err, ErrClaimLost)`. Confirms the pre-existing branch
+  still classifies correctly.
+- *T3 (negative — non-NotFound errors NOT classified).* Synthetic stub
+  returning a generic error (e.g. `errors.New("boom")`). Assert NOT
+  `errors.Is(err, ErrClaimLost)` and that the error message wraps
+  the original (operators still get the diagnostic).
+- *T4 (defense-in-depth ErrBucketNotFound branch).* Synthetic stub
+  returning `jetstream.ErrBucketNotFound`. Assert `ErrClaimLost`.
+  The empirical path doesn't surface this for Update, but the
+  classifier branch must work in case future nats.go versions
+  start surfacing it.
+- *T5 (defense-in-depth ErrStreamNotFound branch).* Same as T4 with
+  `jetstream.ErrStreamNotFound`.
+- *T6 (negative — context cancel still generic).* Stub returning
+  `context.DeadlineExceeded`. Assert NOT `ErrClaimLost` (timeouts
+  must NOT trigger pod rotation; they retry on the next tick).
+
+## Verification gates
+
+- `make lint && make test && make test-race` green.
+- New exported symbols: none.
+- Confirm `claimLostShutdown` runs on T1 — the existing self-stop
+  wiring at `manager_election.go:91-98` must observe the new
+  classification. Cover with a small integration test that boots
+  a Manager, deletes the stableID bucket, and asserts the manager
+  enters its degraded / self-stop path within
+  `WorkerIDTTL + safety` of the deletion.
+
+## How this trips readiness
+
+Direct: vanished stableID bucket → `renew` returns `ErrClaimLost`
+→ `claimLostShutdown` → existing `OnError` path → readiness flip →
+pod rotation → re-claim into the (presumably re-provisioned)
+bucket cleanly.
+
+## Out of scope
+
+- Library auto-recreating the stableID bucket (category A; forbidden).
+- Preventing the brief duplicate-ID window during a wipe-and-recreate
+  — closed by F1 (P1.3, the epoch fence). This PR ensures the worker
+  fails *safe* (rotates promptly) but does not coordinate the wipe.
+- Touching `Claimer.Claim` (the initial-claim path) — only
+  `renew` is in scope per the plan. (Claim has its own handling
+  for bucket-missing cases.)
+
+## Dependencies & sequencing
+
+Independent. After P1.1 because P1.1 introduced the
+`isBucketUnavailableErr` pattern that the F2 envelope (P2.4) will
+later reuse — landing P1.1 first gives the codebase one example of
+the classifier pattern before P1.2 introduces a sibling.
+
+## Memory pin (after merge)
+
+[[project-nats-kv-delete-surface]] is the canonical reference for
+which nats.go error each KV op returns after bucket delete; cite it
+whenever a future change touches another error-classification branch
+in the codebase.

--- a/docs/plans/self-healing/06-pr6-spec.md
+++ b/docs/plans/self-healing/06-pr6-spec.md
@@ -1,0 +1,91 @@
+# P1.3 (F1) — Epoch fence: detect bucket wipe-and-recreate
+
+Per-PR spec for the sixth PR (third of Phase 1)
+(`00-fix-plan.md` §P1.3). Prior PRs P1.1, P1.2 committed.
+
+## Background
+
+Today the Manager caches KV handles (`m.assignmentKV`,
+`m.heartbeatKV`, etc.) at `Start`. If the cluster operator wipes a
+bucket and re-creates one under the same name (e.g. via a runbook
+that misjudges scope, or as part of the F9-A migration), the cached
+handles bind to the new stream silently. Writes succeed but the
+new bucket has none of the prior state — workers continue running
+against a freshly empty universe. The current connection monitor
+only detects connectivity-level errors, not bucket-identity
+changes, so the worker stays `Ready`.
+
+This is the highest-impact **readiness-blind** gap. F9-A's
+migration runbook explicitly performs a wipe-and-recreate, so F1
+is a hard prerequisite for P2.1.
+
+## Design deviation from the plan (recorded)
+
+The plan §P1.3 says "each KV-watcher reconciler gains a single new
+step." That requires touching four packages' reconciler loops
+(assignment, commit, claim-resolver, source) — high blast-radius
+for what is, behaviorally, "poll five buckets' Created timestamps."
+
+This implementation uses a **single centralized monitor goroutine**
+(`monitorBucketEpochs`) instead. Equivalent detection latency
+(default 30s, matching the dominant reconciler cadence), much
+smaller surface area. The monitor is started by `Manager.Start`
+after the five Parti-owned buckets have been ensured, runs until
+`m.ctx` is cancelled, and calls `m.enterDegraded("bucket-recreated:<bucket>")`
+on the first detected mismatch.
+
+The deviation does not change the contract: detection latency
+~30s (configurable via the same `OperationTimeout` knob the
+ensure paths use), single `OnDegraded` invocation, no recovery
+attempted in-process.
+
+## Scope (additive — detection only)
+
+1. New `kvutil.BucketStreamCreated(ctx, kv)` helper returning
+   the JetStream stream's `Created` timestamp.
+2. New `Manager.bucketEpochs map[string]time.Time` populated at
+   `Start` for each of the five Parti-owned buckets (stableid,
+   election, heartbeat, assignment, handoff).
+3. New `Manager.captureBucketEpoch(bucket, kv)` helper called
+   from each existing ensure path.
+4. New `Manager.monitorBucketEpochs(ctx)` goroutine started from
+   `Start` after all buckets are captured.
+5. New degraded reason constant `degradedReasonBucketRecreated`
+   and a per-bucket formatted reason string
+   `"bucket-recreated:<bucketName>"` passed to `enterDegraded`.
+
+No public API change. The `OnDegraded` hook already receives the
+reason; no caller migration needed.
+
+## Reproducer tests
+
+- *T1 (primary, per bucket).* For each of the five Parti-owned
+  buckets: start a Manager, capture the epoch, delete + recreate
+  the bucket, assert `OnDegraded` fires within 2 × monitor tick
+  with reason `bucket-recreated:<bucket>`. On parent the
+  detection does not exist — test times out.
+- *T2 (happy path).* Same bucket, no recreate. Monitor ticks for
+  3 cycles; no `OnDegraded`. Prevents false-positive.
+- *T3 (NATS restart with state intact).* Use the existing
+  `claim_resolver_nats_restart_test.go` server-restart pattern.
+  Restart NATS server preserving the StoreDir; assert NO epoch
+  fence trip — `Created` is preserved across the restart.
+
+## How this trips readiness
+
+Direct: detection → degraded → `OnDegraded` → readiness flip →
+pod rotation → restart re-provisions every missing bucket via
+get-first `EnsureKVBucket`. The previously-silent wipe-and-recreate
+path now triggers the standard recovery loop.
+
+## Dependencies
+
+Independent of P1.1, P1.2. **Hard prerequisite for P2.1 (F9-A)** —
+F9-A's migration runbook performs a bucket-delete, and the F1
+fence is what catches the resulting recreate event safely.
+
+## Out of scope
+
+- Healing the corruption in-process (fail-loud only).
+- `provision/marker` alternative (mentioned in plan; not chosen).
+- Source bucket — covered by P1.1 (F6-A) hook, not the epoch fence.

--- a/docs/plans/self-healing/07-pr7-spec.md
+++ b/docs/plans/self-healing/07-pr7-spec.md
@@ -1,0 +1,116 @@
+# P2.1 (F9-A) — Election bucket → FileStorage + OperationTimeout warning
+
+Per-PR spec for the seventh PR (first of Phase 2)
+(`00-fix-plan.md` §P2.1). Prior PRs P0.1-P0.3, P1.1-P1.3 committed.
+
+## Plan deviation (scope discovery)
+
+The plan says: change `MemoryStorage` → `FileStorage` AND set
+`Replicas: m.cfg.Replicas`. **`Config.Replicas` does not exist**
+(verified: only `provision.Config.Replicas` exists, which is the
+pre-provisioning helper not the runtime knob). Adding a Config knob
+is feature creep for "the lowest change-risk item of Phase 2."
+
+This PR therefore changes **only the storage type**, leaving
+Replicas at the server default (1). Operators who require HA across
+NATS-node restarts must pre-create the election bucket with the
+desired replica count using their provisioning flow (existing
+`docs/OPERATIONS.md` pattern: `nats kv add ... --replicas=3`). The
+migration runbook explicitly names this.
+
+The Storage change alone is still net-positive: a FileStorage R=1
+bucket survives node-process restart in a single-node deployment;
+the R≥3 win for multi-node deployments is operator-driven via
+pre-creation (which Parti already respects — `EnsureKVBucketWithRetry`
+is get-first).
+
+## Background
+
+`manager_setup.go:89` creates the election bucket with
+`MemoryStorage`. On a NATS node restart the bucket's contents (the
+leadership lease key) are lost; every follower notices the missing
+lease, all attempt to re-acquire, and the cluster experiences
+leadership churn. With FileStorage the contents survive the
+restart and leadership rides through.
+
+IOPS evidence: `docs/plans/iops-investigation/findings.md` §M1.9
+shows the storage switch is effectively free (−2% / −1% within
+noise) at N=1000 / N=3000 partitions.
+
+## Scope
+
+1. Change `manager_setup.go:89` election bucket from `MemoryStorage`
+   to `FileStorage`.
+2. Add `Manager.warnOnOperationTimeoutVsElection()` companion warning
+   that fires at Start when `OperationTimeout > ElectionTimeout/3`.
+3. Operator migration runbook in `docs/OPERATIONS.md` (one-time
+   bucket delete + replica recommendation).
+
+The heartbeat bucket stays MemoryStorage (workers re-publish every
+HeartbeatInterval — its loss is recoverable without restart).
+Assignment is already FileStorage. Source / handoff / stableid
+unchanged.
+
+## Hard prerequisite
+
+**P1.3 (F1) epoch fence must be merged first.** The runbook deletes
+the bucket on existing clusters; the epoch fence is what detects the
+recreate event safely.
+
+## Design
+
+**Storage switch (one line):**
+
+```go
+// In ensureCoreKVBuckets:
+electionKV, err = ensure("election", m.cfg.KVBuckets.ElectionBucket,
+    m.cfg.ElectionTimeout, jetstream.FileStorage)
+```
+
+**Companion warning:**
+
+```go
+// In manager_setup.go, alongside other warn helpers:
+func warnOnOperationTimeoutVsElection(cfg Config, logger types.Logger) {
+    if cfg.OperationTimeout > cfg.ElectionTimeout/3 {
+        logger.Warn(
+            "OperationTimeout exceeds ElectionTimeout/3; a single slow "+
+                "renew can consume the lease's three-attempt budget",
+            "OperationTimeout", cfg.OperationTimeout,
+            "ElectionTimeout", cfg.ElectionTimeout,
+            "remedy", "set OperationTimeout <= ElectionTimeout/3",
+        )
+    }
+}
+```
+
+Called from `Manager.Start` alongside the other warning helpers.
+
+## Reproducer tests
+
+- *T1 (companion warning).* Unit test, table-driven:
+  - `OperationTimeout=5s, ElectionTimeout=30s` → silent (5 ≤ 10)
+  - `OperationTimeout=11s, ElectionTimeout=30s` → warns (11 > 10)
+  - `OperationTimeout=ElectionTimeout` → warns
+- *T2 (storage choice).* Start Manager against embedded NATS; read
+  back the election bucket's stream Storage; assert
+  `jetstream.FileStorage`. On parent: returns MemoryStorage.
+
+## Verification gates
+
+- `make lint && make test && make test-race` green.
+- Docs review: migration runbook in `docs/OPERATIONS.md` reads
+  unambiguously.
+
+## How this trips readiness
+
+Indirectly: the change **eliminates** the dominant readiness-trip
+cause (election bucket loss on routine NATS node restart). The
+genuine cluster-rebuild case still trips readiness via the P1.3
+epoch fence.
+
+## Out of scope
+
+- Adding `Config.Replicas` (separate feature, separate PR).
+- Heartbeat / handoff / stableid storage changes.
+- F9-B lease-aware leader (deferred to Phase 3).

--- a/docs/plans/self-healing/08-pr8-spec.md
+++ b/docs/plans/self-healing/08-pr8-spec.md
@@ -1,0 +1,129 @@
+# P2.4a (F2) — Bounded-retry envelope + restartWatcher wiring
+
+Per-PR spec for the eighth PR (P2.4a — first of four F2 sub-PRs).
+Prior PRs through P2.1 committed. Phase 2 dominant fixes begin here.
+
+## Scope deviation (recorded)
+
+The plan §P2.4a says: "After exhaustion, `restartWatcher` fires
+`OnSourceUnavailable` (P1.1's hook) and stops retrying until the
+source reconciler successfully re-reads via `kv.Get`."
+
+P1.1's hook lives on a separate branch (`self-healing-p11-f6a-source-unavailable-hook`),
+not on `main`. This PR is independent and lands cleanly on `main`,
+so wiring to that specific hook waits for the merge sequence.
+Instead, the envelope-exhaustion path here:
+
+1. Logs the exhaustion at WARN.
+2. Exits the `restartWatcher` goroutine, leaving the periodic
+   reconciler as the sole recovery path (already documented in
+   `project_nats_watcher_empirical_finding` as load-bearing).
+3. Records the exhaustion event via a new
+   `parti_source_watcher_restart_exhausted` counter (registered
+   through the new `types.SourceMetrics.IncWatcherRestartExhausted`
+   method — additive only).
+
+When P1.1 and P2.4a merge, the integration PR (or a follow-up)
+wires the exhaustion to `OnSourceUnavailable` directly. This split
+keeps both PRs reviewable independently against `main`.
+
+## Background
+
+Today `restartWatcher` (`source/nats_kv.go:772-805`) retries
+forever on `watchFn` error. With the bucket gone, every retry
+produces `nats.ErrNoResponders` / `jetstream.ErrStreamNotFound`
+and a logError line. The loop is the **dominant thundering-herd
+risk** in the source layer: a transient NATS reconnect surge can
+have every worker hammering the same subject in lockstep, and a
+permanent bucket-loss has the loop running until process death.
+
+## Design
+
+### New package `internal/retry/envelope.go`
+
+```go
+// retryClass classifies an error from the work function for the
+// envelope's next action.
+type retryClass int
+
+const (
+    retryTransient retryClass = iota
+    retryGiveUp
+    retryFatal
+)
+
+type retryEnvelope struct {
+    work        func(ctx context.Context) error
+    classify    func(err error) retryClass
+    onPermanent func(err error)
+    onProgress  func(attempt int, err error)
+    baseBackoff time.Duration
+    maxBackoff  time.Duration
+    maxAttempts int
+    jitter      float64
+}
+
+func (e *retryEnvelope) run(ctx context.Context) error
+```
+
+`run` returns:
+- `nil` on success
+- `ctx.Err()` if cancelled
+- `errRetryExhausted` on attempt budget exhaustion (after firing
+  `onPermanent`)
+- the work's error directly on `retryFatal` (no retries)
+
+### Wiring at `restartWatcher`
+
+```go
+func (s *NatsKV) restartWatcher(ctx context.Context) {
+    env := retry.NewEnvelope(retry.Config{
+        Work:        s.tryRebindWatcher, // wraps watchFn + bookkeeping
+        Classify:    s.classifyRebindErr,
+        OnPermanent: s.onRebindExhausted,
+        BaseBackoff: watcherBaseBackoff,
+        MaxBackoff:  watcherMaxBackoff,
+        MaxAttempts: 6, // ~64s @ 1s base; matches one reconcile cycle
+        Jitter:      watcherJitter,
+    })
+    _ = env.Run(ctx) // ctx cancellation and exhaustion both exit the goroutine
+}
+```
+
+## Reproducer tests (envelope package)
+
+Unit tests against the envelope directly, no NATS dependency:
+
+- *T1.* Success on first attempt → 1 call, no backoff, returns nil.
+- *T2.* Transient × 3 then success → 4 calls total, returns nil.
+- *T3.* Transient × MaxAttempts → returns errRetryExhausted,
+  onPermanent fired exactly once with the LAST error.
+- *T4.* GiveUp on first call → onPermanent fired immediately with
+  that error; returns errRetryExhausted.
+- *T5.* Fatal on first call → returns the original error directly;
+  onPermanent NOT fired (fatal ≠ permanent — fatal means caller
+  needs to handle it; permanent means we gave up).
+- *T6.* Context cancel mid-backoff → returns ctx.Err(); onPermanent
+  NOT fired.
+- *T7.* Backoff capped at MaxBackoff (no exponential overshoot).
+- *T8.* Jitter applied (statistical: 100 runs; backoff in
+  [base × (1-jitter), base × (1+jitter)]).
+
+## Verification gates
+
+- `make lint && make test && make test-race` green.
+- New exported symbols audited (only the `internal/retry` package's
+  surface; no public-API change).
+
+## How this trips readiness
+
+P2.4a alone does NOT trip readiness — exhaustion exits the
+restart goroutine, leaving the reconciler as recovery. The
+readiness trip arrives once P1.1's hook is wired (after both
+land on main; the integration is a small follow-up).
+
+## Out of scope
+
+- Wiring P1.1's `OnSourceUnavailable` (separate branch, separate
+  merge).
+- Applying the envelope to other call sites — P2.4b/c/d.

--- a/docs/plans/self-healing/README.md
+++ b/docs/plans/self-healing/README.md
@@ -1,0 +1,97 @@
+# Self-Healing Hardening
+
+Phased fix plan for the ten findings in [`findings.md`](./findings.md)
+(reviewed clean across 9 rounds; trail in
+[`review-trail.md`](./review-trail.md)). The findings span the connectivity
+layer, KV-bucket state, JetStream stream / consumer recovery, manager
+orchestration, and election / double-assignment correctness.
+
+## Why this exists
+
+Parti's self-healing is **strong for transient faults and consumer loss, has a
+hard floor at server-side state loss, and has two latent correctness gaps
+under *partial* NATS failure** (the F9 / F10 area). The review investigation
+established that on this k8s deployment the readiness probe IS the recovery
+mechanism — so the organising invariant is:
+
+> **Every unrecoverable failure must trip the Kubernetes readiness probe.**
+
+The plan turns each finding into one PR (F2 split into four), sequenced so
+low-risk warm-ups land first and the dominant
+correctness work lands against a stable baseline.
+
+## Status
+
+| Phase | State |
+|---|---|
+| Investigation | Done — [`findings.md`](./findings.md) |
+| 9-round findings review | Done — [`review-trail.md`](./review-trail.md) |
+| Phased plan (this doc + [`00-fix-plan.md`](./00-fix-plan.md)) | **Plan-review clean (3 rounds)** — ready to implement |
+| Phase 0 — F7, F8, F10-B | Not started |
+| Phase 1 — F6-A, F3, F1 | Not started |
+| Phase 2 — F9-A, F6-B, F5, F2 (×4 PRs), F10-A | Not started |
+| Phase 3 — F9-B, F4 | Deferred — gated on operational evidence |
+
+## Layout
+
+```
+docs/plans/self-healing/
+├── README.md            # This file: status, layout, PR sequencing
+├── 00-fix-plan.md       # Phase-organised per-finding plan (scope, design, reproducers, gates, deps)
+├── findings.md          # Authoritative findings doc (reviewed clean across 9 rounds)
+└── review-trail.md      # Consolidated review history (9 rounds → 1 file)
+```
+
+Per-PR specs are written **lazily** — only when the prior PR is merge-clean,
+mirroring `docs/plans/worker-state-hardening/README.md`'s explicit pattern:
+*"avoids speculative spec drift."* Spec files will be added here as
+`01-pr1-spec.md`, `02-pr2-spec.md`, … using the existing convention.
+
+## PR sequence
+
+Full table with anchors, design, reproducers, and gates lives in
+`00-fix-plan.md`. Compact view:
+
+Tier = version-neutral model recommendation (**strong** = use the
+strongest available Claude model; **standard** = standard tier);
+Review = `/codex:review` effort for the post-impl review. See
+`00-fix-plan.md` discipline rule 7 for the selection heuristic.
+
+| Order | ID | Finding | Risk | Reproducer | Tier | Review | Notes |
+|---|---|---|---|---|---|---|---|
+| **Phase 0 — warm-ups** ||||||||
+| P0.1 | F7 | Connection-config docs + warning | **LOW** | no | standard | `high` | Docs + read-only warning |
+| P0.2 | F8 | `source.WithReconcileInterval(0)` guard | **LOW** | no | standard | `high` | Godoc + warning |
+| P0.3 | F10-B | Two-phase config diagnostic warning | **LOW** | yes | standard | `high` | Fires at first two-phase apply, not at `Start` |
+| **Phase 1 — additive correctness** ||||||||
+| P1.1 | F6-A | Source-bucket escalation hook | LOW–MED | yes | standard | `high` | `OnSourceUnavailable` |
+| P1.2 | F3 | stableID NotFound classification | **MED** | yes | standard | `high` | Small surface |
+| P1.3 | F1 | Epoch fence | **MED** | yes | **strong** | `xhigh` | **Prerequisite for F9-A** |
+| **Phase 2 — dominant fixes** ||||||||
+| P2.1 | F9-A | Election bucket → `FileStorage` R≥3 | **LOW** | yes | **strong** | `xhigh` | Depends on F1; operator runbook in spec |
+| P2.2 | F6-B | Calculator-layer partition floor | **MED** | yes | **strong** | `xhigh` | Symmetric with F10-A |
+| P2.4a | F2 | Envelope + `restartWatcher` wiring | **MED–HIGH** | yes | **strong** | `xhigh` | Envelope crystallises here |
+| P2.4b | F2 | Envelope → handoff watcher | **MED–HIGH** | yes | standard | `high` | Reuses envelope from P2.4a |
+| P2.4c | F2 | Envelope → assignment watcher | **MED–HIGH** | yes | standard | `high` | Reuses; trips degraded on exhaustion |
+| P2.4d | F2 | Envelope → dynamic-consumer recovery | **MED–HIGH** | yes | **strong** | `xhigh` | Prerequisite for P2.3 (F5) |
+| P2.3 | F5 | Stream-gone hook + checkpoint reset | **MED** | yes | **strong** | `xhigh` | Depends on P2.4d for envelope wiring |
+| P2.5 | F10-A | Truncated-`Keys()` defense + worker-set floor | **MED** | **chaos test FIRST** | **strong** | `xhigh` | Hard gate |
+| **Phase 3 — DEFERRED** ||||||||
+| P3.1 | F9-B | Lease-aware leader | **HIGH** | yes | tbd | tbd | Re-evaluate at re-promotion |
+| P3.2 | F4 | In-process re-provision (OPTIONAL) | **HIGH** | yes | tbd | tbd | Likely dropped; F9-A subsumes election-bucket case |
+
+13 in-scope PRs (P0–P2). 2 deferred (P3). Sequencing rationale and per-finding
+detail in `00-fix-plan.md`.
+
+## Cross-references
+
+- Authoritative source: [`findings.md`](./findings.md)
+- Consolidated review trail: [`review-trail.md`](./review-trail.md)
+- IOPS justification for F9-A storage switch:
+  [`docs/plans/iops-investigation/findings.md`](../iops-investigation/findings.md)
+  §2 cell M1.9 (−2 % / −1 % within noise → switch is effectively free)
+- Plan-shape mirror:
+  [`docs/plans/worker-state-hardening/README.md`](../worker-state-hardening/README.md)
+  (lazy per-PR specs)
+- Partition-fencing roadmap (F10-C scope cross-reference):
+  [`docs/plans/partition-fencing/README.md`](../partition-fencing/README.md)

--- a/docs/plans/self-healing/STATUS.md
+++ b/docs/plans/self-healing/STATUS.md
@@ -1,0 +1,111 @@
+# Self-Healing Implementation Status
+
+This file tracks per-PR delivery state. Updated 2026-05-23 mid-session.
+
+See [`README.md`](./README.md) for the plan overview and
+[`00-fix-plan.md`](./00-fix-plan.md) for the per-PR specs.
+
+## Delivered (9 of 13 in-scope PRs)
+
+All branches below are local-only at session end and need
+`git push -u origin <branch>` followed by per-PR review +
+merge. Each PR is branched off `main`, not stacked.
+
+| Order | ID | Branch | Spec | Commit | Notes |
+|---|---|---|---|---|---|
+| P0.1 | F7 | `self-healing-p01-f7-conn-config` | [01](./01-pr1-spec.md) | `14d857e` | Docs + finite-MaxReconnect WARN |
+| P0.2 | F8 | `self-healing-p02-f8-reconcile-guard` | [02](./02-pr2-spec.md) | `c25eb8c` | Source reconciler-disabled WARN |
+| P0.3 | F10-B | `self-healing-p03-f10b-twophase-warning` | [03](./03-pr3-spec.md) | `6fbbb27` | Two-phase + no-gate WARN |
+| P1.1 | F6-A | `self-healing-p11-f6a-source-unavailable-hook` | [04](./04-pr4-spec.md) | `715833c` | Source-bucket hook + metric |
+| P1.2 | F3 | `self-healing-p12-f3-stableid-notfound` | [05](./05-pr5-spec.md) | `dee6d7d` | stableID NotFound → ErrClaimLost |
+| P1.3 | F1 | `self-healing-p13-f1-epoch-fence` | [06](./06-pr6-spec.md) | `8017ae1` | Bucket-recreate detection |
+| P2.1 | F9-A | `self-healing-p21-f9a-election-filestorage` | [07](./07-pr7-spec.md) | `375c517` | Election bucket FileStorage |
+| P2.4a | F2 | `self-healing-p24a-f2-retry-envelope` | [08](./08-pr8-spec.md) | `908f181` | Retry envelope + restartWatcher wiring |
+| P2.2 | F6-B | `self-healing-p22-f6b-partition-floor` | (in plan) | `8c072dc` | Calculator empty/shrunk floor |
+
+Phase 0 (P0.1-P0.3) and Phase 1 (P1.1-P1.3) are complete. Phase 2
+has the **three dominant fixes**: P2.1 (eliminates leadership-churn),
+P2.4a (bounds the source watcher's infinite retry loop), and P2.2
+(prevents reassign-to-zero thundering herd on a transient empty
+partition observation).
+
+## Remaining (4 of 13 in-scope PRs)
+
+Each needs its own session — none is mechanical reuse:
+
+| Order | ID | Status | Reason |
+|---|---|---|---|
+| P2.4b | F2 | Not started | Envelope reuse on `claim_resolver` supervise loop. Site has nested supervisor + restart-reason classification — read carefully. |
+| P2.4c | F2 | Not started | Envelope reuse on `monitorAssignmentChanges`. Different stop semantics; exhaustion must call `enterDegraded("assignment-watcher-exhausted")` per plan. |
+| P2.4d | F2 | Not started | Envelope reuse on `partition_consumer.go` recovery loop. Larger surface; **P2.3's prerequisite**. |
+| P2.3 | F5 | Not started | Stream-gone hook + checkpoint reset + stream-epoch generation fence. **HIGH risk** (three coordinated mechanisms; manual-ack late-ack defense). Depends on P2.4d. |
+| P2.5 | F10-A | Not started | **Chaos reproducer first** (hard gate). Truncated `Keys()` defense + worker-set floor. |
+
+Deferred to Phase 3 (post-promotion gated):
+- P3.1 (F9-B) Lease-aware leader
+- P3.2 (F4) In-process re-provision
+
+## Merge ordering — IMPORTANT
+
+The 9 branches are **not stacked**; they all branch from `main`. They
+will conflict on shared files when merged. Merge in plan order to
+minimize conflict resolution work:
+
+```
+P0.1 → P0.2 → P0.3 → P1.1 → P1.2 → P1.3 → P2.1 → P2.4a → P2.2
+```
+
+Known overlap zones:
+
+- `manager.go` — P0.1 (warn call), P0.3 (`capProcessingGateWarned`
+  field + helper), P1.3 (epoch fence field + monitor wireup), P2.1
+  (`warnOnOperationTimeoutVsElection` call) all add to disjoint
+  regions; mostly mechanical merges.
+- `manager_setup.go` — P0.1 adds `warnOnFiniteMaxReconnects`, P1.3
+  adds `bucketEpoch` / `captureBucketEpoch` / `monitorBucketEpochs`
+  helpers, P2.1 flips the election-bucket storage type + adds
+  `warnOnOperationTimeoutVsElection`. All in different regions of
+  the file.
+- `source/nats_kv.go` — P0.2 adds `logWarn` helper; P1.1 adds the
+  unavailable-hook scaffold + the same `logWarn` helper (the latter
+  is the first to land); P2.4a replaces `restartWatcher`'s body and
+  also adds a `logWarn` helper. **When merging after P0.2 or P1.1
+  already provides `logWarn`, drop the duplicate from the later PR.**
+
+The spec files (`01-pr1-spec.md` … `08-pr8-spec.md`) and this STATUS
+live on the `self-healing-plan-specs` branch. Merge it first so
+subsequent PR reviews can reference the specs in-tree.
+
+## Workflow note
+
+Per the project's `feedback_post_impl_review_workflow` memory pin, the
+standard cycle is **spec → impl → /simplify → /codex:review (or
+copilot post-impl) → squash on merge**. All 9 PRs here have gone
+through **spec → impl → make lint && make test (-race)** only. The
+`/simplify` pass and external review are pending — recommended to
+run as a batch before merging.
+
+## Empirical findings discovered during implementation
+
+Two non-obvious facts about the nats.go KV surface that the plan got
+wrong, surfaced by reproducer probes:
+
+1. **After `js.DeleteKeyValue`, no production call site returns
+   `jetstream.ErrBucketNotFound`** (the plan's named error):
+   - `kv.Get` → `nats.ErrNoResponders`
+   - `kv.Watch` → `jetstream.ErrStreamNotFound`
+   - `kv.Update` → `jetstream.ErrNoStreamResponse`
+   - Only `js.KeyValue(...)` lookup returns `ErrBucketNotFound`.
+
+   Pinned in memory: [[project-nats-kv-delete-surface]]. Affects
+   the P1.1 (F6-A) and P1.2 (F3) classifiers — both ship with the
+   empirically-correct error set.
+
+2. **No `Config.Replicas` field exists in Parti's runtime config**
+   (only in `provision.Config`). The plan's P2.1 instruction to set
+   `Replicas: m.cfg.Replicas` was therefore not actionable; P2.1
+   ships the storage-type change only, with operator-driven
+   pre-creation for the replica count documented in the migration
+   runbook.
+
+Both deviations are recorded in the respective per-PR spec files.

--- a/docs/plans/self-healing/STATUS.md
+++ b/docs/plans/self-healing/STATUS.md
@@ -1,15 +1,16 @@
 # Self-Healing Implementation Status
 
-This file tracks per-PR delivery state. Updated 2026-05-23 mid-session.
+This file tracks per-PR delivery state. Updated 2026-05-23
+(post-`KVBuckets.Replicas` follow-up).
 
 See [`README.md`](./README.md) for the plan overview and
 [`00-fix-plan.md`](./00-fix-plan.md) for the per-PR specs.
 
-## Delivered (9 of 13 in-scope PRs)
+## Delivered (9 of 13 in-scope PRs + 1 follow-up)
 
-All branches below are local-only at session end and need
-`git push -u origin <branch>` followed by per-PR review +
-merge. Each PR is branched off `main`, not stacked.
+All branches below have been pushed to `origin`. Each PR is branched
+off `main`, not stacked — see "Merge ordering" below for the conflict
+zones.
 
 | Order | ID | Branch | Spec | Commit | Notes |
 |---|---|---|---|---|---|
@@ -22,12 +23,39 @@ merge. Each PR is branched off `main`, not stacked.
 | P2.1 | F9-A | `self-healing-p21-f9a-election-filestorage` | [07](./07-pr7-spec.md) | `375c517` | Election bucket FileStorage |
 | P2.4a | F2 | `self-healing-p24a-f2-retry-envelope` | [08](./08-pr8-spec.md) | `908f181` | Retry envelope + restartWatcher wiring |
 | P2.2 | F6-B | `self-healing-p22-f6b-partition-floor` | (in plan) | `8c072dc` | Calculator empty/shrunk floor |
+| F/U  | —     | `self-healing-kvbuckets-replicas`              | (this STATUS) | `399dfb1` | `Config.KVBuckets.Replicas` + warn-on-mismatch helper |
 
 Phase 0 (P0.1-P0.3) and Phase 1 (P1.1-P1.3) are complete. Phase 2
 has the **three dominant fixes**: P2.1 (eliminates leadership-churn),
 P2.4a (bounds the source watcher's infinite retry loop), and P2.2
 (prevents reassign-to-zero thundering herd on a transient empty
 partition observation).
+
+### Follow-up: `Config.KVBuckets.Replicas`
+
+A separate PR (not part of the original plan, but discovered during
+P2.1 implementation when the plan's `m.cfg.Replicas` anchor was
+found to be non-existent). Adds:
+
+- `Config.KVBuckets.Replicas int` — JetStream stream-replication
+  factor stamped onto Parti-owned KV buckets at create time. Defaults
+  to 0 (legacy server-default behavior).
+- `warnOnReplicasMismatch` helper — fires at `Manager.Start` when an
+  existing bucket's Replicas differs from the requested value.
+- Deliberately does **NOT** auto-reconcile Replicas. JetStream
+  `UpdateStream` DOES support changing Replicas on an existing
+  bucket (verified empirically against nats.go v1.50.0), but
+  Replicas is HA-quality, not a correctness invariant like MaxAge.
+  Silently rewriting an operator's bucket config could trigger
+  expensive cross-node replication or mask a deliberate downsize.
+  The warning is the operator-actionable signal; running
+  `nats stream update KV_<bucket> --replicas=N` is the manual
+  remedy.
+
+Independent of P2.1; can land before or after. If P2.1 lands first,
+the migration runbook should get a one-line addendum mentioning the
+new config option as an alternative to pre-creating with
+`--replicas=3`.
 
 ## Remaining (4 of 13 in-scope PRs)
 
@@ -47,12 +75,13 @@ Deferred to Phase 3 (post-promotion gated):
 
 ## Merge ordering — IMPORTANT
 
-The 9 branches are **not stacked**; they all branch from `main`. They
+The 10 branches are **not stacked**; they all branch from `main`. They
 will conflict on shared files when merged. Merge in plan order to
 minimize conflict resolution work:
 
 ```
-P0.1 → P0.2 → P0.3 → P1.1 → P1.2 → P1.3 → P2.1 → P2.4a → P2.2
+plan-specs → P0.1 → P0.2 → P0.3 → P1.1 → P1.2 → P1.3 →
+  P2.1 → kvbuckets-replicas → P2.4a → P2.2
 ```
 
 Known overlap zones:
@@ -64,8 +93,14 @@ Known overlap zones:
 - `manager_setup.go` — P0.1 adds `warnOnFiniteMaxReconnects`, P1.3
   adds `bucketEpoch` / `captureBucketEpoch` / `monitorBucketEpochs`
   helpers, P2.1 flips the election-bucket storage type + adds
-  `warnOnOperationTimeoutVsElection`. All in different regions of
-  the file.
+  `warnOnOperationTimeoutVsElection`, `kvbuckets-replicas` stamps
+  `m.cfg.KVBuckets.Replicas` in `ensureKVBucket` + adds
+  `warnOnReplicasMismatch`. All in different regions of the file
+  except `ensureKVBucket`, where `kvbuckets-replicas` adds two
+  lines (the Replicas stamp + the mismatch warn call) — easy
+  3-way merge.
+- `config.go` — only `kvbuckets-replicas` touches it (adds the
+  `Replicas` field to `KVBucketConfig`). No other PR conflicts.
 - `source/nats_kv.go` — P0.2 adds `logWarn` helper; P1.1 adds the
   unavailable-hook scaffold + the same `logWarn` helper (the latter
   is the first to land); P2.4a replaces `restartWatcher`'s body and
@@ -80,15 +115,15 @@ subsequent PR reviews can reference the specs in-tree.
 
 Per the project's `feedback_post_impl_review_workflow` memory pin, the
 standard cycle is **spec → impl → /simplify → /codex:review (or
-copilot post-impl) → squash on merge**. All 9 PRs here have gone
+copilot post-impl) → squash on merge**. All 10 branches here have gone
 through **spec → impl → make lint && make test (-race)** only. The
 `/simplify` pass and external review are pending — recommended to
 run as a batch before merging.
 
 ## Empirical findings discovered during implementation
 
-Two non-obvious facts about the nats.go KV surface that the plan got
-wrong, surfaced by reproducer probes:
+Three non-obvious facts about the nats.go KV surface that the plan got
+wrong (or didn't address), surfaced by reproducer probes:
 
 1. **After `js.DeleteKeyValue`, no production call site returns
    `jetstream.ErrBucketNotFound`** (the plan's named error):
@@ -104,8 +139,24 @@ wrong, surfaced by reproducer probes:
 2. **No `Config.Replicas` field exists in Parti's runtime config**
    (only in `provision.Config`). The plan's P2.1 instruction to set
    `Replicas: m.cfg.Replicas` was therefore not actionable; P2.1
-   ships the storage-type change only, with operator-driven
-   pre-creation for the replica count documented in the migration
-   runbook.
+   ships the storage-type change only. The `kvbuckets-replicas`
+   follow-up branch adds `Config.KVBuckets.Replicas` as the
+   operator-ergonomics fix (nested under `KVBuckets` rather than
+   top-level because plain `Replicas` would be ambiguous with
+   worker-pod replica notions).
 
-Both deviations are recorded in the respective per-PR spec files.
+3. **JetStream `UpdateStream` accepts post-create Replicas changes.**
+   The library could in principle auto-reconcile Replicas on every
+   `Manager.Start` the way it reconciles MaxAge for stableID and
+   handoff buckets. The `kvbuckets-replicas` follow-up deliberately
+   does NOT do this: Replicas is HA quality (not a correctness
+   invariant like MaxAge), silently rewriting an existing bucket
+   could trigger expensive cross-node replication the operator did
+   not ask for, and the get-first contract ("pre-creation wins")
+   is the safer default. The follow-up's `warnOnReplicasMismatch`
+   helper surfaces divergence so operators can run
+   `nats stream update KV_<bucket> --replicas=N` themselves when
+   they want the change to take effect.
+
+All three deviations are recorded in the respective per-PR spec or
+commit-message bodies.

--- a/docs/plans/self-healing/findings.md
+++ b/docs/plans/self-healing/findings.md
@@ -1,0 +1,996 @@
+# Parti Self-Healing Review — Findings & Recommendations
+
+**Date:** 2026-05-23
+**Branch:** main
+**Status:** Investigation deliverable — for review. No code changed.
+
+**Scope:** Self-healing posture of the Parti library, with emphasis on dynamic
+partitioning, against the stated requirements:
+
+1. Keep working when the NATS cluster has problems and is rebuilt.
+2. When consumer / KV buckets are gone, try to re-create them *if possible*.
+3. **Partial NATS abnormality** — when the election / heartbeat subsystem fails
+   while the rest of NATS works, retain the current leader and avoid a follower
+   promoting into a second leader.
+4. **Double assignment** — whether the same partition can be owned and processed
+   by two workers at once.
+
+**Deployment (confirmed):** Kubernetes, with the `OnDegraded` → readiness-probe
+→ pod-rotation pattern (`examples/degraded-readiness`).
+
+---
+
+## 1. Scope & Method
+
+Five read-only investigations covered the independent self-healing surfaces:
+
+- **Connectivity layer** — `internal/natsutil/`, connection lifecycle, the
+  KV-watcher + reconciler pattern.
+- **KV-bucket-backed state** — `internal/election/`, `internal/stableid/`,
+  `source/nats_kv.go`, `internal/kvbuckets/`, `manager_handoff.go`,
+  `internal/durable/claim_resolver.go`, `provision/`.
+- **JetStream stream / consumer recovery** — `internal/recovery/`,
+  `internal/durable/partition_consumer.go`, `worker_consumer.go`,
+  `consumer/dynamic.go`, `internal/dynamicbuild/`.
+- **Manager orchestration** — `manager.go`, `manager_setup.go`,
+  `manager_degraded.go`, `manager_assignment.go`, `manager_election.go`,
+  `internal/heartbeat/`.
+- **Election stability & double-assignment** — `internal/election/`,
+  `internal/assignment/` (calculator, worker monitor, audit, emergency),
+  `internal/assignment/handoff/`, `internal/durable/processing_gate.go`.
+
+Every claim is backed by a `file:line` citation. Where a behavior could not be
+verified from source it is marked **unverified** and the reason given. Two
+findings (F9, F10) were added after the initial review in response to the
+partial-failure and double-assignment considerations.
+
+---
+
+## 2. Executive Summary
+
+Parti's self-healing is **strong for transient faults and consumer loss, has a
+hard floor at server-side state loss, and has two latent correctness gaps under
+*partial* NATS failure** (the new F9/F10 area).
+
+Connection reconnect (delegated to nats.go), silent KV-watcher stalls (covered
+by four 30 s reconcilers), and durable-consumer deletion (covered by the
+`recovery.Controller`) all heal cleanly and are proven by integration tests.
+
+The floor: **no runtime code path re-creates a missing stream or KV bucket.**
+Provisioning runs exactly once, inside `Manager.Start` (`manager.go:417,434,441`),
+and is get-first. When server-side state vanishes while a worker runs, the
+library *detects* the loss and enters **degraded mode** to keep processing on
+the cached assignment, but does not repair the state — recovery needs a process
+restart (which, on this Kubernetes deployment, the readiness probe triggers) or
+an operator `provision` run.
+
+Findings worse than "needs a restart" — the **correctness gaps**:
+
+- **F1** — a wipe-and-recreate of buckets under the same names is neither
+  detected nor healed; the worker runs against incoherent empty state with no
+  readiness signal.
+- **F2** — several recovery loops retry forever, silently and unbounded.
+- **F10** — under a *partial* heartbeat-bucket failure, live workers can be
+  declared dead and their partitions reassigned; combined with degraded mode
+  (which keeps the wrongly-evicted worker processing), this is the realistic
+  route to genuine double ownership.
+- **F6-B** — the partition-input analogue: if the source returns an empty
+  (or sharply shrunk non-empty) observation, the leader currently proceeds to
+  reassign every partition to zero, silently and across the fleet, with no
+  degraded signal. (The erroring path already aborts cleanly — see F6.)
+- **F9-A** — the partial-failure / leadership-churn concern: the current code
+  is in fact **split-brain-safe** (eager leader step-down + the
+  `CheckLeadership` publish fence), but it pays for that safety with
+  leadership *churn* on every transient election-bucket blip. Per the IOPS
+  investigation, the dominant cause — the election bucket being
+  `MemoryStorage` (lost on any node restart) — is closed by switching to
+  `FileStorage` R≥3, a one-line code change at essentially zero IOPS cost
+  (F9-B, the lease-aware leader for residual transient unavailability, is
+  **deferred**).
+
+### How the findings bite dynamic partitioning
+
+Dynamic partitioning transits every layer here — election, the assignment KV,
+the partition source, JetStream streams, durable per-partition consumers — so
+the findings are not separable from it:
+
+- **F1** corrupts dynamic assignment: a `parti-election`-bucket wipe resets the
+  leader-revision space (`LeaderRevision` is sourced from the election agent's
+  `Revision()`, `manager_election.go:316-323`), making the
+  `lastSeenLeaderRevision` ordering fence meaningless; a `parti-assignment`-bucket
+  wipe resets the commit/CAS history the assignment watcher relies on.
+- **F2 / F5** turn a stream wipe into a fleet-wide thundering herd of
+  per-partition consumer recovery attempts.
+- **F3** lets duplicate worker IDs hand the same partition out twice after a
+  wipe-and-recreate.
+- **F4** is what would let a leader's recomputed assignment reach followers
+  without a fleet-wide restart.
+- **F6** has two faces: silent source loss (F6-A — no readiness signal) and
+  an unguarded **empty / sharply shrunk** non-erroring source observation
+  that can reassign every partition to zero (F6-B — the partition-input
+  "minimum credible inputs" floor). The erroring path is already correctly
+  aborted at `calculator.go:1280-1283`.
+- **F9-A** is leadership stability for the dynamic calculator: churn at the
+  leader/calculator boundary forces an assignment recompute and cache-affinity
+  loss on every transient election-bucket fault. Switching the election bucket
+  to `FileStorage` R≥3 is the primary fix — near-free per IOPS analysis. F9-B
+  (lease-aware leader) is deferred unless residual transient churn warrants
+  the HIGH-risk election-code change.
+- **F10** is the dynamic-partitioning correctness invariant itself: one
+  partition, one active owner.
+
+### Deployment context: the readiness-probe lens
+
+On this Kubernetes deployment the readiness probe *is* the recovery mechanism:
+a worker that fails readiness is rotated, and the restart re-provisions every
+missing bucket via get-first `EnsureKVBucket`. A finding's true danger is
+therefore **"does it fail to trip the readiness probe?"**
+
+- **Trips readiness → already acceptably handled** (at the cost of a pod
+  restart): bucket-absent cluster rebuild, the `MaxReconnects` zombie.
+- **Readiness-blind → defeats the recovery design** (worker stays `Ready` while
+  silently broken): **F1** (no degraded entry), **F5** (consumer-layer recovery
+  loop does not feed the degraded circuit), **F6** (source loss never escalates
+  to the manager), **F8** (a silently-stalled watcher), and **F10** (a wrong
+  reassignment looks like a valid one — no error anywhere).
+
+The unifying objective: **every unrecoverable failure must trip the readiness
+probe.**
+
+### Reading the risk ratings
+
+The user asked for a risk evaluation and ranking, and stressed: *these fixes
+are risky, easy to produce side effects; keep changes as small as possible and
+verify step by step.* Every finding in Section 6 therefore carries two ratings:
+
+- **Impact if unfixed** — severity of the gap (LOW / MEDIUM / HIGH).
+- **Change risk** — how dangerous the *fix itself* is: blast radius, how much
+  load-bearing concurrency/coordination code it touches, how easily a mistuned
+  fix creates a *new* fault (LOW / MEDIUM / HIGH).
+
+Section 7 consolidates both into a single ranked table and an implementation
+discipline (one finding per PR, reproducer-first, step-by-step verification).
+Section 8 turns that into a phased sequence. **A high-impact finding is not
+automatically done first** — a low-risk quick win that builds the
+verify-as-you-go rhythm is sequenced ahead of a high-risk correctness fix.
+
+---
+
+## 3. What Self-Heals Today (Inventory)
+
+The working baseline — recommendations must not regress it.
+
+| Mechanism | What it heals | Evidence |
+|---|---|---|
+| nats.go reconnect (caller-owned `*nats.Conn`) | TCP drop, server bounce; rebinds JetStream subscriptions | `manager.go:410-414` (conn is injected) |
+| Four KV-watcher reconcilers @ 30 s | Silent watcher stalls after a server restart — the *load-bearing* recovery path | assignment/commit `manager_assignment.go:325,478`; claim-resolver `claim_resolver.go:748`; source `source/nats_kv.go:812` |
+| Claim-resolver drift-driven watcher rebind | Forcibly re-binds a silently-stalled watcher on detected drift | `claim_resolver.go:882,902` |
+| Heartbeat-monitor polling backstop @ `hbTTL/2` | Topology changes missed by a stalled heartbeat watcher | `internal/assignment/worker_monitor.go:267-294` |
+| `recovery.Controller` + legacy escalation | **Durable consumer deleted** under a running consumer — recreated | `internal/recovery/controller.go:237`; `partition_consumer.go:372-439` |
+| `EmergencyDetector` grace window | Absorbs a *transient* worker-absence blip — a worker must be absent across `gracePeriod` before being declared dead | `internal/assignment/emergency.go:89-133` |
+| `LeaderRevision` + commit fences | A former leader cannot make a stale assignment authoritative | `manager_assignment.go:434-437,602-606,831-847`; `CheckLeadership` `nats_election.go:351-390` |
+| Degraded mode | Detects sustained connectivity / JetStream-state loss; keeps processing on cached assignment; escalating alerts; `OnDegraded` hook | `manager_degraded.go:33-55,80-132,153-190` |
+| Get-first provisioning at `Start` | Re-creates *missing* buckets — **but only on process restart** | `kvutil` `EnsureKVBucketWithRetry`; `manager_setup.go:158-186` |
+| `provision` SDK / `partictl apply` | Re-runnable; re-creates missing streams + buckets | `provision/apply_recreate.go:21-22,106-117` |
+
+**Key empirical finding (re-confirmed):** a NATS server restart does **not**
+reliably close a KV watcher's `Updates()` channel — the client transparently
+rebinds, the channel stays open, the watcher silently stops delivering. The
+**periodic reconciler is the load-bearing recovery path**
+(`test/integration/failure/claim_resolver_nats_restart_test.go:34-41`).
+
+---
+
+## 4. Failure-Mode Matrix
+
+✓ self-heals · ⚠ partial / restart-dependent · ✗ does not self-heal
+
+| # | Scenario | Current behavior | Verdict |
+|---|---|---|---|
+| 1 | Brief connection blip (< `EnterThreshold`) | nats.go reconnects; watchers may stall; reconcilers re-sync ≤ 30 s | ✓ |
+| 2 | Server restart, state intact (same `StoreDir`, R≥3) † | Watchers silently stall; reconcilers re-sync; claim-resolver force-rebinds | ✓ |
+| 3 | Server restart, ephemeral storage — buckets/streams empty or gone | Degrading-JS errors → degraded mode; no in-process re-create | ✗ in-process · ⚠ via restart |
+| 4 | Full cluster rebuild, buckets absent | Detected → degraded; stays degraded until restart / operator re-provision | ✗ in-process · ⚠ via restart |
+| 5 | Wipe-and-recreate, same bucket names | KV ops succeed against empty state; **not detected, no degraded signal** | ✗ (F1) |
+| 6 | JetStream message stream deleted | Dynamic-consumer recovery fails; unbounded silent retry loop, no give-up | ✗ (F2 / F5) |
+| 7 | Durable consumer deleted | `recovery.Controller` + legacy escalation re-create it | ✓ |
+| 8 | Partition-source bucket deleted | Watcher/reconcile spin on generic errors; recovers only if the *user* re-creates it; no escalation | ⚠ (F6-A) |
+| 9 | Outage longer than `MaxReconnects × ReconnectWait` | Caller's conn goes `CLOSED`; degraded forever; reconcilers fail on a dead conn — zombie | ⚠ on k8s — degraded → rotated (F7) |
+| 10 | **Election bucket transient blip** (slow/erroring, key still present) | Calculator stops + restarts (churn); on a context-timeout renew error the election term is retained, on a definite-loss error a leaderless gap ≤ `ElectionTimeout` opens; **no two leaders** | ⚠ residual churn (F9-B, deferred) |
+| 11 | **NATS node restart — election bucket** (`MemoryStorage`) † | Election bucket lost on that node; if not R≥3-survivable, leadership outage until pod rotation | ⚠ — closed by **F9-A** (FileStorage R≥3 switch) |
+| 12 | **Partial heartbeat-bucket degradation** (`Keys()` returns a truncated list) | Live workers may be declared dead and reassigned past the grace window; no shrink floor | ✗ (F10-A) |
+| 13 | **Partition source returns empty / sharply shrunk (non-erroring) list mid-run** | Leader currently recomputes against the suspicious input and can publish a zero-partition assignment fleet-wide; no degraded signal. (Snapshot *errors* already abort cleanly, `calculator.go:1280-1283`.) | ✗ (F6-B) |
+
+† The election bucket is `MemoryStorage` (`manager_setup.go:89`). It survives a
+single-node restart only if Raft-replicated across surviving nodes (R≥3); a
+full-cluster restart or an R=1 memory bucket loses it outright.
+
+---
+
+## 5. The Central Design Tension (re-creation)
+
+`docs/OPERATIONS.md:626` states the current position:
+
+> "Parti deliberately does not auto-recreate buckets from the live publish path.
+> Recreating on a transient `ErrStreamNotFound` during a JetStream leader
+> reshuffle would cause the data loss it was trying to prevent … Parti cannot
+> distinguish 'data permanently gone' from 'data coming back'."
+
+Sound — but only for resources that carry irreplaceable **data**. The resources
+Parti depends on fall into four categories:
+
+| Category | Resources | Loss of content means… | Re-creation policy |
+|---|---|---|---|
+| **A. User-owned data** | Partition-source KV bucket | Partition definitions gone — real data loss | Library must not re-create; surface loudly (F6). |
+| **B. Message streams** | JetStream work/subject streams | Unprocessed messages gone — real data loss | Never auto-recreate from the consumer layer; escalate via a caller hook (F5). |
+| **C. Regenerable coordination, leader-rebuilt** | `parti-assignment`, `parti-heartbeat` | Nothing irreplaceable — recomputed / re-published in seconds | Eligible for in-process re-create, opt-in, after a confirmation delay (F4). |
+| **D. Coordination, continuity-sensitive** | `parti-election`, `parti-handoff` | Regenerable, but a naive empty re-create resets the leader-revision space / in-flight handoffs | Eligible with extra guards (F1 epoch fence; handoff abort). |
+
+The `OPERATIONS.md:626` rationale applies fully to A and B. For C and D the risk
+is far smaller and a **confirmation delay** closes the "coming back" race —
+this is the basis for F4 (demoted to optional under the k8s deployment).
+
+---
+
+## 6. Findings & Recommendations
+
+Finding numbers (F1–F10) are stable identifiers, **not** a priority order — see
+Section 7 for the risk-ranked order and Section 8 for the phased sequence. Each
+finding states **Impact if unfixed** and **Change risk** of the fix.
+
+---
+
+### F1 — Wipe-and-recreate under the same names is silent corruption
+
+**Finding.** If buckets are deleted and re-created with the same names (operator
+`nats kv rm` + recreate, backup/restore, ephemeral-storage node restart), every
+KV operation succeeds against the new empty streams. `monitorNATSConnection`
+checks only `conn.Status()` (`manager_degraded.go:33-35`); `recordKVError` fires
+only on connectivity or NotFound-family errors (`manager_degraded.go:84`).
+Neither triggers. The worker keeps running on cached handles `m.assignmentKV` /
+`m.heartbeatKV` (`manager.go:455-456`) against wiped state: the election
+revision space resets (stale `lastSeenLeaderRevision` fences become
+meaningless), in-flight handoff / stable-ID claims have vanished, and **no
+`OnDegraded` ever fires** — so on this k8s deployment the pod is never rotated.
+
+**Recommendation R1 — epoch fence.** Cache an immutable per-bucket identity at
+`Start` and verify it in the reconcilers. The JetStream stream backing each KV
+bucket has an immutable server-assigned `Created` timestamp — cache
+`StreamInfo().Created` per bucket at `Start`; have each reconciler re-read stream
+info and compare. A changed `Created` ⇒ the bucket was re-created underneath the
+worker ⇒ enter degraded / fire `OnDegraded` with a distinct reason. (Alternative:
+reuse the `provision` marker mechanism, `provision/marker.go`.)
+
+**Design tension:** none — pure fail-loud, independent of the re-create debate.
+
+**Impact if unfixed:** **HIGH** — the only true silent-corruption path; on k8s
+it is also readiness-blind, so the deployment's own recovery mechanism never
+engages.
+
+**Change risk:** **MEDIUM** — additive (detection only; does not change recovery
+behavior), but it adds a new degraded-entry trigger on the hot reconcile path; a
+wrong epoch comparison causes spurious degraded entry → spurious pod rotation.
+Mitigated by: the `Created` timestamp is a stable server value; the fix needs a
+reproducer that wipes+recreates a bucket and asserts degraded entry.
+
+**Does not:** recover the lost data — converts silent corruption into a visible,
+actionable signal. Pairs with F9 (closes the follower side of the split-brain
+surface — see F9).
+
+---
+
+### F2 — Unbounded, silent, infinite retry loops
+
+**Finding.** Multiple recovery loops retry forever against a genuinely-gone
+resource, with no attempt cap, no permanent-failure state, no escalation:
+
+- Dynamic-consumer recovery on a deleted stream: `recreateFn`
+  (`partition_consumer.go:508-512`) → `controller.go:294-302` logs and fails →
+  the run loop backs off and `continue`s (`partition_consumer.go:195-199`)
+  forever.
+- `source.NatsKV.restartWatcher` retries `kv.Watch` forever on a missing bucket
+  (`source/nats_kv.go:772-805`).
+- `ClaimBasedResolver` retries `WatchAll` forever on a missing handoff bucket
+  (`claim_resolver.go:558-571`).
+- `monitorAssignmentChanges` retries forever — the comment at
+  `manager_assignment.go:339` names "a wiped assignment bucket" as the expected
+  case.
+
+During a cluster rebuild every worker generates sustained, unbounded NATS API
+pressure — a thundering herd aimed at the cluster while it is most fragile.
+
+**Recommendation R2 — bounded retry with a give-up state.** Standardize a retry
+envelope for every "recover an existing resource" loop: exponential backoff with
+a hard ceiling; a bounded attempt budget per failure episode (reset on success);
+on exhaustion, transition to an explicit permanent-failure state, fire
+`OnError` / a hook **wired so it can fail the readiness probe** (§2), set a
+metric, and stop generating API load until connectivity is re-confirmed.
+
+**Design tension:** minimal — the only judgement call is the attempt budget;
+make it configurable with a safe default.
+
+**Impact if unfixed:** **MEDIUM–HIGH** — thundering herd; no clean operator
+alert; load never abates.
+
+**Change risk:** **MEDIUM–HIGH** — changes retry semantics across *many* call
+sites; a too-aggressive give-up turns a recoverable blip into a premature
+permanent failure. **Must be done loop-by-loop, one PR per loop**, each with its
+own reproducer — do not change all loops in one change.
+
+**Does not:** re-create anything — bounds the damage and makes failure
+observable. Prerequisite for F4/F5.
+
+---
+
+### F3 — `stableID` renew misclassifies "bucket gone" as transient
+
+**Finding.** `Claimer.renew` translates **only** `jetstream.ErrKeyExists` into
+`ErrClaimLost` (`internal/stableid/claimer.go:364-368`); every other error,
+including `ErrBucketNotFound` / `ErrStreamNotFound`, returns the generic
+`"failed to renew ID"` (`claimer.go:369`). So the claim-loss self-stop
+(`claimer.go:329` → `claimLostShutdown`, `manager_election.go:91-98`) never
+fires when the bucket is gone; the worker keeps `m.workerID` set and keeps
+advertising it. After a wipe-and-recreate (F1), two workers can each `Create`
+the *same* ID into the fresh empty bucket — **duplicate worker IDs**.
+
+**Recommendation R3.** In `renew`, classify `ErrBucketNotFound` /
+`ErrStreamNotFound` explicitly and treat a vanished claim backing-store as
+claim-loss — return `ErrClaimLost` so the existing self-stop runs (worker stops
+→ `OnError` → k8s restarts it → it re-claims cleanly). Matches the documented
+contract (`docs/OPERATIONS.md:649-659`).
+
+**Design tension:** low.
+
+**Impact if unfixed:** **MEDIUM–HIGH** — duplicate worker IDs break the core
+stable-ID invariant and (via F10) can hand a partition to two workers.
+
+**Change risk:** **MEDIUM** — small, localized surface (one error-classification
+branch), but it changes *when the worker self-stops*; a wrong classification
+causes a spurious self-stop (and pod rotation). Needs a reproducer that deletes
+the stableID bucket and asserts `ErrClaimLost`.
+
+**Does not:** prevent the brief duplicate-ID window during a wipe — that is
+closed by F1 (detection); R3 ensures the worker fails *safe*.
+
+---
+
+### F4 — No in-process re-provision of coordination buckets *(demoted — optional)*
+
+> **Re-prioritized.** With Kubernetes readiness-probe recovery confirmed, the
+> bucket-absent cluster rebuild already heals: degraded → failed readiness → pod
+> rotation → restart re-provisions. F4 is **not** a recovery requirement — it is
+> an optimization that avoids a restart. Retained for completeness; it is the
+> last phase and may reasonably be dropped. **One exception worth weighing:**
+> the election bucket is `MemoryStorage` (`manager_setup.go:89`), so a routine
+> NATS node restart can wipe it — an in-process re-create *for the election
+> bucket specifically* would avoid a pod rotation on an ordinary node bounce.
+> See F9.
+
+**Finding.** `ensureStableIDKV` / `ensureCoreKVBuckets` / `setupHandoff` are
+reachable only from `Manager.Start` (`manager.go:417,434,441`). No path
+re-creates a coordination bucket at runtime; `attemptRecoveryFromDegraded` only
+does a KV `Get` (`manager_degraded.go:236`).
+
+**Recommendation R4 — gated, opt-in, in-process re-create** for the regenerable
+coordination buckets (`parti-assignment`, `parti-heartbeat`, `parti-election`,
+`parti-handoff`), off by default, only after the bucket is confirmed absent on a
+healthy connection for a sustained window (`RecreateGracePeriod`). Excludes the
+source bucket and message streams. `parti-stableid` is **not** an in-process
+target — F3 handles it via restart.
+
+**Design tension:** modifies the `OPERATIONS.md:626` stance — done narrowly
+(coordination buckets only, opt-in, confirmation delay); the operator-owned
+default is preserved.
+
+**Impact if unfixed:** **LOW–MEDIUM** on this deployment — pod rotation already
+re-provisions.
+
+**Change risk:** **HIGH** — creates buckets at runtime; largest blast radius;
+can race a recovering cluster. If implemented, gate behind F1 + F2 and an
+opt-in flag.
+
+**Does not:** re-create message streams or the source bucket.
+
+---
+
+### F5 — A deleted message stream wedges every dynamic partition consumer
+
+**Finding.** When the JetStream **stream** a dynamic consumer pulls from is
+deleted, neither recovery path can succeed — a consumer cannot be created on a
+missing stream. The legacy escalation bails (`partition_consumer.go:457-460`);
+the `recovery.Controller` logs and fails (`controller.go:294-302`). No code in
+`internal/durable/`, `internal/recovery/`, or `consumer/` creates a stream. The
+run loop retries forever. Secondary: `CheckWorkQueueRecoveryCompat` runs under
+`sync.Once` only inside `Dynamic.Update` (`consumer/dynamic.go:309-316`);
+`Dynamic.UpdateWorkerConsumer` — the path the manager and the handoff
+coordinators actually use — bypasses it entirely (`:319-327`), so a stream
+re-created with a different retention policy is never re-validated on any path.
+
+**Recommendation R5.** Message streams stay category B — do **not** auto-recreate
+from the consumer layer. Apply the F2 envelope; add a caller hook
+`OnStreamMissing(streamName string) error` so provisioning-owning callers can
+re-create the stream. **Critically for k8s:** the dynamic-consumer recovery loop
+lives in `internal/durable/` and does not feed the manager's degraded circuit,
+so a stream wipe never trips readiness today. Note the limit precisely — unlike
+a KV-bucket loss, a **pod restart does NOT recover a deleted message stream**:
+`Manager.Start` ensures only Parti's KV buckets (`manager.go:417,434,441`), and
+`ensureConsumer` bails on stream-not-found without creating the stream
+(`partition_consumer.go:457-460`). Readiness can therefore only *stop a silently
+wedged pod and alert orchestration*; the stream itself must be restored by an
+operator or a provisioning path wired to `OnStreamMissing`. Re-arm the
+work-queue-compat check after a successful recovery — and run it on the
+**manager-facing path too** (`Dynamic.UpdateWorkerConsumer` currently skips it).
+Reseed the checkpoint from the *new* stream's `AckFloor` after a stream
+re-create (`recovery/config.go:27-28` + monotonic `checkpoint.go:33-40` would
+otherwise start a `FromLastProcessed` consumer past an empty stream's tip and
+deliver nothing).
+
+**Design tension:** none — respects `OPERATIONS.md:626` for category B.
+
+**Impact if unfixed:** **HIGH** — readiness-blind; every dynamic partition
+consumer wedges on a stream wipe with no recovery and no signal.
+
+**Change risk:** **MEDIUM** — the hook is additive; the bounded-retry change
+inherits F2's risk; the checkpoint reseed touches delivery-position logic and
+needs care (a wrong reseed silently skips or re-delivers messages).
+
+---
+
+### F6 — Partition-source loss is invisible AND can trigger an empty-source reassignment
+
+**Finding.** `source.NatsKV` never creates the source bucket — it receives a
+handle (`source/nats_kv.go:178`); the bucket is the user's by contract. Two
+problems compound on a source loss:
+
+- *F6-A (signaling).* On deletion, `restartWatcher` loops on `kv.Watch`
+  (`nats_kv.go:772-805`) and `reconcileOnce` treats `ErrBucketNotFound` as a
+  generic logged error (`nats_kv.go:864-878`) — both forever, with **no
+  escalation to the Manager and no degraded signal.** The watcher *will*
+  recover once the user restores the bucket, but the loss is invisible until
+  then.
+- *F6-B (freeze).* If the partition source returns an **empty list, or a
+  sharply shrunk (but non-empty) list**, the leader currently proceeds to
+  recompute and republish an assignment based on that suspicious input —
+  potentially with **zero partitions**, removing every worker's partitions
+  across the fleet. The calculator already aborts cleanly on a snapshot
+  *error* (`internal/assignment/calculator.go:1280-1283`), so the error path
+  is correctly handled (previous assignment is preserved by abortion of the
+  rebalance attempt). The gap is the *suspicious-but-non-erroring* case:
+  there is no analogue of the existing `len(workers) == 0` floor
+  (`calculator.go:1290-1296`) for the partition input.
+
+**Recommendation R6-A — make the loss loud (additive).** Keep category-A policy
+(the library must not re-create a user-owned bucket) but distinguish
+`ErrBucketNotFound` from transient errors; surface it via a metric
+(`parti_source_bucket_missing`) and a hook (`OnSourceUnavailable`) wireable to
+readiness; document the responsibility split.
+
+**Recommendation R6-B — freeze the reassignment on a suspicious non-erroring
+source observation.** The behavioral contract: an **empty** or **sharply
+shrunk (but non-empty)** source observation must **not** propagate into a
+fleet-wide reassignment. (The *erroring* path is already correct — see the
+finding.) The implementation phase chooses between two natural locations:
+
+- *Source-layer suppression (likely the smaller change).* The
+  `source.NatsKV` watcher already holds the partition set as state for its
+  `Updates()` channel; it can cache its last non-empty observation and **not
+  emit** an empty/shrunk result downstream until a new non-empty observation
+  arrives (or until the shrunk observation is confirmed across multiple polls).
+- *Calculator-layer guard.* Add a `len(partitions) == 0` floor at the
+  rebalance attempt analogous to the existing `len(workers) == 0`
+  (`calculator.go:1290-1296`), plus a shrunk-detection guard using a cached
+  last-known partition count. Note that the current calculator does **not**
+  retain inter-poll partition state — it processes each observation
+  independently — so this option adds state that does not exist today.
+
+Either location must also handle the *sharply shrunk* (but non-empty) case
+with a confirmation-across-polls / grace window analogous to
+`EmergencyDetector` for workers (`internal/assignment/emergency.go:89-133`)
+and the F10-A worker-set floor. Together these form a *"minimum credible
+inputs"* doctrine for the calculator: never reassign on a suspicious
+observation of either input.
+
+**Design tension:** R6-B prefers brief staleness over correctness loss. A
+*legitimate* partition-set shrink (operator removed a partition) is delayed by
+the grace window. That is a deliberate trade — delaying a legitimate shrink by
+seconds is far cheaper than reassigning every partition to zero on a transient
+source blip.
+
+**Impact if unfixed:** **F6-A** is **MEDIUM** (readiness-blind silence; loss of
+source is invisible). **F6-B** is **HIGH** (a non-erroring empty / sharply
+shrunk source observation can trigger a fleet-wide reassign-to-zero — silent,
+no degraded signal — which is exactly the failure the "keep working when the
+source goes" requirement is about; the erroring path is already correctly
+aborted at `calculator.go:1280-1283`).
+
+**Change risk:** **F6-A** is **LOW–MEDIUM** (additive — a metric, a hook, one
+error classification). **F6-B** is **MEDIUM** (touches the calculator input
+path; mistuned, it can suppress a legitimate partition-set shrink — parallels
+F10-A's risk profile and needs the same reproducer-first discipline).
+
+---
+
+### F7 — Caller connection config can turn an outage into a zombie
+
+**Finding.** The core library never creates the `nats.Conn` — it is injected
+(`manager.go:410-414`) — and registers zero connection callbacks. The public
+docstrings (`doc.go:30`, `manager.go:258`) and example apps
+(`examples/basic/main.go:34`) use bare `nats.Connect`, inheriting the nats.go
+default `MaxReconnects = 60`. After ~60 failed attempts the connection goes
+permanently `CLOSED`; degraded mode keeps the worker "alive" forever on a stale
+cache.
+
+**Recommendation R7 — documentation + a startup warning, no behavior change.**
+Document the required posture (`MaxReconnects = -1`, sane `ReconnectWait` /
+`ReconnectJitter`, `RetryOnFailedConnect`) in `doc.go` / `docs/OPERATIONS.md` /
+examples. Optionally, at `Start`, inspect `conn.Opts` and **warn** if
+`MaxReconnects` is finite — the pattern `warnOnShortAuditGrace`
+(`manager_setup.go:387-406`) already uses.
+
+**Design tension:** none.
+
+**Impact if unfixed:** **LOW–MEDIUM** — on k8s the zombie still enters degraded
+mode, so the readiness probe rotates it; the cost is an avoidable pod restart
+and operator confusion.
+
+**Change risk:** **LOW** — docs plus an optional read-only startup warning.
+
+---
+
+### F8 — `source.WithReconcileInterval(0)` silently disables the recovery path
+
+**Finding.** Because the reconciler — not the watcher's close-detection — is what
+recovers a silent stall, disabling it removes the only server-restart recovery
+path for that watcher. The **public consumer path is safe**: `ReconcileInterval
+= 0` on `consumer.ResolverConfig` means "use the 30 s default," and only
+negative values are rejected (`consumer/resolver_config.go:61-63`,
+`internal/durable/config.go:89`); `worker_consumer.go:536-545` passes an
+already-normalized positive value. The foot-gun is the **partition source**:
+`source.WithReconcileInterval(0)` is documented only as "disables polling"
+(`source/nats_kv.go:50-63`), and `reconcileLoop` exits when the interval is
+non-positive with no leadership probe set (`source/nats_kv.go:807-814`) — the
+source watcher then has no recovery from a NATS server restart (it stalls
+silently and never rebinds).
+
+**Recommendation R8.** For `source.WithReconcileInterval`, either reject `0` /
+clamp to a minimum with a startup warning, or update the Godoc to state plainly
+that disabling the reconciler disables server-restart recovery for the source
+watcher. No change is needed on the `consumer.ResolverConfig` path.
+
+**Design tension:** none.
+
+**Impact if unfixed:** **LOW** — bites only a user who explicitly disables the
+source reconciler; when it bites it is a readiness-blind silent stall.
+
+**Change risk:** **LOW** — Godoc plus an optional config warning; tiny surface.
+
+---
+
+### F9 — Election leadership churn under partial NATS failure
+
+**The concern, addressed directly.** The danger raised — "election/heartbeat
+fail → a follower promotes → two leaders" — is correctly identified as the thing
+to avoid. The current code *happens to avoid it*, by erring toward eager leader
+step-down, and at a real churn cost. The proposed remedy ("retain the current
+leader") is right in spirit but, implemented naively, would create exactly the
+split-brain it is meant to prevent. Details:
+
+**Finding — current behavior is split-brain-SAFE but CHURNY.**
+
+- *Manager side — unconditional flip.* `monitorLeadership` bounds each renew
+  with `OperationTimeout` (`renewCtx`). On *any* renew error it does
+  `m.isLeader.Store(false)`, fires `OnLeadershipChanged(false)`, and
+  `stopCalculator()` (`manager_election.go:206-230`) — no retry.
+- *Election-agent side — error-dependent.* `RenewLeadership` clears the local
+  term only on a *definite* loss error; on `context.Canceled` /
+  `context.DeadlineExceeded` it deliberately does **not** call
+  `clearLeadership()` (`nats_election.go:190-207`). Two regimes follow:
+  - *Definite-loss renew error* (wrong revision, a non-context NATS error) →
+    `clearLeadership()` → `termRevision=0`. The term is fully surrendered;
+    re-acquisition needs a fresh `kv.Create` after TTL expiry.
+  - *Context-timeout renew error* (the `OperationTimeout` fired — the typical
+    "election bucket slow/abnormal" symptom) → the agent **retains**
+    `isLeader`, `workerID`, `termRevision`. On the next tick the manager is in
+    the follower branch, but `RequestLeadership` sees the agent still holds the
+    term and re-issues a *renew* rather than a `kv.Create`
+    (`nats_election.go:112-130`). If the blip cleared, the worker re-renews
+    into the **same term** — no key release, no follower takeover.
+- *Follower side — TTL-gated.* A follower acquires only via `kv.Create`
+  (`nats_election.go:140`), which succeeds only after the leader key's TTL
+  expires. The election bucket TTL = `ElectionTimeout` (`manager_setup.go:89`,
+  default 10 s); the leader renews every `ElectionTimeout/3`.
+- *Split-brain safety holds in both regimes.* The calculator is stopped for the
+  whole window (so no leader publishes), and the assignment publisher's
+  `CheckLeadership` fence (`nats_election.go:351-390`, wired as `LeaderCheck` at
+  `manager_assignment.go:123` — the only non-test call site) independently
+  rejects a publish from a stale term. There is **no two-leaders path** today.
+- *The real cost — churn at the manager/calculator layer.* Even in the
+  context-timeout regime where the election *term* is retained, the manager
+  still flips `m.isLeader` and stops+restarts the calculator on every blip —
+  firing `OnLeadershipChanged` twice and forcing an assignment recompute. In
+  the definite-loss regime the term is surrendered too, adding a leaderless gap
+  of up to `ElectionTimeout`. On `MemoryStorage` (see below) this churn fires on
+  *every* NATS node restart.
+
+**The `MemoryStorage` amplifier — the dominant churn source.** The election
+bucket is `MemoryStorage` (`manager_setup.go:89`) — the most fragile bucket
+Parti owns. A NATS node restart can wipe it (a memory bucket survives a
+single-node loss only if R≥3; a full-cluster restart loses it outright). The
+cached `electionKV` handle then errors on both renew and acquire, so the
+cluster is leaderless until pod rotation. **Routine k8s NATS node bounces
+therefore cause fleet-wide leadership thrash, and this is the dominant churn
+cause** — far more than transient JetStream Raft reshuffles on a healthy bucket.
+
+**Recommendation R9-A — switch the election bucket from `MemoryStorage` to
+`FileStorage`, R≥3 (PRIMARY; LOW risk, near-zero IOPS cost).** Per the IOPS
+investigation, cell M1.9 (*all parti KV buckets → memory*) yields **−2 % / −1 %
+of total IOPS at N=1000 / N=3000 — within measurement noise**
+(`docs/plans/iops-investigation/findings.md` §2). The inverse (memory → file)
+is the same noise-level delta, so the FileStorage switch is **effectively free**
+on the IOPS dimension while eliminating the dominant churn cause. TTL semantics
+are unchanged (the bucket TTL behaves identically on either storage), so the
+existing election machinery works without modification. The code diff is a one-line storage-type change at `manager_setup.go:89`; the
+operational migration on an existing cluster is more involved — see *Migration
+constraint* below.
+
+- *Migration constraint.* `EnsureKVBucket` is **get-then-create**
+  (`kvutil/bucket.go:50-64`) — it returns the existing bucket if present,
+  creates only on `ErrBucketNotFound`, and **never updates an existing bucket's
+  storage type**. So a live `MemoryStorage` election bucket is *not*
+  transparently upgraded by the new code. Existing deployments require the
+  operator to **delete the bucket** so the new code's `Start` recreates it
+  with the new storage (or `partictl apply` with a force / a similar
+  re-provision). The delete-then-recreate is exactly the scenario **F1's
+  epoch fence is designed to detect**, so **F9-A depends on F1 shipping
+  first** (see Section 8 sequencing). Without F1, the migration itself can
+  put workers into a stuck-stale `lastSeenLeaderRevision` state until pod
+  rotation.
+- *Companion: validate `OperationTimeout ≤ ElectionTimeout/3`.* While the
+  F9-A PR is already touching the election machinery, add a startup
+  validation/warning for this relationship. The lease design gives the leader
+  three renew attempts within one `ElectionTimeout` window (renew every
+  `ElectionTimeout/3`, `manager_election.go:192`), but each renew is bounded
+  by `OperationTimeout` (`manager_election.go:207-209`). With both defaults
+  at 10 s (`config.go:360,366`) the *worst-case* single renew can consume the
+  entire lease window — `monitorLeadership` is a single-goroutine ticker so a
+  hanging renew drops subsequent ticks (`manager_election.go:191-275`). In
+  steady state every renew completes in milliseconds and this never fires;
+  the concern is only the adversarial slow-NATS case, which is the same case
+  F9-A and F9-B target. A warning ("`OperationTimeout` should be ≤
+  `ElectionTimeout/3` to preserve the three-attempt renew budget") follows
+  the existing `warnOnShortAuditGrace` pattern (`manager_setup.go:387-406`),
+  is **LOW change risk** (read-only validation), and naturally lives in the
+  F9-A PR. *Not* a stand-alone finding.
+
+**Recommendation R9-B — lease-aware leader (hold through transient blips, step
+down at the lease deadline) — DEFERRED.** F9-A closes the dominant *bucket-loss*
+churn source but does not close *transient bucket unavailability* (e.g. a
+JetStream Raft leader reshuffle on the election bucket causes a few seconds of
+errors against the existing bucket). The lease-aware change would close that
+residual:
+
+- *Recommended (minimal) variant.* The election agent **already** retains the
+  term on a context-timeout renew error; the churn comes from
+  `monitorLeadership` flipping `m.isLeader` and stopping the calculator anyway.
+  The minimal fix extends that existing leniency up into the manager: on an
+  *ambiguous* (context-timeout) renew error, do **not** immediately flip
+  `m.isLeader` / stop the calculator — retry the renew, tracking the *initiation
+  timestamp of the last successful renew*. Keep leadership while
+  `now − lastSuccessfulRenew < ElectionTimeout − margin`; **force self-demote**
+  (flip + stop the calculator + `clearLeadership`) once that deadline passes, or
+  immediately on a *definite-loss* error. This rides out a transient blip
+  without calculator churn yet preserves the split-brain guarantee.
+- *Invariant (must hold):* `leader_local_stepdown_deadline + clock_skew ≤
+  follower_earliest_acquire` (= bucket TTL since the last write). Derive the
+  leader deadline *from* the bucket TTL — never let it exceed it.
+- *Follower side — unchanged.* Followers already only acquire after a genuine
+  TTL expiry; that is correct, keep it. A follower wrongly promoting requires
+  the key to be *wrongly absent* — which is the **F1** wipe-and-recreate case.
+  F9-A + F9-B (leader side) + F1 (follower side, epoch fence) together close
+  the full split-brain surface.
+- *Coupled with F10-A / F6-B — a kept leader must not act on bad inputs.*
+  "Retain the leader" is only safe if the kept leader also quiesces destructive
+  calculator actions while the input data is untrustworthy (F10-A for workers;
+  F6-B for partitions). Otherwise R9-B trades a two-leaders risk for a
+  wrong-eviction risk.
+- *Audit prerequisite.* `CheckLeadership` is currently wired only into the
+  assignment calculator's publish (`LeaderCheck`, `manager_assignment.go:123` —
+  the only non-test call site). Before relying on "hold the leader longer,"
+  audit that no other leader-exclusive write exists unfenced.
+
+**Defer R9-B until after F9-A is deployed and operationally observed.** If
+post-F9-A churn from transient bucket-unavailability proves significant in
+practice, revisit; otherwise the HIGH change risk of touching election code is
+not justified to address a residual minor churn source.
+
+**Design tension — surfaced.** The simplest correct option for the residual
+case is "do nothing — the current design is safe; just document why." R9-A is
+recommended because the storage switch is free and addresses the dominant churn
+at LOW risk; R9-B is *explicitly contingent* on operational evidence after
+R9-A, not pre-emptive.
+
+**Impact if unfixed:**
+
+- **F9-A**: **MEDIUM–HIGH** — the dominant operational churn cause; a routine
+  NATS node bounce = fleet-wide leadership thrash and a leaderless gap.
+- **F9-B (post-F9-A)**: **LOW–MEDIUM** — only the residual
+  transient-unavailability churn remains; not a correctness bug.
+
+**Change risk:**
+
+- **F9-A**: **LOW** — one-line storage type change; identical KV semantics;
+  near-zero IOPS impact verified by M1.9 (`iops-investigation/findings.md` §2).
+  Migration requires F1 first; the change itself is mechanically trivial.
+- **F9-B**: **HIGH** — touches election code, the most safety-critical
+  coordination in the system; a mistake here *is* split-brain. The minimal
+  variant is still **MEDIUM–HIGH**.
+
+---
+
+### F10 — Double assignment / double partition ownership
+
+**Investigation result.** The literal first hypothesis — that the silent
+per-key `Get` omission in `GetHeartbeats` (`worker_monitor.go:229-231`) shrinks
+the worker set and causes reassignment — is **REFUTED**: a worker missing from
+the `GetHeartbeats` map is classified `unverifiable`, not `behind`
+(`calculator_audit.go:111-114`), and `maybeEscalateAudit` escalates only the
+`behind` set (`calculator_audit.go:169-183`). That path is fenced. A different,
+real path was found.
+
+**F10-A — Partial heartbeat-read degradation → false worker death
+(UNFENCED).** Worker-death detection runs through `GetActiveWorkers`
+(`worker_monitor.go:162`) → `heartbeatKV.Keys()`. In nats.go v1.50.0,
+`KeyValue.Keys()` ranges an ordered-consumer watcher channel; the watcher's
+`SetClosedHandler` closes `Updates()` **without a `nil` end-of-data marker**
+(`jetstream/kv.go:1335-1339`). If that ordered consumer is dropped/reset
+mid-scan, `Keys()` returns the **partial slice it accumulated, with
+`err == nil`** (`jetstream/kv.go:1373-1393`). `getActiveWorkers` sees no error →
+treats it as a *fresh, complete* observation (`calculator.go:1071-1102`).
+Connectivity errors are correctly handled (cache fallback, `fresh=false`,
+`calculator.go:1076-1092`) — but a *silently truncated non-empty list* is not an
+error. If the truncation is sustained past `EmergencyGracePeriod`, the omitted
+workers are confirmed dead (`emergency.go:89-133`) and their partitions
+reassigned. There is **no shrink floor**: `rebalance()` guards only
+`len(workers) == 0` (`calculator.go:1290-1296`); a drop from N to 1 only logs
+(`calculator.go:1271-1277`).
+
+- *Severity is conditional.* If the wrongly-omitted worker is healthy and
+  connected, it receives the corrected assignment and stops — a bounded
+  overlap (see F10-D). It escalates to **genuine unbounded double ownership**
+  when the wrongly-evicted worker is *simultaneously* unable to receive its
+  corrected assignment — i.e. it is itself in degraded mode on a cached
+  assignment, which degraded mode is *designed* to keep processing. A correlated
+  partial NATS failure (heartbeat path flaky for both the leader's read and a
+  worker's write/read) makes this realistic.
+- *Verification status — important.* The `Keys()` partial-return behavior is
+  established from nats.go source (`jetstream/kv.go:1335-1393`), **not
+  empirically reproduced.** Per the repo's verify-first discipline, a fix must
+  be preceded by a chaos test that drops the heartbeat-bucket ordered consumer
+  mid-scan and reproduces the truncated read. Treat F10-A as *strongly
+  indicated, pending empirical confirmation.*
+
+**Recommendation R10-A.** (1) Make `GetActiveWorkers` defend against a silently
+truncated `Keys()`: cross-check the result count against the last-known worker
+count and treat a large unexplained single-poll shrink as non-fresh (degraded),
+or require two consecutive shrunk reads before trusting it. (2) Add a "minimum
+credible worker set" floor in `rebalance()` analogous to the `len == 0` guard —
+refuse to reassign on a suspiciously large shrink without emergency confirmation
+across the full grace window.
+
+**F10-B — Two-phase handoff without consumer-side gating (UNFENCED,
+config-dependent).** `EnableTwoPhaseHandoff` (default false, `config.go:412`)
+makes the leader write per-partition claims to the handoff KV, but enabling it
+only starts the manager-side coordinator and reports `CapTwoPhaseHandoff` — it
+does not prove the *consumer* will consult those claims. The consumer-side gate
+is `ProcessingGate.Enabled` (default false, `processing_gate.go:19,135-139`);
+when a processing gate is configured, `WorkerConsumerConfig.SetDefaults`
+auto-enables pull gating (`internal/durable/config.go:295-305`) — so it is one
+flag, not two. An operator who enables two-phase handoff alone, without a
+processing gate on the consumer, believes they have fencing but does not: the
+claims are written and never consulted.
+
+**Recommendation R10-B.** Warn (or reject) when `EnableTwoPhaseHandoff` is true
+but the consumer does not actually wire a processing gate — but **not at
+`Start`**. `CapProcessingGate` is a runtime "successfully wired" bit, set only
+after a gate-wrapped handler is created during assignment apply
+(`internal/durable/worker_consumer.go:386-398,604-623`), and the manager samples
+consumer capabilities only after `handoffCoordinator.Apply` in
+`applyAssignmentWithPrev` (`manager_assignment.go:851-859` →
+`reportConsumerCapabilities`, `manager.go:815-832`). A `Start`-time check would
+false-positive on every correctly-configured gated consumer before its first
+non-empty assignment. Place the check at the capability-sampling point instead:
+after the first non-empty two-phase apply, warn/reject if `CapProcessingGate`
+has still not appeared. (If a construction-time "gate-capable" predicate is
+added later, the check could move earlier — but the runtime bit cannot.)
+
+**F10-C — In-flight handler commits after a partition moved (UNFENCED,
+deferred).** A handler that *started* under old ownership can finish and commit
+side effects after the partition has moved. The commit-fence design
+(`docs/plans/partition-fencing/`) is **unimplemented**; the README marks the
+design ready to pick up but still lists P1 fixes to fold into the proposal
+before implementation begins (`partition-fencing/README.md:22-41,43-75`). Note
+its status; no action proposed here beyond keeping it on the roadmap with the
+pending P1 fold-in.
+
+**F10-D — Bounded overlap during a normal move (BY DESIGN, not a gap).** In the
+default `direct` handoff mode, when P moves A→B, A removes P and B adds P
+asynchronously; a brief duplicate-consumption window is documented and accepted
+(`config.go:402-405`, `docs/LIFECYCLE.md:252`). Listed for completeness — no
+change recommended.
+
+**Stale-leader path — FENCED.** A former leader cannot re-grant a partition:
+`LeaderRevision` embed + watcher rejection (`manager_assignment.go:434-437,
+602-606`), the pre-Apply `(Version, LeaderRevision)` stale gate (`:831-847`),
+and the publisher `LeaderCheck` + `_commit` CAS. No action needed.
+
+**Design tension:** R10-A must not over-correct — a floor that is too strict
+*suppresses a legitimate emergency rebalance* when a real mass worker death
+occurs. The floor must interact correctly with the existing `EmergencyDetector`
+grace window, not duplicate or fight it.
+
+**Impact if unfixed:** **HIGH** — F10-A is the realistic route to genuine double
+ownership (the dynamic-partitioning correctness invariant: one partition, one
+active owner) and is readiness-blind (a wrong reassignment looks valid).
+F10-B/F10-C are MEDIUM.
+
+**Change risk:** **MEDIUM** for R10-A (the floor touches the live rebalance
+decision; mistuned, it suppresses real emergencies — needs the chaos
+reproducer first and careful grace-window interplay). **LOW** for R10-B (a
+diagnostic warning emitted at the first two-phase apply — no behavior change).
+
+---
+
+## 7. Risk & Impact Ranking + Implementation Discipline
+
+The user's constraint: *these fixes are risky and easy to produce side effects;
+keep changes as small as possible and verify them step by step.* The ranking
+below is ordered to **build a verify-as-you-go rhythm with low-risk work first**,
+then take the high-impact correctness fixes carefully, then the high-risk
+coordination work last.
+
+| Order | Finding | Impact if unfixed | Change risk | Reproducer required first | Notes |
+|---|---|---|---|---|---|
+| 1 | **F7** connection-config docs + warning | LOW–MED | **LOW** | no | Docs + read-only startup warning. Safe warm-up. |
+| 2 | **F8** source reconcile-disable guard | LOW | **LOW** | no | Godoc + optional config warning; `source` only. |
+| 3 | **F10-B** two-phase config validation | MED | **LOW** | no | Warning at first two-phase apply — no behavior change. |
+| 4 | **F6-A** source-bucket escalation hook | MED | LOW–MED | yes (bucket-delete test) | Additive metric + `OnSourceUnavailable` hook. |
+| 5 | **F3** stableID NotFound classification | MED–HIGH | **MED** | yes | Small surface; changes self-stop trigger. |
+| 6 | **F1** epoch fence | **HIGH** | **MED** | yes (wipe+recreate test) | Highest-impact readiness-blind gap; additive detection. **Prerequisite for F9-A.** |
+| 7 | **F9-A** election bucket → `FileStorage` R≥3 | MED–HIGH | **LOW** | yes (storage-migrate test) | One-line + migration; ~0 IOPS cost per M1.9. Depends on F1. Includes a companion `OperationTimeout ≤ ElectionTimeout/3` startup-warning. |
+| 8 | **F6-B** partition-input freeze (no reassign on empty / shrunk non-erroring source) | **HIGH** | **MED** | yes | Parallel to F10-A; "minimum credible inputs" for the calculator. Erroring path already handled. |
+| 9 | **F5** stream-gone handling | **HIGH** | **MED** | yes | `OnStreamMissing` hook additive; checkpoint reseed needs care. |
+| 10 | **F2** bounded retry / give-up | MED–HIGH | **MED–HIGH** | yes (per loop) | **One PR per loop** — never all at once. |
+| 11 | **F10-A** false-death floor + truncated-`Keys()` defense | **HIGH** | **MED** | **yes — chaos test FIRST** | Must not suppress legitimate emergencies. |
+| 12 | **F9-B** lease-aware leader | LOW–MED (post-F9-A) | **HIGH** | yes | DEFERRED — only if residual transient churn warrants. Split-brain risk; minimal variant still MED–HIGH. |
+| 13 | **F4** in-process re-provision | LOW–MED (k8s) | **HIGH** | yes | Optional; may be dropped. F9-A largely subsumes the election-bucket-only case. |
+
+### Implementation discipline (applies to every item)
+
+1. **One finding per PR.** F2 is further split — one PR per retry loop. Never
+   bundle findings; a bundled change cannot be bisected when a regression
+   appears.
+2. **Reproducer-first.** Where "Reproducer required" is *yes*, write the failing
+   test **first** and confirm it fails on the parent commit before writing the
+   fix (the repo's established verify-first discipline). For F10-A this means a
+   chaos test that reproduces the truncated `Keys()` read — the fix is not
+   justified until the bug is observed.
+3. **Step-by-step verification.** Run the full lint + build + test suite between
+   every finding; do not start the next until the previous is merge-clean.
+4. **Extra scrutiny for HIGH change-risk (F9-B, F4, F2).** These get an external
+   review round (`/post-impl-review`) before merge; F9-B additionally needs the
+   lease-ordering invariant stated and checked explicitly. F9-A is mechanically
+   trivial but its *migration* needs F1 in place first.
+5. **Additive before behavioral.** Items 1–4 and 6 are mostly additive
+   (warnings, metrics, hooks, detection) — they make failures *visible* without
+   changing recovery behavior, so they are safe to land early and they improve
+   observability for the riskier items that follow.
+6. **No drive-by refactors.** Each PR touches only what its finding requires.
+   A recovery-controller consolidation is a separate, future effort — do not
+   fold it in.
+
+---
+
+## 8. Suggested Sequencing
+
+Four phases, ordered by the ranking in Section 7 — low-risk confidence-builders
+first, the high-impact correctness gaps next done carefully, the high-risk
+coordination work last.
+
+- **Phase 0 — low-risk quick wins (F7, F8, F10-B).** Docs, config guards, and a
+  diagnostic warning (F10-B fires at the first two-phase apply, not at `Start`).
+  No behavior change. Establishes the one-PR-per-finding, verify-between rhythm.
+- **Phase 1 — make readiness-blind failures visible (F6-A, F3, F1).** Additive
+  detection / escalation so the deployment's readiness-probe recovery can
+  actually engage on a wipe-recreate (F1), a source loss (F6-A), and a stableID
+  bucket loss (F3). F1 ships here because it is a prerequisite for F9-A's
+  migration. Each with a reproducer.
+- **Phase 2 — eliminate the dominant churn and bound operational failures
+  (F9-A, F6-B, F5, F2, F10-A).** F9-A first (the election-bucket storage switch
+  — one line, near-zero IOPS cost per M1.9; depends on F1 from Phase 1). Then
+  F6-B (partition-input freeze), F5 (stream-gone hook + `OnStreamMissing`), F2
+  (bounded retry loops, one PR per loop), and F10-A (false-death floor — chaos
+  reproducer first). After this phase every unrecoverable failure trips the
+  readiness probe, and the dominant leadership-churn source is gone.
+- **Phase 3 — DEFERRED high-risk and optional (F9-B, F4).** F9-B (lease-aware
+  leader) is gated on operational evidence after F9-A — only ship if residual
+  transient bucket-unavailability churn is significant; the HIGH change risk is
+  not justified pre-emptively. F4 (in-process re-provision) is largely
+  subsumed by F9-A for the election bucket; consider only if the rest of the
+  bucket-loss pod-rotation cost is operationally significant.
+
+Phases 0–2 deliver the correctness and observability wins at LOW–MEDIUM change
+risk. Phase 3 is deliberately isolated so the riskiest change lands alone,
+against an otherwise-stable baseline.
+
+---
+
+## 9. Resolved Decisions
+
+All open questions have been resolved by the user. Recorded here for the
+implementation phase to reference.
+
+1. **Deployment target — RESOLVED.** Kubernetes + `OnDegraded` → readiness-probe
+   → pod-rotation. Drives Section 2's readiness lens; F4 demoted to optional.
+2. **F10-A empirical confirmation — RESOLVED: build the chaos reproducer first.**
+   F10-A rests on nats.go-source analysis of `Keys()` truncation
+   (`jetstream/kv.go:1335-1393`); the fix must not precede an empirical
+   reproduction. Section 7 row 11 and Section 8 Phase 2 both pin "chaos test
+   FIRST" as a hard prerequisite.
+3. **F9 — RESOLVED: evaluate IOPS first, then F9-A primary / F9-B deferred.**
+   IOPS investigation cell M1.9 (*all parti KV buckets → memory*) yields
+   **−2 % / −1 % of total IOPS at N=1000 / N=3000 — within noise**
+   (`docs/plans/iops-investigation/findings.md` §2). So switching the election
+   bucket from `MemoryStorage` to `FileStorage` R≥3 (F9-A) is **effectively
+   free on IOPS** and closes the dominant churn cause at LOW change risk.
+   F9-B (lease-aware leader, HIGH change risk) is **deferred** unless the
+   residual transient-bucket-unavailability churn after F9-A proves
+   operationally significant.
+4. **`MemoryStorage` for the election bucket — RESOLVED: switch to
+   `FileStorage` R≥3 (F9-A).** Same decision as #3.
+5. **New public API hooks — RESOLVED: add both `OnStreamMissing` (F5) and
+   `OnSourceUnavailable` (F6-A).** AND a load-bearing behavioral requirement:
+   when the source is unavailable or returns empty, the leader must **retain
+   the cached partition list and not proceed with reassignment until the
+   source returns a non-empty list** — captured as F6-B in Section 6 and as
+   Phase 2 row 8 in the ranking.
+6. **F4 default — RESOLVED: off-by-default (opt-in).** Consistent with the
+   "small changes, verify step by step" constraint and with F9-A largely
+   subsuming the election-bucket-only motivation.
+
+---
+
+## Appendix — Evidence Index
+
+- **Connectivity / reconcilers:** `manager.go:410-414,386-393`;
+  `manager_assignment.go:325,367,478,509,398-418`;
+  `claim_resolver.go:504,525,613,748,783,882,902`;
+  `source/nats_kv.go:729,772,812,864`;
+  `internal/assignment/worker_monitor.go:267-294,299,349`;
+  `test/integration/failure/claim_resolver_nats_restart_test.go:34-41`.
+- **KV buckets:** `config.go:14-37`;
+  `manager_setup.go:39-53,89-113,158-186,224-270,291-349`;
+  `internal/kvbuckets/builder.go:35`; `kvutil` `EnsureKVBucketWithRetry`;
+  `internal/election/nats_election.go:140,154,200-202`;
+  `internal/stableid/claimer.go:299-338,329,347,364-369`.
+- **Stream / consumer recovery:** `internal/recovery/classify.go:32-50`;
+  `internal/recovery/controller.go:118-165,237-316`;
+  `internal/recovery/config.go:12-38`; `internal/recovery/checkpoint.go:33-59`;
+  `internal/durable/partition_consumer.go:195-199,372-439,442-474,508-512`;
+  `consumer/dynamic.go:310-315`.
+- **Manager / degraded mode:** `manager.go:417,434,441,455-456`;
+  `manager_degraded.go:12-30,33-55,80-132,153-190,229-245`;
+  `manager_election.go:91-98,191-275,210-244,361`.
+- **Election (F9):** `internal/election/nats_election.go:140,176-218,351-390`;
+  `manager_election.go:191-275`; `manager_setup.go:89`;
+  `config.go:362-366` (`ElectionTimeout`).
+- **Double assignment (F10):** `internal/assignment/worker_monitor.go:162-194,
+  208-236`; `internal/assignment/calculator.go:880,976-991,1071-1102,1238-1383,
+  1271-1296`; `internal/assignment/calculator_audit.go:59-86,111-114,169-183`;
+  `internal/assignment/emergency.go:89-133`;
+  `internal/assignment/handoff/{direct.go:28-41,twophase.go:57-121,
+  coordinator.go:107-139}`;
+  `consumer/dynamic.go:83-88`; `internal/durable/processing_gate.go:19,137-153`;
+  `config.go:400-416`; `docs/LIFECYCLE.md:180-254`;
+  `docs/plans/partition-fencing/README.md:22-41`;
+  `nats.go@v1.50.0/jetstream/kv.go:1335-1393`.
+- **Documented design rationale:** `docs/OPERATIONS.md:616-647,649-659,626`.

--- a/docs/plans/self-healing/review-trail.md
+++ b/docs/plans/self-healing/review-trail.md
@@ -1,0 +1,262 @@
+# Self-Healing Findings — Review Trail (Consolidated)
+
+Compact summary of the 9-round review loop that produced
+`findings.md`. Each round's verbatim transcript was retired once its findings
+were folded into the authoritative findings document — `findings.md` is the
+source of truth. This file exists only to record **what was flagged and how it
+was resolved**, so a future reader can trace the evolution without re-loading
+9 verbatim files.
+
+Reviewer: external (Codex `xhigh`) over rounds 1, 2, 3, 5, 9; final-confirmation
+spot-checks in rounds 4, 6, 7, 8.
+
+## Round 1 — substantive review
+
+**Verdict.** Not yet implementation-ready. Several high-impact claims were
+stale or overstated.
+
+Findings:
+
+- **P0 — F8** falsely claimed the public `consumer.ResolverConfig.ReconcileInterval = 0`
+  disables the claim-resolver reconciler. Stale: that path documents 0 as the
+  30 s default and rejects only negative values (`consumer/resolver_config.go:61-63`,
+  `internal/durable/config.go:87-89`). The foot-gun is real only for
+  `source.WithReconcileInterval(0)` (`source/nats_kv.go:50-63,807-814`) and
+  for direct internal-resolver use.
+  Fix: scope F8 to source only.
+- **P0 — F9** misread `RenewLeadership`. It claimed every renew failure calls
+  `clearLeadership()`. Actually, `context.Canceled` and `context.DeadlineExceeded`
+  skip the clear (`internal/election/nats_election.go:190-207`), so the
+  agent retains `workerID` / `termRevision` on ambiguous failures, and a later
+  `RequestLeadership` re-renews into the same term
+  (`internal/election/nats_election.go:112-130`). The split-brain-safety
+  conclusion still holds — but for different reasons.
+  Fix: split definite-loss errors from context-timeout errors; explain term
+  retention.
+- **P0 — F5** said the permanent-failure state must surface to readiness so
+  pod rotation can recover a stream wipe. Runtime restart does NOT create
+  message streams — `Manager.Start` ensures only the Parti KV buckets
+  (`manager.go:417,434,441`); `ensureConsumer` bails on stream-not-found
+  (`internal/durable/partition_consumer.go:441-460`).
+  Fix: state plainly that readiness can stop a silently wedged pod and alert
+  orchestration, but the stream itself must be restored via an
+  `OnStreamMissing` hook or a provisioning path.
+- **P1 — F5 compat path.** `Dynamic.Update` runs `CheckWorkQueueRecoveryCompat`
+  under `sync.Once`, but the manager-facing `Dynamic.UpdateWorkerConsumer`
+  bypasses it (`consumer/dynamic.go:309-327`).
+  Fix: require the compat re-arm on both paths.
+- **P1 — F10-B.** Overstated as a three-flag requirement. The real model is
+  one: a configured processing gate auto-enables pull gating
+  (`internal/durable/config.go:295-305`).
+  Fix: warn/reject when two-phase handoff is enabled and the consumer does
+  not report `CapProcessingGate`.
+- **P1 — F1** attributed the leader-revision reset to a `parti-assignment`
+  bucket wipe. Wrong: `LeaderRevision` is sourced from the election agent
+  (`internal/election/nats_election.go` via `manager_election.go:316-323`),
+  not the assignment bucket. An assignment-bucket wipe resets commit/CAS
+  history, not the leader-revision space.
+  Fix: split — election-bucket wipe ⇒ leader-revision; assignment-bucket
+  wipe ⇒ commit/CAS state.
+- **P2 — F10-C** partition-fencing status was too strong ("locked,
+  unimplemented, deferred"). README still has pending P1 fold-in.
+  Fix: name the pending P1 work explicitly.
+
+## Round 2 — Round-1 fix verification + scan
+
+All Round-1 P0s **correctly fixed**. F1, F5 compat, F10-C **correctly fixed**.
+
+**P1 — F10-B remained wrong.** The R10-B recommendation still placed the
+check at `Start`, but `CapProcessingGate` is a *runtime* "successfully wired"
+bit — the durable consumer sets it only inside `addSubjectLoop` after a gated
+handler is wrapped (`internal/durable/worker_consumer.go:386-398, 604-623`),
+and the manager samples capabilities only after
+`handoffCoordinator.Apply` (`manager_assignment.go:851-859` →
+`manager.go:815-832`). A literal `Start`-time check would false-positive on
+correctly-configured gated consumers.
+
+Fix: place the check at the capability-sampling point (after the first
+non-empty two-phase apply), not at `Start`.
+
+## Round 3 — Round-2 fix verification
+
+R10-B core is correctly fixed (post-apply lifecycle). **P1 — F10 change-risk
+paragraph remained stale**: still called the warning "a startup warning"
+even though the recommendation, ranking, and Phase-0 sequencing had all been
+updated to "first two-phase apply."
+
+Fix: clean up the stale phrasing in the change-risk text.
+
+## Round 4 — final confirmation
+
+R10-B change-risk text correctly fixed. Final glance clean. **No P0/P1
+remaining.**
+
+## Round 5 — F6 restructuring pass
+
+F6 was split into F6-A (source-loss signalling) and F6-B (empty/shrunk
+partition-input freeze). Two issues surfaced after the split:
+
+- **P0 — F6-B** still treated an *erroring* partition-source observation
+  as one that could publish zero partitions. Wrong: `rebalance` returns
+  immediately on `snapshotSource` error before assignment calculation or
+  publish (`internal/assignment/calculator.go:1279-1283`).
+  Fix: scope F6-B to **non-erroring** empty/shrunk observations only;
+  explicitly state the erroring path is already correctly handled.
+- **P1 — Cross-references** still said umbrella "F6" where the text
+  specifically described F6-A.
+  Fix: rewrite the two stale cross-references.
+
+## Round 6 — Round-5 fix verification
+
+F9-A correctly fixed (one-line code diff vs operational migration cleanly
+separated; F1 dependency named).
+
+**Still wrong:**
+- F6-B's recommendation now has the right contract, but the finding's
+  *description* still said an erroring source proceeds to recompute/republish.
+- Executive summary still had a bare `F9` bullet where the rest of the
+  doc had moved to `F9-A`.
+
+Fix: rewrite the F6-B finding description; promote the executive-summary
+bullet to `F9-A`.
+
+## Round 7 — Round-6 fix verification
+
+F6-B finding correctly fixed; F9-A bullet correctly fixed; remaining bare
+"F9" references are umbrella-section contexts only (acceptable).
+
+**P1 — Stale F6-B error-path overstatements** still appeared *outside* the
+main finding/recommendation: in the executive summary, the
+dynamic-partitioning summary, the failure-mode matrix, the impact paragraph,
+and the ranking table — each still implied an empty/erroring source could
+reassign or publish zero.
+
+Fix: scope every cross-reference of F6-B to "empty / sharply shrunk
+*non-erroring*" observations.
+
+## Round 8 — Round-7 fix verification
+
+All five F6-B cross-references correctly fixed (executive summary,
+dynamic-partitioning summary, matrix row 13, impact paragraph, ranking
+table row).
+
+**Final glance clean. No P0/P1 remaining.**
+
+## Round 9 — Companion-addition validation
+
+Round 9 evaluated the F9-A "OperationTimeout ≤ ElectionTimeout/3"
+companion warning addition. Every technical claim was confirmed against
+source:
+
+- `OperationTimeout` default `10s` (`config.go:358-360`).
+- `ElectionTimeout` default `10s` (`config.go:362-366`).
+- Renew ticker interval `ElectionTimeout/3` (`manager_election.go:191-192`).
+- Renew bounded by `context.WithTimeout(m.ctx, m.cfg.OperationTimeout)`
+  (`manager_election.go:205-209`).
+- `monitorLeadership` is single-goroutine ticker; a hanging renew
+  blocks subsequent ticks (`manager_election.go:191-275`).
+- `warnOnShortAuditGrace` is a valid one-shot startup-warning pattern
+  reference (`manager_setup.go:385-408`).
+
+The companion addition was accepted as part of the F9-A PR.
+
+## Net result (findings review)
+
+After 9 rounds, every P0 was resolved, every P1 closed, and the only
+P2 finding (F10-C status) was corrected. The findings document
+(`findings.md`) is the artefact that absorbed every fix; this trail
+exists so a future reader knows the document's history without
+re-loading nine verbatim transcripts.
+
+---
+
+## Implementation-plan review (a separate 3-round loop)
+
+After the findings doc landed, the phased implementation plan
+(`00-fix-plan.md`) went through its own external-reviewer loop via
+the `/plan-review` skill. Reports archived under
+`tmp/00-fix-plan_self-healing-v{1,2,3}_review.md`.
+
+### Plan-review round 1 (v1)
+
+External reviewer flagged **3 P0** and **2 P1** items in the initial
+draft of `00-fix-plan.md`:
+
+- **P0 — F5 checkpoint reseed** would still skip messages on a fresh
+  recreated stream. The plan said "fetch new stream's `AckFloor` and
+  overwrite the in-memory checkpoint", but `Checkpoint.Seed` is
+  monotonic (`internal/recovery/checkpoint.go:30-40`) and
+  `BuildConfig`'s `FromLastProcessed`-with-`checkpoint==0` falls
+  through to `DeliverNewPolicy` (`internal/recovery/config.go:22-28`).
+  Both paths skip messages on a fresh stream.
+- **P0 — F5/P2.4d dependency.** The Phase-2 sequence had P2.3 (F5)
+  before P2.4a, but P2.3's "no hook = `OnError` + readiness flip"
+  test requires the envelope wired into `partition_consumer.go`
+  (P2.4d's territory), not the source watcher (P2.4a).
+- **P0 — F6-B readiness claim unreachable.** The "How this trips
+  readiness" line said F6-A would eventually fire for a sustained
+  non-erroring empty source — but F6-A only triggers on
+  `ErrBucketNotFound`, never on a non-erroring observation.
+- **P1 — F10-A pseudocode** referenced fictitious APIs
+  (`HasConfirmedDeaths()`) and the wrong layer
+  (`WorkerMonitor.GetActiveWorkers` instead of
+  `Calculator.getActiveWorkers`).
+- **P1 — F9-A runbook** used `nats kv del` (key delete) instead of
+  `nats kv rm` (bucket removal), and invented a
+  `parti version --features` command that doesn't exist.
+
+### Plan-review round 2 (v2)
+
+Round-1 items closed; two new findings raised by the revisions:
+
+- **P0 — F5 reset ordering + generation fencing.** The new
+  `ResetForStreamRecreate` design didn't pin the control-flow
+  ordering. `Controller.recover` reads checkpoint + calls
+  `BuildConfig` *before* `recreate`
+  (`internal/recovery/controller.go:273-294`), so a hook fired
+  inside `recreate` would still see the stale config. Separately,
+  manual-ack mode (`controller.go:185-188`, `tracking_msg.go:19-37`)
+  could let a late ack from the OLD-stream handler raise the
+  checkpoint after the reset, defeating it.
+- **P1 — `shrunkObservations` collision** between F6-B (P2.2) and
+  F10-A (P2.5): both added a field with that name to the same
+  `Calculator` struct. Additionally, F6-B T1's boundary wording was
+  off-by-one — it described `PartitionShrinkConfirmationCount`
+  total observations of suppression where the design suppresses
+  only `N-1`.
+- **P2 — F9-A wording** claimed "the rest are already `FileStorage`"
+  but heartbeat is `MemoryStorage` (`manager_setup.go:93`); the
+  companion warning's remedy said "defaults: 10s / 30s" but both
+  timeouts default to 10s.
+
+### Plan-review round 3 (v3) — clean
+
+All v2 items closed. Verdict: **ready to implement**. The only
+remaining gate is the plan's existing requirement that P2.4d land
+before P2.3 — which is now stated consistently across the PR
+table, the F5 dependency paragraph, and the P2.4d section.
+
+Net effect of the plan-review loop:
+
+- F5's design now pins the stream-missing control-flow ordering
+  explicitly (detection → hook → `HandleStreamRecreated`
+  [`streamEpoch++` → `ResetForStreamRecreate` → re-seed → set the
+  one-shot `recreatedSinceLastBuild` flag] → re-enter `recover`).
+- A stream-epoch generation fence on `Checkpoint.Advance` prevents
+  late acks from prior stream generations from raising the reset
+  checkpoint.
+- `BuildConfig` gains a new rule: on the recreated-stream path with
+  checkpoint 0, deliver via `DeliverAllPolicy` (not
+  `DeliverNewPolicy`), replaying the fresh stream from sequence 1.
+- F6-B and F10-A use distinct counter names
+  (`partitionShrunkObservations` and `workerShrunkObservations`),
+  and a cross-feature isolation test (P2.5 T7) locks the separation.
+- F6-B's readiness policy is now explicit: confirmed shrink is
+  treated as legitimate operator intent; the library cannot
+  distinguish a buggy source from intent; mitigation is operator
+  vigilance via warn logs + the new
+  `parti_partition_observation_suspicious_total` counter.
+- F9-A's operator runbook uses `nats kv rm` consistently with
+  `docs/OPERATIONS.md`, and the verification steps use real
+  commands (release-tag check, log grep, `nats stream ls`,
+  `nats kv info | grep Storage`).

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -31,7 +31,19 @@ func main() {
 		natsURL = nats.DefaultURL
 	}
 
-	nc, err := nats.Connect(natsURL)
+	// Connect with the recommended Parti posture:
+	//   - MaxReconnects(-1): ride through transient NATS outages instead
+	//     of going CLOSED and forcing the manager into degraded mode.
+	//   - ReconnectWait + ReconnectJitter: avoid thundering reconnects.
+	//   - RetryOnFailedConnect: tolerate NATS startup races.
+	// See docs/OPERATIONS.md "NATS Client Connection" for the full
+	// rationale.
+	nc, err := nats.Connect(natsURL,
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2*time.Second),
+		nats.ReconnectJitter(500*time.Millisecond, 2*time.Second),
+		nats.RetryOnFailedConnect(true),
+	)
 	if err != nil {
 		log.Fatalf("Failed to connect to NATS: %v", err)
 	}

--- a/internal/assignment/calculator.go
+++ b/internal/assignment/calculator.go
@@ -26,11 +26,11 @@ var errShuttingDown = errors.New("rebalance aborted: leader is shutting down")
 // because it is an explicit "keep cached assignment" decision, not a
 // failure.
 //
-// This implements the F6-B doctrine of "minimum credible partition input":
-// a single observation of an empty / sharply-shrunk source is more likely a
-// transient blip (KV miss, watcher race) than legitimate operator intent;
-// the confirmation window prevents one bad poll from triggering a
-// fleet-wide reassign-to-zero thundering herd.
+// This implements the "minimum credible partition input" doctrine: a
+// single observation of an empty / sharply-shrunk source is more likely
+// a transient blip (KV miss, watcher race) than legitimate operator
+// intent; the confirmation window prevents one bad poll from triggering
+// a fleet-wide reassign-to-zero thundering herd.
 var errSuspiciousPartitionObservation = errors.New("rebalance skipped: partition observation pending confirmation")
 
 // Calculator manages partition assignment calculation and distribution.
@@ -97,7 +97,8 @@ type Calculator struct {
 	// counter delta equal to 1 per dropped partition update.
 	partitionRebalanceEntries atomic.Int64
 
-	// F6-B (P2.2): minimum-credible-partition-input doctrine.
+	// Minimum-credible-partition-input doctrine (see
+	// errSuspiciousPartitionObservation Godoc):
 	//
 	// lastKnownPartitionCount is the most recent partition count the
 	// calculator acted on. Empty / sharply-shrunk observations do NOT
@@ -1212,7 +1213,9 @@ func (c *Calculator) getActiveWorkersFiltered(ctx context.Context, disappearedWo
 	return filtered, fresh, nil
 }
 
-// partitionInputCredibilityGuard implements the F6-B confirmation window.
+// partitionInputCredibilityGuard implements the confirmation window for
+// the minimum-credible-partition-input doctrine (see
+// errSuspiciousPartitionObservation Godoc).
 // Returns true when the observation is suspicious and the caller must skip
 // the rebalance (the caller surfaces errSuspiciousPartitionObservation).
 // Returns false when the observation is credible (the caller advances the
@@ -1281,7 +1284,7 @@ func (c *Calculator) handleRebalance(ctx context.Context, reason string) error {
 			c.Logger.Info("rebalance skipped during shutdown", "reason", reason)
 			return nil
 		}
-		// F6-B: suspicious partition observation is an explicit "keep
+		// A suspicious partition observation is an explicit "keep
 		// cached assignment for now" decision, not a failure. Treat as
 		// no-op so the state machine does not escalate. The rebalance
 		// path already logged a WARN with the confirmation progress.
@@ -1351,7 +1354,7 @@ func snapshotSource(ctx context.Context, src types.PartitionSource) ([]types.Par
 
 // rebalance calculates and publishes new assignments.
 //
-//nolint:cyclop // already-large function; F6-B adds one credibility-guard branch — refactoring is a separate effort
+//nolint:cyclop // already-large function; the credibility-guard branch adds one more — refactoring is a separate effort
 func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 	// Serialize rebalance operations to prevent race conditions
 	c.rebalanceMu.Lock()
@@ -1412,7 +1415,8 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 		return nil
 	}
 
-	// F6-B (P2.2): minimum-credible-partition-input guard.
+	// Minimum-credible-partition-input guard (see
+	// errSuspiciousPartitionObservation Godoc).
 	if suspicious := c.partitionInputCredibilityGuard(lifecycle, len(partitions)); suspicious {
 		c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
 		c.Metrics.RecordRebalanceAttempt(lifecycle, true)

--- a/internal/assignment/calculator.go
+++ b/internal/assignment/calculator.go
@@ -17,6 +17,22 @@ import (
 // that normal manager shutdown does not produce spurious error-level log entries.
 var errShuttingDown = errors.New("rebalance aborted: leader is shutting down")
 
+// errSuspiciousPartitionObservation is returned by rebalance() when the
+// partition-source snapshot is empty or has sharply shrunk relative to the
+// last known credible count, and the confirmation window
+// (PartitionShrinkConfirmationCount) has not yet been satisfied. The
+// candidate rebalance is skipped — the cached assignment remains in
+// effect. handleRebalance treats this sentinel like a no-op (no error)
+// because it is an explicit "keep cached assignment" decision, not a
+// failure.
+//
+// This implements the F6-B doctrine of "minimum credible partition input":
+// a single observation of an empty / sharply-shrunk source is more likely a
+// transient blip (KV miss, watcher race) than legitimate operator intent;
+// the confirmation window prevents one bad poll from triggering a
+// fleet-wide reassign-to-zero thundering herd.
+var errSuspiciousPartitionObservation = errors.New("rebalance skipped: partition observation pending confirmation")
+
 // Calculator manages partition assignment calculation and distribution.
 //
 // The calculator runs on the leader worker and orchestrates three focused components:
@@ -80,6 +96,24 @@ type Calculator struct {
 	// the §2.2.3 / §10.3 "at most one extra cycle" invariant is asserted as a
 	// counter delta equal to 1 per dropped partition update.
 	partitionRebalanceEntries atomic.Int64
+
+	// F6-B (P2.2): minimum-credible-partition-input doctrine.
+	//
+	// lastKnownPartitionCount is the most recent partition count the
+	// calculator acted on. Empty / sharply-shrunk observations do NOT
+	// advance it — that is the load-bearing safety. Only confirmed
+	// observations (the rebalance proceeds) update it.
+	//
+	// partitionShrunkObservations is the running count of consecutive
+	// suspicious observations. Once it reaches
+	// PartitionShrinkConfirmationCount the calculator trusts the
+	// shrink and rebalances; any healthy observation resets it to 0.
+	//
+	// Both fields are read+written only on the rebalance path, which is
+	// already serialized by rebalanceMu/pollMu — no extra synchronization
+	// is needed.
+	lastKnownPartitionCount     int
+	partitionShrunkObservations int
 }
 
 // cachedWorkerList bundles worker data with its timestamp for atomic operations.
@@ -715,6 +749,17 @@ func (c *Calculator) handlePartitionRebalance(ctx context.Context, lifecycle str
 				"lifecycle", lifecycle)
 			return err
 		}
+		// A suspicious partition observation is an explicit skip, not a
+		// failure. Surface the sentinel to the lifecycle caller
+		// (triggerPartitionRebalance) so it can re-arm
+		// pendingPartitionUpdate for the next drainTick. The lifecycle
+		// caller translates it to a benign nil; nothing else escalates
+		// because handlePartitionRebalance is wired only as the
+		// state-machine's onPartitionRebalanceCb callback.
+		if errors.Is(err, errSuspiciousPartitionObservation) {
+			return err
+		}
+
 		return fmt.Errorf("partition rebalance failed for %s: %w", lifecycle, err)
 	}
 	// IMPORTANT: do NOT update lastWorkers here. The immediate tail-check in
@@ -748,6 +793,20 @@ func (c *Calculator) triggerPartitionRebalance(lifecycle string) error {
 	defer cancel()
 
 	err := c.stateMach.RunClaimedRebalanceErr(reqCtx, lifecycle)
+
+	// A suspicious-observation suppression is a deferred no-op, not a
+	// failure. The watcher in monitorPartitions fires only when the
+	// partition list changes, so a single N→0 (or N→tiny) transition
+	// produces one signal; without a re-arm the confirmation window
+	// stalls forever because the drainTick has nothing pending to drain.
+	// Re-arm here so the next drainTick re-attempts (each re-attempt
+	// observes the same shrunk source and advances the counter toward
+	// PartitionShrinkConfirmationCount). The lifecycle caller sees a
+	// benign nil; the rebalance was suppressed, not failed.
+	if errors.Is(err, errSuspiciousPartitionObservation) {
+		c.pendingPartitionUpdate.Store(true)
+		err = nil
+	}
 
 	// Tail-check on a FRESH stop-aware context: reqCtx may already be near or
 	// past its deadline; observeAndDecide exits fast on a cancelled context
@@ -1153,6 +1212,54 @@ func (c *Calculator) getActiveWorkersFiltered(ctx context.Context, disappearedWo
 	return filtered, fresh, nil
 }
 
+// partitionInputCredibilityGuard implements the F6-B confirmation window.
+// Returns true when the observation is suspicious and the caller must skip
+// the rebalance (the caller surfaces errSuspiciousPartitionObservation).
+// Returns false when the observation is credible (the caller advances the
+// baseline and proceeds). A healthy observation also resets the running
+// suspicious-observations counter.
+//
+// The guard is silent until lastKnownPartitionCount > 0 — the first ever
+// rebalance must run so the baseline can be established. Subsequent
+// empty / sharply-shrunk observations require
+// PartitionShrinkConfirmationCount consecutive sightings before being
+// trusted.
+func (c *Calculator) partitionInputCredibilityGuard(lifecycle string, observed int) bool {
+	if c.lastKnownPartitionCount == 0 {
+		return false // baseline not yet established; let the first rebalance run
+	}
+	switch {
+	case observed == 0:
+		c.partitionShrunkObservations++
+		if c.partitionShrunkObservations < c.PartitionShrinkConfirmationCount {
+			c.Logger.Warn("ignoring empty partition observation pending confirmation",
+				"lifecycle", lifecycle,
+				"last_known", c.lastKnownPartitionCount,
+				"consecutive_observations", c.partitionShrunkObservations,
+				"required", c.PartitionShrinkConfirmationCount)
+
+			return true
+		}
+	case observed*100 < c.lastKnownPartitionCount*c.PartitionShrinkConfirmationThresholdPct:
+		c.partitionShrunkObservations++
+		if c.partitionShrunkObservations < c.PartitionShrinkConfirmationCount {
+			c.Logger.Warn("ignoring sharply-shrunk partition observation pending confirmation",
+				"lifecycle", lifecycle,
+				"last_known", c.lastKnownPartitionCount,
+				"observed", observed,
+				"threshold_pct", c.PartitionShrinkConfirmationThresholdPct,
+				"consecutive_observations", c.partitionShrunkObservations,
+				"required", c.PartitionShrinkConfirmationCount)
+
+			return true
+		}
+	default:
+		c.partitionShrunkObservations = 0 // healthy observation; reset counter
+	}
+
+	return false
+}
+
 // handleRebalance is the callback invoked by StateMachine when rebalancing should occur.
 //
 // This method bridges the StateMachine component to the Calculator's rebalancing logic
@@ -1174,6 +1281,14 @@ func (c *Calculator) handleRebalance(ctx context.Context, reason string) error {
 			c.Logger.Info("rebalance skipped during shutdown", "reason", reason)
 			return nil
 		}
+		// F6-B: suspicious partition observation is an explicit "keep
+		// cached assignment for now" decision, not a failure. Treat as
+		// no-op so the state machine does not escalate. The rebalance
+		// path already logged a WARN with the confirmation progress.
+		if errors.Is(err, errSuspiciousPartitionObservation) {
+			return nil
+		}
+
 		return fmt.Errorf("rebalance failed for %s: %w", reason, err)
 	}
 
@@ -1235,6 +1350,8 @@ func snapshotSource(ctx context.Context, src types.PartitionSource) ([]types.Par
 }
 
 // rebalance calculates and publishes new assignments.
+//
+//nolint:cyclop // already-large function; F6-B adds one credibility-guard branch — refactoring is a separate effort
 func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 	// Serialize rebalance operations to prevent race conditions
 	c.rebalanceMu.Lock()
@@ -1294,6 +1411,15 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 
 		return nil
 	}
+
+	// F6-B (P2.2): minimum-credible-partition-input guard.
+	if suspicious := c.partitionInputCredibilityGuard(lifecycle, len(partitions)); suspicious {
+		c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
+		c.Metrics.RecordRebalanceAttempt(lifecycle, true)
+
+		return errSuspiciousPartitionObservation
+	}
+	c.lastKnownPartitionCount = len(partitions)
 
 	// Calculate new assignments using strategy
 	assignments, err := c.Strategy.Assign(workers, partitions)

--- a/internal/assignment/calculator_f6b_partition_floor_test.go
+++ b/internal/assignment/calculator_f6b_partition_floor_test.go
@@ -1,0 +1,368 @@
+package assignment
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// mutableSource is a mockSource whose partitions can be mutated between
+// rebalance calls, letting the F6-B tests drive specific shape sequences
+// (healthy → empty → empty → healthy, etc.) deterministically.
+type mutableSource struct {
+	mu         sync.Mutex
+	partitions []types.Partition
+}
+
+func (m *mutableSource) Start(context.Context) error { return nil }
+func (m *mutableSource) Stop(context.Context) error  { return nil }
+func (m *mutableSource) List(context.Context) ([]types.Partition, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]types.Partition, len(m.partitions))
+	copy(out, m.partitions)
+
+	return out, nil
+}
+
+func (m *mutableSource) set(p []types.Partition) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.partitions = p
+}
+
+// setupF6BCalculator wires a minimal Calculator with a mutable source and
+// one worker heartbeat. The Calculator is constructed but NOT Start()ed —
+// these tests drive rebalance directly to make the F6-B counter
+// transitions deterministic. Calling Start would spawn monitor goroutines
+// that race with the test's explicit rebalance calls (the race detector
+// flagged this on the integration branch's first full-suite run; the
+// monitor goroutine and test both wrote to partitionShrunkObservations
+// concurrently and double-advanced the counter).
+//
+// confirmCount stays a parameter (even though every current call site
+// passes 3) so future tests can exercise different confirmation windows.
+//
+// logger is optional — passing nil keeps the default nop logger; a
+// recording logger lets a test assert against log-level behavior (see
+// TestCalculator_F6B_SuspiciousObservation_DoesNotLogPartitionRebalanceFailed
+// for the regression-pin case).
+//
+//nolint:unparam // confirmCount is intentionally configurable for future tests
+func setupF6BCalculator(t *testing.T, ctx context.Context, src *mutableSource, confirmCount int, logger types.Logger) *Calculator {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	assignmentKV := partitest.CreateJetStreamKV(t, nc, "test-f6b-assignment-"+t.Name())
+	heartbeatKV := partitest.CreateJetStreamKV(t, nc, "test-f6b-heartbeat-"+t.Name())
+
+	// One worker so calculator has a non-empty active set.
+	_, err := heartbeatKV.Put(ctx, "worker-hb.worker-1", []byte(time.Now().Format(time.RFC3339Nano)))
+	require.NoError(t, err)
+
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:                     assignmentKV,
+		HeartbeatKV:                      heartbeatKV,
+		AssignmentPrefix:                 "assignment",
+		Source:                           src,
+		Strategy:                         &mockStrategy{},
+		HeartbeatPrefix:                  "worker-hb",
+		HeartbeatTTL:                     5 * time.Second,
+		EmergencyGracePeriod:             1 * time.Second,
+		ColdStartWindow:                  10 * time.Millisecond,
+		PlannedScaleWindow:               10 * time.Millisecond,
+		Cooldown:                         0, // test drives rebalance directly
+		PartitionShrinkConfirmationCount: confirmCount,
+		Logger:                           logger,
+	})
+	require.NoError(t, err)
+
+	// Pump one rebalance with the healthy starting partitions so
+	// lastKnownPartitionCount > 0 (the F6-B guard's enabling condition).
+	// Direct call — no Start()-spawned monitor goroutines to race with.
+	require.NoError(t, calc.rebalance(ctx, "test-seed"))
+	require.Greater(t, calc.lastKnownPartitionCount, 0,
+		"sanity: the seed rebalance must populate lastKnownPartitionCount")
+
+	return calc
+}
+
+// TestCalculator_F6B_EmptyObservation_SuppressedUntilConfirmation drives
+// the calculator with N=10 partitions then injects an empty observation
+// PartitionShrinkConfirmationCount times in a row. The first
+// (count - 1) calls must return errSuspiciousPartitionObservation
+// without advancing lastKnownPartitionCount; the count-th call must
+// accept the shrink and update the baseline.
+func TestCalculator_F6B_EmptyObservation_SuppressedUntilConfirmation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	src := &mutableSource{partitions: makePartitions(10)}
+	calc := setupF6BCalculator(t, ctx, src, 3, nil)
+
+	// Seed baseline was 10 partitions. Now go empty.
+	src.set(nil)
+
+	// First (count - 1) = 2 calls: suppressed.
+	for i := 1; i <= 2; i++ {
+		err := calc.rebalance(ctx, "f6b-test")
+		require.ErrorIs(t, err, errSuspiciousPartitionObservation,
+			"observation %d/3 must surface errSuspiciousPartitionObservation", i)
+		require.Equal(t, 10, calc.lastKnownPartitionCount,
+			"suppressed observation MUST NOT advance lastKnownPartitionCount")
+		require.Equal(t, i, calc.partitionShrunkObservations,
+			"counter must advance once per suppressed observation")
+	}
+
+	// Third call: confirmation reached; shrink is honored.
+	require.NoError(t, calc.rebalance(ctx, "f6b-test"))
+	require.Equal(t, 0, calc.lastKnownPartitionCount,
+		"after confirmation the baseline updates to the new (empty) shape")
+}
+
+// TestCalculator_F6B_SharplyShrunkObservation_Suppressed mirrors the
+// empty case for the "sharply shrunk but non-empty" branch.
+func TestCalculator_F6B_SharplyShrunkObservation_Suppressed(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	src := &mutableSource{partitions: makePartitions(20)}
+	calc := setupF6BCalculator(t, ctx, src, 3, nil)
+
+	// 20 → 3 is an 85% drop, well below the default 50% threshold.
+	src.set(makePartitions(3))
+
+	for i := 1; i <= 2; i++ {
+		err := calc.rebalance(ctx, "f6b-test")
+		require.ErrorIs(t, err, errSuspiciousPartitionObservation,
+			"observation %d/3 must surface errSuspiciousPartitionObservation", i)
+		require.Equal(t, 20, calc.lastKnownPartitionCount,
+			"suppressed observation MUST NOT advance lastKnownPartitionCount")
+	}
+
+	// Third call: confirmation reached; shrink is honored.
+	require.NoError(t, calc.rebalance(ctx, "f6b-test"))
+	require.Equal(t, 3, calc.lastKnownPartitionCount,
+		"after confirmation the baseline updates to the new (3-partition) shape")
+}
+
+// TestCalculator_F6B_LegitimateGrowth_NotGated verifies the guard
+// fires ONLY on shrinks. Growth must always be accepted immediately.
+func TestCalculator_F6B_LegitimateGrowth_NotGated(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	src := &mutableSource{partitions: makePartitions(10)}
+	calc := setupF6BCalculator(t, ctx, src, 3, nil)
+
+	src.set(makePartitions(50))
+	require.NoError(t, calc.rebalance(ctx, "f6b-test"),
+		"growth must pass through the guard immediately")
+	require.Equal(t, 50, calc.lastKnownPartitionCount)
+	require.Equal(t, 0, calc.partitionShrunkObservations,
+		"growth must keep the suspicious counter at 0")
+}
+
+// TestCalculator_F6B_HealingObservationResetsCounter sets up a
+// half-shrunk-then-healed sequence: observation 1 is suspicious
+// (counter advances), observation 2 is healthy (counter resets to 0).
+// A subsequent suspicious observation then needs the FULL confirmation
+// window again — the counter must start fresh.
+func TestCalculator_F6B_HealingObservationResetsCounter(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	src := &mutableSource{partitions: makePartitions(10)}
+	calc := setupF6BCalculator(t, ctx, src, 3, nil)
+
+	src.set(makePartitions(3)) // 70% drop; suspicious
+	err := calc.rebalance(ctx, "f6b-test")
+	require.ErrorIs(t, err, errSuspiciousPartitionObservation)
+	require.Equal(t, 1, calc.partitionShrunkObservations)
+
+	src.set(makePartitions(10)) // healed
+	require.NoError(t, calc.rebalance(ctx, "f6b-test"))
+	require.Equal(t, 0, calc.partitionShrunkObservations,
+		"healing observation must reset the counter to 0")
+
+	src.set(makePartitions(2)) // suspicious again
+	err = calc.rebalance(ctx, "f6b-test")
+	require.ErrorIs(t, err, errSuspiciousPartitionObservation,
+		"new suspicious sequence must start from counter=0, NOT continue the old one")
+	require.Equal(t, 1, calc.partitionShrunkObservations)
+}
+
+// TestCalculator_F6B_RebalanceCallbacks_HandleSuspiciousObservation
+// pins the per-callback contract for errSuspiciousPartitionObservation:
+//
+//   - handleRebalance (the worker-monitor lifecycle path) swallows the
+//     sentinel — its caller is a periodic poll loop that does not need
+//     a re-arm signal; the next poll naturally re-observes.
+//   - handlePartitionRebalance (the partition-watcher lifecycle path)
+//     PROPAGATES the sentinel so triggerPartitionRebalance can re-arm
+//     pendingPartitionUpdate; the watcher fires only on partition-list
+//     changes and a single N→0 event must not strand the confirmation
+//     window. The lifecycle caller (triggerPartitionRebalance) is the
+//     sole user of this callback and translates the sentinel to nil
+//     after re-arming.
+//
+// The contracts diverge deliberately — see the per-function Godoc.
+func TestCalculator_F6B_RebalanceCallbacks_HandleSuspiciousObservation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	src := &mutableSource{partitions: makePartitions(10)}
+	calc := setupF6BCalculator(t, ctx, src, 3, nil)
+
+	src.set(nil)
+	require.NoError(t, calc.handleRebalance(ctx, "f6b-test"),
+		"handleRebalance must swallow errSuspiciousPartitionObservation "+
+			"(the periodic poll caller re-observes naturally)")
+	require.ErrorIs(t, calc.handlePartitionRebalance(ctx, "f6b-test"),
+		errSuspiciousPartitionObservation,
+		"handlePartitionRebalance must propagate errSuspiciousPartitionObservation "+
+			"so triggerPartitionRebalance can re-arm pendingPartitionUpdate")
+}
+
+// TestCalculator_F6B_SuspiciousObservation_RearmsPendingPartitionUpdate
+// pins the contract that watchable-source-driven shrinks converge. The
+// watcher emits exactly one signal when the source goes from N→0 (or
+// N→tiny); monitorPartitions then clears pendingPartitionUpdate and
+// invokes triggerPartitionRebalance. If the F6-B guard suppresses the
+// first observation, the next confirmation tick has to come from the
+// drainTick — which only fires when pendingPartitionUpdate is true.
+//
+// Without a re-arm on the suspicious-observation path the watcher
+// signal is consumed once, the counter advances to 1, and the
+// confirmation window stalls forever (partitions stay at 0 so no
+// further watcher events arrive; drainTick has nothing pending to
+// drain). This is the exact "fault-papering" pattern the goal anchor
+// in docs/plans/self-healing/README.md warns against.
+func TestCalculator_F6B_SuspiciousObservation_RearmsPendingPartitionUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	src := &mutableSource{partitions: makePartitions(10)}
+	calc := setupF6BCalculator(t, ctx, src, 3, nil)
+
+	// Mirror monitorPartitions's pre-trigger contract: pendingPartitionUpdate
+	// is cleared just BEFORE triggerPartitionRebalance runs (see
+	// calculator.go's "Immediate trigger supersedes any pending deferred
+	// update" comment in monitorPartitions).
+	calc.pendingPartitionUpdate.Store(false)
+
+	// Inject a suspicious shrink the F6-B guard will suppress on this
+	// first observation: 10 → 0.
+	src.set(nil)
+
+	// Drive the rebalance through the same state-machine path
+	// monitorPartitions uses.
+	err := calc.triggerPartitionRebalance("f6b-test")
+	require.NoError(t, err,
+		"the lifecycle caller must see a benign nil; suspicious-observation "+
+			"suppression is an explicit skip, not a failure")
+
+	// F6-B suppression took effect: counter advanced, baseline unchanged.
+	require.Equal(t, 1, calc.partitionShrunkObservations,
+		"the suspicious observation must advance the confirmation counter")
+	require.Equal(t, 10, calc.lastKnownPartitionCount,
+		"a suppressed observation MUST NOT advance the baseline")
+
+	// The bug this test pins. Without a re-arm, the next drainTick has
+	// nothing pending, the watcher will not re-fire (partitions did not
+	// change again), and the confirmation window stalls forever.
+	require.True(t, calc.pendingPartitionUpdate.Load(),
+		"F6-B suspicious-observation suppression MUST re-arm "+
+			"pendingPartitionUpdate so the drainTick re-attempts and the "+
+			"confirmation window converges; without this the watcher-driven "+
+			"shrink path papers over a real fault (counter pinned at 1, "+
+			"shrink never applied)")
+}
+
+// errorRecordingLogger captures Error-level log messages so a test can
+// assert that a benign sentinel does NOT trigger an operator-visible
+// "failed" line. It defers other levels to a delegate so a developer
+// running the test can still see Info/Warn output via -v.
+type errorRecordingLogger struct {
+	delegate types.Logger
+	mu       sync.Mutex
+	errors   []string
+}
+
+func (l *errorRecordingLogger) Debug(msg string, kv ...any) { l.delegate.Debug(msg, kv...) }
+func (l *errorRecordingLogger) Info(msg string, kv ...any)  { l.delegate.Info(msg, kv...) }
+func (l *errorRecordingLogger) Warn(msg string, kv ...any)  { l.delegate.Warn(msg, kv...) }
+func (l *errorRecordingLogger) Fatal(msg string, kv ...any) { l.delegate.Fatal(msg, kv...) }
+func (l *errorRecordingLogger) Error(msg string, kv ...any) {
+	l.mu.Lock()
+	l.errors = append(l.errors, msg)
+	l.mu.Unlock()
+	l.delegate.Error(msg, kv...)
+}
+
+func (l *errorRecordingLogger) capturedErrors() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.errors))
+	copy(out, l.errors)
+
+	return out
+}
+
+// TestCalculator_F6B_SuspiciousObservation_DoesNotLogPartitionRebalanceFailed
+// regression-pins the contract: a benign suspicious-observation suppression
+// must not surface as an Error-level "partition rebalance failed" log line.
+// The state-machine's RunClaimedRebalanceErr unconditionally logs every
+// non-nil callback error at Error level; when the F6-B re-arm fix made
+// handlePartitionRebalance propagate the sentinel instead of swallowing
+// it, every suppressed observation began producing a spurious
+// "partition rebalance failed" line — false-failure noise for operators
+// tailing the worker logs.
+//
+// The state-machine path must skip the Error log for the
+// errSuspiciousPartitionObservation sentinel specifically; the
+// observability of the suppression is preserved by the Warn line that
+// partitionInputCredibilityGuard already emits ("ignoring empty
+// partition observation pending confirmation").
+func TestCalculator_F6B_SuspiciousObservation_DoesNotLogPartitionRebalanceFailed(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	rec := &errorRecordingLogger{delegate: partitest.NewTestLogger(t)}
+
+	src := &mutableSource{partitions: makePartitions(10)}
+	calc := setupF6BCalculator(t, ctx, src, 3, rec)
+
+	// Mirror monitorPartitions's pre-trigger contract.
+	calc.pendingPartitionUpdate.Store(false)
+
+	// Inject a suspicious shrink the F6-B guard will suppress.
+	src.set(nil)
+
+	err := calc.triggerPartitionRebalance("f6b-test")
+	require.NoError(t, err, "the lifecycle caller must see nil; the sentinel is benign")
+	require.True(t, calc.pendingPartitionUpdate.Load(),
+		"sanity: the re-arm must still happen (the prior fix is intact)")
+
+	// The regression we're pinning.
+	for _, msg := range rec.capturedErrors() {
+		require.NotEqual(t, "partition rebalance failed", msg,
+			"a benign suspicious-observation suppression MUST NOT surface "+
+				"as an Error-level 'partition rebalance failed' log; this is "+
+				"false-failure noise for operators tailing the worker logs")
+	}
+}
+
+func makePartitions(n int) []types.Partition {
+	out := make([]types.Partition, n)
+	for i := range n {
+		out[i] = types.Partition{Keys: []string{fmt.Sprintf("p%d", i)}}
+	}
+
+	return out
+}

--- a/internal/assignment/config.go
+++ b/internal/assignment/config.go
@@ -51,6 +51,23 @@ type Config struct {
 	ColdStartWindow      time.Duration // Stabilization window for cold start (default: 30s)
 	PlannedScaleWindow   time.Duration // Stabilization window for planned scale (default: 10s)
 
+	// F6-B partition-input credibility (P2.2).
+	//
+	// PartitionShrinkConfirmationCount is the number of consecutive
+	// suspicious partition-source observations the calculator requires
+	// before trusting an empty / sharply-shrunk shape. Default: 3.
+	// Setting this to 1 disables the confirmation window (every
+	// observation is acted on immediately — restores pre-F6-B behavior).
+	PartitionShrinkConfirmationCount int
+
+	// PartitionShrinkConfirmationThresholdPct defines "sharply shrunk".
+	// A new partition count below
+	//   lastKnownPartitionCount * Pct / 100
+	// is suspicious. Default: 50 (a >=50% drop in one poll is
+	// suspicious). An empty observation is always suspicious
+	// regardless of this threshold.
+	PartitionShrinkConfirmationThresholdPct int
+
 	// RebalanceGraceDrainInterval is the period at which monitorPartitions
 	// checks for a partition-source update that was deferred because the
 	// leader was in recovery grace. When grace lifts, the deferred update
@@ -173,5 +190,11 @@ func (c *Config) SetDefaults() {
 	}
 	if c.Logger == nil {
 		c.Logger = logging.NewNop()
+	}
+	if c.PartitionShrinkConfirmationCount == 0 {
+		c.PartitionShrinkConfirmationCount = 3
+	}
+	if c.PartitionShrinkConfirmationThresholdPct == 0 {
+		c.PartitionShrinkConfirmationThresholdPct = 50
 	}
 }

--- a/internal/assignment/config.go
+++ b/internal/assignment/config.go
@@ -51,13 +51,14 @@ type Config struct {
 	ColdStartWindow      time.Duration // Stabilization window for cold start (default: 30s)
 	PlannedScaleWindow   time.Duration // Stabilization window for planned scale (default: 10s)
 
-	// F6-B partition-input credibility (P2.2).
+	// Partition-input credibility (see
+	// errSuspiciousPartitionObservation Godoc in calculator.go):
 	//
 	// PartitionShrinkConfirmationCount is the number of consecutive
 	// suspicious partition-source observations the calculator requires
 	// before trusting an empty / sharply-shrunk shape. Default: 3.
 	// Setting this to 1 disables the confirmation window (every
-	// observation is acted on immediately — restores pre-F6-B behavior).
+	// observation is acted on immediately).
 	PartitionShrinkConfirmationCount int
 
 	// PartitionShrinkConfirmationThresholdPct defines "sharply shrunk".

--- a/internal/assignment/state_machine.go
+++ b/internal/assignment/state_machine.go
@@ -2,6 +2,7 @@ package assignment
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -37,8 +38,11 @@ type StateMachine struct {
 
 	// Callback invoked by RunClaimedRebalanceErr for partition-lifecycle
 	// rebalances. Distinct from onRebalanceCb because the partition path needs
-	// errShuttingDown to propagate to restorePendingOnGraceBail rather than
-	// being swallowed (see calculator.go handlePartitionRebalance).
+	// the callback's sentinel errors to propagate to its lifecycle owner —
+	// errShuttingDown to restorePendingOnGraceBail, and
+	// errSuspiciousPartitionObservation to triggerPartitionRebalance for the
+	// re-arm on the pending flag. See calculator.go handlePartitionRebalance
+	// and triggerPartitionRebalance for the consumers.
 	onPartitionRebalanceCb func(ctx context.Context, reason string) error
 
 	// For tracking scaling timer goroutine
@@ -365,7 +369,14 @@ func (sm *StateMachine) RunClaimedRebalanceErr(ctx context.Context, reason strin
 	var cbErr error
 	if sm.onPartitionRebalanceCb != nil {
 		cbErr = sm.onPartitionRebalanceCb(ctx, reason)
-		if cbErr != nil {
+		// errSuspiciousPartitionObservation is a benign deferred no-op —
+		// the credibility guard suppressed the rebalance pending more
+		// observations and the lifecycle owner (triggerPartitionRebalance)
+		// re-arms pendingPartitionUpdate so the next drain tick retries.
+		// Logging it as a "failed" Error would surface false failures to
+		// operators tailing worker logs; the suppression is already
+		// recorded at Warn level by partitionInputCredibilityGuard.
+		if cbErr != nil && !errors.Is(cbErr, errSuspiciousPartitionObservation) {
 			sm.logger.Error("partition rebalance failed", "reason", reason, "error", cbErr)
 		}
 	}

--- a/internal/retry/envelope.go
+++ b/internal/retry/envelope.go
@@ -1,4 +1,4 @@
-// Package retry implements the F2 bounded-retry envelope used to wrap
+// Package retry implements the bounded-retry envelope used to wrap
 // the long-lived retry loops in the Parti runtime (source watcher
 // restart, handoff watcher restart, assignment watcher, dynamic
 // consumer recovery). The envelope replaces forever-retry loops with

--- a/internal/retry/envelope.go
+++ b/internal/retry/envelope.go
@@ -1,0 +1,201 @@
+// Package retry implements the F2 bounded-retry envelope used to wrap
+// the long-lived retry loops in the Parti runtime (source watcher
+// restart, handoff watcher restart, assignment watcher, dynamic
+// consumer recovery). The envelope replaces forever-retry loops with
+// a bounded attempt budget, exponential backoff with a hard ceiling,
+// jitter to avoid thundering herds, and a one-shot escalation callback
+// on exhaustion so the worker can take itself out of rotation rather
+// than generate infinite API load against a vanished resource.
+//
+// The package is internal — callers wire their site-specific Work,
+// Classify, and OnPermanent functions through the Config struct.
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+)
+
+// Class categorises an error returned by the work function.
+type Class int
+
+const (
+	// Transient: retry after backoff (subject to the attempt budget).
+	Transient Class = iota
+	// GiveUp: stop immediately; the resource is gone and waiting longer
+	// will not help. Fires the permanent-failure callback.
+	GiveUp
+	// Fatal: bubble the error up to the caller without retry and without
+	// firing the permanent-failure callback. Use this when the caller
+	// must inspect the error directly (e.g. configuration mistakes).
+	Fatal
+)
+
+// ErrExhausted is returned by Run when the attempt budget is exhausted
+// (after firing OnPermanent) or when Classify returned GiveUp.
+var ErrExhausted = errors.New("retry envelope: attempt budget exhausted")
+
+// Config configures a bounded-retry envelope.
+type Config struct {
+	// Work is invoked on each attempt. nil is not permitted.
+	Work func(ctx context.Context) error
+	// Classify maps a Work error to a Class. If nil, every error is
+	// treated as Transient.
+	Classify func(err error) Class
+	// OnPermanent is invoked at most once when the envelope gives up
+	// (attempt budget exhausted OR Classify returned GiveUp). The
+	// caller's last error is passed in. The callback runs synchronously
+	// on the envelope's goroutine — it must be non-blocking.
+	OnPermanent func(err error)
+	// OnProgress is invoked after each failed attempt with the (1-based)
+	// attempt number and the error returned. Optional.
+	OnProgress func(attempt int, err error)
+	// BaseBackoff is the delay before the second attempt; doubles each
+	// step up to MaxBackoff. Required.
+	BaseBackoff time.Duration
+	// MaxBackoff caps the per-attempt delay. Required.
+	MaxBackoff time.Duration
+	// MaxAttempts is the total attempt budget per Run invocation. After
+	// the Nth failure (counting from 1) the envelope fires OnPermanent
+	// and returns ErrExhausted. Must be > 0.
+	MaxAttempts int
+	// Jitter is the ± fraction applied to each backoff delay
+	// (0..1 reasonable; 0 disables). Avoids synchronized reconnect
+	// thundering herds across worker fleets.
+	Jitter float64
+	// Clock and Sleep are optional indirections for tests; production
+	// uses time.Now and time.After.
+	Now   func() time.Time
+	Sleep func(ctx context.Context, d time.Duration) error
+}
+
+// Envelope is the bounded-retry runner.
+type Envelope struct {
+	cfg Config
+}
+
+// New builds an Envelope from the given Config. Panics on invalid
+// configuration (Work nil, MaxAttempts <= 0, MaxBackoff <= 0,
+// BaseBackoff <= 0). These are programmer errors, not user errors —
+// fail loudly.
+func New(cfg Config) *Envelope {
+	if cfg.Work == nil {
+		panic("retry.New: Work is required")
+	}
+	if cfg.MaxAttempts <= 0 {
+		panic(fmt.Sprintf("retry.New: MaxAttempts must be > 0, got %d", cfg.MaxAttempts))
+	}
+	if cfg.BaseBackoff <= 0 {
+		panic("retry.New: BaseBackoff must be > 0")
+	}
+	if cfg.MaxBackoff < cfg.BaseBackoff {
+		panic(fmt.Sprintf("retry.New: MaxBackoff (%v) must be >= BaseBackoff (%v)", cfg.MaxBackoff, cfg.BaseBackoff))
+	}
+	if cfg.Classify == nil {
+		cfg.Classify = func(error) Class { return Transient }
+	}
+	if cfg.Sleep == nil {
+		cfg.Sleep = defaultSleep
+	}
+
+	return &Envelope{cfg: cfg}
+}
+
+// Run drives the envelope. Returns:
+//   - nil on success
+//   - ctx.Err() if the context cancels at any point (no OnPermanent fired)
+//   - the original Work error on a Fatal classification (no OnPermanent fired)
+//   - ErrExhausted on attempt-budget exhaustion or GiveUp (OnPermanent fired
+//     exactly once with the most recent Work error)
+//
+// Concurrency: Run is single-shot; one Envelope per logical retry loop.
+// Reusing the same Envelope concurrently is not supported.
+func (e *Envelope) Run(ctx context.Context) error {
+	var lastErr error
+	for attempt := 1; attempt <= e.cfg.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := e.cfg.Work(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		class := e.cfg.Classify(err)
+		switch class {
+		case Fatal:
+			return err
+		case GiveUp:
+			e.firePermanent(err)
+			return ErrExhausted
+		case Transient:
+			// fall through to backoff
+		}
+
+		if e.cfg.OnProgress != nil {
+			e.cfg.OnProgress(attempt, err)
+		}
+
+		if attempt == e.cfg.MaxAttempts {
+			break
+		}
+
+		delay := e.backoffFor(attempt)
+		if sleepErr := e.cfg.Sleep(ctx, delay); sleepErr != nil {
+			return sleepErr
+		}
+	}
+	e.firePermanent(lastErr)
+
+	return ErrExhausted
+}
+
+func (e *Envelope) firePermanent(err error) {
+	if e.cfg.OnPermanent != nil {
+		e.cfg.OnPermanent(err)
+	}
+}
+
+// backoffFor returns the (jittered) delay between the Nth and (N+1)th
+// attempt. attempt is 1-based.
+func (e *Envelope) backoffFor(attempt int) time.Duration {
+	// Exponential: base × 2^(attempt-1), capped at MaxBackoff.
+	delay := e.cfg.BaseBackoff
+	for i := 1; i < attempt && delay < e.cfg.MaxBackoff; i++ {
+		delay *= 2
+	}
+	if delay > e.cfg.MaxBackoff {
+		delay = e.cfg.MaxBackoff
+	}
+	if e.cfg.Jitter <= 0 {
+		return delay
+	}
+	// Apply ± jitter fraction.
+	low := 1 - e.cfg.Jitter
+	high := 1 + e.cfg.Jitter
+	//nolint:gosec // not a security context; rand/v2 is fine for jitter
+	f := rand.Float64()
+	scale := low + f*(high-low)
+
+	return time.Duration(float64(delay) * scale)
+}
+
+// defaultSleep is the production Sleep — returns nil after d elapses or
+// ctx.Err() if the context cancels first.
+func defaultSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/retry/envelope_test.go
+++ b/internal/retry/envelope_test.go
@@ -1,0 +1,306 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// instantSleep is a Sleep replacement that records its arguments and
+// returns immediately, so tests can assert on backoff math without
+// waiting real time. Returns ctx.Err() if cancelled (mirrors the
+// production sleep contract).
+type instantSleep struct {
+	delays []time.Duration
+}
+
+func (s *instantSleep) sleep(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.delays = append(s.delays, d)
+	return nil
+}
+
+func TestEnvelope_Run_SuccessFirstAttempt(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	sl := &instantSleep{}
+	env := New(Config{
+		Work:        func(context.Context) error { calls.Add(1); return nil },
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		MaxAttempts: 5,
+		Sleep:       sl.sleep,
+	})
+	require.NoError(t, env.Run(context.Background()))
+	require.Equal(t, int64(1), calls.Load())
+	require.Empty(t, sl.delays, "success on first attempt must not sleep")
+}
+
+func TestEnvelope_Run_TransientThenSuccess(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	sl := &instantSleep{}
+	env := New(Config{
+		Work: func(context.Context) error {
+			if calls.Add(1) < 4 {
+				return errors.New("transient")
+			}
+			return nil
+		},
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  80 * time.Millisecond,
+		MaxAttempts: 5,
+		Sleep:       sl.sleep,
+	})
+	require.NoError(t, env.Run(context.Background()))
+	require.Equal(t, int64(4), calls.Load())
+	require.Len(t, sl.delays, 3, "three failures must produce three backoffs")
+}
+
+func TestEnvelope_Run_ExhaustsAndFiresPermanent(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	var permErr error
+	var permFires atomic.Int64
+	last := errors.New("attempt-N")
+	sl := &instantSleep{}
+	env := New(Config{
+		Work: func(context.Context) error {
+			calls.Add(1)
+			return last
+		},
+		OnPermanent: func(err error) {
+			permFires.Add(1)
+			permErr = err
+		},
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		MaxAttempts: 4,
+		Sleep:       sl.sleep,
+	})
+	err := env.Run(context.Background())
+	require.ErrorIs(t, err, ErrExhausted)
+	require.Equal(t, int64(4), calls.Load())
+	require.Equal(t, int64(1), permFires.Load(),
+		"OnPermanent must fire EXACTLY once on exhaustion")
+	require.Same(t, last, permErr, "OnPermanent receives the last error")
+	require.Len(t, sl.delays, 3, "N attempts → N-1 sleeps")
+}
+
+func TestEnvelope_Run_GiveUpFiresPermanentImmediately(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int64
+	var permFires atomic.Int64
+	err := errors.New("bucket-gone")
+	env := New(Config{
+		Work: func(context.Context) error {
+			calls.Add(1)
+			return err
+		},
+		Classify:    func(error) Class { return GiveUp },
+		OnPermanent: func(error) { permFires.Add(1) },
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		MaxAttempts: 10,
+		Sleep:       (&instantSleep{}).sleep,
+	})
+	require.ErrorIs(t, env.Run(context.Background()), ErrExhausted)
+	require.Equal(t, int64(1), calls.Load(), "GiveUp must short-circuit on the first attempt")
+	require.Equal(t, int64(1), permFires.Load())
+}
+
+func TestEnvelope_Run_FatalReturnsErrorNoPermanent(t *testing.T) {
+	t.Parallel()
+	var permFires atomic.Int64
+	original := errors.New("config-mistake")
+	env := New(Config{
+		Work:        func(context.Context) error { return original },
+		Classify:    func(error) Class { return Fatal },
+		OnPermanent: func(error) { permFires.Add(1) },
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		MaxAttempts: 10,
+		Sleep:       (&instantSleep{}).sleep,
+	})
+	err := env.Run(context.Background())
+	require.Same(t, original, err, "Fatal returns the original error directly")
+	require.Equal(t, int64(0), permFires.Load(),
+		"Fatal must NOT fire OnPermanent (caller handles it)")
+}
+
+func TestEnvelope_Run_ContextCancelMidBackoff(t *testing.T) {
+	t.Parallel()
+	var permFires atomic.Int64
+	env := New(Config{
+		Work:        func(context.Context) error { return errors.New("transient") },
+		OnPermanent: func(error) { permFires.Add(1) },
+		BaseBackoff: 100 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+		MaxAttempts: 100,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := env.Run(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, int64(0), permFires.Load(),
+		"context cancel must NOT fire OnPermanent — it's not an exhaustion event")
+}
+
+func TestEnvelope_Run_BackoffCappedAtMaxBackoff(t *testing.T) {
+	t.Parallel()
+	sl := &instantSleep{}
+	env := New(Config{
+		Work:        func(context.Context) error { return errors.New("transient") },
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  40 * time.Millisecond,
+		MaxAttempts: 6,
+		Sleep:       sl.sleep,
+		// Jitter omitted (0) so the math is exact.
+	})
+	_ = env.Run(context.Background())
+	// Backoffs after attempts 1..5: 10, 20, 40, 40, 40
+	require.Equal(t, []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+	}, sl.delays)
+}
+
+func TestEnvelope_Run_JitterStaysWithinBounds(t *testing.T) {
+	t.Parallel()
+	const trials = 200
+	const base = 100 * time.Millisecond
+	const jitter = 0.3 // ± 30%
+	low := time.Duration(float64(base) * (1 - jitter))
+	high := time.Duration(float64(base) * (1 + jitter))
+	for i := 0; i < trials; i++ {
+		sl := &instantSleep{}
+		env := New(Config{
+			Work: func(context.Context) error {
+				return errors.New("transient")
+			},
+			BaseBackoff: base,
+			MaxBackoff:  base,
+			MaxAttempts: 2, // one failure → one backoff
+			Jitter:      jitter,
+			Sleep:       sl.sleep,
+		})
+		_ = env.Run(context.Background())
+		require.Len(t, sl.delays, 1)
+		d := sl.delays[0]
+		require.GreaterOrEqual(t, d, low,
+			"jittered backoff must not drop below %v; got %v", low, d)
+		require.LessOrEqual(t, d, high,
+			"jittered backoff must not exceed %v; got %v", high, d)
+	}
+}
+
+func TestEnvelope_Run_ProgressFiredOnEachAttempt(t *testing.T) {
+	t.Parallel()
+	var progressN atomic.Int64
+	env := New(Config{
+		Work: func(context.Context) error {
+			return errors.New("transient")
+		},
+		OnProgress: func(_ int, _ error) { progressN.Add(1) },
+		// silence OnPermanent — irrelevant for this test
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		MaxAttempts: 5,
+		Sleep:       (&instantSleep{}).sleep,
+	})
+	_ = env.Run(context.Background())
+	require.Equal(t, int64(5), progressN.Load(),
+		"OnProgress must fire once per failed attempt (including the final one that exhausts)")
+}
+
+func TestEnvelope_New_PanicsOnBadConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"nil Work", Config{BaseBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxAttempts: 1}},
+		{"zero MaxAttempts", Config{Work: func(context.Context) error { return nil }, BaseBackoff: time.Millisecond, MaxBackoff: time.Millisecond}},
+		{"zero BaseBackoff", Config{Work: func(context.Context) error { return nil }, MaxBackoff: time.Millisecond, MaxAttempts: 1}},
+		{"MaxBackoff < BaseBackoff", Config{Work: func(context.Context) error { return nil }, BaseBackoff: 100 * time.Millisecond, MaxBackoff: 50 * time.Millisecond, MaxAttempts: 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Panics(t, func() {
+				New(tc.cfg)
+			})
+		})
+	}
+}
+
+// TestEnvelope_DefaultClassifyIsTransient confirms that omitting
+// Classify defaults to Transient, so callers that only care about
+// the attempt-budget contract do not need to provide a classifier.
+func TestEnvelope_DefaultClassifyIsTransient(t *testing.T) {
+	t.Parallel()
+	var permFires atomic.Int64
+	env := New(Config{
+		Work:        func(context.Context) error { return errors.New("anything") },
+		OnPermanent: func(error) { permFires.Add(1) },
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  time.Millisecond,
+		MaxAttempts: 3,
+		Sleep:       (&instantSleep{}).sleep,
+	})
+	require.ErrorIs(t, env.Run(context.Background()), ErrExhausted)
+	require.Equal(t, int64(1), permFires.Load())
+}
+
+// TestEnvelope_Run_BackoffDoublingMath sanity-checks the exponential
+// expansion against a hand-computed table. Independent of jitter
+// (jitter=0) so the table is exact.
+func TestEnvelope_Run_BackoffDoublingMath(t *testing.T) {
+	t.Parallel()
+	sl := &instantSleep{}
+	env := New(Config{
+		Work:        func(context.Context) error { return errors.New("transient") },
+		BaseBackoff: 100 * time.Millisecond,
+		MaxBackoff:  1 * time.Second,
+		MaxAttempts: 5,
+		Sleep:       sl.sleep,
+	})
+	_ = env.Run(context.Background())
+	want := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+	}
+	require.Equal(t, want, sl.delays)
+}
+
+// TestEnvelope_Run_NoOverflowOnHugeAttempt guards against integer
+// overflow in the backoff doubling loop if MaxAttempts is large.
+func TestEnvelope_Run_NoOverflowOnHugeAttempt(t *testing.T) {
+	t.Parallel()
+	sl := &instantSleep{}
+	env := New(Config{
+		Work:        func(context.Context) error { return errors.New("transient") },
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+		MaxAttempts: 64,
+		Sleep:       sl.sleep,
+	})
+	_ = env.Run(context.Background())
+	for _, d := range sl.delays {
+		require.LessOrEqual(t, d, 100*time.Millisecond,
+			"capped backoff must never exceed MaxBackoff under any attempt count")
+		require.GreaterOrEqual(t, d, time.Duration(0),
+			"backoff must never be negative under any attempt count")
+	}
+}

--- a/internal/stableid/claimer.go
+++ b/internal/stableid/claimer.go
@@ -361,12 +361,30 @@ func (c *Claimer) renew(ctx context.Context) error {
 
 	newRev, err := c.kv.Update(ctx, key, []byte(value), c.lastRevision.Load())
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
-			// Revision mismatch: another worker took this ID over, or it
-			// expired and was re-created. The claim is lost.
+		switch {
+		case errors.Is(err, jetstream.ErrKeyExists):
+			// Revision mismatch: another worker took this ID over (or it
+			// expired and was re-created under us). The claim is lost.
 			return fmt.Errorf("%w: ID %s", ErrClaimLost, wid)
+		case errors.Is(err, jetstream.ErrNoStreamResponse),
+			errors.Is(err, jetstream.ErrBucketNotFound),
+			errors.Is(err, jetstream.ErrStreamNotFound):
+			// Bucket / backing stream vanished from under us. We cannot
+			// renew, so the claim is effectively lost — keep running
+			// would mean holding a stale claim the bucket no longer
+			// recognizes. Triggering claimLostShutdown lets the readiness
+			// probe rotate the pod which can then re-claim into the
+			// re-provisioned bucket cleanly.
+			//
+			// Empirical surface (against nats.go v1.50.0): kv.Update on a
+			// cached KV handle after js.DeleteKeyValue returns
+			// ErrNoStreamResponse. The other two sentinels are kept for
+			// defense-in-depth (different transports / future versions /
+			// internal retry paths). See [[project-nats-kv-delete-surface]].
+			return fmt.Errorf("%w: ID %s (bucket missing): %w", ErrClaimLost, wid, err)
+		default:
+			return fmt.Errorf("failed to renew ID %s: %w", wid, err)
 		}
-		return fmt.Errorf("failed to renew ID %s: %w", wid, err)
 	}
 	c.lastRevision.Store(newRev)
 

--- a/internal/stableid/claimer.go
+++ b/internal/stableid/claimer.go
@@ -380,7 +380,7 @@ func (c *Claimer) renew(ctx context.Context) error {
 			// cached KV handle after js.DeleteKeyValue returns
 			// ErrNoStreamResponse. The other two sentinels are kept for
 			// defense-in-depth (different transports / future versions /
-			// internal retry paths). See [[project-nats-kv-delete-surface]].
+			// internal retry paths).
 			return fmt.Errorf("%w: ID %s (bucket missing): %w", ErrClaimLost, wid, err)
 		default:
 			return fmt.Errorf("failed to renew ID %s: %w", wid, err)

--- a/internal/stableid/claimer_notfound_classification_test.go
+++ b/internal/stableid/claimer_notfound_classification_test.go
@@ -1,0 +1,121 @@
+package stableid
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaimer_renew_BucketDeleted_ClassifiesAsClaimLost is the primary
+// F3 reproducer: end-to-end against a real embedded NATS, delete the
+// stableID bucket under a claimed worker, and assert the next renew
+// returns ErrClaimLost (not a generic "failed to renew ID" wrap).
+//
+// Empirical surface: kv.Update on a cached handle after
+// js.DeleteKeyValue returns jetstream.ErrNoStreamResponse. See
+// [[project-nats-kv-delete-surface]]. On parent commit the classifier
+// only recognizes ErrKeyExists, so the wrapped ErrNoStreamResponse
+// falls through to the generic branch and this test fails.
+func TestClaimer_renew_BucketDeleted_ClassifiesAsClaimLost(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := "unit-stableid-bucket-deleted"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:  bucket,
+		Storage: jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	c := NewClaimer(kv, "worker", 0, 0, time.Second, nil)
+	wid, err := c.Claim(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "worker-0", wid)
+
+	// Bucket vanishes under the worker.
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+
+	renewErr := c.renew(ctx)
+	require.Error(t, renewErr)
+	require.ErrorIs(t, renewErr, ErrClaimLost,
+		"a vanished stableID bucket must surface as ErrClaimLost so claimLostShutdown can rotate the pod; got %v", renewErr)
+}
+
+// TestClaimer_renew_DefenseInDepth_NotFoundSentinels covers the
+// defense-in-depth branches the plan named (ErrBucketNotFound /
+// ErrStreamNotFound). Empirically kv.Update does not surface these
+// from the production embedded server today, but a future nats.go
+// version or a different transport may, and the classifier must
+// stay correct.
+func TestClaimer_renew_DefenseInDepth_NotFoundSentinels(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ErrBucketNotFound", jetstream.ErrBucketNotFound},
+		{"ErrStreamNotFound", jetstream.ErrStreamNotFound},
+		{"ErrNoStreamResponse", jetstream.ErrNoStreamResponse},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			kv := &mockKV{
+				createCalls: []func(context.Context, string, []byte) (uint64, error){
+					func(_ context.Context, _ string, _ []byte) (uint64, error) { return 7, nil },
+				},
+				updateCalls: []func(context.Context, string, []byte, uint64) (uint64, error){
+					func(_ context.Context, _ string, _ []byte, _ uint64) (uint64, error) {
+						return 0, tc.err
+					},
+				},
+			}
+			c := NewClaimer(kv, "worker", 0, 0, time.Second, nil)
+			_, err := c.Claim(context.Background())
+			require.NoError(t, err)
+
+			renewErr := c.renew(context.Background())
+			require.Error(t, renewErr)
+			require.ErrorIs(t, renewErr, ErrClaimLost,
+				"%s must classify as ErrClaimLost; got %v", tc.name, renewErr)
+		})
+	}
+}
+
+// TestClaimer_renew_ContextDeadlineNotClaimLost guards the negative
+// side: a context-timeout error MUST NOT classify as ErrClaimLost.
+// Timeouts retry on the next tick; mis-classifying them as claim-loss
+// would rotate pods on every transient NATS slowdown.
+func TestClaimer_renew_ContextDeadlineNotClaimLost(t *testing.T) {
+	t.Parallel()
+
+	kv := &mockKV{
+		createCalls: []func(context.Context, string, []byte) (uint64, error){
+			func(_ context.Context, _ string, _ []byte) (uint64, error) { return 7, nil },
+		},
+		updateCalls: []func(context.Context, string, []byte, uint64) (uint64, error){
+			func(_ context.Context, _ string, _ []byte, _ uint64) (uint64, error) {
+				return 0, context.DeadlineExceeded
+			},
+		},
+	}
+	c := NewClaimer(kv, "worker", 0, 0, time.Second, nil)
+	_, err := c.Claim(context.Background())
+	require.NoError(t, err)
+
+	renewErr := c.renew(context.Background())
+	require.Error(t, renewErr)
+	require.NotErrorIs(t, renewErr, ErrClaimLost,
+		"context.DeadlineExceeded MUST stay generic — timeouts retry, they do not trigger pod rotation")
+	require.True(t, errors.Is(renewErr, context.DeadlineExceeded),
+		"the wrapped error must preserve the original sentinel for operator diagnostics")
+}

--- a/kvutil/bucket.go
+++ b/kvutil/bucket.go
@@ -119,6 +119,38 @@ func EnsureKVBucket(ctx context.Context, js jetstream.JetStream, bucket string, 
 	return EnsureKVBucketWithRetry(ctx, js, cfg, 3)
 }
 
+// BucketStreamCreated returns the JetStream stream backing the given KV
+// bucket's Created timestamp. The timestamp is the source-of-truth identity
+// for the bucket: it is an immutable server-recorded value that changes
+// precisely when the backing stream is recreated (which is the case Parti's
+// epoch fence needs to detect). It is independent of any in-band marker the
+// caller might write into the bucket.
+//
+// Implementation note: a KV bucket is backed by a JetStream stream named
+// KV_<bucket>. This helper unwraps the bucket status to read that stream's
+// info; it does not require any extra permissions beyond what the caller
+// already has on the bucket.
+//
+// Parameters:
+//   - ctx: Context for timeout/cancellation
+//   - kv: KV bucket handle (typically returned by EnsureKVBucket)
+//
+// Returns:
+//   - time.Time: The backing stream's Created timestamp
+//   - error: status read error or an introspection-incompatible status type
+func BucketStreamCreated(ctx context.Context, kv jetstream.KeyValue) (time.Time, error) {
+	status, err := kv.Status(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read KV bucket status: %w", err)
+	}
+	bs, ok := status.(*jetstream.KeyValueBucketStatus)
+	if !ok || bs.StreamInfo() == nil {
+		return time.Time{}, fmt.Errorf("KV bucket status %T is not introspectable", status)
+	}
+
+	return bs.StreamInfo().Created, nil
+}
+
 // OpenKVBucket opens an existing KV bucket without attempting to create it.
 //
 // Use this when the bucket is expected to be pre-provisioned and the NATS user

--- a/manager.go
+++ b/manager.go
@@ -92,6 +92,15 @@ type Manager struct {
 	assignment   atomic.Value  // Assignment
 	capabilities atomic.Uint32 // capability bitmask; see types.CapXxx constants
 
+	// capProcessingGateWarned guards the one-shot WARN that fires when
+	// EnableTwoPhaseHandoff is true and the consumer has not reported
+	// CapProcessingGate by the time reportConsumerCapabilities runs.
+	// One-shot per Manager lifetime — a subsequent apply that DOES wire
+	// the gate (operator rolled the consumer config and re-deployed)
+	// will not re-trigger the warning; a single noisy log at the first
+	// misconfigured apply is sufficient to surface the issue.
+	capProcessingGateWarned atomic.Bool
+
 	// Phase 4 commit-path state machine state. Read by both watchers and the
 	// dual-read selector. All four are atomic-only; no mutex needed.
 
@@ -841,6 +850,42 @@ func (m *Manager) reportConsumerCapabilities() {
 	if newBits != 0 {
 		m.capabilities.Or(newBits)
 	}
+	// Post-merge: surface a misconfigured two-phase handoff. If
+	// EnableTwoPhaseHandoff is on but the consumer never wired a
+	// processing gate, claims are written and never consulted —
+	// effectively a silent disable. Fires at most once per Manager
+	// lifetime (guard below).
+	m.maybeWarnMissingProcessingGate()
+}
+
+// maybeWarnMissingProcessingGate emits the F10-B WARN exactly once for
+// the lifetime of the Manager when EnableTwoPhaseHandoff is on and the
+// consumer's reported capabilities (post-merge in
+// reportConsumerCapabilities) do not include CapProcessingGate.
+//
+// Limitation: if the consumer updater does NOT implement
+// CapabilityReporter (m.capReporter == nil), reportConsumerCapabilities
+// returns early and never calls this helper. The warning depends on
+// capability reporting; consumers that bypass it are responsible for
+// their own gate-wiring verification.
+func (m *Manager) maybeWarnMissingProcessingGate() {
+	if !m.cfg.EnableTwoPhaseHandoff {
+		return
+	}
+	if m.capProcessingGateWarned.Load() {
+		return
+	}
+	if m.capabilities.Load()&types.CapProcessingGate != 0 {
+		return // gate present post-merge; silent
+	}
+	if !m.capProcessingGateWarned.CompareAndSwap(false, true) {
+		return // raced another goroutine; that one fired the warning
+	}
+	m.logger.Warn(
+		"two-phase handoff is enabled but the consumer reports no processing gate; "+
+			"partition claims are written and never consulted",
+		"remedy", "wire a processing gate on the consumer (e.g. consumer.Dynamic) so claims fence delivery",
+	)
 }
 
 // invokeHook executes a hook function asynchronously with error logging.

--- a/manager.go
+++ b/manager.go
@@ -393,6 +393,16 @@ func (m *Manager) Start(ctx context.Context) (startErr error) {
 	// consumer.ResolverConfig.ReconcileInterval at the consumer config layer.
 	m.warnOnShortAuditGrace()
 
+	// Warn when the caller-owned nats.Conn is configured with a finite
+	// MaxReconnect budget. A finite budget turns a sustained outage into
+	// a permanently CLOSED zombie connection (the manager's connection
+	// monitor then enters degraded mode and the readiness probe rotates
+	// the pod). The recommended posture is nats.MaxReconnects(-1) — see
+	// docs/OPERATIONS.md "NATS Client Connection".
+	if m.js != nil {
+		warnOnFiniteMaxReconnects(m.js.Conn(), m.logger)
+	}
+
 	// Auto-cleanup on startup failure: release any partially-acquired resources
 	// so callers do not need to call Stop after a failed Start.
 	defer func() {

--- a/manager.go
+++ b/manager.go
@@ -412,6 +412,9 @@ func (m *Manager) Start(ctx context.Context) (startErr error) {
 	// while the worker's cache is still stale. The fix is to tune
 	// consumer.ResolverConfig.ReconcileInterval at the consumer config layer.
 	m.warnOnShortAuditGrace()
+	// F9-A (P2.1): warn when OperationTimeout could let a single slow
+	// renew consume the lease's three-attempt budget.
+	warnOnOperationTimeoutVsElection(m.cfg, m.logger)
 
 	// Warn when the caller-owned nats.Conn is configured with a finite
 	// MaxReconnect budget. A finite budget turns a sustained outage into

--- a/manager.go
+++ b/manager.go
@@ -85,6 +85,17 @@ type Manager struct {
 	assignmentKV jetstream.KeyValue
 	heartbeatKV  jetstream.KeyValue
 
+	// F1 epoch fence (P1.3): cached JetStream Created timestamp per
+	// Parti-owned bucket, populated at Start. monitorBucketEpochs
+	// periodically re-reads each bucket's stream info and trips
+	// degraded mode on a mismatch (wipe-and-recreate detection).
+	// Read-only after Start; the map itself is never mutated post-Start
+	// so no mutex is needed for the lookup. The protected fields are
+	// the per-bucket KeyValue handles (already stable) and the cached
+	// time.Time values (also stable). monitorBucketEpochs reads the
+	// snapshot; no writes happen after Start completes.
+	bucketEpochs map[string]bucketEpoch
+
 	// State management
 	state        atomic.Int32  // State
 	workerID     atomic.Value  // string
@@ -535,6 +546,11 @@ func (m *Manager) Start(ctx context.Context) (startErr error) {
 	m.wg.Go(func() { m.monitorCommitChanges(m.ctx, assignmentKV) })
 	m.wg.Go(func() { m.monitorAssignmentChanges(m.ctx, assignmentKV) })
 	m.monitorNATSConnection()
+
+	// F1 epoch fence (P1.3): detect bucket wipe-and-recreate on any of
+	// the Parti-owned KV buckets. Started after all buckets are
+	// ensured + captured so the map is stable for the monitor goroutine.
+	m.wg.Go(func() { m.monitorBucketEpochs(m.ctx) })
 
 	return nil
 }

--- a/manager.go
+++ b/manager.go
@@ -85,15 +85,12 @@ type Manager struct {
 	assignmentKV jetstream.KeyValue
 	heartbeatKV  jetstream.KeyValue
 
-	// F1 epoch fence (P1.3): cached JetStream Created timestamp per
-	// Parti-owned bucket, populated at Start. monitorBucketEpochs
-	// periodically re-reads each bucket's stream info and trips
-	// degraded mode on a mismatch (wipe-and-recreate detection).
-	// Read-only after Start; the map itself is never mutated post-Start
-	// so no mutex is needed for the lookup. The protected fields are
-	// the per-bucket KeyValue handles (already stable) and the cached
-	// time.Time values (also stable). monitorBucketEpochs reads the
-	// snapshot; no writes happen after Start completes.
+	// bucketEpochs caches each Parti-owned bucket's JetStream Created
+	// timestamp at Start. monitorBucketEpochs periodically re-reads the
+	// live timestamp and trips degraded mode on a mismatch (bucket
+	// wipe-and-recreate detection). The map is populated only during
+	// Start and read-only afterwards, so the monitor goroutine needs
+	// no synchronization.
 	bucketEpochs map[string]bucketEpoch
 
 	// State management
@@ -106,10 +103,9 @@ type Manager struct {
 	// capProcessingGateWarned guards the one-shot WARN that fires when
 	// EnableTwoPhaseHandoff is true and the consumer has not reported
 	// CapProcessingGate by the time reportConsumerCapabilities runs.
-	// One-shot per Manager lifetime — a subsequent apply that DOES wire
-	// the gate (operator rolled the consumer config and re-deployed)
-	// will not re-trigger the warning; a single noisy log at the first
-	// misconfigured apply is sufficient to surface the issue.
+	// A subsequent apply that wires the gate (operator rolled the
+	// consumer config and re-deployed) does not re-trigger the warning;
+	// a single log line at the first misconfigured apply is enough.
 	capProcessingGateWarned atomic.Bool
 
 	// Phase 4 commit-path state machine state. Read by both watchers and the
@@ -412,8 +408,8 @@ func (m *Manager) Start(ctx context.Context) (startErr error) {
 	// while the worker's cache is still stale. The fix is to tune
 	// consumer.ResolverConfig.ReconcileInterval at the consumer config layer.
 	m.warnOnShortAuditGrace()
-	// F9-A (P2.1): warn when OperationTimeout could let a single slow
-	// renew consume the lease's three-attempt budget.
+	// Warn when OperationTimeout could let a single slow renew consume
+	// the lease's three-attempt budget.
 	warnOnOperationTimeoutVsElection(m.cfg, m.logger)
 
 	// Warn when the caller-owned nats.Conn is configured with a finite
@@ -550,9 +546,9 @@ func (m *Manager) Start(ctx context.Context) (startErr error) {
 	m.wg.Go(func() { m.monitorAssignmentChanges(m.ctx, assignmentKV) })
 	m.monitorNATSConnection()
 
-	// F1 epoch fence (P1.3): detect bucket wipe-and-recreate on any of
-	// the Parti-owned KV buckets. Started after all buckets are
-	// ensured + captured so the map is stable for the monitor goroutine.
+	// Detect bucket wipe-and-recreate on any of the Parti-owned KV
+	// buckets. Started after all buckets are ensured + captured so the
+	// map is stable for the monitor goroutine.
 	m.wg.Go(func() { m.monitorBucketEpochs(m.ctx) })
 
 	return nil
@@ -869,18 +865,16 @@ func (m *Manager) reportConsumerCapabilities() {
 	if newBits != 0 {
 		m.capabilities.Or(newBits)
 	}
-	// Post-merge: surface a misconfigured two-phase handoff. If
-	// EnableTwoPhaseHandoff is on but the consumer never wired a
-	// processing gate, claims are written and never consulted —
-	// effectively a silent disable. Fires at most once per Manager
-	// lifetime (guard below).
+	// Surface a misconfigured two-phase handoff: if EnableTwoPhaseHandoff
+	// is on but the consumer never wired a processing gate, claims are
+	// written and never consulted — effectively a silent disable.
+	// Fires at most once per Manager lifetime (guarded below).
 	m.maybeWarnMissingProcessingGate()
 }
 
-// maybeWarnMissingProcessingGate emits the F10-B WARN exactly once for
-// the lifetime of the Manager when EnableTwoPhaseHandoff is on and the
-// consumer's reported capabilities (post-merge in
-// reportConsumerCapabilities) do not include CapProcessingGate.
+// maybeWarnMissingProcessingGate emits a one-shot WARN when
+// EnableTwoPhaseHandoff is on but the consumer's reported capabilities
+// do not include CapProcessingGate.
 //
 // Limitation: if the consumer updater does NOT implement
 // CapabilityReporter (m.capReporter == nil), reportConsumerCapabilities

--- a/manager_election.go
+++ b/manager_election.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arloliu/parti/v2/internal/election"
 	"github.com/arloliu/parti/v2/internal/heartbeat"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/stableid"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
@@ -81,15 +82,38 @@ var claimLostShutdown = func(m *Manager) {
 
 // onClaimerError handles background errors from the stable-ID claimer.
 //
-// ErrClaimLost means another worker now owns this ID. recordKVError would
-// silently drop it (it is neither a connectivity nor a degrading-JetStream
-// error), and Degraded mode does not halt processing — so the worker is
-// stopped outright via claimLostShutdown, and the cause is surfaced through the
-// OnError hook (fired by logError) so the embedding application can start a
-// fresh worker. Every other error flows through the normal degraded-mode KV
-// circuit.
+// ErrClaimLost has two distinct underlying causes that the manager must
+// route differently:
+//
+//   - Peer takeover: another worker holds this ID, the bucket itself is
+//     fine. recordKVError would silently drop it (it is neither a
+//     connectivity nor a degrading-JetStream error), and Degraded mode
+//     does not halt processing — so the worker is stopped outright via
+//     claimLostShutdown, and the cause is surfaced through the OnError
+//     hook (fired by logError) so the embedding application can start a
+//     fresh worker.
+//   - Whole-bucket loss: the StableID bucket was wiped (operator action
+//     or NATS data loss). Every worker observes this globally, so the
+//     correct response is the same as for any other bucket-missing
+//     surface — feed the degraded circuit so all workers flip readiness
+//     in lockstep. Without this branch a single worker that happens to
+//     renew first would self-terminate while peers wait for the same
+//     observation, which loses the "all workers Degraded" contract the
+//     live-NATS-bucket-loss tests pin.
+//
+// Every non-ErrClaimLost error flows through the normal degraded-mode KV
+// circuit unchanged.
 func (m *Manager) onClaimerError(err error) {
 	if errors.Is(err, stableid.ErrClaimLost) {
+		// The stableid classifier wraps degrading JetStream and
+		// connectivity errors as ErrClaimLost; both predicates accept
+		// what recordKVError already routes through the degraded
+		// circuit, so the union is the exact "this is bucket loss,
+		// not peer takeover" gate.
+		if natsutil.IsConnectivityError(err) || natsutil.IsDegradingJetStreamError(err) {
+			m.recordKVError(err)
+			return
+		}
 		m.logError("stable worker ID claim lost, stopping worker", "worker_id", m.WorkerID(), "error", err)
 		claimLostShutdown(m)
 		return

--- a/manager_election_filestorage_test.go
+++ b/manager_election_filestorage_test.go
@@ -1,0 +1,77 @@
+package parti
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// opTimeoutSpy captures WARN messages for the F9-A companion warning.
+type opTimeoutSpy struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (s *opTimeoutSpy) Debug(string, ...any) {}
+func (s *opTimeoutSpy) Info(string, ...any)  {}
+func (s *opTimeoutSpy) Warn(msg string, _ ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.warns = append(s.warns, msg)
+}
+func (s *opTimeoutSpy) Error(string, ...any) {}
+func (s *opTimeoutSpy) Fatal(string, ...any) {}
+
+func (s *opTimeoutSpy) countContaining(substr string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, w := range s.warns {
+		if strings.Contains(w, substr) {
+			n++
+		}
+	}
+
+	return n
+}
+
+var _ types.Logger = (*opTimeoutSpy)(nil)
+
+// TestWarnOnOperationTimeoutVsElection covers the F9-A companion
+// warning that fires when OperationTimeout > ElectionTimeout/3 — at
+// that ratio a single slow renew can consume the lease's three-
+// attempt budget and produce false leadership flips.
+func TestWarnOnOperationTimeoutVsElection(t *testing.T) {
+	t.Parallel()
+	const warnSubstr = "OperationTimeout exceeds ElectionTimeout/3"
+
+	cases := []struct {
+		name        string
+		opTimeout   time.Duration
+		electionTO  time.Duration
+		expectWarns int
+	}{
+		{"safe ratio (OT=1/6 ET)", 5 * time.Second, 30 * time.Second, 0},
+		{"boundary OT=ET/3 (silent)", 10 * time.Second, 30 * time.Second, 0},
+		{"OT just over ET/3 warns", 11 * time.Second, 30 * time.Second, 1},
+		{"OT equals ET warns", 30 * time.Second, 30 * time.Second, 1},
+		{"default pair (10s/10s) warns", 10 * time.Second, 10 * time.Second, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spy := &opTimeoutSpy{}
+			warnOnOperationTimeoutVsElection(Config{
+				OperationTimeout: tc.opTimeout,
+				ElectionTimeout:  tc.electionTO,
+			}, spy)
+			require.Equal(t, tc.expectWarns, spy.countContaining(warnSubstr),
+				"warn count mismatch for OperationTimeout=%v ElectionTimeout=%v",
+				tc.opTimeout, tc.electionTO)
+		})
+	}
+}

--- a/manager_epoch_fence_test.go
+++ b/manager_epoch_fence_test.go
@@ -90,6 +90,7 @@ func TestManager_F1_BucketRecreate_TripsDegraded(t *testing.T) {
 				},
 				logger: logging.NewNop(),
 				hooks:  &Hooks{OnDegraded: spy.record},
+				js:     js,
 			}
 			m.state.Store(int32(StateStable))
 			m.degradedSince.Store(0)
@@ -157,6 +158,7 @@ func TestManager_F1_HappyPath_NoDegraded(t *testing.T) {
 		},
 		logger: logging.NewNop(),
 		hooks:  &Hooks{OnDegraded: spy.record},
+		js:     js,
 	}
 	m.state.Store(int32(StateStable))
 	m.metrics = nopManagerMetrics{}

--- a/manager_epoch_fence_test.go
+++ b/manager_epoch_fence_test.go
@@ -1,0 +1,183 @@
+package parti
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/kvutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// epochSpy captures the OnDegraded callback so the F1 reproducers can
+// observe (a) whether degraded mode was entered and (b) the reason
+// string. degraded-mode entry is what trips the readiness probe in
+// production.
+type epochSpy struct {
+	mu      sync.Mutex
+	reasons []string
+}
+
+func (s *epochSpy) record(_ context.Context, reason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reasons = append(s.reasons, reason)
+	return nil
+}
+
+func (s *epochSpy) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.reasons))
+	copy(out, s.reasons)
+	return out
+}
+
+// makeBucket creates a freshly-named bucket and returns its handle.
+// Bucket names are caller-provided so tests can probe a specific
+// expected name (e.g. the heartbeat bucket the Manager would pick).
+func makeBucket(t *testing.T, js jetstream.JetStream, name string) jetstream.KeyValue {
+	t.Helper()
+	kv, err := js.CreateKeyValue(context.Background(), jetstream.KeyValueConfig{
+		Bucket:  name,
+		Storage: jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+	return kv
+}
+
+// TestManager_F1_BucketRecreate_TripsDegraded is the primary F1
+// reproducer. For each Parti-owned bucket name shape the Manager's
+// captureBucketEpoch flow would record, delete and recreate the
+// backing stream and assert checkBucketEpochs trips degraded mode
+// with the expected reason. The test drives checkBucketEpochs
+// directly so the assertion is deterministic (no polling on the
+// production OperationTimeout tick).
+func TestManager_F1_BucketRecreate_TripsDegraded(t *testing.T) {
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	cases := []string{
+		"parti-epoch-test-stableid",
+		"parti-epoch-test-election",
+		"parti-epoch-test-heartbeat",
+		"parti-epoch-test-assignment",
+		"parti-epoch-test-handoff",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			bucket := name + "-" + t.Name()[len("TestManager_F1_BucketRecreate_TripsDegraded/"):]
+			// Bucket names are not allowed to contain '/'; strip just in case.
+			bucket = strings.ReplaceAll(bucket, "/", "-")
+
+			kv := makeBucket(t, js, bucket)
+
+			spy := &epochSpy{}
+			m := &Manager{
+				cfg: Config{
+					OperationTimeout: 500 * time.Millisecond,
+					DegradedAlert:    DegradedAlertConfig{AlertInterval: time.Second},
+				},
+				logger: logging.NewNop(),
+				hooks:  &Hooks{OnDegraded: spy.record},
+			}
+			m.state.Store(int32(StateStable))
+			m.degradedSince.Store(0)
+			m.metrics = nopManagerMetrics{}
+			testCtx, cancel := context.WithCancel(ctx)
+			m.ctx = testCtx
+			m.cancel = cancel
+			t.Cleanup(cancel)
+
+			m.captureBucketEpoch(ctx, bucket, kv)
+			require.Contains(t, m.bucketEpochs, bucket,
+				"sanity: captureBucketEpoch must have recorded the bucket")
+
+			// Wipe and recreate so the backing stream gets a fresh Created.
+			require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+			// time.Now() advances; recreate gets a strictly later Created.
+			time.Sleep(50 * time.Millisecond)
+			kv2 := makeBucket(t, js, bucket)
+			liveCreated, err := kvutil.BucketStreamCreated(ctx, kv2)
+			require.NoError(t, err)
+			require.True(t, liveCreated.After(m.bucketEpochs[bucket].created),
+				"sanity: recreate must produce a later Created timestamp")
+
+			// The cached kv handle points at the OLD stream and would
+			// return an error on a status read; replace it with the new
+			// handle to model the production path where the Manager's
+			// cached handle silently re-binds after the recreate.
+			ep := m.bucketEpochs[bucket]
+			ep.kv = kv2
+			m.bucketEpochs[bucket] = ep
+
+			m.checkBucketEpochs(ctx)
+			// OnDegraded fires asynchronously via invokeHook → wg.Go;
+			// poll briefly for the hook to land.
+			require.Eventually(t, func() bool {
+				return len(spy.snapshot()) >= 1
+			}, time.Second, 10*time.Millisecond,
+				"epoch fence must fire OnDegraded after checkBucketEpochs returns")
+			reasons := spy.snapshot()
+			require.Len(t, reasons, 1,
+				"epoch fence must fire OnDegraded exactly once")
+			require.Equal(t, "bucket-recreated:"+bucket, reasons[0])
+		})
+	}
+}
+
+// TestManager_F1_HappyPath_NoDegraded confirms that a bucket whose
+// Created timestamp is unchanged (no recreate) does NOT trip the
+// fence. False-positive guard — the fence must be silent on
+// healthy operation.
+func TestManager_F1_HappyPath_NoDegraded(t *testing.T) {
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := "parti-epoch-happy"
+	kv := makeBucket(t, js, bucket)
+
+	spy := &epochSpy{}
+	m := &Manager{
+		cfg: Config{
+			OperationTimeout: 500 * time.Millisecond,
+			DegradedAlert:    DegradedAlertConfig{AlertInterval: time.Second},
+		},
+		logger: logging.NewNop(),
+		hooks:  &Hooks{OnDegraded: spy.record},
+	}
+	m.state.Store(int32(StateStable))
+	m.metrics = nopManagerMetrics{}
+	ctx, cancel := context.WithCancel(t.Context())
+	m.ctx = ctx
+	m.cancel = cancel
+	t.Cleanup(cancel)
+
+	m.captureBucketEpoch(ctx, bucket, kv)
+
+	for range 3 {
+		m.checkBucketEpochs(ctx)
+	}
+	require.Empty(t, spy.snapshot(),
+		"three consecutive ticks against an unchanged bucket must NOT trip degraded")
+}
+
+// nopManagerMetrics is the minimum metrics surface monitorBucketEpochs
+// needs (enterDegraded calls SetDegradedMode). Implements just enough
+// of MetricsCollector to satisfy the field type.
+type nopManagerMetrics struct{ types.MetricsCollector }
+
+func (nopManagerMetrics) SetDegradedMode(float64)                     {}
+func (nopManagerMetrics) RecordStateTransition(_, _ State, _ float64) {}

--- a/manager_kvbuckets_replicas_test.go
+++ b/manager_kvbuckets_replicas_test.go
@@ -1,0 +1,293 @@
+package parti
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// replicaBucketSeq mints fresh bucket names per sub-test so the parallel
+// runs do not collide on a shared embedded NATS server.
+var replicaBucketSeq atomic.Uint64
+
+// TestEnsureKVBucket_ReplicasZero_DefaultsToServer verifies the legacy
+// behavior: Replicas == 0 leaves the field unset, nats.go normalizes
+// to 1 server-side. This is the path every pre-existing deployment is
+// on; the new field must not regress it.
+func TestEnsureKVBucket_ReplicasZero_DefaultsToServer(t *testing.T) {
+	t.Parallel()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := mintReplicaBucket("zero")
+	m := &Manager{
+		cfg: Config{
+			KVBuckets: KVBucketConfig{Replicas: 0},
+		},
+		logger: nopLogger{},
+	}
+	kv, err := m.ensureKVBucket(t.Context(), js, bucket, 0, jetstream.FileStorage)
+	require.NoError(t, err)
+	require.NotNil(t, kv)
+
+	cfg := streamConfigForBucket(t, kv)
+	require.Equal(t, 1, cfg.Replicas,
+		"server default normalizes an unset (0) replicas to 1 — legacy behavior")
+}
+
+// TestEnsureKVBucket_ReplicasOne_ExplicitSingleNode verifies that an
+// explicit Replicas=1 (typical for single-node test deployments) is
+// honored without ambiguity. This is the value the partitest helper
+// would set if a test wanted to mirror production posture without HA.
+func TestEnsureKVBucket_ReplicasOne_ExplicitSingleNode(t *testing.T) {
+	t.Parallel()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := mintReplicaBucket("one")
+	m := &Manager{
+		cfg: Config{
+			KVBuckets: KVBucketConfig{Replicas: 1},
+		},
+		logger: nopLogger{},
+	}
+	kv, err := m.ensureKVBucket(t.Context(), js, bucket, 0, jetstream.FileStorage)
+	require.NoError(t, err)
+
+	cfg := streamConfigForBucket(t, kv)
+	require.Equal(t, 1, cfg.Replicas,
+		"Replicas=1 must be honored explicitly on single-node clusters")
+}
+
+// TestEnsureKVBucket_ReplicasThree_FailsLoudlyOnSingleNode verifies the
+// documented loud-failure path: setting Replicas=3 against a single-
+// node NATS cluster must return a clear error at Manager.Start, not
+// silently fall back. This is the documented "cluster topology must
+// support the value" contract.
+func TestEnsureKVBucket_ReplicasThree_FailsLoudlyOnSingleNode(t *testing.T) {
+	t.Parallel()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := mintReplicaBucket("three")
+	m := &Manager{
+		cfg: Config{
+			KVBuckets: KVBucketConfig{Replicas: 3},
+		},
+		logger: nopLogger{},
+	}
+	_, err = m.ensureKVBucket(t.Context(), js, bucket, 0, jetstream.FileStorage)
+	require.Error(t, err,
+		"Replicas=3 against a single-node cluster MUST fail loudly so operators see the topology mismatch")
+	// The exact error string varies by nats.go version; the important
+	// guarantee is that the call returns an error rather than silently
+	// creating a single-replica bucket.
+	require.Contains(t, strings.ToLower(err.Error()), "kv bucket",
+		"error must reference KV bucket creation; got %v", err)
+}
+
+// TestEnsureKVBucket_PreCreatedBucket_KeepsExistingReplicas verifies
+// the get-first contract called out in the Godoc: a pre-created bucket
+// with explicit replicas is opened as-is even when the runtime
+// Config.KVBuckets.Replicas would have created it differently.
+func TestEnsureKVBucket_PreCreatedBucket_KeepsExistingReplicas(t *testing.T) {
+	t.Parallel()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := mintReplicaBucket("pre")
+	// Operator pre-creates the bucket with Replicas=1 explicitly. On a
+	// single-node embedded NATS this is the only viable value, but the
+	// point of the test is that the pre-created value is kept regardless
+	// of what the runtime Config asks for.
+	_, err = js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		Storage:  jetstream.FileStorage,
+		Replicas: 1,
+	})
+	require.NoError(t, err)
+
+	// Runtime config wants Replicas=3, but get-first opens the existing
+	// bucket and leaves its config alone.
+	m := &Manager{
+		cfg: Config{
+			KVBuckets: KVBucketConfig{Replicas: 3},
+		},
+		logger: nopLogger{},
+	}
+	kv, err := m.ensureKVBucket(t.Context(), js, bucket, 0, jetstream.FileStorage)
+	require.NoError(t, err,
+		"get-first must succeed even when Config.Replicas would otherwise fail to create")
+
+	cfg := streamConfigForBucket(t, kv)
+	require.Equal(t, 1, cfg.Replicas,
+		"pre-created bucket's Replicas (1) wins over Config.Replicas (3); get-first does not upgrade")
+}
+
+// streamConfigForBucket reads the backing JetStream stream's Config so
+// the test can assert on the replica count actually applied. Lives in
+// the test file to avoid bloating the public API.
+func streamConfigForBucket(t *testing.T, kv jetstream.KeyValue) jetstream.StreamConfig {
+	t.Helper()
+	status, err := kv.Status(t.Context())
+	require.NoError(t, err)
+	bs, ok := status.(*jetstream.KeyValueBucketStatus)
+	require.True(t, ok, "bucket status type %T is not introspectable", status)
+	si := bs.StreamInfo()
+	require.NotNil(t, si)
+
+	return si.Config
+}
+
+// mintReplicaBucket returns a bucket name unique to this test process.
+// Combines the per-test label with an atomic counter so parallel
+// sub-tests cannot collide on the shared embedded NATS instance.
+func mintReplicaBucket(label string) string {
+	const prefix = "parti-replicas-test-"
+	n := replicaBucketSeq.Add(1)
+	return prefix + label + "-" + timeSuffix(n)
+}
+
+// timeSuffix is a small base-10 stringifier so the bucket name stays
+// human-readable in test failure logs.
+func timeSuffix(n uint64) string {
+	const digits = "0123456789"
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = digits[n%10]
+		n /= 10
+	}
+
+	return string(buf[i:])
+}
+
+// nopLogger satisfies the types.Logger interface for the replicas
+// tests without taking on the integration-shaped spy from other test
+// files. Silent by design — these tests assert on behavior, not logs.
+type nopLogger struct{}
+
+func (nopLogger) Debug(string, ...any) {}
+func (nopLogger) Info(string, ...any)  {}
+func (nopLogger) Warn(string, ...any)  {}
+func (nopLogger) Error(string, ...any) {}
+func (nopLogger) Fatal(string, ...any) {}
+
+// replicaWarnSpy captures WARN lines for the mismatch test.
+type replicaWarnSpy struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *replicaWarnSpy) Debug(string, ...any) {}
+func (l *replicaWarnSpy) Info(string, ...any)  {}
+func (l *replicaWarnSpy) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+func (l *replicaWarnSpy) Error(string, ...any) {}
+func (l *replicaWarnSpy) Fatal(string, ...any) {}
+
+func (l *replicaWarnSpy) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.warns))
+	copy(out, l.warns)
+
+	return out
+}
+
+// TestEnsureKVBucket_PreCreated_ReplicasMismatch_WARNs verifies the
+// warnOnReplicasMismatch helper fires when an existing bucket's
+// replica count differs from what Config.KVBuckets.Replicas requests.
+// The library deliberately does NOT auto-reconcile (Replicas is HA
+// quality, not correctness); the warn is the only operator signal that
+// the requested value is not in effect.
+func TestEnsureKVBucket_PreCreated_ReplicasMismatch_WARNs(t *testing.T) {
+	t.Parallel()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := mintReplicaBucket("mismatch-warn")
+	// Operator pre-creates with Replicas=1.
+	_, err = js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		Storage:  jetstream.FileStorage,
+		Replicas: 1,
+	})
+	require.NoError(t, err)
+
+	spy := &replicaWarnSpy{}
+	m := &Manager{
+		cfg: Config{
+			KVBuckets: KVBucketConfig{Replicas: 3}, // mismatched with pre-created
+		},
+		logger: spy,
+	}
+	_, err = m.ensureKVBucket(t.Context(), js, bucket, 0, jetstream.FileStorage)
+	require.NoError(t, err)
+
+	var saw bool
+	for _, w := range spy.snapshot() {
+		if strings.Contains(w, "replica count differs from Config.KVBuckets.Replicas") {
+			saw = true
+			break
+		}
+	}
+	require.True(t, saw,
+		"warnOnReplicasMismatch must emit the named WARN when existing Replicas differs from requested; got %v",
+		spy.snapshot())
+}
+
+// TestEnsureKVBucket_ReplicasZero_NoMismatchWarning verifies the
+// warning is silent when Config.KVBuckets.Replicas is 0 (no expectation
+// expressed). Otherwise every existing deployment would log spurious
+// "1 != 0" warnings.
+func TestEnsureKVBucket_ReplicasZero_NoMismatchWarning(t *testing.T) {
+	t.Parallel()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := mintReplicaBucket("zero-no-warn")
+	_, err = js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		Storage:  jetstream.FileStorage,
+		Replicas: 1,
+	})
+	require.NoError(t, err)
+
+	spy := &replicaWarnSpy{}
+	m := &Manager{
+		cfg:    Config{KVBuckets: KVBucketConfig{Replicas: 0}}, // legacy default
+		logger: spy,
+	}
+	_, err = m.ensureKVBucket(t.Context(), js, bucket, 0, jetstream.FileStorage)
+	require.NoError(t, err)
+
+	for _, w := range spy.snapshot() {
+		require.NotContains(t, w, "replica count differs",
+			"Config.KVBuckets.Replicas=0 must NOT trigger the mismatch warning")
+	}
+}

--- a/manager_max_reconnects_warning_test.go
+++ b/manager_max_reconnects_warning_test.go
@@ -1,0 +1,119 @@
+package parti_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// maxReconnectSpy captures WARN messages so the integration test can
+// assert that warnOnFiniteMaxReconnects fires (or stays silent) when
+// reached via Manager.Start's real call site — not just in isolation.
+type maxReconnectSpy struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *maxReconnectSpy) Debug(string, ...any) {}
+func (l *maxReconnectSpy) Info(string, ...any)  {}
+func (l *maxReconnectSpy) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+func (l *maxReconnectSpy) Error(string, ...any) {}
+func (l *maxReconnectSpy) Fatal(string, ...any) {}
+
+func (l *maxReconnectSpy) countFiniteMaxReconnectWarns() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, w := range l.warns {
+		if strings.Contains(w, "finite MaxReconnect") {
+			n++
+		}
+	}
+
+	return n
+}
+
+var _ types.Logger = (*maxReconnectSpy)(nil)
+
+// startManagerWithMaxReconnects spins up an embedded NATS server, connects
+// with the given MaxReconnect setting (caller-controlled — distinct from
+// the partitest helper which now uses the recommended -1), and starts a
+// Manager wired with a spy logger so the test can verify the warning
+// reaches Manager.Start via the real call site.
+func startManagerWithMaxReconnects(t *testing.T, maxReconnect int) *maxReconnectSpy {
+	t.Helper()
+
+	srv, defaultNC := partitest.StartEmbeddedNATS(t)
+	defaultNC.Close() // unused; we reconnect with caller-controlled opts below
+
+	nc, err := nats.Connect(srv.ClientURL(),
+		nats.Timeout(2*time.Second),
+		nats.RetryOnFailedConnect(true),
+		nats.MaxReconnects(maxReconnect),
+	)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	cfg := parti.DefaultConfig()
+	cfg.StartupTimeout = 5 * time.Second
+
+	// Unique bucket names so concurrent t.Parallel runs do not collide.
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	cfg.KVBuckets.StableIDBucket = "parti-stable-" + suffix
+	cfg.KVBuckets.ElectionBucket = "parti-election-" + suffix
+	cfg.KVBuckets.HeartbeatBucket = "parti-heartbeat-" + suffix
+	cfg.KVBuckets.AssignmentBucket = "parti-assignment-" + suffix
+	cfg.KVBuckets.HandoffBucket = "parti-handoff-" + suffix
+
+	spy := &maxReconnectSpy{}
+
+	src := source.NewStatic([]types.Partition{})
+	mgr, err := parti.NewManager(&cfg, js, src, strategy.NewRoundRobin(), parti.WithLogger(spy))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	require.NoError(t, mgr.Start(context.Background()))
+
+	return spy
+}
+
+// TestManager_MaxReconnects_WarnsOnFiniteCap verifies the warning reaches
+// Manager.Start through the real call site (not just the unit-test helper)
+// when the caller-owned nats.Conn was configured with a finite reconnect
+// budget. Without this end-to-end test the helper's correctness does not
+// prove the wiring is reachable.
+func TestManager_MaxReconnects_WarnsOnFiniteCap(t *testing.T) {
+	t.Parallel()
+	spy := startManagerWithMaxReconnects(t, 5)
+	require.Equal(t, 1, spy.countFiniteMaxReconnectWarns(),
+		"Manager.Start must emit the finite-MaxReconnect WARN exactly once on a finite cap")
+}
+
+// TestManager_MaxReconnects_SilentOnUnlimited verifies the recommended
+// posture (-1) leaves Manager.Start silent on this axis. Pairs with the
+// finite-cap test to bracket the call-site behavior.
+func TestManager_MaxReconnects_SilentOnUnlimited(t *testing.T) {
+	t.Parallel()
+	spy := startManagerWithMaxReconnects(t, -1)
+	require.Equal(t, 0, spy.countFiniteMaxReconnectWarns(),
+		"Manager.Start must NOT warn when MaxReconnects is unlimited (-1)")
+}

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -59,8 +59,9 @@ func (m *Manager) ensureStableIDKV(ctx context.Context, js jetstream.JetStream) 
 // IOPS cost:
 //   - election:   FileStorage   — the leadership lease key must survive a
 //     NATS node restart, otherwise every restart triggers fleet-wide
-//     leadership churn (was MemoryStorage prior to F9-A; the switch is
-//     IOPS-free at production scales per iops-investigation §M1.9).
+//     leadership churn. The switch from MemoryStorage is effectively
+//     IOPS-free at production scales (see
+//     docs/plans/iops-investigation/findings.md §M1.9).
 //   - heartbeat:  MemoryStorage — workers re-publish every HeartbeatInterval,
 //     so a missed window is recovered by the next publish.
 //   - assignment: FileStorage  — must survive NATS restart so followers
@@ -91,13 +92,10 @@ func (m *Manager) ensureCoreKVBuckets( //nolint:revive
 		return kv, nil
 	}
 
-	// F9-A (P2.1): election bucket uses FileStorage so the leadership
-	// lease key survives a NATS node restart. Previously MemoryStorage —
-	// any node restart lost the lease and triggered fleet-wide
-	// leadership churn. The switch is effectively IOPS-free at
-	// production scales (see docs/plans/iops-investigation/findings.md
-	// §M1.9). Replicas remain at the server default (1) here; operators
-	// who need cross-node HA pre-create the bucket with --replicas=3
+	// Election bucket uses FileStorage (see the package comment above)
+	// so the leadership lease key survives a NATS node restart.
+	// Replicas remain at the server default (1) here; operators who
+	// need cross-node HA pre-create the bucket with --replicas=3
 	// (EnsureKVBucketWithRetry is get-first and honors the existing
 	// config). See docs/OPERATIONS.md for the migration runbook.
 	electionKV, err = ensure("election", m.cfg.KVBuckets.ElectionBucket, m.cfg.ElectionTimeout, jetstream.FileStorage)
@@ -207,9 +205,9 @@ func (m *Manager) ensureKVBucket(
 
 	m.warnOnStorageMismatch(ctx, kv, bucket, storage)
 	m.warnOnReplicasMismatch(ctx, kv, bucket)
-	// F1 epoch fence (P1.3): record this bucket's stream-Created
-	// timestamp so monitorBucketEpochs can detect a future wipe-and-
-	// recreate event. Failures are logged but never block Start.
+	// Record this bucket's stream-Created timestamp so
+	// monitorBucketEpochs can detect a future wipe-and-recreate event.
+	// Failures are logged but never block Start.
 	m.captureBucketEpoch(ctx, bucket, kv)
 
 	return kv, nil
@@ -518,7 +516,7 @@ func warnOnFiniteMaxReconnects(conn *nats.Conn, logger types.Logger) {
 }
 
 // bucketEpoch records a Parti-owned KV bucket's identity at Start for the
-// F1 epoch fence. The Created timestamp changes precisely when the bucket's
+// epoch fence. The Created timestamp changes precisely when the bucket's
 // backing stream is recreated — exactly the wipe-and-recreate case the
 // fence must detect.
 type bucketEpoch struct {
@@ -530,8 +528,8 @@ type bucketEpoch struct {
 // m.bucketEpochs for the monitorBucketEpochs goroutine to compare against.
 // A failure to read the stream info at Start is logged but not fatal — the
 // epoch fence simply does not protect that bucket; the existing readiness-
-// degraded paths (recordKVError, connection monitor, P1.1 source hook) still
-// apply. This keeps the change additive and never blocks Start.
+// degraded paths (recordKVError, connection monitor, source-unavailable
+// hook) still apply. This keeps the change additive and never blocks Start.
 func (m *Manager) captureBucketEpoch(ctx context.Context, bucket string, kv jetstream.KeyValue) {
 	if kv == nil {
 		return

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -55,10 +55,14 @@ func (m *Manager) ensureStableIDKV(ctx context.Context, js jetstream.JetStream) 
 
 // ensureCoreKVBuckets ensures election, heartbeat, and assignment KV buckets.
 //
-// Storage choices are fixed per bucket to minimize PVC IOPS on file-backed
-// JetStream clusters while preserving durability where it matters:
-//   - election:   MemoryStorage — a lost leader key simply triggers re-election.
-//   - heartbeat:  MemoryStorage — workers re-publish every HeartbeatInterval.
+// Storage choices are fixed per bucket to balance durability against PVC
+// IOPS cost:
+//   - election:   FileStorage   — the leadership lease key must survive a
+//     NATS node restart, otherwise every restart triggers fleet-wide
+//     leadership churn (was MemoryStorage prior to F9-A; the switch is
+//     IOPS-free at production scales per iops-investigation §M1.9).
+//   - heartbeat:  MemoryStorage — workers re-publish every HeartbeatInterval,
+//     so a missed window is recovered by the next publish.
 //   - assignment: FileStorage  — must survive NATS restart so followers
 //     joining during the outage window can receive their assignment.
 //
@@ -87,7 +91,16 @@ func (m *Manager) ensureCoreKVBuckets( //nolint:revive
 		return kv, nil
 	}
 
-	electionKV, err = ensure("election", m.cfg.KVBuckets.ElectionBucket, m.cfg.ElectionTimeout, jetstream.MemoryStorage)
+	// F9-A (P2.1): election bucket uses FileStorage so the leadership
+	// lease key survives a NATS node restart. Previously MemoryStorage —
+	// any node restart lost the lease and triggered fleet-wide
+	// leadership churn. The switch is effectively IOPS-free at
+	// production scales (see docs/plans/iops-investigation/findings.md
+	// §M1.9). Replicas remain at the server default (1) here; operators
+	// who need cross-node HA pre-create the bucket with --replicas=3
+	// (EnsureKVBucketWithRetry is get-first and honors the existing
+	// config). See docs/OPERATIONS.md for the migration runbook.
+	electionKV, err = ensure("election", m.cfg.KVBuckets.ElectionBucket, m.cfg.ElectionTimeout, jetstream.FileStorage)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -541,6 +554,29 @@ func (m *Manager) checkBucketEpochs(ctx context.Context) {
 			return // once degraded; no need to probe the rest this tick
 		}
 	}
+}
+
+// warnOnOperationTimeoutVsElection emits a one-shot WARN when
+// OperationTimeout is too close to ElectionTimeout. The leader's renew
+// loop has three attempts within ElectionTimeout to refresh the lease;
+// if a single attempt's timeout (OperationTimeout) exceeds
+// ElectionTimeout/3, one slow renew consumes the lease's entire budget
+// and produces a false leadership flip.
+//
+// The boundary is non-strict (OperationTimeout == ElectionTimeout/3
+// is acceptable). Anything strictly greater warns.
+func warnOnOperationTimeoutVsElection(cfg Config, logger types.Logger) {
+	if cfg.OperationTimeout <= cfg.ElectionTimeout/3 {
+		return
+	}
+	logger.Warn(
+		"OperationTimeout exceeds ElectionTimeout/3; a single slow "+
+			"renew can consume the lease's three-attempt budget and "+
+			"trigger a false leadership flip. Set OperationTimeout "+
+			"<= ElectionTimeout/3.",
+		"OperationTimeout", cfg.OperationTimeout,
+		"ElectionTimeout", cfg.ElectionTimeout,
+	)
 }
 
 // storageTypeName renders jetstream.StorageType as a human-readable string.

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -182,6 +182,10 @@ func (m *Manager) ensureKVBucket(
 	}
 
 	m.warnOnStorageMismatch(ctx, kv, bucket, storage)
+	// F1 epoch fence (P1.3): record this bucket's stream-Created
+	// timestamp so monitorBucketEpochs can detect a future wipe-and-
+	// recreate event. Failures are logged but never block Start.
+	m.captureBucketEpoch(ctx, bucket, kv)
 
 	return kv, nil
 }
@@ -441,6 +445,102 @@ func warnOnFiniteMaxReconnects(conn *nats.Conn, logger types.Logger) {
 			"ReconnectJitter (see docs/OPERATIONS.md \"NATS Client Connection\").",
 		"max_reconnect", limit,
 	)
+}
+
+// bucketEpoch records a Parti-owned KV bucket's identity at Start for the
+// F1 epoch fence. The Created timestamp changes precisely when the bucket's
+// backing stream is recreated — exactly the wipe-and-recreate case the
+// fence must detect.
+type bucketEpoch struct {
+	kv      jetstream.KeyValue
+	created time.Time
+}
+
+// captureBucketEpoch records a bucket's stream-Created timestamp into
+// m.bucketEpochs for the monitorBucketEpochs goroutine to compare against.
+// A failure to read the stream info at Start is logged but not fatal — the
+// epoch fence simply does not protect that bucket; the existing readiness-
+// degraded paths (recordKVError, connection monitor, P1.1 source hook) still
+// apply. This keeps the change additive and never blocks Start.
+func (m *Manager) captureBucketEpoch(ctx context.Context, bucket string, kv jetstream.KeyValue) {
+	if kv == nil {
+		return
+	}
+	if m.bucketEpochs == nil {
+		m.bucketEpochs = make(map[string]bucketEpoch, 5)
+	}
+	created, err := kvutil.BucketStreamCreated(ctx, kv)
+	if err != nil {
+		m.logger.Warn("epoch fence: failed to capture bucket stream Created at Start; bucket-recreate detection disabled for this bucket",
+			"bucket", bucket, "error", err)
+		return
+	}
+	m.bucketEpochs[bucket] = bucketEpoch{kv: kv, created: created}
+}
+
+// monitorBucketEpochs polls each Parti-owned bucket's stream-Created
+// timestamp on a periodic ticker. A mismatch against the cached value
+// means the bucket was wiped and recreated under us; we enter degraded
+// mode with reason "bucket-recreated:<bucket>" so the readiness probe
+// can rotate the pod and start re-provisions the missing buckets.
+//
+// The poll interval is OperationTimeout (defaults to 10s; the same knob
+// that bounds the ensure-bucket calls at Start). A stream-info read that
+// itself fails is not degraded-mode worthy — the connection monitor,
+// source-hook, and generic kvErrorCount paths handle connectivity
+// errors. The epoch fence is solely concerned with the wipe-and-recreate
+// case where the operation succeeds but returns a different Created.
+//
+// Exits when m.ctx is cancelled. Started by Start after the five Parti-
+// owned buckets have been captured.
+func (m *Manager) monitorBucketEpochs(ctx context.Context) {
+	if len(m.bucketEpochs) == 0 {
+		return
+	}
+	interval := m.cfg.OperationTimeout
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkBucketEpochs(ctx)
+		}
+	}
+}
+
+// checkBucketEpochs is one tick of monitorBucketEpochs, split out so a
+// unit test can drive it deterministically without waiting on the
+// ticker.
+func (m *Manager) checkBucketEpochs(ctx context.Context) {
+	for bucket, ep := range m.bucketEpochs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, m.cfg.OperationTimeout)
+		live, err := kvutil.BucketStreamCreated(probeCtx, ep.kv)
+		cancel()
+		if err != nil {
+			m.logger.Debug("epoch fence: probe failed; relying on next tick",
+				"bucket", bucket, "error", err)
+			continue
+		}
+		if !live.Equal(ep.created) {
+			m.logger.Warn("epoch fence: bucket stream Created mismatch — bucket was wiped and recreated",
+				"bucket", bucket,
+				"cached_created", ep.created,
+				"live_created", live)
+			m.enterDegraded("bucket-recreated:" + bucket)
+			return // once degraded; no need to probe the rest this tick
+		}
+	}
 }
 
 // storageTypeName renders jetstream.StorageType as a human-readable string.

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -174,10 +174,18 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 // Uses retry logic to handle race conditions when multiple workers
 // try to create the same bucket concurrently.
 //
-// Note: if the bucket already exists, its existing storage type is honored
-// (kvutil.EnsureKVBucketWithRetry is get-first). A warning is logged when the
-// existing storage type does not match the requested one so operators can
-// diagnose why they're not seeing the IOPS profile they expect after upgrading.
+// Note: if the bucket already exists, its existing storage type and
+// replica count are honored (kvutil.EnsureKVBucketWithRetry is
+// get-first). A warning is logged when the existing storage type does
+// not match the requested one so operators can diagnose why they're
+// not seeing the IOPS profile they expect after upgrading.
+//
+// Replicas: m.cfg.KVBuckets.Replicas is stamped onto the canonical
+// builder output when > 0 (mirrors the provision package's pattern —
+// see internal/kvbuckets/builder.go Godoc). Zero leaves the field
+// unset, which nats.go normalizes to 1 server-side (legacy behavior).
+// Pre-created buckets keep their existing replica count regardless of
+// this setting.
 func (m *Manager) ensureKVBucket(
 	ctx context.Context,
 	js jetstream.JetStream,
@@ -186,6 +194,9 @@ func (m *Manager) ensureKVBucket(
 	storage jetstream.StorageType,
 ) (jetstream.KeyValue, error) {
 	cfg := kvbuckets.BuildKeyValueConfig(bucket, ttl, storage)
+	if m.cfg.KVBuckets.Replicas > 0 {
+		cfg.Replicas = m.cfg.KVBuckets.Replicas
+	}
 
 	// Use retry logic to handle concurrent creation
 	const maxRetries = 5
@@ -195,6 +206,7 @@ func (m *Manager) ensureKVBucket(
 	}
 
 	m.warnOnStorageMismatch(ctx, kv, bucket, storage)
+	m.warnOnReplicasMismatch(ctx, kv, bucket)
 	// F1 epoch fence (P1.3): record this bucket's stream-Created
 	// timestamp so monitorBucketEpochs can detect a future wipe-and-
 	// recreate event. Failures are logged but never block Start.
@@ -391,6 +403,51 @@ func (m *Manager) warnOnStorageMismatch(
 		"bucket", bucket,
 		"existing_storage", storageTypeName(got),
 		"parti_default_storage", storageTypeName(want),
+	)
+}
+
+// warnOnReplicasMismatch logs a warning when an existing bucket's
+// replica count differs from Config.KVBuckets.Replicas. Mirrors
+// warnOnStorageMismatch.
+//
+// The library does NOT auto-reconcile Replicas (unlike MaxAge, which IS
+// reconciled because it carries a correctness invariant). Replicas is a
+// per-deployment HA-quality decision: silently rewriting an operator's
+// existing bucket config could trigger expensive cross-node replication
+// they did not ask for, or mask a deliberate downsize. The library's
+// contract is "pre-creation wins" (get-first); this warning makes a
+// silent divergence visible so operators can run
+// `nats stream update KV_<bucket> --replicas=N` themselves if they
+// want the change.
+//
+// Silent when Config.KVBuckets.Replicas is 0 (legacy default — no
+// expectation expressed) or when the existing bucket's replica count
+// matches.
+func (m *Manager) warnOnReplicasMismatch(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	bucket string,
+) {
+	want := m.cfg.KVBuckets.Replicas
+	if want <= 0 {
+		return // operator expressed no preference; nothing to compare against
+	}
+	cfg, err := kvStreamConfig(ctx, kv)
+	if err != nil {
+		return
+	}
+	got := cfg.Replicas
+	if got == want {
+		return
+	}
+	m.logger.Warn(
+		"KV bucket replica count differs from Config.KVBuckets.Replicas — "+
+			"the library does NOT auto-reconcile Replicas (pre-creation wins). "+
+			"To apply the requested value run "+
+			"`nats stream update KV_"+bucket+" --replicas=<N>` against your cluster.",
+		"bucket", bucket,
+		"existing_replicas", got,
+		"requested_replicas", want,
 	)
 }
 

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -530,20 +530,47 @@ type bucketEpoch struct {
 // epoch fence simply does not protect that bucket; the existing readiness-
 // degraded paths (recordKVError, connection monitor, source-unavailable
 // hook) still apply. This keeps the change additive and never blocks Start.
+//
+// The probe stores a DEDICATED [jetstream.KeyValue] handle, separate from
+// the one the rest of the manager uses. nats.go's KeyValue / stream objects
+// cache state internally and are NOT documented as safe for concurrent use
+// across goroutines — calling kv.Status() (which internally calls
+// stream.Info()) from the monitorBucketEpochs ticker while assignment /
+// heartbeat / election code paths concurrently read or write through the
+// SAME handle races on the cached *stream fields. Opening a fresh handle
+// via [jetstream.JetStream.KeyValue] returns a new *kvs with its own
+// *stream, so the monitor goroutine never shares state with production
+// paths. If the per-bucket dedicated handle cannot be opened (e.g. an
+// account-permission edge), the epoch fence falls back to the bucket-not-
+// protected behaviour described above.
 func (m *Manager) captureBucketEpoch(ctx context.Context, bucket string, kv jetstream.KeyValue) {
 	if kv == nil {
+		return
+	}
+	if m.js == nil {
+		// No JetStream context wired (tests that exercise ensureKVBucket
+		// without setting m.js take this path). The epoch fence cannot
+		// open its own probe handle, so disable bucket-recreate
+		// detection for this bucket; production code paths always wire
+		// m.js via NewManager.
 		return
 	}
 	if m.bucketEpochs == nil {
 		m.bucketEpochs = make(map[string]bucketEpoch, 5)
 	}
-	created, err := kvutil.BucketStreamCreated(ctx, kv)
+	probeKV, err := m.js.KeyValue(ctx, bucket)
+	if err != nil {
+		m.logger.Warn("epoch fence: failed to open dedicated probe handle; bucket-recreate detection disabled for this bucket",
+			"bucket", bucket, "error", err)
+		return
+	}
+	created, err := kvutil.BucketStreamCreated(ctx, probeKV)
 	if err != nil {
 		m.logger.Warn("epoch fence: failed to capture bucket stream Created at Start; bucket-recreate detection disabled for this bucket",
 			"bucket", bucket, "error", err)
 		return
 	}
-	m.bucketEpochs[bucket] = bucketEpoch{kv: kv, created: created}
+	m.bucketEpochs[bucket] = bucketEpoch{kv: probeKV, created: created}
 }
 
 // monitorBucketEpochs polls each Parti-owned bucket's stream-Created

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/kvbuckets"
 	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -404,6 +405,41 @@ func (m *Manager) warnOnShortAuditGrace() {
 		"heartbeat_ttl", m.cfg.HeartbeatTTL,
 		"audit_grace", auditGrace,
 		"resolver_reconcile_default", resolverReconcileDefault,
+	)
+}
+
+// warnOnFiniteMaxReconnects emits a one-shot WARN when the caller-owned
+// nats.Conn is configured with a finite MaxReconnect budget. A finite
+// budget turns a sustained NATS outage into a permanently CLOSED zombie
+// connection — the manager's connection monitor then enters degraded
+// mode and the readiness probe rotates the pod. The recommended posture
+// (documented in docs/OPERATIONS.md "NATS Client Connection") is
+// nats.MaxReconnects(-1) (unlimited), which lets the client ride
+// through an outage instead.
+//
+// The warning is read-only; finite MaxReconnect is not rejected (some
+// deployments may consciously choose pod rotation on outage). The plan
+// is to make the foot-gun visible at first deploy rather than during
+// an actual outage.
+//
+// Negative MaxReconnect (-1 or any negative) is unlimited and silent.
+// A nil conn is silent (defensive — test doubles that bypass the real
+// JetStream surface must not panic here).
+func warnOnFiniteMaxReconnects(conn *nats.Conn, logger types.Logger) {
+	if conn == nil {
+		return
+	}
+	limit := conn.Opts.MaxReconnect
+	if limit < 0 {
+		return // unlimited; recommended posture
+	}
+	logger.Warn(
+		"nats.Conn is configured with a finite MaxReconnect; on a sustained "+
+			"NATS outage the connection exhausts its budget, stays CLOSED, "+
+			"forces degraded mode and rotates the pod. Configure with "+
+			"nats.MaxReconnects(-1) plus a reasonable nats.ReconnectWait/"+
+			"ReconnectJitter (see docs/OPERATIONS.md \"NATS Client Connection\").",
+		"max_reconnect", limit,
 	)
 }
 

--- a/manager_setup_test.go
+++ b/manager_setup_test.go
@@ -2,10 +2,13 @@ package parti
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,5 +51,110 @@ func TestManager_prepareStart(t *testing.T) {
 		// Verify context has NO deadline (if parent doesn't)
 		_, ok := ctx.Deadline()
 		require.False(t, ok)
+	})
+}
+
+// warnCaptureLogger records WARN-level message strings so the
+// warnOnFiniteMaxReconnects test can assert on emission count and
+// content without taking on the full captureLogger from
+// pull_gating_repro_test.go (which is integration-shaped).
+type warnCaptureLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *warnCaptureLogger) Debug(string, ...any) {}
+func (l *warnCaptureLogger) Info(string, ...any)  {}
+func (l *warnCaptureLogger) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+func (l *warnCaptureLogger) Error(string, ...any) {}
+func (l *warnCaptureLogger) Fatal(string, ...any) {}
+
+// snapshot returns the recorded WARN messages so the caller can
+// assert on count and substring content without exposing the
+// internal slice or holding the lock externally.
+func (l *warnCaptureLogger) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.warns))
+	copy(out, l.warns)
+
+	return out
+}
+
+// TestManager_warnOnFiniteMaxReconnects covers the read-only startup
+// warning that fires when the caller-owned nats.Conn is configured
+// with a finite MaxReconnects. -1 (unlimited) is the recommended
+// posture and must be silent. Anything else (including 0 = disabled
+// and any positive cap) must emit the warning exactly once.
+//
+// Defensive cases: a nil m.js or a nil m.js.Conn() must NOT panic and
+// must NOT emit a warning (the helper is read-only and must not
+// constrain test doubles that bypass the real JetStream surface).
+func TestManager_warnOnFiniteMaxReconnects(t *testing.T) {
+	// The helper accesses ONLY conn.Opts.MaxReconnects, which is a
+	// value field on nats.Options. A zero-valued *nats.Conn with only
+	// Opts populated is therefore safe to construct directly for this
+	// unit test — no embedded NATS server required.
+	// nats.Options field name is MaxReconnect (singular). The nats.MaxReconnects
+	// setter (plural) is the Option-constructor; the underlying field is singular.
+	mkConn := func(maxReconnect int) *nats.Conn {
+		return &nats.Conn{Opts: nats.Options{MaxReconnect: maxReconnect}}
+	}
+
+	const warnSubstr = "finite MaxReconnect"
+
+	// assertWarnedAbout fails the test unless exactly one WARN line
+	// containing warnSubstr was emitted. Inlined assertion sidesteps
+	// the unparam lint warning that fires on a single-call helper
+	// whose substring argument never varies.
+	assertWarnedOnce := func(t *testing.T, log *warnCaptureLogger) {
+		t.Helper()
+		var matches int
+		for _, w := range log.snapshot() {
+			if strings.Contains(w, warnSubstr) {
+				matches++
+			}
+		}
+		require.Equal(t, 1, matches, "expected exactly one warning matching %q; got warns=%v", warnSubstr, log.snapshot())
+	}
+	assertSilent := func(t *testing.T, log *warnCaptureLogger) {
+		t.Helper()
+		var matches int
+		for _, w := range log.snapshot() {
+			if strings.Contains(w, warnSubstr) {
+				matches++
+			}
+		}
+		require.Equal(t, 0, matches, "expected no warnings; got warns=%v", log.snapshot())
+	}
+
+	t.Run("unlimited -1 silent (recommended posture)", func(t *testing.T) {
+		log := &warnCaptureLogger{}
+		warnOnFiniteMaxReconnects(mkConn(-1), log)
+		assertSilent(t, log)
+	})
+
+	t.Run("zero (disabled reconnect) warns", func(t *testing.T) {
+		log := &warnCaptureLogger{}
+		warnOnFiniteMaxReconnects(mkConn(0), log)
+		assertWarnedOnce(t, log)
+	})
+
+	t.Run("finite positive warns", func(t *testing.T) {
+		log := &warnCaptureLogger{}
+		warnOnFiniteMaxReconnects(mkConn(5), log)
+		assertWarnedOnce(t, log)
+	})
+
+	t.Run("nil conn silent (defensive)", func(t *testing.T) {
+		log := &warnCaptureLogger{}
+		require.NotPanics(t, func() {
+			warnOnFiniteMaxReconnects(nil, log)
+		})
+		assertSilent(t, log)
 	})
 }

--- a/manager_twophase_gate_warning_test.go
+++ b/manager_twophase_gate_warning_test.go
@@ -1,0 +1,157 @@
+package parti
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// configurableGateUpdater is a WorkerConsumerUpdater + CapabilityReporter
+// whose reported capability bits are caller-controlled. Unlike
+// gateReportingUpdater (which flips the gate ON in UpdateWorkerConsumer),
+// this stub leaves the bits at whatever the test set them to, letting the
+// F10-B warning test exercise the "consumer never wires the gate"
+// misconfiguration scenario.
+type configurableGateUpdater struct {
+	reported atomic.Uint32
+	updates  atomic.Int64
+}
+
+func (g *configurableGateUpdater) UpdateWorkerConsumer(_ context.Context, _ string, _ []Partition) error {
+	g.updates.Add(1)
+	return nil
+}
+
+func (g *configurableGateUpdater) Capabilities() uint32 { return g.reported.Load() }
+
+// twoPhaseWarnSpy captures WARN messages for assertion. Mirrors the
+// shape of warnCaptureLogger (manager_setup_test.go) but lives here so
+// the P0.3 test does not couple to P0.1's branch.
+type twoPhaseWarnSpy struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *twoPhaseWarnSpy) Debug(string, ...any) {}
+func (l *twoPhaseWarnSpy) Info(string, ...any)  {}
+func (l *twoPhaseWarnSpy) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+func (l *twoPhaseWarnSpy) Error(string, ...any) {}
+func (l *twoPhaseWarnSpy) Fatal(string, ...any) {}
+
+func (l *twoPhaseWarnSpy) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.warns))
+	copy(out, l.warns)
+
+	return out
+}
+
+// setupTwoPhaseGateWarningTest wires a Manager with a spy logger and a
+// caller-controlled capability stub. The stub's initial reported bit is
+// `initialCaps`, which the test can mutate before driving apply.
+func setupTwoPhaseGateWarningTest(t *testing.T, twoPhase bool, initialCaps uint32) (*Manager, *twoPhaseWarnSpy) {
+	t.Helper()
+
+	stub := &configurableGateUpdater{}
+	stub.reported.Store(initialCaps)
+
+	m, _, _, _ := newTestManager(t)
+	m.cfg = Config{EnableTwoPhaseHandoff: twoPhase}
+	spy := &twoPhaseWarnSpy{}
+	m.logger = spy
+	m.consumerUpdater = stub
+	m.capReporter = asCapabilityReporter(stub)
+	m.handoffCoordinator = &forwardingHandoff{updater: stub}
+
+	return m, spy
+}
+
+func driveOneApply(t *testing.T, m *Manager, version int64) {
+	t.Helper()
+	err := m.applyAssignmentWithPrev(Assignment{}, Assignment{
+		Version:        version,
+		LeaderRevision: uint64(version), //nolint:gosec // monotonic test sequence; non-negative
+		Partitions:     []Partition{{Keys: []string{"p1"}}},
+	})
+	require.NoError(t, err, "applyAssignmentWithPrev must succeed for the warning-path tests")
+}
+
+func countTwoPhaseGateWarns(spy *twoPhaseWarnSpy) int {
+	n := 0
+	for _, w := range spy.snapshot() {
+		if strings.Contains(w, "two-phase handoff is enabled but the consumer reports no processing gate") {
+			n++
+		}
+	}
+
+	return n
+}
+
+// TestManager_F10B_TwoPhaseHandoffWithoutGate_Warns covers the five
+// configurations that distinguish the F10-B warning's intended
+// behavior from any silent-failure or false-positive mode.
+func TestManager_F10B_TwoPhaseHandoffWithoutGate_Warns(t *testing.T) {
+	t.Parallel()
+	t.Run("two-phase ON + no gate reported → warns once", func(t *testing.T) {
+		t.Parallel()
+		m, spy := setupTwoPhaseGateWarningTest(t, true, 0)
+		driveOneApply(t, m, 1)
+		require.Equal(t, 1, countTwoPhaseGateWarns(spy),
+			"misconfigured two-phase handoff must surface a single WARN")
+	})
+
+	t.Run("two-phase ON + gate reported → silent", func(t *testing.T) {
+		t.Parallel()
+		m, spy := setupTwoPhaseGateWarningTest(t, true, types.CapProcessingGate)
+		driveOneApply(t, m, 1)
+		require.Equal(t, 0, countTwoPhaseGateWarns(spy),
+			"the happy path (gate present) must be silent")
+	})
+
+	t.Run("two-phase ON + no gate, repeated applies → warns only once", func(t *testing.T) {
+		t.Parallel()
+		m, spy := setupTwoPhaseGateWarningTest(t, true, 0)
+		driveOneApply(t, m, 1)
+		driveOneApply(t, m, 2)
+		driveOneApply(t, m, 3)
+		require.Equal(t, 1, countTwoPhaseGateWarns(spy),
+			"capProcessingGateWarned guard must suppress repeat applies")
+	})
+
+	t.Run("two-phase OFF → silent regardless of caps", func(t *testing.T) {
+		t.Parallel()
+		m, spy := setupTwoPhaseGateWarningTest(t, false, 0)
+		driveOneApply(t, m, 1)
+		require.Equal(t, 0, countTwoPhaseGateWarns(spy),
+			"the flag gates the warning; nothing to warn about when off")
+	})
+
+	t.Run("nil capReporter → silent (limitation acknowledged)", func(t *testing.T) {
+		t.Parallel()
+		m, _, _, _ := newTestManager(t)
+		m.cfg = Config{EnableTwoPhaseHandoff: true}
+		spy := &twoPhaseWarnSpy{}
+		m.logger = spy
+		// Important: leave m.capReporter == nil (no CapabilityReporter
+		// wired). The fwdHandoff still needs an updater; provide a
+		// non-reporting stub for that.
+		nonReportingStub := &configurableGateUpdater{}
+		m.consumerUpdater = nonReportingStub
+		m.capReporter = nil
+		m.handoffCoordinator = &forwardingHandoff{updater: nonReportingStub}
+
+		driveOneApply(t, m, 1)
+		require.Equal(t, 0, countTwoPhaseGateWarns(spy),
+			"without a CapabilityReporter the gate signal is undetectable; the warning correctly stays silent (documented limitation)")
+	})
+}

--- a/partitest/nats.go
+++ b/partitest/nats.go
@@ -71,11 +71,14 @@ func StartEmbeddedNATS(t testing.TB) (*server.Server, *nats.Conn) {
 		t.Fatal("Embedded NATS server not ready within timeout")
 	}
 
-	// Connect client to the server
+	// Connect client to the server with the recommended Parti posture:
+	// MaxReconnects(-1) lets the client ride through transient outages
+	// instead of giving up and going CLOSED. Mirrors the guidance in
+	// docs/OPERATIONS.md "NATS Client Connection".
 	nc, err := nats.Connect(ns.ClientURL(),
 		nats.Timeout(2*time.Second),
 		nats.RetryOnFailedConnect(true),
-		nats.MaxReconnects(3),
+		nats.MaxReconnects(-1),
 	)
 	if err != nil {
 		ns.Shutdown()

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -52,6 +52,15 @@ type NatsKVOption func(*NatsKV)
 // also set the fixed interval is ignored in favour of the leadership-driven
 // cadence (leader=30s / follower=5min).
 //
+// Disabling the reconciler (d <= 0 with no leadership probe wired)
+// disables the load-bearing recovery path for the source watcher: the
+// nats.go KV watcher's Updates() channel does NOT close on a NATS
+// server restart, and the periodic reconcile is the only mechanism
+// that re-syncs source state after a silently stalled watcher. Disable
+// polling only with full awareness — Start emits a one-shot WARN log
+// line when this state is detected so the operational consequence is
+// visible at first deploy.
+//
 // Parameters:
 //   - d: Reconcile interval (0 disables; default 30s)
 //
@@ -250,6 +259,15 @@ func (s *NatsKV) Start(ctx context.Context) error {
 	}
 	s.watcher = watcher
 	s.running = true
+
+	// Warn when the reconciler is disabled with no leadership probe wired.
+	// reconcileLoop (below) exits immediately on this condition; without a
+	// running reconciler, a silent NATS server restart leaves the source
+	// watcher stalled with no recovery path. See the
+	// project_nats_watcher_empirical_finding memory pin.
+	if s.reconcileInterval <= 0 && s.leadershipProbe == nil {
+		s.logWarn("source reconciler disabled; server-restart recovery will not work — call source.WithReconcileInterval with a positive duration (or wire a leadership probe via source.WithLeadershipProbe)")
+	}
 
 	s.wg.Add(2)
 	go func() { defer s.wg.Done(); s.watchLoop(s.ctx, s.watcher) }()
@@ -1013,5 +1031,11 @@ func isCASConflict(err error) bool {
 func (s *NatsKV) logError(msg string, args ...any) {
 	if s.logger != nil {
 		s.logger.Error(msg, args...)
+	}
+}
+
+func (s *NatsKV) logWarn(msg string, args ...any) {
+	if s.logger != nil {
+		s.logger.Warn(msg, args...)
 	}
 }

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -1186,6 +1186,7 @@ func (s *NatsKV) logWarn(msg string, args ...any) {
 		s.logger.Warn(msg, args...)
 	}
 }
+
 // isBucketUnavailableErr classifies an error from a cached KV / watcher
 // operation as "the source bucket is unavailable from this connection's
 // point of view". Empirical surface (verified against nats.go v1.50.0):

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/internal/retry"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -31,14 +31,27 @@ const (
 	// defaultUpdateRetries is the default maximum CAS attempts for Update/Modify.
 	defaultUpdateRetries = 5
 
+	// watcherJitter is the ±fraction applied to the backoff delay.
+	watcherJitter = 0.3
+)
+
+// Watcher retry-envelope parameters. Declared as vars (not consts) so
+// integration tests in this package can drive the bounded-retry envelope
+// at a sub-second cadence without waiting the production 60-second
+// cycle. Production code must NEVER mutate these.
+var (
 	// watcherBaseBackoff is the initial backoff for watcher restart attempts.
 	watcherBaseBackoff = 2 * time.Second
 
 	// watcherMaxBackoff is the maximum backoff for watcher restart attempts.
 	watcherMaxBackoff = 30 * time.Second
 
-	// watcherJitter is the ±fraction applied to the backoff delay.
-	watcherJitter = 0.3
+	// watcherMaxAttempts caps the F2 retry envelope on the watcher-restart
+	// loop. With watcherBaseBackoff=2s and watcherMaxBackoff=30s, six
+	// attempts span roughly one reconcile cycle (≤ defaultReconcileInterval).
+	// Past this point we rely on the periodic reconciler for recovery and
+	// emit the onWatcherRetryExhausted callback.
+	watcherMaxAttempts = 6
 )
 
 // ErrUpdateRetryExhausted is returned by Update and Modify when all CAS retry
@@ -875,50 +888,74 @@ func (s *NatsKV) watchLoop(ctx context.Context, watcher jetstream.KeyWatcher) {
 // On success it spawns a new watchLoop and returns. On context cancellation
 // it returns immediately. The reconcile loop is the correctness safety net
 // while the watcher is being re-established.
+//
+// F2 (P2.4a): the retry loop is bounded by an internal/retry envelope. After
+// watcherMaxAttempts consecutive failures the envelope fires onWatcherRetryExhausted
+// (logged at WARN) and the goroutine exits. The periodic reconciler then
+// remains as the sole recovery path (the load-bearing recovery per the
+// project_nats_watcher_empirical_finding memory pin). Without the bound, a
+// vanished bucket or a sustained NATS outage produced infinite watcher-create
+// API load and no escalation signal.
 func (s *NatsKV) restartWatcher(ctx context.Context) {
-	backoff := watcherBaseBackoff
-	for {
-		if ctx.Err() != nil {
-			return
+	env := retry.New(retry.Config{
+		Work:        s.tryRebindWatcher(ctx),
+		OnPermanent: s.onWatcherRetryExhausted,
+		BaseBackoff: watcherBaseBackoff,
+		MaxBackoff:  watcherMaxBackoff,
+		MaxAttempts: watcherMaxAttempts,
+		Jitter:      watcherJitter,
+		OnProgress: func(attempt int, err error) {
+			s.logError("failed to restart watcher, will retry", "error", err, "attempt", attempt)
+		},
+	})
+	_ = env.Run(ctx) // ctx-cancel and exhaustion both terminate the goroutine
+}
+
+// tryRebindWatcher captures the lifecycle ctx and returns the Work function
+// the retry envelope drives. Each successful rebind installs the new watcher,
+// spawns the watchLoop goroutine, and clears the F6-A bucket-missing gauge;
+// the envelope then returns nil from Run and restartWatcher exits cleanly.
+// On error the per-attempt path classifies the failure via the F6-A
+// noteBucketUnavailable helper (sets the gauge + fires the rate-limited
+// SourceUnavailableHook) before returning the error to the envelope for
+// the bounded-retry decision.
+func (s *NatsKV) tryRebindWatcher(loopCtx context.Context) func(context.Context) error {
+	return func(_ context.Context) error {
+		// Watch uses the source-lifetime context (loopCtx) so the watcher
+		// outlives this single retry attempt — the envelope's per-attempt
+		// ctx would cancel it on success.
+		watcher, err := s.watchFn(loopCtx)
+		if err != nil {
+			// F6-A: classify the rebind error. noteBucketUnavailable
+			// fires the SourceUnavailableHook (rate-limited) + sets the
+			// SourceBucketMissing gauge on a wrapped bucket-unavailable
+			// error. The envelope still drives the bounded retry; this
+			// just makes the loss observable to operators during the
+			// retry window.
+			s.noteBucketUnavailable(err)
+			return err
 		}
+		s.mu.Lock()
+		s.watcher = watcher
+		s.mu.Unlock()
+		s.wg.Go(func() { s.watchLoop(loopCtx, watcher) })
+		// F6-A: a successful rebind confirms the bucket is reachable.
+		s.noteBucketAvailable()
 
-		watcher, err := s.watchFn(ctx)
-		if err == nil {
-			s.mu.Lock()
-			s.watcher = watcher
-			s.mu.Unlock()
-			s.wg.Go(func() { s.watchLoop(ctx, watcher) })
-			s.noteBucketAvailable()
-
-			return
-		}
-
-		// F6-A: bucket-missing escalation. noteBucketUnavailable returns
-		// true on a wrapped ErrBucketNotFound and fires the hook (rate-
-		// limited) + sets the SourceBucketMissing gauge. The log line is
-		// still emitted in both branches so operators see the retry
-		// cadence; only the message text changes to distinguish the
-		// bucket-loss case from a generic watcher error.
-		if s.noteBucketUnavailable(err) {
-			s.logError("source bucket missing; will retry watcher", "error", err, "backoff", backoff)
-		} else {
-			s.logError("failed to restart watcher, will retry", "error", err, "backoff", backoff)
-		}
-
-		//nolint:gosec // jitter does not require crypto-secure random
-		f := rand.Float64()
-		low := 1 - watcherJitter
-		high := 1 + watcherJitter
-		delay := time.Duration(float64(backoff) * (low + f*(high-low)))
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(delay):
-		}
-
-		backoff = min(backoff*2, watcherMaxBackoff)
+		return nil
 	}
+}
+
+// onWatcherRetryExhausted is the envelope's permanent-failure callback.
+// The reconcileLoop remains running and will continue to converge state on
+// each tick; operators should treat sustained watcher-restart exhaustion
+// as a signal that the source bucket needs investigation (and the F6-A
+// SourceUnavailableHook, on its branch, is the wired-up escalation path
+// once that PR merges).
+func (s *NatsKV) onWatcherRetryExhausted(err error) {
+	s.logWarn("source watcher restart attempt budget exhausted; relying on reconciler for recovery",
+		"error", err,
+		"max_attempts", watcherMaxAttempts)
 }
 
 // reconcileLoop runs a background goroutine that periodically fetches the
@@ -1149,7 +1186,6 @@ func (s *NatsKV) logWarn(msg string, args ...any) {
 		s.logger.Warn(msg, args...)
 	}
 }
-
 // isBucketUnavailableErr classifies an error from a cached KV / watcher
 // operation as "the source bucket is unavailable from this connection's
 // point of view". Empirical surface (verified against nats.go v1.50.0):

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/partcodec"
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -106,6 +107,70 @@ func WithUpdateRetries(n int) NatsKVOption {
 	}
 }
 
+// SourceUnavailableHook fires when the partition-source bucket is observed to
+// be missing on the live connection. The reconciler and watcher-restart paths
+// each see a distinct error from the nats.go surface — [jetstream.ErrBucketNotFound]
+// from a fresh [jetstream.JetStream.KeyValue] lookup, [jetstream.ErrStreamNotFound]
+// from a cached watcher rebind, or [nats.ErrNoResponders] from a cached
+// [jetstream.KeyValue.Get] — and all three classify to bucket-loss internally.
+// The err argument hands the original sentinel to the hook so implementations
+// can log or surface the raw cause, but **do not gate readiness on a single
+// sentinel type**: when the hook fires, the bucket is missing.
+//
+// The library does not recreate the bucket — it is caller-owned, and rebuilding
+// it requires the operator's provisioning flow. Wire this hook into your
+// readiness logic (e.g. flip a readiness flag and let the orchestrator rotate
+// the pod) so the loss becomes an actionable signal rather than a silent stall.
+//
+// Concurrency contract: the hook is invoked synchronously from the source's
+// reconcile / restart goroutine. Implementations MUST be non-blocking and
+// MUST NOT call back into the source (recursive Get / Update / Stop will
+// deadlock against the watcher's restart path).
+//
+// Rate-limiting: repeated observations within a cooldown window (default
+// 30s, matching the default reconcile cadence) suppress the hook so the
+// callback is not flooded. The companion [SourceMetrics] gauge stays set
+// for the full duration of the outage and clears once a subsequent
+// operation succeeds.
+type SourceUnavailableHook func(err error)
+
+// WithUnavailableHook registers a [SourceUnavailableHook] that fires when
+// the partition-source bucket is observed to be missing. See
+// [SourceUnavailableHook] for the deadlock contract and rate-limiting
+// behavior. Without a hook, the loss is still logged and the metric is
+// set (when [WithMetrics] is configured), but no escalation runs — the
+// library cannot recreate a user-owned bucket on its own.
+//
+// Parameters:
+//   - h: Callback invoked on bucket-loss detection
+//
+// Returns:
+//   - NatsKVOption: Option function
+func WithUnavailableHook(h SourceUnavailableHook) NatsKVOption {
+	return func(s *NatsKV) {
+		s.unavailableHook = h
+	}
+}
+
+// WithMetrics wires a [types.SourceMetrics] collector. The source uses the
+// collector to expose its `parti_source_bucket_missing` gauge (set to 1 on
+// the first bucket-loss observation — see [SourceUnavailableHook] for the
+// empirical error surface — cleared on the next successful operation). The
+// default is [types.NopSourceMetrics].
+//
+// Parameters:
+//   - m: SourceMetrics collector
+//
+// Returns:
+//   - NatsKVOption: Option function
+func WithMetrics(m types.SourceMetrics) NatsKVOption {
+	return func(s *NatsKV) {
+		if m != nil {
+			s.metrics = m
+		}
+	}
+}
+
 // NatsKV implements a partition source backed by a NATS KeyValue bucket.
 //
 // It watches a specific key in the KV bucket for updates to the partition list,
@@ -155,6 +220,27 @@ type NatsKV struct {
 	// was scheduled for that tick. It is nil in production and set by tests that
 	// need to observe reconcile cadence without polling test-only struct fields.
 	onReconcileTick func(interval time.Duration)
+
+	// F6-A: bucket-unavailability escalation.
+	//
+	// unavailableHook fires (rate-limited) when the watcher-restart loop or
+	// the reconciler observes any error in the bucket-loss surface — see
+	// isBucketUnavailableErr for the empirical set (currently
+	// jetstream.ErrBucketNotFound, jetstream.ErrStreamNotFound, and
+	// nats.ErrNoResponders).
+	// metrics receives a SetSourceBucketMissing(true/false) call on the
+	// degradation/recovery edges.
+	// unavailableMu serialises lastUnavailableAt and bucketMissing — the two
+	// fields that govern rate-limiting and the gauge state.
+	// unavailableCooldown is the minimum interval between successive hook
+	// invocations under sustained bucket-loss; the default 30s matches the
+	// reconcile cadence.
+	unavailableHook     SourceUnavailableHook
+	metrics             types.SourceMetrics
+	unavailableMu       sync.Mutex
+	lastUnavailableAt   time.Time
+	unavailableCooldown time.Duration
+	bucketMissing       bool
 }
 
 // natsKVListener wraps a channel with a sync.Once to prevent double-close panics.
@@ -186,13 +272,15 @@ var (
 //   - *NatsKV: Configured source (call Start before use)
 func NewNatsKV(kv jetstream.KeyValue, key string, logger types.Logger, opts ...NatsKVOption) *NatsKV {
 	s := &NatsKV{
-		kv:                kv,
-		key:               key,
-		logger:            logger,
-		reconcileInterval: defaultReconcileInterval,
-		updateRetries:     defaultUpdateRetries,
-		leaderInterval:    leaderReconcileInterval,
-		followerInterval:  followerReconcileInterval,
+		kv:                  kv,
+		key:                 key,
+		logger:              logger,
+		reconcileInterval:   defaultReconcileInterval,
+		updateRetries:       defaultUpdateRetries,
+		leaderInterval:      leaderReconcileInterval,
+		followerInterval:    followerReconcileInterval,
+		metrics:             types.NopSourceMetrics{},
+		unavailableCooldown: defaultReconcileInterval, // 30s
 	}
 	s.watchFn = func(ctx context.Context) (jetstream.KeyWatcher, error) {
 		return s.kv.Watch(ctx, s.key)
@@ -800,11 +888,22 @@ func (s *NatsKV) restartWatcher(ctx context.Context) {
 			s.watcher = watcher
 			s.mu.Unlock()
 			s.wg.Go(func() { s.watchLoop(ctx, watcher) })
+			s.noteBucketAvailable()
 
 			return
 		}
 
-		s.logError("failed to restart watcher, will retry", "error", err, "backoff", backoff)
+		// F6-A: bucket-missing escalation. noteBucketUnavailable returns
+		// true on a wrapped ErrBucketNotFound and fires the hook (rate-
+		// limited) + sets the SourceBucketMissing gauge. The log line is
+		// still emitted in both branches so operators see the retry
+		// cadence; only the message text changes to distinguish the
+		// bucket-loss case from a generic watcher error.
+		if s.noteBucketUnavailable(err) {
+			s.logError("source bucket missing; will retry watcher", "error", err, "backoff", backoff)
+		} else {
+			s.logError("failed to restart watcher, will retry", "error", err, "backoff", backoff)
+		}
 
 		//nolint:gosec // jitter does not require crypto-secure random
 		f := rand.Float64()
@@ -883,10 +982,19 @@ func (s *NatsKV) reconcileOnce(ctx context.Context) {
 	entry, err := s.kv.Get(ctx, s.key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			// Key does not exist. Preserve revision/known if already known — the
-			// watcher will deliver the delete event with the correct revision.
-			// Only the initial-never-written case (known=false) leaves state unchanged.
+			// Key does not exist but the bucket does — confirm the
+			// bucket-available gauge and apply the empty state.
+			s.noteBucketAvailable()
+			// Preserve revision/known if already known — the watcher will deliver
+			// the delete event with the correct revision. Only the
+			// initial-never-written case (known=false) leaves state unchanged.
 			s.applyEmptyPreservingKnown()
+
+			return
+		}
+		// F6-A: bucket-missing escalation. See noteBucketUnavailable Godoc.
+		if s.noteBucketUnavailable(err) {
+			s.logError("reconcile: source bucket missing", "error", err)
 
 			return
 		}
@@ -902,6 +1010,8 @@ func (s *NatsKV) reconcileOnce(ctx context.Context) {
 		return
 	}
 
+	// Successful kv.Get confirms the bucket is reachable.
+	s.noteBucketAvailable()
 	s.applyLocal(partitions, entry.Revision(), true)
 }
 
@@ -1037,5 +1147,93 @@ func (s *NatsKV) logError(msg string, args ...any) {
 func (s *NatsKV) logWarn(msg string, args ...any) {
 	if s.logger != nil {
 		s.logger.Warn(msg, args...)
+	}
+}
+
+// isBucketUnavailableErr classifies an error from a cached KV / watcher
+// operation as "the source bucket is unavailable from this connection's
+// point of view". Empirical surface (verified against nats.go v1.50.0):
+//
+//   - jetstream.ErrBucketNotFound: returned by js.KeyValue(...) when the
+//     bucket has been deleted (lookup path).
+//   - jetstream.ErrStreamNotFound: returned by kv.Watch on a CACHED kv
+//     handle after the bucket was deleted under it. The KV bucket is
+//     backed by a stream named KV_<bucket>; once the stream is gone the
+//     watcher's bind fails with this error.
+//   - nats.ErrNoResponders: returned by kv.Get on a cached handle after
+//     the bucket was deleted — the request reaches the JetStream subject
+//     but no responder is listening.
+//
+// The latter two are what production paths actually see (the reconciler
+// uses cached kv.Get; restartWatcher uses cached kv.Watch). The first is
+// included for completeness and for any future code path that re-binds
+// the bucket via js.KeyValue.
+//
+// nats.ErrNoResponders is broader than "bucket deleted" — it also fires
+// during a transient NATS reconnect when no JetStream node has surfaced
+// the subject yet. The cooldown + gauge-clears-on-success design tolerates
+// the false-positive: the hook fires once, the gauge clears on the next
+// successful op, and the operator's readiness probe sees the brief blip.
+// This is preferable to missing the genuine bucket-loss case.
+func isBucketUnavailableErr(err error) bool {
+	return errors.Is(err, jetstream.ErrBucketNotFound) ||
+		errors.Is(err, jetstream.ErrStreamNotFound) ||
+		errors.Is(err, nats.ErrNoResponders)
+}
+
+// noteBucketUnavailable handles the bucket-missing escalation path. Returns
+// true iff err is classified as a bucket-unavailable error (see
+// isBucketUnavailableErr), so the caller can substitute a more specific
+// log line for the existing generic one.
+//
+// On a match:
+//   - Sets the SourceBucketMissing gauge to true (idempotent — no-op if
+//     already set).
+//   - Invokes the configured SourceUnavailableHook, rate-limited by
+//     unavailableCooldown so a sustained outage does not flood the
+//     caller's escalation logic.
+//
+// The hook is invoked OUTSIDE unavailableMu so a long-running caller hook
+// does not block the reconcile / restart goroutine's next tick.
+func (s *NatsKV) noteBucketUnavailable(err error) bool {
+	if !isBucketUnavailableErr(err) {
+		return false
+	}
+	s.unavailableMu.Lock()
+	var fire bool
+	if s.unavailableHook != nil && time.Since(s.lastUnavailableAt) >= s.unavailableCooldown {
+		s.lastUnavailableAt = time.Now()
+		fire = true
+	}
+	gaugeChanged := !s.bucketMissing
+	if gaugeChanged {
+		s.bucketMissing = true
+	}
+	s.unavailableMu.Unlock()
+
+	if gaugeChanged {
+		s.metrics.SetSourceBucketMissing(true)
+	}
+	if fire {
+		s.unavailableHook(err)
+	}
+
+	return true
+}
+
+// noteBucketAvailable clears the SourceBucketMissing gauge after a
+// successful watcher-restart or kv.Get. The hook is NOT re-fired on
+// recovery — escalation is one-way; the gauge carries the recovery
+// signal. Cheap: a no-op if the gauge is already clear.
+func (s *NatsKV) noteBucketAvailable() {
+	s.unavailableMu.Lock()
+	gaugeChanged := s.bucketMissing
+	if gaugeChanged {
+		s.bucketMissing = false
+	}
+	s.unavailableMu.Unlock()
+
+	if gaugeChanged {
+		s.metrics.SetSourceBucketMissing(false)
 	}
 }

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -46,7 +46,7 @@ var (
 	// watcherMaxBackoff is the maximum backoff for watcher restart attempts.
 	watcherMaxBackoff = 30 * time.Second
 
-	// watcherMaxAttempts caps the F2 retry envelope on the watcher-restart
+	// watcherMaxAttempts caps the bounded-retry envelope on the watcher-restart
 	// loop. With watcherBaseBackoff=2s and watcherMaxBackoff=30s, six
 	// attempts span roughly one reconcile cycle (≤ defaultReconcileInterval).
 	// Past this point we rely on the periodic reconciler for recovery and
@@ -234,7 +234,7 @@ type NatsKV struct {
 	// need to observe reconcile cadence without polling test-only struct fields.
 	onReconcileTick func(interval time.Duration)
 
-	// F6-A: bucket-unavailability escalation.
+	// Bucket-unavailability escalation:
 	//
 	// unavailableHook fires (rate-limited) when the watcher-restart loop or
 	// the reconciler observes any error in the bucket-loss surface — see
@@ -889,13 +889,14 @@ func (s *NatsKV) watchLoop(ctx context.Context, watcher jetstream.KeyWatcher) {
 // it returns immediately. The reconcile loop is the correctness safety net
 // while the watcher is being re-established.
 //
-// F2 (P2.4a): the retry loop is bounded by an internal/retry envelope. After
-// watcherMaxAttempts consecutive failures the envelope fires onWatcherRetryExhausted
-// (logged at WARN) and the goroutine exits. The periodic reconciler then
-// remains as the sole recovery path (the load-bearing recovery per the
-// project_nats_watcher_empirical_finding memory pin). Without the bound, a
-// vanished bucket or a sustained NATS outage produced infinite watcher-create
-// API load and no escalation signal.
+// The retry loop is bounded by an internal/retry envelope. After
+// watcherMaxAttempts consecutive failures the envelope fires
+// onWatcherRetryExhausted (logged at WARN) and the goroutine exits.
+// The periodic reconciler then remains as the sole recovery path
+// (load-bearing because the nats.go KV watcher's Updates() channel
+// does NOT close on a NATS server restart). Without the bound, a
+// vanished bucket or a sustained NATS outage produced infinite
+// watcher-create API load and no escalation signal.
 func (s *NatsKV) restartWatcher(ctx context.Context) {
 	env := retry.New(retry.Config{
 		Work:        s.tryRebindWatcher(ctx),
@@ -913,10 +914,10 @@ func (s *NatsKV) restartWatcher(ctx context.Context) {
 
 // tryRebindWatcher captures the lifecycle ctx and returns the Work function
 // the retry envelope drives. Each successful rebind installs the new watcher,
-// spawns the watchLoop goroutine, and clears the F6-A bucket-missing gauge;
+// spawns the watchLoop goroutine, and clears the bucket-missing gauge;
 // the envelope then returns nil from Run and restartWatcher exits cleanly.
-// On error the per-attempt path classifies the failure via the F6-A
-// noteBucketUnavailable helper (sets the gauge + fires the rate-limited
+// On error the per-attempt path classifies the failure via
+// noteBucketUnavailable (sets the gauge + fires the rate-limited
 // SourceUnavailableHook) before returning the error to the envelope for
 // the bounded-retry decision.
 func (s *NatsKV) tryRebindWatcher(loopCtx context.Context) func(context.Context) error {
@@ -926,8 +927,8 @@ func (s *NatsKV) tryRebindWatcher(loopCtx context.Context) func(context.Context)
 		// ctx would cancel it on success.
 		watcher, err := s.watchFn(loopCtx)
 		if err != nil {
-			// F6-A: classify the rebind error. noteBucketUnavailable
-			// fires the SourceUnavailableHook (rate-limited) + sets the
+			// Classify the rebind error. noteBucketUnavailable fires
+			// the SourceUnavailableHook (rate-limited) + sets the
 			// SourceBucketMissing gauge on a wrapped bucket-unavailable
 			// error. The envelope still drives the bounded retry; this
 			// just makes the loss observable to operators during the
@@ -939,7 +940,7 @@ func (s *NatsKV) tryRebindWatcher(loopCtx context.Context) func(context.Context)
 		s.watcher = watcher
 		s.mu.Unlock()
 		s.wg.Go(func() { s.watchLoop(loopCtx, watcher) })
-		// F6-A: a successful rebind confirms the bucket is reachable.
+		// A successful rebind confirms the bucket is reachable.
 		s.noteBucketAvailable()
 
 		return nil
@@ -949,9 +950,8 @@ func (s *NatsKV) tryRebindWatcher(loopCtx context.Context) func(context.Context)
 // onWatcherRetryExhausted is the envelope's permanent-failure callback.
 // The reconcileLoop remains running and will continue to converge state on
 // each tick; operators should treat sustained watcher-restart exhaustion
-// as a signal that the source bucket needs investigation (and the F6-A
-// SourceUnavailableHook, on its branch, is the wired-up escalation path
-// once that PR merges).
+// as a signal that the source bucket needs investigation (the
+// SourceUnavailableHook, when wired, is the escalation path).
 func (s *NatsKV) onWatcherRetryExhausted(err error) {
 	s.logWarn("source watcher restart attempt budget exhausted; relying on reconciler for recovery",
 		"error", err,
@@ -1029,7 +1029,7 @@ func (s *NatsKV) reconcileOnce(ctx context.Context) {
 
 			return
 		}
-		// F6-A: bucket-missing escalation. See noteBucketUnavailable Godoc.
+		// Bucket-missing escalation: see noteBucketUnavailable Godoc.
 		if s.noteBucketUnavailable(err) {
 			s.logError("reconcile: source bucket missing", "error", err)
 

--- a/source/nats_kv_reconcile_disabled_warning_test.go
+++ b/source/nats_kv_reconcile_disabled_warning_test.go
@@ -1,0 +1,159 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// f8BucketSeq makes each sub-test get a fresh KV bucket name without
+// embedding t.Name() (which contains characters NATS rejects).
+var f8BucketSeq atomic.Uint64
+
+// reconcileDisabledSpy captures WARN messages so the F8 reconciler-
+// disabled tests can assert the warning fires (or stays silent)
+// depending on whether a leadership probe is wired.
+type reconcileDisabledSpy struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *reconcileDisabledSpy) Debug(string, ...any) {}
+func (l *reconcileDisabledSpy) Info(string, ...any)  {}
+func (l *reconcileDisabledSpy) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+func (l *reconcileDisabledSpy) Error(string, ...any) {}
+func (l *reconcileDisabledSpy) Fatal(string, ...any) {}
+
+// snapshot returns a copy of the recorded WARN lines so callers can
+// inline the substring assertion (avoids unparam complaints on a
+// helper whose argument is a single test-scoped constant).
+func (l *reconcileDisabledSpy) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.warns))
+	copy(out, l.warns)
+
+	return out
+}
+
+var _ types.Logger = (*reconcileDisabledSpy)(nil)
+
+// newKVForReconcileWarningTest spins up an embedded NATS, creates a KV
+// bucket, and returns the bucket handle ready for NewNatsKV — extracted
+// so the four sub-tests below share the boilerplate without duplicating
+// it.
+func newKVForReconcileWarningTest(t *testing.T) (jetstream.KeyValue, context.Context) {
+	t.Helper()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	bucket := fmt.Sprintf("f8warn-%d", f8BucketSeq.Add(1))
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket: bucket,
+	})
+	require.NoError(t, err)
+
+	return kv, ctx
+}
+
+// TestNatsKV_WarnsWhenReconcilerDisabled covers the four meaningful
+// configurations of WithReconcileInterval × WithLeadershipProbe:
+//
+//   - interval <= 0 AND no probe → reconciler completely disabled →
+//     server-restart recovery does not work → MUST warn.
+//   - interval <= 0 AND probe wired → reconciler still runs (driven by
+//     the probe's cadence choice) → MUST be silent.
+//   - default interval (no option) → reconciler runs normally → silent.
+//   - explicit positive interval → reconciler runs normally → silent.
+//
+// The warning is the only signal that surfaces this readiness-blind
+// configuration to operators (the reconcileLoop silently exits at
+// source/nats_kv.go L812-815). See memory pin
+// project_nats_watcher_empirical_finding for why the reconciler is
+// load-bearing.
+func TestNatsKV_WarnsWhenReconcilerDisabled(t *testing.T) {
+	const warnSubstr = "source reconciler disabled"
+
+	countWarns := func(spy *reconcileDisabledSpy) int {
+		n := 0
+		for _, w := range spy.snapshot() {
+			if strings.Contains(w, warnSubstr) {
+				n++
+			}
+		}
+
+		return n
+	}
+
+	t.Run("interval=0, no probe → warns", func(t *testing.T) {
+		kv, ctx := newKVForReconcileWarningTest(t)
+		spy := &reconcileDisabledSpy{}
+		src := NewNatsKV(kv, "config", spy, WithReconcileInterval(0))
+		require.NoError(t, src.Start(ctx))
+		t.Cleanup(func() { _ = src.Stop(ctx) })
+
+		require.Equal(t, 1, countWarns(spy),
+			"reconciler disabled + no leadership probe must warn exactly once")
+	})
+
+	t.Run("interval=0, probe set → silent", func(t *testing.T) {
+		kv, ctx := newKVForReconcileWarningTest(t)
+		spy := &reconcileDisabledSpy{}
+		src := NewNatsKV(kv, "config", spy,
+			WithReconcileInterval(0),
+			WithLeadershipProbe(func() bool { return true }),
+		)
+		require.NoError(t, src.Start(ctx))
+		t.Cleanup(func() { _ = src.Stop(ctx) })
+
+		require.Equal(t, 0, countWarns(spy),
+			"a wired leadership probe drives the reconciler; the warning must NOT fire")
+	})
+
+	t.Run("default interval → silent", func(t *testing.T) {
+		kv, ctx := newKVForReconcileWarningTest(t)
+		spy := &reconcileDisabledSpy{}
+		src := NewNatsKV(kv, "config", spy) // no options; defaults apply
+		require.NoError(t, src.Start(ctx))
+		t.Cleanup(func() { _ = src.Stop(ctx) })
+
+		require.Equal(t, 0, countWarns(spy),
+			"default reconciler interval is the happy path; warning must not fire")
+	})
+
+	t.Run("negative interval, no probe → warns", func(t *testing.T) {
+		kv, ctx := newKVForReconcileWarningTest(t)
+		spy := &reconcileDisabledSpy{}
+		src := NewNatsKV(kv, "config", spy, WithReconcileInterval(-1*time.Second))
+		require.NoError(t, src.Start(ctx))
+		t.Cleanup(func() { _ = src.Stop(ctx) })
+
+		require.Equal(t, 1, countWarns(spy),
+			"a negative interval is treated the same as zero by reconcileLoop and must warn")
+	})
+
+	t.Run("nil logger does not panic", func(t *testing.T) {
+		kv, ctx := newKVForReconcileWarningTest(t)
+		require.NotPanics(t, func() {
+			src := NewNatsKV(kv, "config", nil, WithReconcileInterval(0))
+			require.NoError(t, src.Start(ctx))
+			_ = src.Stop(ctx)
+		})
+	})
+}

--- a/source/nats_kv_retry_envelope_test.go
+++ b/source/nats_kv_retry_envelope_test.go
@@ -1,0 +1,163 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// withWatcherBackoff temporarily shortens the package-level retry
+// constants so the integration tests run in seconds, not the production
+// 60s cycle. Restores the originals via t.Cleanup. The package vars are
+// declared specifically for this test seam — production code MUST NOT
+// mutate them.
+//
+// NOT safe for t.Parallel across multiple tests that touch these vars
+// (a parallel test could observe mid-restore values). The tests that
+// use this helper run serially.
+func withWatcherBackoff(t *testing.T, base, maxBackoff time.Duration, maxAttempts int) {
+	t.Helper()
+	origBase, origMax, origMaxAttempts := watcherBaseBackoff, watcherMaxBackoff, watcherMaxAttempts
+	watcherBaseBackoff = base
+	watcherMaxBackoff = maxBackoff
+	watcherMaxAttempts = maxAttempts
+	t.Cleanup(func() {
+		watcherBaseBackoff = origBase
+		watcherMaxBackoff = origMax
+		watcherMaxAttempts = origMaxAttempts
+	})
+}
+
+// TestRestartWatcher_BoundedByEnvelope verifies the F2 envelope wires
+// into restartWatcher correctly: under sustained failure, the goroutine
+// exits after watcherMaxAttempts attempts and the onWatcherRetryExhausted
+// callback fires exactly once. Without the bound the previous loop
+// retried forever.
+func TestRestartWatcher_BoundedByEnvelope(t *testing.T) {
+	// NOT t.Parallel — the test mutates package-level retry vars via the
+	// withWatcherBackoff seam.
+	withWatcherBackoff(t, 5*time.Millisecond, 20*time.Millisecond, 4)
+
+	var watchFnCalls atomic.Int64
+	bucketGone := errors.New("simulated: bucket missing")
+
+	var warnMu sync.Mutex
+	var warnLines []string
+	spy := &captureWarnLogger{
+		mu:    &warnMu,
+		warns: &warnLines,
+	}
+
+	s := &NatsKV{
+		logger: spy,
+	}
+	s.watchFn = func(context.Context) (jetstream.KeyWatcher, error) {
+		watchFnCalls.Add(1)
+		return nil, bucketGone
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.restartWatcher(ctx)
+	}()
+
+	// With the test seam (5ms/20ms × 4 attempts) the envelope exhausts
+	// in well under a second. Generous deadline so transient CI scheduling
+	// jitter does not cause flakes.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("restartWatcher did not return promptly; the envelope bound is not in effect")
+	}
+
+	require.LessOrEqual(t, watchFnCalls.Load(), int64(watcherMaxAttempts),
+		"watchFn must be called at most watcherMaxAttempts times under sustained failure")
+	require.Equal(t, int64(watcherMaxAttempts), watchFnCalls.Load(),
+		"watchFn should be called exactly watcherMaxAttempts times when every attempt fails")
+
+	warnMu.Lock()
+	defer warnMu.Unlock()
+	var sawExhausted bool
+	for _, w := range warnLines {
+		if w == "source watcher restart attempt budget exhausted; relying on reconciler for recovery" {
+			sawExhausted = true
+			break
+		}
+	}
+	require.True(t, sawExhausted,
+		"onWatcherRetryExhausted must emit the named WARN line at exhaustion; got %v", warnLines)
+}
+
+// TestRestartWatcher_ContextCancelStopsCleanly verifies a cancelled
+// context terminates the envelope without firing the permanent-failure
+// callback (cancellation ≠ exhaustion).
+func TestRestartWatcher_ContextCancelStopsCleanly(t *testing.T) {
+	// Use a generous backoff so the test exercises the "cancel during
+	// sleep" path (default 2s base is plenty); does not touch the
+	// shared package vars so concurrent tests are unaffected.
+
+	bucketGone := errors.New("simulated")
+
+	var warnMu sync.Mutex
+	var warnLines []string
+	spy := &captureWarnLogger{
+		mu:    &warnMu,
+		warns: &warnLines,
+	}
+
+	s := &NatsKV{logger: spy}
+	s.watchFn = func(context.Context) (jetstream.KeyWatcher, error) {
+		return nil, bucketGone
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.restartWatcher(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("restartWatcher did not exit promptly after ctx cancel")
+	}
+
+	warnMu.Lock()
+	defer warnMu.Unlock()
+	for _, w := range warnLines {
+		if w == "source watcher restart attempt budget exhausted; relying on reconciler for recovery" {
+			t.Fatalf("context cancel must NOT fire the exhaustion WARN; got %q", w)
+		}
+	}
+}
+
+// captureWarnLogger records WARN messages so the bounded-envelope test
+// can assert on the exhaustion line without coupling to the production
+// logger.
+type captureWarnLogger struct {
+	mu    *sync.Mutex
+	warns *[]string
+}
+
+func (l *captureWarnLogger) Debug(string, ...any) {}
+func (l *captureWarnLogger) Info(string, ...any)  {}
+func (l *captureWarnLogger) Warn(msg string, _ ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	*l.warns = append(*l.warns, msg)
+}
+func (l *captureWarnLogger) Error(string, ...any) {}
+func (l *captureWarnLogger) Fatal(string, ...any) {}

--- a/source/nats_kv_unavailable_hook_test.go
+++ b/source/nats_kv_unavailable_hook_test.go
@@ -1,0 +1,312 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// f6aBucketSeq mints a fresh bucket name per test, avoiding the
+// invalid-bucket-name issue with t.Name().
+var f6aBucketSeq atomic.Uint64
+
+// hookRecorder captures every SourceUnavailableHook invocation so
+// the F6-A tests can assert on count and most-recent error.
+type hookRecorder struct {
+	mu     sync.Mutex
+	errs   []error
+	calls  atomic.Int64
+	notify chan struct{} // closed lazily on first call when set
+}
+
+func (r *hookRecorder) fn() SourceUnavailableHook {
+	return func(err error) {
+		r.mu.Lock()
+		r.errs = append(r.errs, err)
+		r.mu.Unlock()
+		r.calls.Add(1)
+		if r.notify != nil {
+			select {
+			case r.notify <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+func (r *hookRecorder) snapshot() []error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]error, len(r.errs))
+	copy(out, r.errs)
+
+	return out
+}
+
+// gaugeMetrics is a SourceMetrics implementation that exposes the
+// most-recent SetSourceBucketMissing value so tests can assert on the
+// transitions without scraping logs.
+type gaugeMetrics struct {
+	missing atomic.Bool
+	sets    atomic.Int64
+}
+
+func (g *gaugeMetrics) SetSourceBucketMissing(missing bool) {
+	g.missing.Store(missing)
+	g.sets.Add(1)
+}
+
+// f6aFixture bundles the four values an F6-A integration sub-test needs:
+// the cached KV handle, the JetStream context (for triggering the bucket
+// delete mid-test), the test context, and the bucket name.
+type f6aFixture struct {
+	kv     jetstream.KeyValue
+	js     jetstream.JetStream
+	ctx    context.Context
+	bucket string
+}
+
+// newKVForF6ATest spins an embedded NATS, creates a fresh source
+// bucket, and returns the fixture. The bucket name is unique per call
+// so concurrent t.Parallel sub-tests do not collide.
+func newKVForF6ATest(t *testing.T) f6aFixture {
+	t.Helper()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	bucket := fmt.Sprintf("f6a-%d", f6aBucketSeq.Add(1))
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	return f6aFixture{kv: kv, js: js, ctx: ctx, bucket: bucket}
+}
+
+// TestNatsKV_F6A_BucketMissing_FiresHookAndSetsMetric covers the
+// hook + metric path end-to-end with a real NATS server, a real
+// bucket-delete, and an active reconciler.
+func TestNatsKV_F6A_BucketMissing_FiresHookAndSetsMetric(t *testing.T) {
+	t.Parallel()
+
+	f := newKVForF6ATest(t)
+	kv, js, ctx, bucket := f.kv, f.js, f.ctx, f.bucket
+
+	rec := &hookRecorder{notify: make(chan struct{}, 8)}
+	gauge := &gaugeMetrics{}
+	src := NewNatsKV(kv, "config", nil,
+		WithReconcileInterval(150*time.Millisecond),
+		WithUnavailableHook(rec.fn()),
+		WithMetrics(gauge),
+	)
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(ctx) })
+
+	require.False(t, gauge.missing.Load(),
+		"gauge must read 0 on a healthy source pre-delete")
+
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+
+	// Wait for the hook to fire from a reconcile or watcher-restart tick.
+	select {
+	case <-rec.notify:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("hook did not fire within 2s after bucket delete; calls=%d gauge=%t", rec.calls.Load(), gauge.missing.Load())
+	}
+
+	require.GreaterOrEqual(t, rec.calls.Load(), int64(1), "hook must fire at least once")
+	errs := rec.snapshot()
+	require.NotEmpty(t, errs)
+	// Empirical reality (verified with a probe against nats.go v1.50.0):
+	// after js.DeleteKeyValue, a cached KV's Get returns nats.ErrNoResponders
+	// (the JetStream subject has no listener anymore), and the cached
+	// watcher's Watch returns jetstream.ErrStreamNotFound (the backing
+	// KV_<bucket> stream is gone). jetstream.ErrBucketNotFound is only
+	// surfaced by the lookup-path js.KeyValue(...), which neither the
+	// reconciler nor restartWatcher uses. The hook may legitimately receive
+	// any of the three.
+	lastErr := errs[len(errs)-1]
+	require.True(t, isBucketUnavailableErr(lastErr),
+		"hook error must be classified as bucket-unavailable; got %v", lastErr)
+	require.True(t, gauge.missing.Load(),
+		"metric gauge must read 1 (missing) after bucket-loss detection")
+}
+
+// TestNatsKV_F6A_HookCooldown_LimitsFiringRate ensures the hook is
+// rate-limited (default 30s but overridable via a test seam) so the
+// reconcile loop's tick cadence does not flood the caller.
+func TestNatsKV_F6A_HookCooldown_LimitsFiringRate(t *testing.T) {
+	t.Parallel()
+
+	f := newKVForF6ATest(t)
+	kv, js, ctx, bucket := f.kv, f.js, f.ctx, f.bucket
+
+	rec := &hookRecorder{}
+	gauge := &gaugeMetrics{}
+	src := NewNatsKV(kv, "config", nil,
+		WithReconcileInterval(80*time.Millisecond),
+		WithUnavailableHook(rec.fn()),
+		WithMetrics(gauge),
+	)
+	// Test-only seam: shorten the cooldown so the assertion runs in
+	// bounded test time. Production default is 30s.
+	src.unavailableCooldown = 250 * time.Millisecond
+
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(ctx) })
+
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+
+	// Let the reconciler tick several times within the cooldown window.
+	require.Eventually(t, func() bool { return rec.calls.Load() >= 1 },
+		2*time.Second, 20*time.Millisecond,
+		"first hook firing must arrive promptly after bucket delete")
+	firstSeen := time.Now()
+
+	// Polled at 4× the reconcile cadence; over one cooldown window the
+	// hook must NOT fire a second time.
+	time.Sleep(220 * time.Millisecond) // still inside the 250ms cooldown
+	require.Equal(t, int64(1), rec.calls.Load(),
+		"hook must be suppressed within the cooldown window; got %d calls", rec.calls.Load())
+
+	// Advance past the cooldown and confirm a second firing is allowed.
+	elapsed := time.Since(firstSeen)
+	if elapsed < src.unavailableCooldown+50*time.Millisecond {
+		time.Sleep(src.unavailableCooldown + 50*time.Millisecond - elapsed)
+	}
+	require.Eventually(t, func() bool { return rec.calls.Load() >= 2 },
+		2*time.Second, 30*time.Millisecond,
+		"hook must fire again after cooldown elapses")
+}
+
+// TestNatsKV_F6A_RecoveryClearsGauge confirms the gauge transitions
+// back to 0 when the bucket is re-created. The hook is NOT re-fired
+// on recovery — escalation is one-way; the gauge is the recovery
+// signal.
+func TestNatsKV_F6A_RecoveryClearsGauge(t *testing.T) {
+	t.Parallel()
+
+	f := newKVForF6ATest(t)
+	kv, js, ctx, bucket := f.kv, f.js, f.ctx, f.bucket
+
+	rec := &hookRecorder{notify: make(chan struct{}, 8)}
+	gauge := &gaugeMetrics{}
+	src := NewNatsKV(kv, "config", nil,
+		WithReconcileInterval(100*time.Millisecond),
+		WithUnavailableHook(rec.fn()),
+		WithMetrics(gauge),
+	)
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(ctx) })
+
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+
+	select {
+	case <-rec.notify:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hook did not fire within 2s after bucket delete")
+	}
+	require.True(t, gauge.missing.Load())
+	preRecoveryCalls := rec.calls.Load()
+
+	// Re-create the bucket under the same name; the next successful
+	// kv.Get from the reconciler should clear the gauge.
+	_, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return !gauge.missing.Load() },
+		3*time.Second, 50*time.Millisecond,
+		"gauge must clear once the bucket is reachable again")
+	require.Equal(t, preRecoveryCalls, rec.calls.Load(),
+		"hook MUST NOT re-fire on recovery; escalation is one-way")
+}
+
+// TestNatsKV_F6A_NoHook_NoPanic exercises the documented "no hook
+// configured" path: the reconcile keeps running, the metric is set,
+// and nothing panics.
+func TestNatsKV_F6A_NoHook_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	f := newKVForF6ATest(t)
+	kv, js, ctx, bucket := f.kv, f.js, f.ctx, f.bucket
+
+	gauge := &gaugeMetrics{}
+	src := NewNatsKV(kv, "config", nil,
+		WithReconcileInterval(120*time.Millisecond),
+		WithMetrics(gauge),
+	)
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(ctx) })
+
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+	require.Eventually(t, func() bool { return gauge.missing.Load() },
+		3*time.Second, 50*time.Millisecond,
+		"gauge must still flip even without a hook configured")
+}
+
+// TestNatsKV_F6A_NoMetrics_NoPanic exercises the documented "no
+// metrics configured" path: the hook still fires; nothing panics.
+func TestNatsKV_F6A_NoMetrics_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	f := newKVForF6ATest(t)
+	kv, js, ctx, bucket := f.kv, f.js, f.ctx, f.bucket
+
+	rec := &hookRecorder{notify: make(chan struct{}, 8)}
+	src := NewNatsKV(kv, "config", nil,
+		WithReconcileInterval(100*time.Millisecond),
+		WithUnavailableHook(rec.fn()),
+	)
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(ctx) })
+
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+
+	select {
+	case <-rec.notify:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hook did not fire within 2s after bucket delete")
+	}
+}
+
+// TestNatsKV_F6A_DefaultCooldown_PureUnit exercises the cooldown
+// arithmetic without spinning a NATS server. Asserts that three
+// rapid-fire noteBucketUnavailable calls produce exactly one hook
+// invocation under the default cooldown.
+func TestNatsKV_F6A_DefaultCooldown_PureUnit(t *testing.T) {
+	t.Parallel()
+
+	rec := &hookRecorder{}
+	src := &NatsKV{
+		logger:          nil,
+		metrics:         types.NopSourceMetrics{},
+		unavailableHook: rec.fn(),
+		// unavailableCooldown intentionally left at zero-value to
+		// confirm the constructor-applied default is what the test
+		// expects (NewNatsKV must set it to 30s; here we mimic the
+		// default explicitly so the test is independent of that).
+		unavailableCooldown: 30 * time.Second,
+	}
+
+	bucketGoneErr := fmt.Errorf("simulated: %w", jetstream.ErrBucketNotFound)
+	for range 3 {
+		require.True(t, src.noteBucketUnavailable(bucketGoneErr),
+			"noteBucketUnavailable must return true on a wrapped ErrBucketNotFound")
+	}
+	require.Equal(t, int64(1), rec.calls.Load(),
+		"three rapid-fire calls under a 30s cooldown must fire the hook exactly once")
+
+	// Non-matching error must not advance the counters or fire.
+	require.False(t, src.noteBucketUnavailable(errors.New("unrelated")))
+	require.Equal(t, int64(1), rec.calls.Load())
+}

--- a/test/simulation/internal/natsutil/embedded.go
+++ b/test/simulation/internal/natsutil/embedded.go
@@ -34,7 +34,11 @@ func StartEmbeddedNATS() (*server.Server, *nats.Conn, error) {
 		return nil, nil, errors.New("NATS server not ready")
 	}
 
-	nc, err := nats.Connect(ns.ClientURL())
+	// Use MaxReconnects(-1) — the recommended Parti posture (see
+	// docs/OPERATIONS.md "NATS Client Connection"). The simulation
+	// runs against an embedded server that does not go away during
+	// the run; an unlimited reconnect budget is appropriate.
+	nc, err := nats.Connect(ns.ClientURL(), nats.MaxReconnects(-1))
 	if err != nil {
 		ns.Shutdown()
 		return nil, nil, fmt.Errorf("failed to connect to NATS: %w", err)

--- a/types/source_metrics.go
+++ b/types/source_metrics.go
@@ -1,0 +1,32 @@
+package types
+
+// SourceMetrics captures source-layer health metrics.
+//
+// Implementations must be non-blocking and thread-safe. A no-op
+// implementation ([NopSourceMetrics]) is provided for callers that do
+// not need source metrics.
+//
+// This interface is intentionally separate from [MetricsCollector] because
+// the source layer is independent of the Manager runtime — a
+// [WatchablePartitionSource] can run standalone, without a Manager, and the
+// source-side observability surface is small enough that bundling it into
+// the larger collector would add coupling without value.
+type SourceMetrics interface {
+	// SetSourceBucketMissing reports whether the partition-source bucket is
+	// currently observed to be missing on the live connection. true =
+	// missing (the gauge reads 1); false = available (the gauge reads 0).
+	//
+	// Called from the source's reconcile / restart goroutines at the first
+	// bucket-loss observation and again when a subsequent successful
+	// operation confirms recovery. The error surface that classifies as
+	// "missing" is broader than a single sentinel — implementations should
+	// not assume a specific [jetstream] / [nats] error type. Implementations
+	// should treat repeated identical values as idempotent.
+	SetSourceBucketMissing(missing bool)
+}
+
+// NopSourceMetrics is a no-op implementation of [SourceMetrics] suitable as
+// the default when callers do not wire a real collector.
+type NopSourceMetrics struct{}
+
+func (NopSourceMetrics) SetSourceBucketMissing(bool) {}


### PR DESCRIPTION
## Summary

Implements 10 of 13 in-scope PRs from `docs/plans/self-healing/` plus one config follow-up. The plan targets Parti's tolerance for transient faults and consumer loss, with the organising invariant **every unrecoverable failure must trip the Kubernetes readiness probe** and the goal of avoiding thundering-herd patterns (infinite election, reassign-partition loops).

## What's in this PR (13 commits, plan order)

**Phase 0 — low-risk warm-ups**
- `f4cd635 feat(manager): warn at Start when nats.Conn has a finite MaxReconnect` *(F7)*
- `d469dcc feat(source): warn when NatsKV reconciler is disabled without leadership probe` *(F8)*
- `58f298e feat(manager): warn when two-phase handoff is enabled but the consumer has no processing gate` *(F10-B)*

**Phase 1 — additive correctness**
- `2e870c8 feat(source): escalate bucket-loss via SourceUnavailableHook + missing-gauge` *(F6-A; folded: Godoc widening to reflect full empirical bucket-loss surface)*
- `ba8a245 fix(stableid): classify bucket-missing renewal errors as ErrClaimLost` *(F3)*
- `2bb8c93 feat(manager): epoch fence — detect bucket wipe-and-recreate via stream Created` *(F1)*

**Phase 2 — dominant fixes (partial: 3 of 6 PRs)**
- `df4b93d feat(manager): election bucket on FileStorage + OperationTimeout warning` *(F9-A)*
- `5cc68f1 feat(config): add KVBuckets.Replicas + warn-on-mismatch helper` *(follow-up to F9-A)*
- `aa89d0d feat(retry,source): bounded-retry envelope + restartWatcher wiring` *(F2 — envelope introduction, P2.4a)*
- `dade6e0 feat(calculator): refuse to rebalance on unconfirmed empty/shrunk partition input` *(F6-B; folded: re-arm pending on suspicious observation + state-machine log-skip for benign sentinel)*

**Docs + cleanup**
- `352c37c docs(self-healing): per-PR specs + STATUS for the in-flight branches`
- `36b2ae6 docs(self-healing): record kvbuckets-replicas follow-up in STATUS`
- `644ae7e simplify(docs): drop in-flight plan markers from Godoc`

## Out of scope (still to come)

- P2.4b — envelope reuse on handoff-claim resolver
- P2.4c — envelope reuse on assignment watcher
- P2.4d — envelope reuse on dynamic-consumer recovery
- P2.3 — F5 stream-gone hook + checkpoint reset (depends on P2.4d)
- P2.5 — F10-A truncated-Keys defense + worker-set floor (chaos-reproducer-gated)

Phase 3 (F9-B lease-aware leader, F4 in-process re-provision) remains deferred per the plan.

## Verification

- `make lint` clean (0 issues)
- `make test` (race detector) green across 35 packages
- Three rounds of external codex review on the integrated stack — final verdict **MERGE-CLEAN**
- Each underlying PR was independently verified via reproducer-first testing for every behavior change

## Empirical findings recorded during implementation

Three non-obvious facts about the nats.go KV surface that the original plan did not name; the implementations ship with the empirically-correct error sets:

1. **After `js.DeleteKeyValue`** no production call site returns `jetstream.ErrBucketNotFound` — `kv.Get` returns `nats.ErrNoResponders`, `kv.Watch` returns `jetstream.ErrStreamNotFound`, `kv.Update` returns `jetstream.ErrNoStreamResponse`. Only `js.KeyValue(...)` lookup returns `ErrBucketNotFound`.
2. **No `Config.Replicas` field exists on Parti's runtime config** (only on `provision.Config`). The follow-up commit adds `Config.KVBuckets.Replicas` as the operator-ergonomics fix, nested for naming clarity.
3. **`UpdateStream` accepts post-create Replicas changes** but the follow-up deliberately does NOT auto-reconcile — Replicas is HA quality, not a correctness invariant like MaxAge; the get-first contract stays the safer default. `warnOnReplicasMismatch` surfaces divergence so operators can issue `nats stream update KV_<bucket> --replicas=N` themselves.

Pinned in `docs/plans/self-healing/STATUS.md` § "Empirical findings discovered during implementation".

## Merge

Use **"Rebase and merge"** to preserve the per-feature commit boundaries. The 13 commits are designed to land linearly on `main`.
