### PR TITLE
feat(durable): bound partition consumer iter-creation retry with F2 envelope

### DIFF
--- a/internal/durable/config.go
+++ b/internal/durable/config.go
@@ -25,6 +25,51 @@ const (
 	RecoverFromBeginning     = recovery.FromBeginning
 )
 
+// RecoveryRetryConfig configures the bounded-retry envelope wrapped
+// around the partition consumer's iterator-creation retry loop.
+//
+// On a vanished resource (consumer or stream deleted, or sustained
+// JetStream outage), iterator creation fails repeatedly. Without a
+// bound, the loop generated infinite consumer-create / iterator-create
+// API load against NATS and never surfaced an escalation signal. The
+// envelope caps consecutive iter-create failures at MaxAttempts; on
+// exhaustion it fires OnPermanentFailure once, logs at WARN, emits a
+// metric, and exits the consumption loop.
+//
+// Budget reset semantics: the envelope is constructed fresh on each
+// outer-loop iteration of the consumer's Run loop, so any iteration
+// that successfully obtains a usable iterator clears the accumulated
+// attempt count. Only consecutive failures within a single failure
+// episode count against the budget. See P2.4a (source/nats_kv.go
+// restartWatcher) for the canonical pattern this mirrors.
+//
+// BaseBackoff defaults to 500ms to compose with recovery.Controller's
+// internal minRecoveryInterval (also 500ms): a smaller BaseBackoff
+// would silently inflate the effective attempt budget because the
+// internal cooldown skips Classify's recover() call without consuming
+// an envelope attempt.
+type RecoveryRetryConfig struct {
+	// MaxAttempts is the total attempt budget per failure episode. After
+	// the Nth consecutive failure the envelope fires OnPermanentFailure
+	// and exits the consumption loop. Must be > 0.
+	// Default: DefaultRecoveryMaxAttempts.
+	MaxAttempts int `default:"8" validate:"gt=0"`
+
+	// BaseBackoff is the delay before the second attempt; doubles each
+	// step up to MaxBackoff. Must be > 0.
+	// Default: DefaultRecoveryBaseBackoff (500ms).
+	BaseBackoff time.Duration `default:"500ms" validate:"gt=0"`
+
+	// MaxBackoff caps the per-attempt delay. Must be >= BaseBackoff.
+	// Default: DefaultRecoveryMaxBackoff (30s).
+	MaxBackoff time.Duration `default:"30s" validate:"gt=0,gtefield=BaseBackoff"`
+
+	// Jitter is the ± fraction applied to each backoff delay
+	// (0..1 reasonable; 0 disables).
+	// Default: DefaultRecoveryJitter (0.2).
+	Jitter float64 `default:"0.2" validate:"gte=0,lte=1"`
+}
+
 // RetryConfig groups retry backoff settings.
 type RetryConfig struct {
 	// Backoff is the delay between retries for control-plane operations.
@@ -237,6 +282,22 @@ type WorkerConsumerConfig struct {
 	// If zero, defaults to DefaultIteratorEscalationThreshold.
 	IteratorEscalationThreshold int `default:"3" validate:"gt=0"`
 
+	// RecoveryRetry configures the bounded-retry envelope wrapped around
+	// the partition consumer's iterator-creation retry loop. See
+	// RecoveryRetryConfig for semantics.
+	RecoveryRetry RecoveryRetryConfig
+
+	// OnPermanentFailure is invoked exactly once per partition consumer
+	// when the iterator-creation retry envelope exhausts its attempt
+	// budget. Callers typically wire this to enterDegraded / Hooks.OnError
+	// at the Manager layer so a vanished consumer or stream trips
+	// readiness rather than generating infinite NATS API load.
+	//
+	// The callback runs synchronously on the consumption loop's goroutine
+	// immediately before the loop exits. It must be non-blocking; long
+	// work should be offloaded to a goroutine inside the callback.
+	OnPermanentFailure func(subject string, err error)
+
 	// AllowWorkerIDChange controls whether workerID changes are allowed after initialization.
 	// Default: false (immutable once set). Intended for controlled migrations only.
 	AllowWorkerIDChange bool
@@ -270,6 +331,12 @@ func DefaultWorkerConsumerConfig() WorkerConsumerConfig {
 		},
 		IteratorEscalationWindow:    DefaultIteratorEscalationWindow,
 		IteratorEscalationThreshold: DefaultIteratorEscalationThreshold,
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: DefaultRecoveryMaxAttempts,
+			BaseBackoff: DefaultRecoveryBaseBackoff,
+			MaxBackoff:  DefaultRecoveryMaxBackoff,
+			Jitter:      DefaultRecoveryJitter,
+		},
 		PartitionRefreshMinInterval: 500 * time.Millisecond,
 		DrainOnRemoveTimeout:        10 * time.Second,
 		Resolver: ResolverConfig{

--- a/internal/durable/constants.go
+++ b/internal/durable/constants.go
@@ -57,4 +57,29 @@ const (
 	// failures within the escalation window required to trigger a single
 	// escalation event (refresh) per window.
 	DefaultIteratorEscalationThreshold = 3
+
+	// DefaultRecoveryMaxAttempts is the default attempt budget for the
+	// bounded-retry envelope that wraps the partition consumer's
+	// iterator-creation retry loop. After this many consecutive iter-create
+	// failures the envelope transitions to permanent failure: it fires
+	// OnPermanentFailure exactly once, logs at WARN, emits a metric, and
+	// exits the consumption loop so no further consumer-create traffic is
+	// generated against the (presumed) vanished resource.
+	DefaultRecoveryMaxAttempts = 8
+
+	// DefaultRecoveryBaseBackoff is the default base delay between iter-create
+	// retry attempts. Set to 500ms to compose with (not fight)
+	// recovery.Controller's internal minRecoveryInterval (500ms cooldown
+	// between consecutive recover() calls) — a BaseBackoff below the
+	// cooldown would silently inflate the effective attempt budget when
+	// Classify hits the cooldown and returns ActionBackoff without consuming
+	// an envelope attempt.
+	DefaultRecoveryBaseBackoff = 500 * time.Millisecond
+
+	// DefaultRecoveryMaxBackoff caps the per-attempt delay.
+	DefaultRecoveryMaxBackoff = 30 * time.Second
+
+	// DefaultRecoveryJitter is the ± fraction applied to each backoff delay
+	// to avoid synchronized reconnect thundering herds across worker fleets.
+	DefaultRecoveryJitter = 0.2
 )

--- a/internal/durable/partition_consumer.go
+++ b/internal/durable/partition_consumer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/recovery"
+	"github.com/arloliu/parti/v2/internal/retry"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -27,6 +28,14 @@ type partitionConsumerConfig struct {
 	Retry                       RetryConfig
 	IteratorEscalationWindow    time.Duration
 	IteratorEscalationThreshold int
+
+	// RecoveryRetry configures the bounded-retry envelope wrapped around
+	// the iterator-creation retry loop. See RecoveryRetryConfig.
+	RecoveryRetry RecoveryRetryConfig
+
+	// OnPermanentFailure is fired exactly once when the iterator-creation
+	// envelope exhausts its attempt budget. See WorkerConsumerConfig.
+	OnPermanentFailure func(subject string, err error)
 
 	// Metrics
 	Metrics types.WorkerConsumerMetrics
@@ -93,6 +102,19 @@ func newPartitionConsumer(
 	config partitionConsumerConfig,
 	opts partitionConsumerOpts,
 ) *partitionConsumer {
+	// Apply recovery-envelope defaults once at construction so callers
+	// (including in-package tests) that omit RecoveryRetry don't trip
+	// retry.New's required-field panics on every outer-loop iteration.
+	if config.RecoveryRetry.MaxAttempts <= 0 {
+		config.RecoveryRetry.MaxAttempts = DefaultRecoveryMaxAttempts
+	}
+	if config.RecoveryRetry.BaseBackoff <= 0 {
+		config.RecoveryRetry.BaseBackoff = DefaultRecoveryBaseBackoff
+	}
+	if config.RecoveryRetry.MaxBackoff < config.RecoveryRetry.BaseBackoff {
+		config.RecoveryRetry.MaxBackoff = config.RecoveryRetry.BaseBackoff
+	}
+
 	return &partitionConsumer{
 		logger:               logger,
 		js:                   js,
@@ -164,28 +186,12 @@ func (pc *partitionConsumer) Run(ctx context.Context, handler messageHandler) {
 		cons := pc.consumer
 		pc.consumerMu.RUnlock()
 
-		// Create iterator and enter message processing loop.
-		pc.consInfoMu.Lock()
-		iter, err := pc.iterFactory(cons, batch, expiry)
-		pc.consInfoMu.Unlock()
+		// Iterator creation runs under a bounded-retry envelope; ErrExhausted
+		// (after OnPermanent fired) and ctx-cancel both terminate the loop.
+		// See RecoveryRetryConfig for the per-episode budget-reset semantics.
+		iter, err := pc.runIteratorEnvelope(ctx, cons, batch, expiry)
 		if err != nil {
-			pc.logger.Warn("iterator creation failed", "subject", pc.subject, "error", err)
-			if pc.config.Metrics != nil {
-				pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("transient")
-			}
-
-			// Iterator creation failures (from cons.Messages()) are distinct from
-			// iterator consumption failures (from iter.Next()). Consumer deletion
-			// is detected via iter.Next() errors, not creation errors. The legacy
-			// escalation mechanism handles creation failures (rebind the durable)
-			// regardless of recovery strategy.
-			pc.maybeEscalateIteratorFailures(ctx)
-
-			if pc.delayWithBackoffOrExit(ctx, "iterate") {
-				return
-			}
-
-			continue
+			return
 		}
 
 		exit, iterErr := pc.processIterator(ctx, iter, handler)
@@ -197,6 +203,75 @@ func (pc *partitionConsumer) Run(ctx context.Context, handler messageHandler) {
 		}
 		// loop continues to recreate iterator on next iteration
 	}
+}
+
+// runIteratorEnvelope drives one bounded-retry envelope around iterator
+// creation. Returns (iter, nil) on success, (nil, ErrExhausted) once
+// OnPermanentFailure has fired, or (nil, ctx.Err()) on cancellation.
+// Mirrors source/nats_kv.go:restartWatcher (P2.4a).
+func (pc *partitionConsumer) runIteratorEnvelope(
+	ctx context.Context,
+	cons jetstream.Consumer,
+	batch int,
+	expiry time.Duration,
+) (jetstream.MessagesContext, error) {
+	cfg := pc.config.RecoveryRetry
+
+	var iter jetstream.MessagesContext
+	env := retry.New(retry.Config{
+		Work: func(workCtx context.Context) error {
+			pc.consInfoMu.Lock()
+			i, err := pc.iterFactory(cons, batch, expiry)
+			pc.consInfoMu.Unlock()
+			if err != nil {
+				pc.logger.Warn("iterator creation failed", "subject", pc.subject, "error", err)
+				if pc.config.Metrics != nil {
+					pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("transient")
+				}
+				// Iterator creation failures (from cons.Messages()) are distinct from
+				// iterator consumption failures (from iter.Next()): consumer deletion
+				// is detected on Next() errors, not creation. The legacy per-subject
+				// escalation handles creation failures (rebind the durable) regardless
+				// of recovery strategy, so it runs inside the envelope.
+				pc.maybeEscalateIteratorFailures(workCtx)
+
+				return err
+			}
+			iter = i
+
+			return nil
+		},
+		OnPermanent: func(err error) {
+			pc.logger.Warn("partition consumer iterator-creation budget exhausted; entering permanent failure",
+				"op", "partition_consumer_permanent_failure",
+				"subject", pc.subject,
+				"durable", pc.durableName,
+				"max_attempts", cfg.MaxAttempts,
+				"error", err)
+			if pc.config.Metrics != nil {
+				pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("recovery_exhausted")
+			}
+			if pc.config.OnPermanentFailure != nil {
+				pc.config.OnPermanentFailure(pc.subject, err)
+			}
+		},
+		OnProgress: func(attempt int, err error) {
+			pc.logger.Debug("partition consumer iterator-creation retry",
+				"subject", pc.subject,
+				"attempt", attempt,
+				"max_attempts", cfg.MaxAttempts,
+				"error", err)
+		},
+		BaseBackoff: cfg.BaseBackoff,
+		MaxBackoff:  cfg.MaxBackoff,
+		MaxAttempts: cfg.MaxAttempts,
+		Jitter:      cfg.Jitter,
+	})
+	if err := env.Run(ctx); err != nil {
+		return nil, err
+	}
+
+	return iter, nil
 }
 
 func (pc *partitionConsumer) handleIteratorFailure(ctx context.Context, iterErr error) bool {

--- a/internal/durable/partition_consumer_envelope_test.go
+++ b/internal/durable/partition_consumer_envelope_test.go
@@ -1,0 +1,265 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+)
+
+// TestPartitionConsumer_RecoveryEnvelope_ExhaustsAndStops is the P2.4d
+// T1 reproducer: when iterator creation fails consecutively (the failure
+// mode that manifests when the underlying consumer/stream has vanished),
+// the bounded-retry envelope MUST cap consecutive attempts at MaxAttempts,
+// fire OnPermanentFailure exactly once, and exit the consumption loop
+// so that no further iter-create / consumer-create traffic is generated
+// against the vanished resource.
+//
+// Without the envelope wiring, the partition consumer's outer for-loop
+// retries iter creation indefinitely on every iteration with only
+// pc.config.Retry's per-iteration backoff in place — there is no overall
+// attempt cap and no escalation signal.
+func TestPartitionConsumer_RecoveryEnvelope_ExhaustsAndStops(t *testing.T) {
+	const maxAttempts = 3
+	var iterCallCount atomic.Int32
+	var permanentCalls atomic.Int32
+	var permanentSubject atomic.Pointer[string]
+
+	iterErr := errors.New("simulated iter-create failure (stream-gone)")
+
+	iterFactory := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		iterCallCount.Add(1)
+		return nil, iterErr
+	}
+
+	cfg := partitionConsumerConfig{
+		BatchSize:    1,
+		FetchTimeout: 50 * time.Millisecond,
+		Retry: RetryConfig{
+			Backoff:    10 * time.Millisecond,
+			Base:       10 * time.Millisecond,
+			Multiplier: 1.5,
+			Max:        20 * time.Millisecond,
+		},
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1000, // disabled — would otherwise call ensureConsumer (needs real js)
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: maxAttempts,
+			BaseBackoff: 10 * time.Millisecond,
+			MaxBackoff:  20 * time.Millisecond,
+			Jitter:      0,
+		},
+		OnPermanentFailure: func(subject string, _ error) {
+			permanentCalls.Add(1)
+			s := subject
+			permanentSubject.Store(&s)
+		},
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		nil, // js not needed; escalation threshold is gated above
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{},
+			consumer:       nil,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// After MaxAttempts (3) iter-create failures the envelope must fire
+	// OnPermanentFailure and the Run loop must return on its own (without
+	// ctx cancel).
+	select {
+	case <-runDone:
+		// expected — envelope exhausted, loop exited
+	case <-time.After(5 * time.Second):
+		t.Fatalf("partition consumer did not exit after envelope exhaustion; "+
+			"iterCallCount=%d, permanentCalls=%d (expected exactly %d iter calls and 1 permanent call)",
+			iterCallCount.Load(), permanentCalls.Load(), maxAttempts)
+	}
+
+	require.Equal(t, int32(maxAttempts), iterCallCount.Load(),
+		"iter creation must be capped at envelope MaxAttempts; without the envelope this is unbounded")
+	require.Equal(t, int32(1), permanentCalls.Load(),
+		"OnPermanentFailure must fire exactly once on exhaustion")
+	if s := permanentSubject.Load(); s == nil || *s != "subj.p1" {
+		t.Fatalf("OnPermanentFailure must receive the partition subject, got %v", s)
+	}
+}
+
+// TestPartitionConsumer_RecoveryEnvelope_RecoveredIterationsResetBudget
+// is the P2.4d negative-space test (per
+// feedback_test_both_directions_of_boundary). It asserts that K isolated
+// iter-create failures, each followed by a full recovery (a usable
+// iterator obtained AND consumed), do NOT accumulate against the
+// envelope's attempt budget. Each fresh outer-loop iteration must
+// construct a fresh envelope, so the total failure count over the
+// lifetime can exceed MaxAttempts without triggering permanent failure
+// — only consecutive failures within a single episode count.
+//
+// This is the test that would have caught the P2.4c v1 monotonic-budget
+// bug (Bug 3) if it had been written for that PR.
+func TestPartitionConsumer_RecoveryEnvelope_RecoveredIterationsResetBudget(t *testing.T) {
+	const maxAttempts = 3
+	const totalEpisodes = 5 // > maxAttempts in total, but none consecutive
+
+	iterErr := errors.New("simulated transient iter-create failure")
+
+	var (
+		mu              sync.Mutex
+		callIdx         int
+		iterFailureSeen int
+	)
+
+	// failPlan[i] == true means: on the i-th iter-create call, return error.
+	// Pattern: fail once, succeed once, fail once, succeed once, ... ensures
+	// no two consecutive failures.
+	var failPlan []bool
+	for i := 0; i < totalEpisodes; i++ {
+		failPlan = append(failPlan, true)  // fail
+		failPlan = append(failPlan, false) // succeed
+	}
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	})
+
+	iterFactory := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		mu.Lock()
+		idx := callIdx
+		callIdx++
+		mu.Unlock()
+
+		if idx < len(failPlan) && failPlan[idx] {
+			mu.Lock()
+			iterFailureSeen++
+			mu.Unlock()
+			return nil, iterErr
+		}
+		// Succeed: return an iterator that blocks on Next() until the test ends,
+		// then returns ErrMsgIteratorClosed (which the consumer treats as a clean exit).
+		return &blockingIter{stopCh: stopCh}, nil
+	}
+
+	var permanentCalls atomic.Int32
+
+	cfg := partitionConsumerConfig{
+		BatchSize:    1,
+		FetchTimeout: 50 * time.Millisecond,
+		Retry: RetryConfig{
+			Backoff:    5 * time.Millisecond,
+			Base:       5 * time.Millisecond,
+			Multiplier: 1.0,
+			Max:        10 * time.Millisecond,
+		},
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1000, // disabled
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: maxAttempts,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+			Jitter:      0,
+		},
+		OnPermanentFailure: func(_ string, _ error) { permanentCalls.Add(1) },
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		nil,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{},
+			consumer:       nil,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// Wait until we have observed >maxAttempts failures total — proves the
+	// envelope did NOT accumulate budget across recovered episodes.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return iterFailureSeen >= maxAttempts+1
+	}, 5*time.Second, 10*time.Millisecond, "expected >%d isolated iter-create failures across separate episodes", maxAttempts)
+
+	require.Equal(t, int32(0), permanentCalls.Load(),
+		"OnPermanentFailure must NOT fire when failures are interleaved with recoveries; "+
+			"firing here would be the monotonic-budget bug (Bug 3 lineage)")
+
+	// Clean shutdown.
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("partition consumer did not exit on ctx cancel")
+	}
+}
+
+// blockingIter is an iterator that blocks on Next() until stopCh is
+// closed, then returns ErrMsgIteratorClosed (the graceful-exit sentinel
+// the partition consumer's processIterator path filters to a nil
+// session error). Used by the negative-space test to simulate a healthy
+// iterator session that "completed cleanly" — driving a fresh outer
+// for-loop iteration and a fresh envelope construction.
+type blockingIter struct {
+	stopCh chan struct{}
+}
+
+func (b *blockingIter) Next(_ ...jetstream.NextOpt) (jetstream.Msg, error) {
+	// Short wait: simulate a brief usable iterator session. Returning
+	// ErrMsgIteratorClosed causes processIterator to return iterErr=nil,
+	// which loops back to a fresh outer iteration. That fresh iteration
+	// is the budget reset signal the test is probing.
+	select {
+	case <-b.stopCh:
+		return nil, jetstream.ErrMsgIteratorClosed
+	case <-time.After(20 * time.Millisecond):
+		return nil, jetstream.ErrMsgIteratorClosed
+	}
+}
+
+func (b *blockingIter) Stop()  {}
+func (b *blockingIter) Drain() {}

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -407,6 +407,8 @@ func (wc *WorkerConsumer) addSubjectLoop(ctx context.Context, workerID string, s
 		Retry:                       wc.config.Retry,
 		IteratorEscalationWindow:    wc.config.IteratorEscalationWindow,
 		IteratorEscalationThreshold: wc.config.IteratorEscalationThreshold,
+		RecoveryRetry:               wc.config.RecoveryRetry,
+		OnPermanentFailure:          wc.config.OnPermanentFailure,
 		Metrics:                     wc.config.Metrics,
 	}
 


