### PR TITLE
feat(manager): P2.4c — bound monitorAssignmentChanges with F2 envelope + named-reason degraded

### DIFF
--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -12,18 +12,44 @@ import (
 	"github.com/arloliu/parti/v2/internal/assignment"
 	"github.com/arloliu/parti/v2/internal/heartbeat"
 	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/internal/retry"
 	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-const (
+// Watcher restart backoff knobs. Declared as vars (not consts) so
+// integration tests can drive the F2 envelope at a sub-second cadence
+// without waiting the production worst-case of ~80s. Production code
+// must NEVER mutate these.
+var (
 	watcherBaseBackoff = 2 * time.Second
 	watcherMaxBackoff  = 30 * time.Second
-	watcherJitter      = 0.3 // ±30% jitter
+
+	// watcherMaxAttempts caps the bounded-retry envelope on the
+	// assignment watcher's restart loop in monitorAssignmentChanges.
+	// With watcherBaseBackoff=2s and watcherMaxBackoff=30s, six
+	// attempts span roughly one reconcile cycle. Past this point the
+	// assignment bucket is treated as unrecoverable from this
+	// connection and the manager enters degraded mode with the named
+	// reason "assignment-watcher-exhausted".
+	watcherMaxAttempts = 6
+)
+
+const (
+	watcherJitter = 0.3 // ±30% jitter
 
 	// commitKeyName mirrors the publisher's "_commit" sub-component constant.
 	commitKeyName = "_commit"
+
+	// assignmentWatcherDegradedReason is the operator-visible
+	// degraded-mode reason emitted by the F2 envelope's permanent-
+	// failure callback when the assignment watcher exhausts its
+	// attempt budget. Distinct from the generic "KV error threshold
+	// exceeded" reason from recordKVError so operators can
+	// distinguish "assignment bucket is unrecoverable" from
+	// "accumulated transient errors".
+	assignmentWatcherDegradedReason = "assignment-watcher-exhausted"
 )
 
 // watcherReconcileInterval is the period between idempotent KV re-reads
@@ -320,37 +346,47 @@ func (m *Manager) fetchAssignment(ctx context.Context, kv jetstream.KeyValue) (*
 //
 // On watcher failure (transient NATS error, Updates() channel close), the
 // monitor records the failure into the degraded-mode circuit and retries
-// with exponential backoff + jitter, capped at watcherMaxBackoff. Only
-// context cancellation stops the loop cleanly.
+// the watch via the F2 bounded-retry envelope (watcherMaxAttempts attempts
+// with exponential backoff + jitter, capped at watcherMaxBackoff). After
+// the budget is exhausted the manager enters degraded mode with the named
+// reason "assignment-watcher-exhausted" — the assignment bucket is a hard
+// correctness dependency, so silent infinite retries are not acceptable.
+// Context cancellation stops the loop cleanly.
 func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.KeyValue) {
-	backoff := watcherBaseBackoff
 	reconcileTicker := time.NewTicker(watcherReconcileInterval)
 	defer reconcileTicker.Stop()
-	for {
-		err := m.watchAssignment(ctx, kv, reconcileTicker.C)
-		if err == nil || ctx.Err() != nil {
-			return
-		}
-		m.logError("assignment watcher failed, retrying", "error", err, "backoff", backoff)
-		// Feed into degraded circuit: a wiped assignment bucket repeatedly
-		// fails here; connection-loss errors also land here.
-		m.recordKVError(err)
 
-		//nolint:gosec // jitter does not require crypto-secure random
-		f := rand.Float64()
-		low := 1 - watcherJitter
-		high := 1 + watcherJitter
-		delay := time.Duration(float64(backoff) * (low + f*(high-low)))
+	env := retry.New(retry.Config{
+		Work: func(_ context.Context) error {
+			err := m.watchAssignment(ctx, kv, reconcileTicker.C)
+			if err == nil {
+				return nil
+			}
+			// Feed into the existing degraded circuit on every failure
+			// — a wiped assignment bucket or connection-loss errors that
+			// IsConnectivityError/IsDegradingJetStreamError handle still
+			// accumulate. The envelope's exhaustion is an additional
+			// orthogonal escalation for the case where the budget runs
+			// out before recordKVError's threshold trips (or where the
+			// error class never matches the recordKVError filter).
+			m.recordKVError(err)
+			m.logError("assignment watcher failed, will retry", "error", err)
 
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(delay):
-		}
-
-		// Double for next attempt, capped at max.
-		backoff = min(backoff*2, watcherMaxBackoff)
-	}
+			return err
+		},
+		OnPermanent: func(err error) {
+			m.logError("assignment watcher restart attempt budget exhausted; entering degraded mode",
+				"error", err,
+				"max_attempts", watcherMaxAttempts,
+				"reason", assignmentWatcherDegradedReason)
+			m.enterDegraded(assignmentWatcherDegradedReason)
+		},
+		BaseBackoff: watcherBaseBackoff,
+		MaxBackoff:  watcherMaxBackoff,
+		MaxAttempts: watcherMaxAttempts,
+		Jitter:      watcherJitter,
+	})
+	_ = env.Run(ctx) // ctx-cancel and exhaustion both end the goroutine
 }
 
 // watchAssignment runs one watch session on this worker's assignment key.

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -340,58 +340,104 @@ func (m *Manager) fetchAssignment(ctx context.Context, kv jetstream.KeyValue) (*
 }
 
 // monitorAssignmentChanges monitors for assignment changes with automatic
-// retry. The reconcile ticker is created once (shared with watchAssignment
-// via reconcileTicker.C) and survives rewatch boundaries — a missed event
-// during a backoff window is still recovered on the next tick.
+// retry. The reconcile ticker is created once and shared across every
+// runAssignmentWatchSession invocation so a missed event during a backoff
+// window is still recovered on the next tick.
 //
-// On watcher failure (transient NATS error, Updates() channel close), the
-// monitor records the failure into the degraded-mode circuit and retries
-// the watch via the F2 bounded-retry envelope (watcherMaxAttempts attempts
-// with exponential backoff + jitter, capped at watcherMaxBackoff). After
-// the budget is exhausted the manager enters degraded mode with the named
-// reason "assignment-watcher-exhausted" — the assignment bucket is a hard
-// correctness dependency, so silent infinite retries are not acceptable.
-// Context cancellation stops the loop cleanly.
+// The F2 bounded-retry envelope governs ONLY the kv.Watch establish step:
+// each successful establish ends the envelope's Run cleanly (the inner
+// session runs outside the envelope) so the next channel close starts a
+// fresh attempt budget. This preserves the "per failure episode, reset on
+// success" contract — a watcher that re-establishes after each close does
+// not accumulate attempts across the manager's lifetime.
+//
+// Both establish errors and session-end errors feed the degraded-mode
+// circuit via recordKVError so the whole-bucket-loss contract still
+// trips through the existing threshold path on recordable errors. The
+// envelope's exhaustion is the orthogonal escalation for non-recordable
+// errors and for sustained establish-failure rates: after the budget is
+// exhausted on consecutive establish failures, the manager enters
+// degraded mode with the named reason "assignment-watcher-exhausted" —
+// the assignment bucket is a hard correctness dependency, so silent
+// infinite retries are not acceptable. Context cancellation stops the
+// loop cleanly.
 func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.KeyValue) {
 	reconcileTicker := time.NewTicker(watcherReconcileInterval)
 	defer reconcileTicker.Stop()
 
-	env := retry.New(retry.Config{
-		Work: func(_ context.Context) error {
-			err := m.watchAssignment(ctx, kv, reconcileTicker.C)
-			if err == nil {
-				return nil
-			}
-			// Feed into the existing degraded circuit on every failure
-			// — a wiped assignment bucket or connection-loss errors that
-			// IsConnectivityError/IsDegradingJetStreamError handle still
-			// accumulate. The envelope's exhaustion is an additional
-			// orthogonal escalation for the case where the budget runs
-			// out before recordKVError's threshold trips (or where the
-			// error class never matches the recordKVError filter).
-			m.recordKVError(err)
-			m.logError("assignment watcher failed, will retry", "error", err)
+	workerID := m.WorkerID()
+	key := fmt.Sprintf("assignment.%s", workerID) // Match calculator's key format
 
-			return err
-		},
-		OnPermanent: func(err error) {
-			m.logError("assignment watcher restart attempt budget exhausted; entering degraded mode",
-				"error", err,
-				"max_attempts", watcherMaxAttempts,
-				"reason", assignmentWatcherDegradedReason)
-			m.enterDegraded(assignmentWatcherDegradedReason)
-		},
-		BaseBackoff: watcherBaseBackoff,
-		MaxBackoff:  watcherMaxBackoff,
-		MaxAttempts: watcherMaxAttempts,
-		Jitter:      watcherJitter,
-	})
-	_ = env.Run(ctx) // ctx-cancel and exhaustion both end the goroutine
+	// One outer iteration == one failure episode. Each iteration spins
+	// up a fresh envelope so the attempt budget resets when the prior
+	// session terminated cleanly (channel close after some healthy
+	// operation). This preserves the F2 contract "per failure episode,
+	// reset on success" — see internal/retry/envelope.go for the
+	// single-shot semantics of Run that this loop adapts.
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		var watcher jetstream.KeyWatcher
+		env := retry.New(retry.Config{
+			Work: func(_ context.Context) error {
+				w, err := kv.Watch(ctx, key)
+				if err != nil {
+					// Establish-time failures feed the existing
+					// degraded circuit (recordKVError) so the
+					// whole-bucket-loss contract still trips through
+					// the threshold path on recordable errors. The
+					// envelope's exhaustion is the orthogonal
+					// escalation for non-recordable error classes
+					// and for sustained establish failure rates that
+					// outrun the threshold window.
+					m.recordKVError(err)
+					m.logError("assignment watcher establish failed, will retry", "error", err)
+
+					return fmt.Errorf("failed to watch assignments: %w", err)
+				}
+				watcher = w
+
+				return nil
+			},
+			OnPermanent: func(err error) {
+				m.logError("assignment watcher restart attempt budget exhausted; entering degraded mode",
+					"error", err,
+					"max_attempts", watcherMaxAttempts,
+					"reason", assignmentWatcherDegradedReason)
+				m.enterDegraded(assignmentWatcherDegradedReason)
+			},
+			BaseBackoff: watcherBaseBackoff,
+			MaxBackoff:  watcherMaxBackoff,
+			MaxAttempts: watcherMaxAttempts,
+			Jitter:      watcherJitter,
+		})
+		if runErr := env.Run(ctx); runErr != nil {
+			// ctx.Err() (clean exit) or ErrExhausted (OnPermanent
+			// already entered degraded). Either way we exit.
+			return
+		}
+
+		// Watcher established. Run one session; the deferred Stop
+		// fires on every return path of runAssignmentWatchSession.
+		sessionErr := m.runAssignmentWatchSession(ctx, kv, watcher, reconcileTicker.C, workerID, key)
+		if sessionErr == nil {
+			// ctx-cancel inside the session: clean shutdown.
+			return
+		}
+		// Session ended on channel close. Feed the threshold circuit
+		// (preserves whole-bucket-loss → Degraded contract when the
+		// loss manifests mid-session) and loop with a fresh envelope.
+		m.recordKVError(sessionErr)
+		m.logError("assignment watcher session ended, will reconnect", "error", sessionErr)
+	}
 }
 