### PR DESCRIPTION
## Summary

Wrap the partition consumer's iterator-creation retry loop in a bounded-retry envelope so a vanished consumer/stream stops generating infinite NATS API load and instead trips a one-shot escalation signal. Mirrors the source-watcher shape (`source/nats_kv.go:restartWatcher`).

- A fresh envelope is constructed per outer-loop iteration: any iteration that obtains a usable iterator implicitly resets the attempt budget for the next failure episode. Only consecutive iter-create failures within a single episode count against `MaxAttempts`.
- On exhaustion the envelope:
  - fires `OnPermanentFailure(subject, err)` exactly once (callers wire this to `enterDegraded` / `Hooks.OnError` at the manager layer);
  - logs at WARN with operator-actionable fields;
  - emits `IncrementWorkerConsumerIteratorRestart("recovery_exhausted")`;
  - exits the consumption loop so no further consumer-create traffic hits NATS for this partition.
- Defaults: `MaxAttempts=8`, `BaseBackoff=500ms` (composes with `recovery.Controller`'s 500ms `minRecoveryInterval`), `MaxBackoff=30s`, `Jitter=0.2`.
- The existing `recovery.Controller` path (iter-runtime failures via `handleIteratorFailure` / `Classify`) is unchanged — that path already has its own burst detector + cooldown bound. The envelope bounds only the iter-creation surface, which is the loop that goes infinite on a vanished resource.

## Test plan

- [x] `TestPartitionConsumer_RecoveryEnvelope_ExhaustsAndStops` — T1 reproducer: drives infinite iter-create failures; verified to fail on the pre-envelope stub state (495 unbounded iter calls + 0 permanent calls) and pass with the envelope wired.
- [x] `TestPartitionConsumer_RecoveryEnvelope_RecoveredIterationsResetBudget` — negative-space pin: K isolated failures interleaved with successful iterator sessions do NOT trigger `OnPermanentFailure`. This is the shape that would have caught the v1 monotonic-budget bug in the assignment-watcher envelope.
- [x] `make lint` — 0 issues
- [x] `make test -race` — full unit suite green
- [x] `make test-integration -race` — live-NATS suite green
- [x] `make pre-pr` — chained gate passes
- [x] Post-impl review (codex, effort xhigh) — verdict `merge`, zero P0/P1/P2. Report at `tmp/00-fix-plan_P2.4d_post_implementation_review_v1.md`.

## Spec

`docs/plans/self-healing/00-fix-plan.md` § P2.4d (lines 1305-1351). Prerequisite for the stream-gone hook work that layers on next.

## Out of scope for this PR

- `OnStreamMissing` hook wiring — layers on next.
- Manager-layer wiring of `OnPermanentFailure` → `enterDegraded` / `Hooks.OnError` — caller responsibility; the new field is the seam.
- Concurrency stress test for shared `*stream` state across multiple partition consumers in recovery — the envelope itself does not introduce new shared state. A wider stress test is tracked separately.