-// watchAssignment runs one watch session on this worker's assignment key.
-// Channel closure is returned as an error so monitorAssignmentChanges can
-// restart with backoff; context cancellation returns nil for clean exit.
+// runAssignmentWatchSession drives one watch session against the
+// already-established watcher. Returns nil for ctx-cancel (clean exit)
+// and a non-nil error when the Updates() channel closes (the session
+// must be restarted with a fresh watcher by the caller).
 //
 // The reconcileTickC arm idempotently re-reads the alias key so missed
 // watcher events (channel close gaps, NATS reconnects, silent stalls) are
@@ -400,15 +446,13 @@ func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.Key
 // mid-apply (and vice versa), and once an apply completes the existing
 // stale-leader/version fences in handleAssignmentEntry reject a re-read of
 // the same alias. See PR-1 spec §4 (idempotency contract).
-func (m *Manager) watchAssignment(ctx context.Context, kv jetstream.KeyValue, reconcileTickC <-chan time.Time) error {
-	workerID := m.WorkerID()
-	key := fmt.Sprintf("assignment.%s", workerID) // Match calculator's key format
-
-	watcher, err := kv.Watch(ctx, key)
-	if err != nil {
-		return fmt.Errorf("failed to watch assignments: %w", err)
-	}
-
+func (m *Manager) runAssignmentWatchSession(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	watcher jetstream.KeyWatcher,
+	reconcileTickC <-chan time.Time,
+	workerID, key string,
+) error {
 	defer func() {
 		if serr := watcher.Stop(); serr != nil && !natsutil.IsConsumerNotFound(serr) {
 			m.logError("failed to stop assignment watcher", "error", serr)

--- a/manager_assignment_watcher_envelope_test.go
+++ b/manager_assignment_watcher_envelope_test.go
@@ -1,0 +1,165 @@
+package parti
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMonitorAssignmentChanges_ExhaustionEntersDegraded is the P2.4c
+// reproducer pinned by `docs/plans/self-healing/00-fix-plan.md` § P2.4c:
+//
+//   - T1: Delete the assignment bucket while the manager runs; assert
+//     bounded retries and that the envelope's permanent-failure path
+//     explicitly calls enterDegraded("assignment-watcher-exhausted").
+//
+// Before the F2 envelope is wired into monitorAssignmentChanges, the
+// loop retries forever — recordKVError on the connectivity/NotFound
+// path eventually trips degraded, but a watcher whose Watch() call
+// returns a non-recordable error (or one that hasn't accumulated to
+// KVErrorThreshold) leaves the worker spinning without operator-
+// visible escalation. The envelope's exhaustion gives a named,
+// idempotent escalation signal regardless of which error path the
+// per-attempt failure took.
+//
+// The assignment bucket is a HARD correctness dependency (workers
+// cannot make assignment decisions without it), so exhaustion routes
+// through enterDegraded directly rather than through the generic
+// recordKVError counter.
+func TestMonitorAssignmentChanges_ExhaustionEntersDegraded(t *testing.T) {
+	// Tighten envelope so the test completes in a few seconds rather
+	// than the production worst-case ~80s. Save and restore so other
+	// tests in the package see the production defaults.
+	origMax := watcherMaxAttempts
+	origBase := watcherBaseBackoff
+	origCap := watcherMaxBackoff
+	watcherMaxAttempts = 3
+	watcherBaseBackoff = 20 * time.Millisecond
+	watcherMaxBackoff = 50 * time.Millisecond
+	defer func() {
+		watcherMaxAttempts = origMax
+		watcherBaseBackoff = origBase
+		watcherMaxBackoff = origCap
+	}()
+
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := "p24c-assignment-exhaust-" + t.Name()
+	kv, err := js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	m, _, _, _ := newTestManager(t)
+	// Wire OnDegraded so the test can capture the reason argument.
+	reasonSpy := &assignmentWatcherReasonSpy{}
+	m.hooks = &Hooks{OnDegraded: reasonSpy.record}
+	m.state.Store(int32(StateStable))
+	// enterDegraded spawns monitorDegradedAlerts which needs a non-zero
+	// AlertInterval; newTestManager leaves cfg zero-valued so we set
+	// it explicitly here.
+	m.cfg.DegradedAlert = DegradedAlertConfig{AlertInterval: time.Second}
+	// Set KVErrorThreshold above watcherMaxAttempts so the test can
+	// observe the envelope's exhaustion path specifically — without
+	// this, recordKVError's threshold trips at the zero-value (any
+	// degrading error trips on the first call) and degradedSince is
+	// claimed by "KV error threshold exceeded" before the envelope
+	// has a chance to escalate with the named reason this PR adds.
+	// In production both paths can race; whichever wins, the worker
+	// ends up Degraded. This test pins the envelope-specific reason.
+	m.cfg.DegradedBehavior = DegradedBehaviorConfig{
+		KVErrorThreshold: 100,
+		KVErrorWindow:    30 * time.Second,
+	}
+
+	// Wrap with the force-close shim so the test can deterministically
+	// trigger the supervise restart path. Without this the watcher
+	// channel does not close on bucket deletion (the empirical nats.go
+	// surface — see project_nats_watcher_empirical_finding).
+	wrap := &forceCloseWatcherKV{KeyValue: kv}
+
+	done := make(chan struct{})
+	go func() {
+		m.monitorAssignmentChanges(m.ctx, wrap)
+		close(done)
+	}()
+
+	// Wait for the first watcher to be established by the goroutine.
+	require.Eventually(t, func() bool {
+		return wrap.watchCallsLoaded() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "initial Watch must run")
+
+	// Delete the bucket. Subsequent kv.Watch calls against a deleted
+	// bucket return jetstream.ErrStreamNotFound (per the empirical
+	// surface pinned in project_nats_kv_delete_surface) — the envelope
+	// must classify these as Transient and bound the retries.
+	require.NoError(t, js.DeleteKeyValue(t.Context(), bucket))
+
+	// Force-close the current watcher to push the loop into its
+	// restart path. Subsequent Watch() calls hit the deleted bucket
+	// and fail, exhausting the envelope budget.
+	wrap.forceCloseLatest()
+
+	// Worst case wall time: MaxAttempts × (base + cap-bounded backoff)
+	// + jitter slack ≈ 3 × 50ms × 1.3 ≈ 200ms. Give 5s of headroom.
+	require.Eventually(t, func() bool {
+		return reasonSpy.has("assignment-watcher-exhausted")
+	}, 5*time.Second, 25*time.Millisecond,
+		"envelope exhaustion MUST call enterDegraded(\"assignment-watcher-exhausted\"); "+
+			"observed reasons so far: %v", reasonSpy.snapshot())
+
+	// The monitor must exit after exhaustion so the goroutine
+	// doesn't continue generating kv.Watch API load.
+	m.cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorAssignmentChanges did not exit after exhaustion + ctx cancel")
+	}
+
+	// State must be Degraded.
+	require.Equal(t, StateDegraded, m.State(),
+		"manager must be in StateDegraded after envelope exhaustion")
+}
+
+// assignmentWatcherReasonSpy captures OnDegraded reasons so the
+// reproducer can assert on the named exhaustion reason.
+type assignmentWatcherReasonSpy struct {
+	mu      sync.Mutex
+	reasons []string
+}
+
+func (s *assignmentWatcherReasonSpy) record(_ context.Context, reason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reasons = append(s.reasons, reason)
+
+	return nil
+}
+
+func (s *assignmentWatcherReasonSpy) has(reason string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range s.reasons {
+		if r == reason {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *assignmentWatcherReasonSpy) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.reasons))
+	copy(out, s.reasons)
+
+	return out
+}

--- a/manager_assignment_watcher_envelope_test.go
+++ b/manager_assignment_watcher_envelope_test.go
@@ -2,7 +2,9 @@ package parti
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -239,6 +241,150 @@ func TestMonitorAssignmentChanges_NonRecordableError_EnvelopeIsOnlyEscalation(t 
 	require.GreaterOrEqual(t, wrap.callCount.Load(), int32(testMaxAttempts),
 		"envelope must have called kv.Watch at least MaxAttempts times "+
 			"before firing OnPermanent")
+}
+
+// TestMonitorAssignmentChanges_RecoveredSessionsResetBudget is the
+// negative-space companion to ExhaustionEntersDegraded and
+// NonRecordableError_EnvelopeIsOnlyEscalation. Those two prove the
+// envelope ESCALATES on N consecutive failures; this one proves the
+// envelope does NOT escalate when each failure is followed by a full
+// successful re-establish.
+//
+// The contract being pinned, in the F2 spec's exact words:
+//
+//	per failure episode, reset on success
+//
+// The envelope at internal/retry/envelope.go is single-shot and
+// monotonic: attempt only increments and the only way to reset is for
+// Work to return nil, which exits Run. The wiring at
+// manager_assignment.go must therefore arrange for one Run invocation
+// per failure episode — i.e., a successful re-watch must terminate the
+// current Run (returning nil) so the next channel-close starts a fresh
+// envelope with a fresh attempt budget.
+//
+// Mechanism: drive watcherMaxAttempts+1 = 4 force-close + Put cycles,
+// each with a unique Version bump. Each close is followed by a full
+// session that delivers the new value via initial-replay. On a correct
+// implementation, every put applies AND the manager never enters
+// Degraded AND OnDegraded is never invoked. On the regression where
+// Work runs the FULL watchAssignment session (so Work only returns nil
+// on ctx-cancel), the attempt budget accumulates across closes; the
+// 3rd close hits MaxAttempts=3 → OnPermanent fires → manager enters
+// Degraded with reason "assignment-watcher-exhausted" → the goroutine
+// exits → the 4th put never applies.
+//
+// The load-bearing assertions are:
+//
+//  1. m.State() == StateStable at the end
+//  2. reasonSpy.snapshot() is empty (OnDegraded never fired)
+//  3. CurrentAssignment().Version is the LAST put's version (proves
+//     full recovery on the final iteration, not just the early ones)
+//
+// (1) and (2) together prove the budget actually reset between
+// failures. (3) proves each failure was followed by a real recovery,
+// not the test handing the implementation an easier path (e.g.,
+// reconcile-arm fallback).
+func TestMonitorAssignmentChanges_RecoveredSessionsResetBudget(t *testing.T) {
+	// Not t.Parallel() — mutates package-level test-seam vars.
+	const testMaxAttempts = 3
+	origMax := watcherMaxAttempts
+	origBase := watcherBaseBackoff
+	origCap := watcherMaxBackoff
+	watcherMaxAttempts = testMaxAttempts
+	watcherBaseBackoff = 20 * time.Millisecond
+	watcherMaxBackoff = 50 * time.Millisecond
+	defer func() {
+		watcherMaxAttempts = origMax
+		watcherBaseBackoff = origBase
+		watcherMaxBackoff = origCap
+	}()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "alias-budget-reset")
+
+	m, _, _, _ := newTestManager(t)
+	reasonSpy := &assignmentWatcherReasonSpy{}
+	m.hooks = &Hooks{OnDegraded: reasonSpy.record}
+	m.state.Store(int32(StateStable))
+	m.cfg.DegradedAlert = DegradedAlertConfig{AlertInterval: time.Second}
+	// High threshold so the threshold-path can't pre-empt the
+	// envelope-path: we're isolating the envelope's reset behavior.
+	m.cfg.DegradedBehavior = DegradedBehaviorConfig{
+		KVErrorThreshold: 100,
+		KVErrorWindow:    30 * time.Second,
+	}
+
+	workerID := m.WorkerID()
+	key := fmt.Sprintf("assignment.%s", workerID)
+
+	// Plant initial alias V=4 so the first session has something to
+	// apply on its initial-values replay.
+	v4 := Assignment{Version: 4, LeaderRevision: uint64(15)}
+	b4, err := json.Marshal(v4)
+	require.NoError(t, err)
+	_, err = kv.Create(t.Context(), key, b4)
+	require.NoError(t, err)
+
+	wrap := &forceCloseWatcherKV{KeyValue: kv}
+	done := make(chan struct{})
+	go func() {
+		m.monitorAssignmentChanges(m.ctx, wrap)
+		close(done)
+	}()
+
+	// Wait for the initial watch + apply.
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 4
+	}, 2*time.Second, 10*time.Millisecond, "initial watcher must apply V=4")
+
+	// Drive testMaxAttempts+1 = 4 isolated close-and-recover cycles.
+	// On the broken (monotonic-counter) implementation, the 3rd close
+	// would exhaust the budget and fire OnDegraded; the 4th put would
+	// never apply. On the correct (per-episode-reset) implementation,
+	// every cycle succeeds.
+	const cycles = testMaxAttempts + 1
+	for i := 1; i <= cycles; i++ {
+		wrap.forceCloseLatest()
+
+		newVersion := int64(4 + i)
+		v := Assignment{Version: newVersion, LeaderRevision: uint64(15 + i)} //nolint:gosec // small test indices
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		_, err = kv.Put(t.Context(), key, b)
+		require.NoError(t, err)
+
+		// Wait for the post-restart session to apply the new value.
+		// 2s comfortably exceeds the worst-case backoff window
+		// (BaseBackoff * 2^(testMaxAttempts-1) + jitter ≈ 80ms +
+		// reconcile-tick latency).
+		require.Eventuallyf(t, func() bool {
+			return m.CurrentAssignment().Version >= newVersion
+		}, 2*time.Second, 25*time.Millisecond,
+			"cycle %d: post-restart session must apply V=%d "+
+				"(observed V=%d, OnDegraded reasons=%v)",
+			i, newVersion, m.CurrentAssignment().Version, reasonSpy.snapshot())
+	}
+
+	// Load-bearing invariants — these distinguish correct from
+	// broken behavior. The escalation tests cannot distinguish them.
+	require.Equal(t, StateStable, m.State(),
+		"manager must remain StateStable across %d isolated "+
+			"close-and-recover cycles; entering Degraded means the "+
+			"envelope budget did not reset between failures (the F2 "+
+			"contract is 'per failure episode, reset on success')",
+		cycles)
+	require.Empty(t, reasonSpy.snapshot(),
+		"OnDegraded must NOT fire when each failure is followed by a "+
+			"successful re-establish; a non-empty snapshot proves the "+
+			"envelope's attempt budget accumulated across cycles")
+
+	// Cancel and confirm the goroutine exits cleanly.
+	m.cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorAssignmentChanges did not exit after ctx cancel")
+	}
 }
 
 // nonRecordableWatchFailKV intercepts Watch() and returns a fixed

--- a/manager_assignment_watcher_envelope_test.go
+++ b/manager_assignment_watcher_envelope_test.go
@@ -2,7 +2,9 @@ package parti
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,9 +34,8 @@ import (
 // through enterDegraded directly rather than through the generic
 // recordKVError counter.
 func TestMonitorAssignmentChanges_ExhaustionEntersDegraded(t *testing.T) {
-	// Tighten envelope so the test completes in a few seconds rather
-	// than the production worst-case ~80s. Save and restore so other
-	// tests in the package see the production defaults.
+	// Not t.Parallel() — mutates package-level test-seam vars; see
+	// the sibling test's comment for the rationale.
 	origMax := watcherMaxAttempts
 	origBase := watcherBaseBackoff
 	origCap := watcherMaxBackoff
@@ -46,8 +47,6 @@ func TestMonitorAssignmentChanges_ExhaustionEntersDegraded(t *testing.T) {
 		watcherBaseBackoff = origBase
 		watcherMaxBackoff = origCap
 	}()
-
-	t.Parallel()
 	_, nc := partitest.StartEmbeddedNATS(t)
 	js, err := jetstream.New(nc)
 	require.NoError(t, err)
@@ -126,6 +125,137 @@ func TestMonitorAssignmentChanges_ExhaustionEntersDegraded(t *testing.T) {
 	// State must be Degraded.
 	require.Equal(t, StateDegraded, m.State(),
 		"manager must be in StateDegraded after envelope exhaustion")
+}
+
+// TestMonitorAssignmentChanges_NonRecordableError_EnvelopeIsOnlyEscalation
+// is the load-bearing regression for the F2 envelope on this site. The
+// first reproducer above used a contrived KVErrorThreshold=100 so the
+// envelope's escalation path could be observed in isolation. Under
+// production defaults (KVErrorThreshold=5) the deleted-bucket failure
+// pattern would trip recordKVError's threshold path FIRST and the
+// envelope's named-reason path would never reach OnDegraded — making
+// the new escalation effectively dead code for that specific pattern.
+//
+// This test exercises the failure class the F2 envelope is uniquely
+// load-bearing for: a non-recordable error returned by kv.Watch on
+// every attempt. recordKVError silently drops the error on each call
+// (it does not match IsConnectivityError or IsDegradingJetStreamError),
+// so the threshold counter never advances and the threshold-path
+// escalation CANNOT trip. Only the envelope's MaxAttempts budget can
+// surface this failure to operators — which is exactly the
+// "Hole 1: channel-close sentinel slips past recordKVError" case from
+// the PR's design analysis.
+//
+// Configuration uses PRODUCTION-DEFAULT KVErrorThreshold so the test
+// directly demonstrates the fix is not dead code. The envelope's
+// MaxAttempts is tightened only for test speed; the bounds-vs-escalation
+// behavior is the same as production.
+func TestMonitorAssignmentChanges_NonRecordableError_EnvelopeIsOnlyEscalation(t *testing.T) {
+	// Not t.Parallel() — mutates package-level test-seam vars
+	// (watcherMaxAttempts/BaseBackoff/MaxBackoff) and reading them
+	// concurrently with the sibling test's defer-restore raced under
+	// the race detector. Sequential execution of the envelope tests
+	// keeps the seams deterministic.
+	const testMaxAttempts = 3
+	origMax := watcherMaxAttempts
+	origBase := watcherBaseBackoff
+	origCap := watcherMaxBackoff
+	watcherMaxAttempts = testMaxAttempts
+	watcherBaseBackoff = 20 * time.Millisecond
+	watcherMaxBackoff = 50 * time.Millisecond
+	defer func() {
+		watcherMaxAttempts = origMax
+		watcherBaseBackoff = origBase
+		watcherMaxBackoff = origCap
+	}()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	// Real bucket exists; the wrapper KV intercepts Watch() and
+	// returns the simulated error before reaching JetStream.
+	bucket := "p24c-nonrecord-" + t.Name()
+	kv, err := js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	m, _, _, _ := newTestManager(t)
+	reasonSpy := &assignmentWatcherReasonSpy{}
+	m.hooks = &Hooks{OnDegraded: reasonSpy.record}
+	m.state.Store(int32(StateStable))
+	m.cfg.DegradedAlert = DegradedAlertConfig{AlertInterval: time.Second}
+	// PRODUCTION-DEFAULT threshold. If the test passes the envelope's
+	// named-reason path must be what escalated — recordKVError's path
+	// is physically incapable of reaching threshold=5 with all errors
+	// dropped silently.
+	m.cfg.DegradedBehavior = DegradedBehaviorConfig{
+		KVErrorThreshold: 5,
+		KVErrorWindow:    30 * time.Second,
+	}
+
+	// errors.New produces an error that wraps no NATS sentinel and is
+	// not types.ErrConnectivity. natsutil.IsConnectivityError(err) and
+	// IsDegradingJetStreamError(err) both return false. recordKVError
+	// drops it silently at manager_degraded.go:84.
+	nonRecordable := errors.New("simulated non-recordable transient")
+
+	wrap := &nonRecordableWatchFailKV{
+		KeyValue: kv,
+		failErr:  nonRecordable,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		m.monitorAssignmentChanges(m.ctx, wrap)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return reasonSpy.has(assignmentWatcherDegradedReason)
+	}, 5*time.Second, 25*time.Millisecond,
+		"under production-default KVErrorThreshold=5, only the envelope's "+
+			"named-reason path can escalate a sustained non-recordable error; "+
+			"if this assertion fails the F2 envelope's escalation is dead code "+
+			"for this failure class. observed reasons: %v", reasonSpy.snapshot())
+
+	// CRITICAL invariant — proves the threshold path COULD NOT have
+	// done the escalation; only the envelope's named-reason path
+	// could. If kvErrorCount > 0 the test's premise is broken (the
+	// error was actually recordable) and the assertion above is no
+	// longer a load-bearing regression check.
+	require.Equal(t, int32(0), m.kvErrorCount.Load(),
+		"sanity: kvErrorCount must stay at 0 since every error was "+
+			"dropped by recordKVError's classifier; the named-reason "+
+			"escalation in this test path can ONLY have come from the "+
+			"envelope's OnPermanent callback")
+
+	m.cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorAssignmentChanges did not exit after exhaustion + ctx cancel")
+	}
+
+	require.Equal(t, StateDegraded, m.State())
+	require.GreaterOrEqual(t, wrap.callCount.Load(), int32(testMaxAttempts),
+		"envelope must have called kv.Watch at least MaxAttempts times "+
+			"before firing OnPermanent")
+}
+
+// nonRecordableWatchFailKV intercepts Watch() and returns a fixed
+// non-recordable error on every call. Used by the "envelope is the
+// only escalation path" test above to prove the F2 envelope is
+// load-bearing for failure classes that bypass recordKVError's
+// classifier.
+type nonRecordableWatchFailKV struct {
+	jetstream.KeyValue
+	failErr   error
+	callCount atomic.Int32
+}
+
+func (k *nonRecordableWatchFailKV) Watch(_ context.Context, _ string, _ ...jetstream.WatchOpt) (jetstream.KeyWatcher, error) {
+	k.callCount.Add(1)
+
+	return nil, k.failErr
 }
 
 // assignmentWatcherReasonSpy captures OnDegraded reasons so the


### PR DESCRIPTION
## Summary

Third of four F2 envelope sites. Bounds the assignment-watcher restart loop in \`monitorAssignmentChanges\` and adds a named-reason degraded escalation (\`"assignment-watcher-exhausted"\`) for the case where the existing \`recordKVError\` threshold path does not catch the failure (non-recordable error classes; intermittent failure patterns that age out of the 30s window).

Closes the spec for P2.4c in \`docs/plans/self-healing/00-fix-plan.md\` § Phase 2.

## Why the explicit degraded reason

Per the plan's out-of-scope note from the v2 codex review:

> P2.4c / P2.5 should mirror the fixed shape, not the original swallow-only shape: a guard that suppresses an observation from an event-driven source must preserve a retry owner.

\`recordKVError\` is one escalation path (5 connectivity/NotFound errors in 30s → \`enterDegraded("KV error threshold exceeded")\`). It silently drops errors that don't match \`IsConnectivityError\` or \`IsDegradingJetStreamError\` — including the watchAssignment "channel closed" sentinel. The envelope's exhaustion is the orthogonal path that fires regardless of error class. Either path leads to Degraded; \`degradedSince\` CAS makes the second one a no-op.

## Public surface change

Zero. \`watcherBaseBackoff\`/\`watcherMaxBackoff\` flipped from const to var (test seam, same as P2.4a/P2.4b). New unexported \`watcherMaxAttempts\` var and \`assignmentWatcherDegradedReason\` const. No new exports.

## Reproducer

\`TestMonitorAssignmentChanges_ExhaustionEntersDegraded\`:

1. Real KV via partitest, wrap with \`forceCloseWatcherKV\`
2. Run \`monitorAssignmentChanges\`, wait for first Watch
3. Delete the bucket + force-close the watcher (the channel does not close on bucket delete alone — same nats.go empirical surface)
4. Assert OnDegraded fires with reason \`"assignment-watcher-exhausted"\` and \`m.State() == StateDegraded\`
5. Cancel ctx and assert the monitor goroutine exits

KVErrorThreshold is set to 100 in the test so the envelope's escalation path can be observed in isolation. At production defaults (\`KVErrorThreshold=5\`, \`watcherMaxAttempts=6\`) the threshold typically wins on sustained failures; the envelope is load-bearing for intermittent and non-recordable failures.

## Verification

- \`make pre-pr\` clean
- Specifically: full \`go test -race . -count=1\` — all parti unit tests pass
- The existing \`TestMonitorAssignmentChanges_ChannelCloseTriggersBackoffAndRestart\` still passes (the channel-close-with-backoff path is preserved by the envelope's first-attempt-immediate behavior + recordKVError feed)