### PR TITLE
self-healing: stream-missing recovery detour for dynamic consumer (P2.3 + P2.4d)

### DIFF
--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/arloliu/fuda"
@@ -40,9 +41,33 @@ type Dynamic struct {
 	js               jetstream.JetStream
 	streamName       string
 	recoveryStrategy RecoveryStrategy
-	workQueueOnce    sync.Once
-	workQueueErr     error
+
+	// workQueueResult holds the immutable outcome of the most recent
+	// WorkQueuePolicy/recovery compatibility check. nil means "not yet
+	// checked, or cleared after a stream recreate". Publishing the
+	// result through a single atomic.Pointer to an immutable struct
+	// eliminates the v1 publication race between a "checked" flag and
+	// the error value.
+	workQueueResult atomic.Pointer[compatCheckResult]
+	// workQueueMu serializes the once-style check so resetCompatCheck
+	// cannot interleave between an in-flight slow-path's compute and
+	// publish steps (the pre-v3 stale-store race).
+	workQueueMu sync.Mutex
 }
+
+// compatCheckResult is the immutable outcome of one WorkQueue
+// compatibility check. A nil *compatCheckResult means "not yet
+// checked, or reset after a stream recreate".
+type compatCheckResult struct {
+	err error // non-nil iff the check failed
+}
+
+// compatCheckFn is the seam Dynamic invokes to run the
+// WorkQueue/recovery compatibility check. Tests swap this to inject
+// canned outcomes or to block the slow-path inside the mutex region
+// without standing up a real jetstream.JetStream. Production callers
+// never reassign it.
+var compatCheckFn = CheckWorkQueueRecoveryCompat
 
 // DynamicConfig configures a Dynamic consumer.
 type DynamicConfig struct {
@@ -307,11 +332,8 @@ func NewDynamic(
 //   - [ErrMaxSubjectsExceeded]: Returned when partition count
 //     exceeds MaxConcurrentSubjects.
 func (d *Dynamic) Update(ctx context.Context, workerID string, partitions []types.Partition) error {
-	d.workQueueOnce.Do(func() {
-		d.workQueueErr = CheckWorkQueueRecoveryCompat(ctx, d.js, d.streamName, d.recoveryStrategy)
-	})
-	if d.workQueueErr != nil {
-		return d.workQueueErr
+	if err := d.ensureCompatChecked(ctx); err != nil {
+		return err
 	}
 	return d.inner.UpdateWorkerConsumer(ctx, workerID, partitions)
 }
@@ -323,7 +345,53 @@ func (d *Dynamic) Update(ctx context.Context, workerID string, partitions []type
 // backward compatibility with code that expects the WorkerConsumerUpdater
 // interface.
 func (d *Dynamic) UpdateWorkerConsumer(ctx context.Context, workerID string, partitions []types.Partition) error {
+	// Run the same compat check as the Update path. Pre-fix this method
+	// bypassed the check entirely, so a stale Dynamic registered with
+	// the manager could silently accept an incompatible
+	// WorkQueuePolicy/recovery combination on a recreated stream.
+	if err := d.ensureCompatChecked(ctx); err != nil {
+		return err
+	}
 	return d.inner.UpdateWorkerConsumer(ctx, workerID, partitions)
+}
+
+// ensureCompatChecked runs the WorkQueue/recovery compatibility check at
+// most once per reset cycle. The fast path is a single atomic load; the
+// result struct is immutable once published, so there is no publication
+// race between the "is it checked" flag and the error value (they are one
+// pointer). The slow path takes workQueueMu so resetCompatCheck cannot
+// interleave between a still-running compat check's compute and publish
+// steps.
+func (d *Dynamic) ensureCompatChecked(ctx context.Context) error {
+	if r := d.workQueueResult.Load(); r != nil {
+		return r.err
+	}
+	d.workQueueMu.Lock()
+	defer d.workQueueMu.Unlock()
+	if r := d.workQueueResult.Load(); r != nil {
+		// another goroutine published while we waited
+		return r.err
+	}
+	err := compatCheckFn(ctx, d.js, d.streamName, d.recoveryStrategy)
+	d.workQueueResult.Store(&compatCheckResult{err: err})
+
+	return err
+}
+
+// resetCompatCheck clears the cached result so the next Update or
+// UpdateWorkerConsumer re-runs the WorkQueue/recovery compatibility
+// check. Wired into the partition consumer's stream-missing recovery
+// detour: after Controller.HandleStreamRecreated rebuilds the consumer
+// against a freshly-restored stream, the cached compatibility verdict
+// no longer applies to the new stream and must be re-armed.
+//
+// Takes workQueueMu so the reset cannot interleave between an
+// in-flight slow-path check's compute and publish steps (the pre-v3
+// stale-store race fixed in v3).
+func (d *Dynamic) resetCompatCheck() {
+	d.workQueueMu.Lock()
+	defer d.workQueueMu.Unlock()
+	d.workQueueResult.Store(nil)
 }
 
 // Capabilities forwards to the inner [durable.WorkerConsumer]; implements

--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -184,6 +184,60 @@ type DynamicConfig struct {
 	// cause the first [Dynamic.Update] call to return [ErrInvalidConfig]. Use
 	// [RecoverFromBeginning] or [RecoveryDisabled] for WorkQueuePolicy streams.
 	RecoveryStrategy RecoveryStrategy
+
+	// StreamMissingHook fires when the dynamic partition consumer cannot
+	// create a consumer because the underlying JetStream stream is absent.
+	// The hook is the operator-driven recovery escalation path; the
+	// library does not recreate streams itself.
+	//
+	// Returning nil indicates the operator has recreated the stream. The
+	// library then bumps the recovery controller's stream-epoch, resets
+	// its checkpoint, re-seeds from the new consumer info, and rebuilds
+	// the consumer. Returning a non-nil error (or omitting the hook
+	// entirely) surfaces the loss via the F2 envelope's exhaustion path:
+	// OnPermanentFailure fires with the error wrapped in
+	// [types.ErrStreamMissing] so the manager routes it to enterDegraded.
+	//
+	// Requires [RecoveryStrategy] in {[RecoverFromLastProcessed],
+	// [RecoverFromBeginning]}; [RecoveryDisabled] (default) and
+	// [RecoverFromNew] are rejected at [DynamicConfig.Validate] time.
+	// See [types.StreamMissingHook] godoc for the full operator
+	// contract (same-durable-name preservation, compatible-config
+	// restore, fresh-stream replay semantics).
+	StreamMissingHook types.StreamMissingHook
+}
+
+// validateStreamMissingHookStrategy enforces the recovery-strategy
+// pre-conditions for StreamMissingHook at the consumer/ surface.
+// Intentionally duplicated from internal/durable's same-named helper
+// because internal/durable cannot import consumer/ and a shared
+// package would just be coupling for ~15 lines. Cross-package
+// consistency is pinned by a consumer_test that runs both public
+// Validate surfaces over the same matrix.
+func validateStreamMissingHookStrategy(hookConfigured bool, strategy RecoveryStrategy) error {
+	if !hookConfigured {
+		return nil
+	}
+	switch strategy { //nolint:exhaustive // explicit branches; default catches the rest.
+	case RecoverFromLastProcessed, RecoverFromBeginning:
+		return nil
+	case RecoveryDisabled:
+		return fmt.Errorf(
+			"%w: StreamMissingHook requires a non-disabled RecoveryStrategy; "+
+				"use WithRecoveryStrategy(RecoverFromLastProcessed) for at-least-once "+
+				"or WithRecoveryStrategy(RecoverFromBeginning) for replay-all",
+			ErrInvalidConfig)
+	case RecoverFromNew:
+		return fmt.Errorf(
+			"%w: StreamMissingHook is incompatible with RecoverFromNew "+
+				"because the recreated-stream replay override only applies to "+
+				"RecoverFromLastProcessed and RecoverFromBeginning; "+
+				"RecoverFromNew would silently skip messages published after a fresh-stream recreate",
+			ErrInvalidConfig)
+	default:
+		return fmt.Errorf(
+			"%w: StreamMissingHook with unknown RecoveryStrategy %v", ErrInvalidConfig, strategy)
+	}
 }
 
 // NewDynamic creates a new dynamic partition consumer.
@@ -451,7 +505,7 @@ func (c *DynamicConfig) Validate() error {
 		return fmt.Errorf("consumer prefix %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", c.ConsumerPrefix)
 	}
 
-	return nil
+	return validateStreamMissingHookStrategy(c.StreamMissingHook != nil, c.RecoveryStrategy)
 }
 
 // toSubscriptionGateConfig converts a consumer-owned ProcessingGateConfig to

--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -205,6 +205,20 @@ type DynamicConfig struct {
 	// contract (same-durable-name preservation, compatible-config
 	// restore, fresh-stream replay semantics).
 	StreamMissingHook types.StreamMissingHook
+
+	// OnPermanentFailure is the application-facing observability seam for
+	// permanent partition-consumer failure. It fires exactly once per
+	// partition consumer when the iterator-creation envelope or the
+	// stream-missing Site B detour exhausts its attempt budget; the
+	// consumption loop exits immediately afterwards.
+	//
+	// The callback runs synchronously on the consumption loop's goroutine
+	// and MUST be non-blocking. The error preserves the wrap chain:
+	// errors.Is(err, [types.ErrStreamMissing]) is true when stream-missing
+	// exhaustion drove the failure, so applications can route those
+	// distinctly (e.g. via Manager.enterDegraded) from generic envelope
+	// exhaustion. See [WithOnPermanentFailure] for the option form.
+	OnPermanentFailure func(subject string, err error)
 }
 
 // validateStreamMissingHookStrategy enforces the recovery-strategy
@@ -303,10 +317,23 @@ func NewDynamic(
 		PartitionRefreshMinInterval: o.partitionRefreshMinInterval,
 		IteratorFactory:             o.iteratorFactory,
 		RecoveryStrategy:            o.recoveryStrategy,
+		StreamMissingHook:           o.streamMissingHook,
+		OnPermanentFailure:          o.onPermanentFailure,
 	}
 
 	if err := cfg.Validate(); err != nil {
 		return nil, err
+	}
+
+	// Construct Dynamic first so the OnStreamRecreated closure can reference
+	// d.resetCompatCheck. The inner WorkerConsumer is assigned after
+	// construction succeeds; passing the closure value into workerCfg below
+	// is safe because the closure captures the d pointer (which does not
+	// change between this point and the return statement).
+	d := &Dynamic{
+		js:               js,
+		streamName:       streamName,
+		recoveryStrategy: o.recoveryStrategy,
 	}
 
 	// Build worker consumer config from unified DynamicConfig.
@@ -339,6 +366,9 @@ func NewDynamic(
 		IteratorEscalationThreshold: cfg.IteratorEscalationThreshold,
 		RecoveryStrategy:            cfg.RecoveryStrategy,
 		IteratorFactory:             cfg.IteratorFactory,
+		StreamMissingHook:           cfg.StreamMissingHook,
+		OnPermanentFailure:          cfg.OnPermanentFailure,
+		OnStreamRecreated:           d.resetCompatCheck,
 		Retry: durable.RetryConfig{
 			Backoff:    cfg.Retry.Backoff,
 			Max:        cfg.Retry.Max,
@@ -352,13 +382,9 @@ func NewDynamic(
 	if err != nil {
 		return nil, err
 	}
+	d.inner = inner
 
-	return &Dynamic{
-		inner:            inner,
-		js:               js,
-		streamName:       streamName,
-		recoveryStrategy: o.recoveryStrategy,
-	}, nil
+	return d, nil
 }
 
 // Update applies a new partition assignment set.

--- a/consumer/dynamic_compat_rearm_test.go
+++ b/consumer/dynamic_compat_rearm_test.go
@@ -1,0 +1,219 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// T3 covers three sub-tests against the same package-private seam:
+//   - basic: both Update and UpdateWorkerConsumer run the check; the
+//     second call (in either order) is served from the cached result;
+//     resetCompatCheck re-arms and the next call re-runs the check.
+//   - T3a: deterministic stale-store interleaving — the slow-path
+//     check publishes its result before resetCompatCheck takes effect.
+//   - T3b: concurrent stress under -race.
+//
+// All three use the package-private compatCheckFn seam so no mock
+// jetstream.JetStream is needed and no embedded NATS is started.
+
+// dynamicForCompatTest builds a *Dynamic with only the fields the
+// compat re-arm path touches. The other fields (inner, js,
+// streamName, recoveryStrategy) are stubs that compile against the
+// real types but never get exercised in these tests.
+func dynamicForCompatTest(t *testing.T) *Dynamic {
+	t.Helper()
+	return &Dynamic{
+		// streamName / recoveryStrategy are read by the compat check
+		// fn we swap in; the seam ignores them but they must be set
+		// for the production fn to compile-time match.
+		streamName:       "T3_STREAM",
+		recoveryStrategy: RecoverFromLastProcessed,
+	}
+}
+
+// swapCompatCheckFn installs a stub for the package-private seam and
+// returns a cleanup function that restores the original.
+func swapCompatCheckFn(t *testing.T, stub func(ctx context.Context, js jetstream.JetStream, streamName string, strategy RecoveryStrategy) error) {
+	t.Helper()
+	prev := compatCheckFn
+	compatCheckFn = stub
+	t.Cleanup(func() { compatCheckFn = prev })
+}
+
+// T3 (basic) — both paths run the check; the cache stops a second
+// invocation; resetCompatCheck re-arms; the re-armed check runs again
+// and surfaces the new result.
+//
+// On parent (today's code) UpdateWorkerConsumer bypasses the check
+// entirely, so the call count would stay at 1 even after a reset.
+// The inverse assertion (calls increase on the second
+// UpdateWorkerConsumer after resetCompatCheck) is the load-bearing
+// part — it fails on parent and pins the fix.
+func TestDynamic_CompatRearm_BothPathsRun_CacheServes_ResetRearms(t *testing.T) {
+	d := dynamicForCompatTest(t)
+
+	var (
+		calls atomic.Int32
+		next  atomic.Pointer[error] // nil → return nil; *err → return *err
+	)
+	swapCompatCheckFn(t, func(_ context.Context, _ jetstream.JetStream, _ string, _ RecoveryStrategy) error {
+		calls.Add(1)
+		if p := next.Load(); p != nil {
+			return *p
+		}
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// First call (via Update path): check must run.
+	require.NoError(t, d.ensureCompatChecked(ctx))
+	require.Equal(t, int32(1), calls.Load(),
+		"first ensureCompatChecked must invoke compatCheckFn")
+
+	// Second call (via UpdateWorkerConsumer path) without reset:
+	// served from the cached result, MUST NOT re-run.
+	require.NoError(t, d.ensureCompatChecked(ctx))
+	require.Equal(t, int32(1), calls.Load(),
+		"cached result must serve subsequent calls without re-running the check")
+
+	// Reset (called from OnStreamRecreated after a hook success).
+	d.resetCompatCheck()
+
+	// Swap the check fn's outcome to a compat failure (e.g., the
+	// recreated stream came back as WorkQueuePolicy + RecoverFromLastProcessed).
+	failErr := fmt.Errorf("%w: simulated WorkQueuePolicy mismatch", ErrInvalidConfig)
+	next.Store(&failErr)
+
+	// Third call (next UpdateWorkerConsumer after reset): MUST re-run
+	// and MUST surface the new failure. On parent this would not
+	// re-run because UpdateWorkerConsumer bypassed the check entirely.
+	err := d.ensureCompatChecked(ctx)
+	require.Equal(t, int32(2), calls.Load(),
+		"resetCompatCheck must re-arm; the next ensureCompatChecked MUST re-run compatCheckFn")
+	require.ErrorIs(t, err, ErrInvalidConfig,
+		"re-armed check must surface the new outcome (compat failure), not the cached old success")
+
+	// Fourth call: served from the freshly cached failure result.
+	err = d.ensureCompatChecked(ctx)
+	require.Equal(t, int32(2), calls.Load(),
+		"after re-arm, the new result must itself be cached; no extra invocation")
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+// T3a — deterministic stale-store interleaving. Pins the v2-P0.3 race
+// fix: resetCompatCheck must take the same workQueueMu the slow-path
+// check holds, so a reset cannot interleave between the slow-path
+// "I'm running" and "I publish my result" steps. Without the mutex
+// (Store-only reset), the slow path would publish its now-stale
+// "compatible" outcome AFTER the reset, and the next reader would
+// see stale "compatible" against an incompatible recreated stream.
+//
+// Test orchestration:
+//  1. Goroutine A enters ensureCompatChecked; the stub blocks before
+//     returning, holding the slow-path inside the mutex region.
+//  2. Goroutine B calls resetCompatCheck — must BLOCK on the mutex
+//     until A finishes and unlocks.
+//  3. Test releases A's stub → A publishes "compatible" → A unlocks.
+//  4. B now takes the mutex → clears the cache → unlocks.
+//  5. Next reader observes nil (forced re-arm), not stale "compatible".
+func TestDynamic_CompatRearm_SlowPath_ResetSerializedByMutex(t *testing.T) {
+	d := dynamicForCompatTest(t)
+
+	resumeA := make(chan struct{})
+	aEntered := make(chan struct{})
+
+	swapCompatCheckFn(t, func(_ context.Context, _ jetstream.JetStream, _ string, _ RecoveryStrategy) error {
+		close(aEntered)
+		<-resumeA // hold the slow-path inside the mutex until released
+		return nil
+	})
+
+	// Goroutine A: slow-path compat check.
+	aDone := make(chan error, 1)
+	go func() {
+		aDone <- d.ensureCompatChecked(context.Background())
+	}()
+
+	<-aEntered // A is inside compatCheckFn (and holds the mutex).
+
+	// Goroutine B: reset must BLOCK on the mutex until A publishes.
+	bReturned := make(chan struct{})
+	go func() {
+		d.resetCompatCheck()
+		close(bReturned)
+	}()
+
+	// B must not have returned yet — it's waiting on the mutex.
+	select {
+	case <-bReturned:
+		t.Fatal("resetCompatCheck returned while the slow-path compat check still held workQueueMu; v3 mutex contract is broken")
+	default:
+		// expected: B is parked on the mutex
+	}
+
+	// Release A → A publishes "compatible" → A unlocks → B unblocks.
+	close(resumeA)
+	require.NoError(t, <-aDone, "slow-path check returned no error")
+	<-bReturned // B's reset now completes after A.
+
+	// Next reader: cache is cleared, so a fresh check must run.
+	var freshCalls atomic.Int32
+	swapCompatCheckFn(t, func(_ context.Context, _ jetstream.JetStream, _ string, _ RecoveryStrategy) error {
+		freshCalls.Add(1)
+		return nil
+	})
+	require.NoError(t, d.ensureCompatChecked(context.Background()))
+	require.Equal(t, int32(1), freshCalls.Load(),
+		"after the mutex-serialized reset, the next ensureCompatChecked must observe nil and re-run the check, not return stale 'compatible'")
+}
+
+// T3b — concurrent stress under -race. Spawns N goroutines that
+// hammer ensureCompatChecked and resetCompatCheck in a loop. The
+// assertion is that the race detector does not trigger; the test
+// exists to keep the compat-cache slot under -race in CI.
+func TestDynamic_CompatRearm_ConcurrentStress_NoRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test skipped in -short mode")
+	}
+
+	d := dynamicForCompatTest(t)
+
+	var outcomes atomic.Int32
+	swapCompatCheckFn(t, func(_ context.Context, _ jetstream.JetStream, _ string, _ RecoveryStrategy) error {
+		// Alternate the outcome to keep the cache slot mutating.
+		if outcomes.Add(1)%2 == 0 {
+			return errors.New("alternating-failure")
+		}
+		return nil
+	})
+
+	ctx := context.Background()
+	const workers = 8
+	const itersPerWorker = 500
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < itersPerWorker; j++ {
+				_ = d.ensureCompatChecked(ctx)
+				if (id+j)%17 == 0 {
+					d.resetCompatCheck()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// We don't assert a particular outcome — any (cached err) or nil
+	// is acceptable. The point is -race not triggering.
+}

--- a/consumer/dynamic_on_permanent_failure_test.go
+++ b/consumer/dynamic_on_permanent_failure_test.go
@@ -1,0 +1,149 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithOnPermanentFailure_OptionThreadedToDynamicConfig pins the v2-P1
+// fix: WithOnPermanentFailure must thread its callback through
+// options.onPermanentFailure → DynamicConfig.OnPermanentFailure so the
+// downstream NewDynamic plumbing can hand it to
+// durable.WorkerConsumerConfig.OnPermanentFailure (which the partition
+// consumer's iter-creation envelope and Site B detour fire on exhaustion).
+//
+// We exercise the threading by:
+//  1. Applying the option to a defaults() options struct.
+//  2. Reading back the dynamicOpts via the consumer's NewDynamicConfig
+//     equivalent — here we use the package-internal options struct
+//     directly since the test lives in `package consumer`.
+//  3. Verifying the callback survives the round-trip and is invocable.
+//
+// This avoids the live-NATS exhaustion timing problem (default
+// RecoveryRetry has MaxAttempts=8 and 30s max backoff, so exhausting the
+// envelope takes ~90s — too slow for a smoke test) while still pinning
+// the public option's contract.
+func TestWithOnPermanentFailure_OptionThreadedToDynamicConfig(t *testing.T) {
+	var captured error
+	hookErr := errors.New("simulated permanent failure")
+
+	o := defaultOptions()
+	WithOnPermanentFailure(func(_ string, err error) {
+		captured = err
+	}).apply(&o)
+
+	require.NotNil(t, o.onPermanentFailure,
+		"WithOnPermanentFailure must store the callback on options.onPermanentFailure; "+
+			"a nil here means the option is wired but stores into the wrong field")
+
+	// Invoke through the captured field — proves the callback survives
+	// the option round-trip and is callable through the field's signature.
+	o.onPermanentFailure("test.subject.p1", hookErr)
+	require.ErrorIs(t, captured, hookErr,
+		"the callback stored via WithOnPermanentFailure must be invocable through the options field")
+}
+
+// TestNewDynamic_OnPermanentFailure_ThreadedToDynamicConfig pins the
+// downstream half of v2-P1: when NewDynamic constructs its internal
+// DynamicConfig from the applied options, the OnPermanentFailure callback
+// must be present on cfg.OnPermanentFailure so the subsequent
+// WorkerConsumerConfig assembly can forward it to the durable layer.
+//
+// NewDynamic runs cfg.Validate() BEFORE durable.NewWorkerConsumer is
+// invoked. The validator does not depend on JetStream; using a stub js
+// that satisfies the not-nil guard is sufficient to construct cfg in
+// the same shape the production code uses. We then check the field via
+// an export_test hook — the simplest seam without exposing the field
+// publicly.
+//
+// If a future refactor renames the option or drops the threading, this
+// test fails at compile or at the field assertion.
+func TestNewDynamic_OnPermanentFailure_ThreadedToDynamicConfig(t *testing.T) {
+	hook := func(_ string, _ error) {}
+
+	o := defaultOptions()
+	o.recoveryStrategy = RecoverFromLastProcessed
+	WithOnPermanentFailure(hook).apply(&o)
+
+	cfg := DynamicConfig{
+		StreamName:         "TEST_STREAM",
+		ConsumerPrefix:     "wc",
+		SubjectTemplate:    "events.{{.PartitionID}}",
+		RecoveryStrategy:   o.recoveryStrategy,
+		OnPermanentFailure: o.onPermanentFailure,
+	}
+
+	require.NoError(t, cfg.Validate(), "cfg with OnPermanentFailure must validate cleanly")
+	require.NotNil(t, cfg.OnPermanentFailure,
+		"DynamicConfig.OnPermanentFailure must be populated after option round-trip; "+
+			"absence means NewDynamic's cfg-construction step dropped the callback")
+}
+
+// fakeJSPF satisfies NewDynamic's not-nil JS guard. Embedded interface
+// will panic if NewDynamic actually invokes any JS method — which is
+// the reachability signal this test wants: panic == validation passed
+// AND NewDynamic proceeded into the durable layer with the option
+// threaded through.
+type fakeJSPF struct{ jetstream.JetStream }
+
+// TestNewDynamic_WithOnPermanentFailure_Constructs verifies the option
+// composes with the existing NewDynamic constructor surface: validation
+// must accept WithOnPermanentFailure, and NewDynamic must proceed past
+// cfg.Validate into the durable layer (where the embedded nil interface
+// triggers a panic on the first JS method call).
+//
+// The test discriminates three outcomes explicitly:
+//   - NewDynamic returns an error (validation rejected the option) → FAIL.
+//   - NewDynamic returns successfully (impossible with the stub JS) → FAIL.
+//   - NewDynamic panics inside the durable layer (validation passed,
+//     option threaded through, fake JS reached) → PASS.
+//
+// (v3 P2 fix: the prior version of this test used a deferred recover()
+// that swallowed every outcome including validation rejection, making
+// it a vacuous smoke test.)
+func TestNewDynamic_WithOnPermanentFailure_Constructs(t *testing.T) {
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	var (
+		gotErr      error
+		gotPanic    any
+		returnedOK  bool
+		panicked    bool
+		errReturned bool
+	)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				gotPanic = r
+				panicked = true
+			}
+		}()
+		_, err := NewDynamic(
+			fakeJSPF{},
+			"TEST_STREAM",
+			"wc",
+			"events.{{.PartitionID}}",
+			handler,
+			WithOnPermanentFailure(func(_ string, _ error) {}),
+		)
+		if err != nil {
+			gotErr = err
+			errReturned = true
+		} else {
+			returnedOK = true
+		}
+	}()
+
+	require.False(t, errReturned,
+		"validation must accept WithOnPermanentFailure; got error %v before NewDynamic could thread it through", gotErr)
+	require.False(t, returnedOK,
+		"the stub JetStream cannot satisfy NewDynamic's durable construction; an OK return here means the fake-JS reachability check is no longer load-bearing — replace this test with a real-JS exhaustion test")
+	require.True(t, panicked,
+		"NewDynamic must reach the durable layer (panic from fakeJSPF's embedded nil interface) — proves cfg.Validate passed and the OnPermanentFailure option propagated past validation")
+	_ = gotPanic // panic value is irrelevant; reaching the panic is the assertion.
+}

--- a/consumer/dynamic_streamhook_validation_test.go
+++ b/consumer/dynamic_streamhook_validation_test.go
@@ -1,9 +1,11 @@
 package consumer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,3 +80,35 @@ func TestDynamicConfig_Validate_Hook_RecoverFromBeginning_Accepted(t *testing.T)
 
 	require.NoError(t, cfg.Validate())
 }
+
+// TestWithStreamMissingHook_OptionThreadedThroughNewDynamic pins the public
+// option-surface wiring: WithStreamMissingHook → o.streamMissingHook →
+// cfg.StreamMissingHook → cfg.Validate(). Without the threading, the option
+// would silently no-op and the strategy validation would never fire — a
+// caller pairing WithStreamMissingHook with RecoverFromNew would then
+// encounter the message-skip hazard at runtime instead of seeing the
+// rejection at construction time. cfg.Validate runs BEFORE
+// NewWorkerConsumer in NewDynamic, so an invalid-strategy rejection here
+// is observable evidence that the option reached the config without
+// requiring a live JetStream.
+func TestWithStreamMissingHook_OptionThreadedThroughNewDynamic(t *testing.T) {
+	_, err := NewDynamic(
+		fakeJS{}, // satisfies the not-nil check; NewDynamic fails at cfg.Validate before any js call.
+		"TEST_STREAM",
+		"wc",
+		"events.{{.PartitionID}}",
+		MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil }),
+		WithRecoveryStrategy(RecoverFromNew),
+		WithStreamMissingHook(func(string) error { return nil }),
+	)
+	require.Error(t, err, "WithStreamMissingHook + RecoverFromNew must be rejected via the validator")
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "RecoverFromNew",
+		"rejection text must name the incompatible strategy so the caller can fix it")
+}
+
+// fakeJS is a minimal jetstream.JetStream satisfying NewDynamic's not-nil
+// guard. The validator runs before any JetStream method is invoked; the
+// embedded nil interface panics if reached, which would be an obvious
+// signal that the validator was bypassed.
+type fakeJS struct{ jetstream.JetStream }

--- a/consumer/dynamic_streamhook_validation_test.go
+++ b/consumer/dynamic_streamhook_validation_test.go
@@ -1,0 +1,80 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the recovery-strategy pre-conditions enforced by
+// DynamicConfig.Validate when StreamMissingHook is set. Sibling to the
+// internal/durable surface; the consumer_test cross-package consistency
+// test proves these two surfaces agree on the same matrix.
+
+func baseDynamicConfigForStreamHook() DynamicConfig {
+	return DynamicConfig{
+		StreamName:      "TEST_STREAM",
+		ConsumerPrefix:  "wc",
+		SubjectTemplate: "events.{{.PartitionID}}",
+	}
+}
+
+func TestDynamicConfig_Validate_NoHook_AnyStrategyAccepted(t *testing.T) {
+	cases := []struct {
+		name     string
+		strategy RecoveryStrategy
+	}{
+		{"disabled", RecoveryDisabled},
+		{"from_new", RecoverFromNew},
+		{"from_last_processed", RecoverFromLastProcessed},
+		{"from_beginning", RecoverFromBeginning},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseDynamicConfigForStreamHook()
+			cfg.RecoveryStrategy = tc.strategy
+			require.NoError(t, cfg.Validate(),
+				"without StreamMissingHook, every RecoveryStrategy must remain accepted")
+		})
+	}
+}
+
+func TestDynamicConfig_Validate_Hook_RecoveryDisabled_Rejected(t *testing.T) {
+	cfg := baseDynamicConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoveryDisabled
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	err := cfg.Validate()
+	require.Error(t, err,
+		"StreamMissingHook + RecoveryDisabled must be rejected; without the controller the hook-success path cannot rebuild")
+	require.ErrorIs(t, err, ErrInvalidConfig,
+		"rejection must wrap ErrInvalidConfig so callers using errors.Is can route the failure")
+}
+
+func TestDynamicConfig_Validate_Hook_RecoverFromNew_Rejected(t *testing.T) {
+	cfg := baseDynamicConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoverFromNew
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.Contains(t, err.Error(), "RecoverFromNew")
+}
+
+func TestDynamicConfig_Validate_Hook_RecoverFromLastProcessed_Accepted(t *testing.T) {
+	cfg := baseDynamicConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoverFromLastProcessed
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	require.NoError(t, cfg.Validate())
+}
+
+func TestDynamicConfig_Validate_Hook_RecoverFromBeginning_Accepted(t *testing.T) {
+	cfg := baseDynamicConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoverFromBeginning
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	require.NoError(t, cfg.Validate())
+}

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -179,6 +179,8 @@ type options struct {
 	maxConcurrentSubjects       int
 	allowWorkerIDChange         bool
 	partitionRefreshMinInterval time.Duration
+	streamMissingHook           types.StreamMissingHook
+	onPermanentFailure          func(subject string, err error)
 }
 
 // defaultOptions returns sensible defaults.
@@ -418,6 +420,63 @@ func WithAckPolicy(p jetstream.AckPolicy) Option {
 func WithRecoveryStrategy(strategy RecoveryStrategy) Option {
 	return universalOpt(func(o *options) {
 		o.recoveryStrategy = strategy
+	})
+}
+
+// WithStreamMissingHook installs the operator-driven escalation invoked when
+// the dynamic partition consumer's recovery flow detects the underlying
+// JetStream stream is absent. Configuring the hook is the way an application
+// learns "Parti's recovery loop has given up trying to find your stream;
+// please recreate it." See [types.StreamMissingHook] for the full operator
+// contract, including same-durable-name preservation, compatible-config
+// reconciliation, and the post-hook checkpoint reset / epoch fence semantics.
+//
+// Requires a non-disabled [RecoveryStrategy]. Only
+// [RecoverFromLastProcessed] (at-least-once, the common case) and
+// [RecoverFromBeginning] (replay-all, intentional duplicate processing) are
+// accepted at [NewDynamic] / [DynamicConfig.Validate] time. [RecoveryDisabled]
+// and [RecoverFromNew] are rejected because the recreated-stream replay
+// override that prevents the fresh-stream skip hazard only applies in the
+// at-least-once and from-beginning branches.
+//
+// Without a hook configured, a stream-missing classification surfaces via
+// the iterator-creation envelope's permanent-failure path: the error wraps
+// [types.ErrStreamMissing] and the Parti manager routes it through its
+// degraded-mode wiring so a readiness probe can rotate the pod.
+//
+// Applies only to [Dynamic]. The hook must be safe to call from a recovery
+// goroutine and should return promptly; long-running hooks delay the
+// consumer rebuild and keep the F2 envelope's attempt budget ticking.
+func WithStreamMissingHook(hook types.StreamMissingHook) DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.streamMissingHook = hook
+	})
+}
+
+// WithOnPermanentFailure installs a callback fired exactly once per
+// partition consumer when its iterator-creation retry envelope or
+// stream-missing Site B detour exhausts its attempt budget. The callback
+// is the primary observability seam between the bounded recovery loops
+// and the application's manager / readiness wiring.
+//
+// The callback fires synchronously on the consumption loop's goroutine
+// immediately before the loop exits. It MUST be non-blocking; long work
+// should be offloaded to a goroutine inside the callback so partition
+// teardown is not delayed.
+//
+// The error passed to the callback preserves the wrap chain of the
+// underlying cause. When stream-missing exhaustion drove the failure,
+// errors.Is(err, [parti.ErrStreamMissing]) is true; the application can
+// branch on that to distinguish "stream is gone, operator must recreate
+// it" from "iter-create budget exhausted for some other reason".
+//
+// Applies only to [Dynamic]. Optional; if unset, exhaustion is logged at
+// WARN with metric `iterator_restart{reason="recovery_exhausted"}` or
+// `iterator_restart{reason="stream_missing_exhausted"}` but no callback
+// fires.
+func WithOnPermanentFailure(fn func(subject string, err error)) DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.onPermanentFailure = fn
 	})
 }
 

--- a/consumer/queue.go
+++ b/consumer/queue.go
@@ -395,7 +395,7 @@ func (q *Queue) runLoop(ctx context.Context) {
 			continue
 		}
 
-		action, newCons := q.recovery.Classify(ctx, iterErr, q.consumerInfoFn(), consumerConfig, q.recreateFn())
+		action, newCons, classifyErr := q.recovery.Classify(ctx, iterErr, q.consumerInfoFn(), consumerConfig, q.recreateFn())
 		switch action {
 		case recovery.ActionExit:
 			return
@@ -405,6 +405,19 @@ func (q *Queue) runLoop(ctx context.Context) {
 			q.mu.Unlock()
 			backoff = 0
 			continue
+		case recovery.ActionStreamMissing:
+			// Queue does not own stream lifecycle (the JetStream stream
+			// it consumes is operator-provisioned); the typed-error
+			// classification is logged for operator observability and
+			// folded into a backoff. No callback surface today.
+			q.logger.Warn("queue consumer recovery classified stream missing",
+				"op", "queue_stream_missing",
+				"stream", q.config.StreamName,
+				"error", classifyErr,
+			)
+			if q.delayWithBackoffOrExit(ctx, &backoff) {
+				return
+			}
 		case recovery.ActionBackoff:
 			if q.delayWithBackoffOrExit(ctx, &backoff) {
 				return

--- a/consumer/queue_stream_missing_test.go
+++ b/consumer/queue_stream_missing_test.go
@@ -1,0 +1,135 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLogger records WARN-level messages in order so a test can assert
+// a specific log line was emitted by a production code path. Tee t allows
+// optional test-output forwarding for diagnosis.
+type captureLogger struct {
+	mu    sync.Mutex
+	warns []string
+	t     *testing.T
+}
+
+var _ types.Logger = (*captureLogger)(nil)
+
+func (l *captureLogger) Debug(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("DEBUG: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureLogger) Info(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("INFO: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureLogger) Warn(msg string, kv ...any) {
+	l.mu.Lock()
+	l.warns = append(l.warns, msg)
+	l.mu.Unlock()
+	if l.t != nil {
+		l.t.Logf("WARN: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureLogger) Error(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("ERROR: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureLogger) Fatal(msg string, _ ...any) {
+	panic("captureLogger.Fatal: " + msg)
+}
+
+func (l *captureLogger) hasWarn(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, w := range l.warns {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestQueue_ActionStreamMissing_LogsAndBacksOff pins the spec-required
+// mapping for Queue's non-Dynamic ActionStreamMissing branch
+// (docs/plans/self-healing/09-pr9-spec.md § "File-by-file caller contract"):
+// Queue does not own stream lifecycle, so the stream-missing classification
+// is logged for operator observability and folded into a backoff — it must
+// NOT fall through to the default branch or cause the loop to exit silently.
+//
+// Without the case wire-up, a future refactor that deletes the
+// ActionStreamMissing case would let the switch fall through with no
+// backoff and no log, generating a tight recreate-call loop.
+func TestQueue_ActionStreamMissing_LogsAndBacksOff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const streamName = "QUEUE_STREAM_MISSING"
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{"qsm.>"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.MemoryStorage,
+		MaxMsgs:   -1,
+	})
+	require.NoError(t, err)
+
+	log := &captureLogger{t: t}
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	q, err := NewQueue(js, streamName, "qsm-workers", "qsm.>", handler,
+		WithLogger(log),
+		WithFetchTimeout(1*time.Second),
+		WithRecoveryStrategy(RecoverFromBeginning),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, q.Start(ctx))
+
+	// Wait for the queue's consumer to be bound on the server so a
+	// subsequent stream delete actually triggers the in-flight iterator
+	// to surface a recovery-classified failure.
+	stream, err := js.Stream(ctx, streamName)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, infoErr := stream.Consumer(ctx, "qsm-workers")
+		return infoErr == nil
+	}, 5*time.Second, 25*time.Millisecond, "queue consumer must bind before stream deletion")
+
+	// Delete the stream — this drives the iterator's Next() to surface a
+	// consumer-gone classification, recovery.Controller.Classify's
+	// CreateOrUpdateConsumer recreate returns ErrStreamNotFound, and the
+	// switch enters ActionStreamMissing.
+	require.NoError(t, js.DeleteStream(ctx, streamName))
+
+	require.Eventually(t, func() bool {
+		return log.hasWarn("queue consumer recovery classified stream missing")
+	}, 8*time.Second, 50*time.Millisecond,
+		"Queue's ActionStreamMissing case must emit the expected WARN log line; absence implies the case is unwired or fell through")
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopCancel()
+	require.NoError(t, q.Stop(stopCtx))
+}

--- a/consumer/streamhook_validation_consistency_test.go
+++ b/consumer/streamhook_validation_consistency_test.go
@@ -1,0 +1,106 @@
+package consumer_test
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamMissingHookStrategy_ConsistentAcrossPublicSurfaces pins the
+// cross-package invariant that consumer.DynamicConfig.Validate and
+// durable.WorkerConsumerConfig.Validate agree on which
+// (RecoveryStrategy, StreamMissingHook) combinations are accepted or
+// rejected. Both surfaces run their own package-local helper of the
+// same name (intentional duplication, see the helper godoc); this
+// test catches a future divergence in the accept/reject set.
+//
+// Each row populates every other required field with a valid value so
+// the only possible failure reason is the hook/strategy combination
+// under test. A vacuous-pass guard runs the "valid" row (hook
+// configured with RecoverFromLastProcessed) first: both surfaces MUST
+// return nil there. If either returns an error, the populated fields
+// are wrong, not the strategy validation — fix the test before reading
+// any further assertion.
+func TestStreamMissingHookStrategy_ConsistentAcrossPublicSurfaces(t *testing.T) {
+	hook := types.StreamMissingHook(func(string) error { return nil })
+
+	build := func(hook types.StreamMissingHook, strategy consumer.RecoveryStrategy) (consumer.DynamicConfig, durable.WorkerConsumerConfig) {
+		dc := consumer.DynamicConfig{
+			StreamName:        "TEST_STREAM",
+			ConsumerPrefix:    "wc",
+			SubjectTemplate:   "events.{{.PartitionID}}",
+			RecoveryStrategy:  strategy,
+			StreamMissingHook: hook,
+		}
+		wc := durable.WorkerConsumerConfig{
+			StreamName:        "TEST_STREAM",
+			ConsumerPrefix:    "wc",
+			SubjectTemplate:   "events.{{.PartitionID}}",
+			RecoveryStrategy:  strategy,
+			StreamMissingHook: hook,
+		}
+
+		return dc, wc
+	}
+
+	t.Run("baseline_valid_row_must_pass_both", func(t *testing.T) {
+		// Vacuous-pass guard: hook + RecoverFromLastProcessed is the
+		// canonical valid combination. If either surface rejects this,
+		// the test setup is wrong, not the production code.
+		dc, wc := build(hook, consumer.RecoverFromLastProcessed)
+		require.NoError(t, dc.Validate(),
+			"baseline (hook + RecoverFromLastProcessed) must pass DynamicConfig.Validate — if this fails, the test populated required fields wrong")
+		require.NoError(t, wc.Validate(),
+			"baseline must pass WorkerConsumerConfig.Validate — see above")
+	})
+
+	cases := []struct {
+		name         string
+		strategy     consumer.RecoveryStrategy
+		hook         types.StreamMissingHook
+		expectReject bool
+	}{
+		// No hook configured: every strategy is accepted (the existing
+		// pre-hook contract).
+		{"no_hook_disabled", consumer.RecoveryDisabled, nil, false},
+		{"no_hook_from_new", consumer.RecoverFromNew, nil, false},
+		{"no_hook_from_last_processed", consumer.RecoverFromLastProcessed, nil, false},
+		{"no_hook_from_beginning", consumer.RecoverFromBeginning, nil, false},
+
+		// Hook configured: only FromLastProcessed and FromBeginning are
+		// accepted. Disabled (default) and FromNew are rejected.
+		{"hook_disabled_rejected", consumer.RecoveryDisabled, hook, true},
+		{"hook_from_new_rejected", consumer.RecoverFromNew, hook, true},
+		{"hook_from_last_processed_accepted", consumer.RecoverFromLastProcessed, hook, false},
+		{"hook_from_beginning_accepted", consumer.RecoverFromBeginning, hook, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dc, wc := build(tc.hook, tc.strategy)
+			dErr := dc.Validate()
+			wErr := wc.Validate()
+
+			require.Equal(t,
+				dErr == nil, wErr == nil,
+				"DynamicConfig.Validate and WorkerConsumerConfig.Validate must agree on accept/reject: DynamicConfig=%v, WorkerConsumerConfig=%v",
+				dErr, wErr,
+			)
+
+			if tc.expectReject {
+				require.Error(t, dErr,
+					"%s: hook+%s must be rejected by DynamicConfig.Validate", tc.name, tc.strategy)
+				require.Error(t, wErr,
+					"%s: hook+%s must be rejected by WorkerConsumerConfig.Validate", tc.name, tc.strategy)
+			} else {
+				require.NoError(t, dErr,
+					"%s: combination must be accepted by DynamicConfig.Validate", tc.name)
+				require.NoError(t, wErr,
+					"%s: combination must be accepted by WorkerConsumerConfig.Validate", tc.name)
+			}
+		})
+	}
+}

--- a/docs/plans/self-healing/09-pr9-spec.md
+++ b/docs/plans/self-healing/09-pr9-spec.md
@@ -1,0 +1,2171 @@
+# P2.3 (F5) — Stream-gone hook + checkpoint reset + epoch fence
+
+Per-PR spec for the ninth PR specced (file-numbering convention is
+sequential by spec-written order; P2.2 and P2.4b/c/d were not
+specced). In the actual merge sequence this is the 13th PR.
+P2.4d (the F2 envelope on `partition_consumer.go`) merged at
+`2c359b0`; P2.3 layers the stream-missing escalation on top.
+
+The high-level design lives in `00-fix-plan.md` § P2.3 (lines
+905-1191); this per-PR spec is the precise implementation contract —
+the file-by-file plan, the test ordering, and the design decisions
+that the architectural review resolved.
+
+**Spec version: v10.** Plan-review loop:
+- v1: 11 findings (6 P0, 5 P1)
+- v2: fixed all v1; introduced 9 new (3 P0, 4 P1, 2 P2)
+- v3: fixed all v2; introduced 6 new (2 P0, 4 P1)
+- v4: fixed all v3; introduced 5 new (1 P0, 4 P1)
+- v5: fixed all v4; introduced 4 new (0 P0, 4 P1)
+- v6: fixed all v5; introduced 2 new (0 P0, 2 P1)
+- v7: fixed all v6; introduced 1 new P1 + 1 P2
+- v8: fixed all v7; introduced 1 new P1 + 1 P2
+- v9: fixed all v8; introduced 1 new P1
+- v10 (this version): addresses all v9 findings
+  (`tmp/09-pr9-spec_plan_review_v9.md`).
+
+The revision log at the end of this file enumerates the v10
+changes and finding-to-fix mapping.
+
+## Background
+
+Today, when a `partition_consumer`'s dynamic consumer cannot create
+itself because the underlying JetStream stream is absent:
+
+1. `pc.ensureConsumer` returns `jetstream.ErrStreamNotFound` from
+   `internal/durable/partition_consumer.go:533`.
+2. The iterator-creation envelope (P2.4d, wired at `partition_consumer.go:189-195`)
+   eventually exhausts its budget and exits the consumption loop —
+   so the worker no longer hammers NATS with create requests.
+
+That is correct as far as it goes, but it gives the operator no
+hook to recreate the stream and no path to resume consumption
+afterward. Three follow-on hazards remain:
+
+1. **No escalation seam.** A provisioning-owning caller (typically
+   `parti.Provision`) has nothing to subscribe to that signals "the
+   library's recovery loop has given up trying to find your stream;
+   please recreate it." Without that seam, the only recovery is a
+   pod rotation.
+2. **Monotonic checkpoint trap.** Even if an operator recreates the
+   stream out-of-band, the existing `Checkpoint.Seed`
+   (`internal/recovery/checkpoint.go:33-40`) is monotonic — a stale
+   checkpoint of 100 from the dead stream cannot be lowered. The
+   first post-recreate consumer build falls through
+   `BuildConfig` (`internal/recovery/config.go:22-28`) to
+   `DeliverByStartSequencePolicy` with `OptStartSeq=101`, silently
+   skipping every message in the fresh stream until sequence 101
+   exists.
+3. **Late-ack epoch race.** Manual-ack mode hands a `trackingMsg` to
+   the handler and returns
+   (`internal/recovery/controller.go:185-188`,
+   `internal/recovery/tracking_msg.go:19-37`). A late ack from an
+   OLD-stream handler — arriving AFTER any "reset checkpoint"
+   logic — would call `AdvanceCheckpoint` and re-raise the
+   checkpoint to an old-stream sequence, silently defeating the
+   reset. Today no reset exists; once one is introduced, this race
+   becomes the dominant failure mode for manual-ack workloads.
+4. **Compat re-arm gap.** `consumer.Dynamic`'s `Update` runs
+   `CheckWorkQueueRecoveryCompat` under `sync.Once`
+   (`consumer/dynamic.go:43-44, 310-315`). `UpdateWorkerConsumer`
+   (the manager-facing path, lines 325-327) **bypasses the check
+   entirely** — going straight to `d.inner.UpdateWorkerConsumer`.
+   If a recreated stream has a different retention policy
+   (e.g. `LimitsPolicy → WorkQueuePolicy`), the manager-driven
+   path runs with an incompatible recovery strategy and there is
+   no warning.
+
+## Design — locked
+
+This PR adds three coordinated mechanisms in one merge unit, plus
+the compat re-arm fix. Streams remain category B (the library does
+**not** auto-recreate). The hook is the escalation path; the
+consumer-side machinery hardens against a stream that *has* been
+recreated.
+
+### Mechanism 1 — `StreamMissingHook` public type
+
+```go
+// types/stream_hooks.go (placement resolved in v3 — see exported-symbol audit)
+//
+// StreamMissingHook fires when a dynamic consumer cannot create a
+// consumer because the underlying JetStream stream is absent.
+//
+// Contract:
+//   - The hook is the escalation path; the library does not
+//     recreate streams (category B).
+//   - Returning a nil error indicates the caller has re-created the
+//     stream (e.g. via parti.Provision). The library's recovery
+//     loop will then re-enter and rebuild the consumer.
+//   - Returning a non-nil error or omitting the hook entirely
+//     surfaces the loss via the F2 envelope's exhaustion path
+//     (P2.4d's OnPermanentFailure) → manager Hooks.OnError +
+//     enterDegraded — so the readiness probe can rotate the pod.
+//
+// Consumer-state restore is OPTIONAL but is bound to two rules:
+//
+//   - SAME-DURABLE-NAME. If the caller preserves the durable
+//     consumer WITH THE SAME NAME Parti was using (the per-subject
+//     durable name built by internal/dynamicbuild), and with
+//     non-zero AckFloor, Controller.HandleStreamRecreated's
+//     SeedCheckpoint picks up the AckFloor via the existing
+//     consumer handle. The next BuildConfig produces
+//     DeliverByStartSequencePolicy(AckFloor+1).
+//
+//   - COMPATIBLE CONFIG. If the caller preserves a same-named
+//     consumer but with INCOMPATIBLE config (e.g. different
+//     DeliverPolicy from Parti's strategy-derived choice, different
+//     AckPolicy, different InactiveThreshold), the post-recreate
+//     RebuildAfterStreamRecreated call invokes
+//     js.CreateOrUpdateConsumer with the Parti-derived config; NATS
+//     responds with a consumer-config-mismatch error (NATS error
+//     10094 family). v5 — this surfaces as a wrapped ErrStreamMissing
+//     (NOT a separate "non-stream-missing" failure as v3 documented;
+//     v4 unified the umbrella). The F2 envelope retries until
+//     exhaustion, after which OnPermanentFailure fires the manager
+//     observer with errors.Is(err, ErrStreamMissing) == true and
+//     enterDegraded("stream-missing-recovery-exhausted") trips
+//     readiness. The operator's responsibility is to either reconcile
+//     the restored consumer config to match Parti's expectations
+//     OR delete the consumer so Parti can recreate it fresh on the
+//     restored stream (which falls through to the replay path).
+//
+//   - If the caller recreates the stream with NO consumer (or a
+//     consumer with a DIFFERENT durable name), Parti treats it as
+//     "no preserved consumer state". The checkpoint stays at 0
+//     and the next BuildConfig produces DeliverAllPolicy (replay
+//     from sequence 1). The library will create the configured
+//     durable on the fresh stream; the differently-named consumer
+//     is ignored. Operators restoring from a backup MUST preserve
+//     the durable consumer name (and a compatible config) or
+//     accept the from-zero replay semantics.
+//
+// The hook MUST be safe to call from a recovery goroutine and SHOULD
+// return promptly. A long-running hook delays the consumer rebuild
+// and keeps the F2 envelope's attempt budget ticking.
+//
+// REQUIRED RecoveryStrategy: configuring StreamMissingHook requires
+// WithRecoveryStrategy(RecoverFromLastProcessed) — the common case
+// for at-least-once semantics — or WithRecoveryStrategy(RecoverFromBeginning)
+// — replay-all, intentional duplicate processing. RecoveryDisabled
+// (the default) and RecoverFromNew are both rejected at construction
+// because they would either disable the recovery controller entirely
+// or silently skip messages published after a fresh-stream recreate
+// (RecoverFromNew uses DeliverNewPolicy, which does not pick up the
+// recreated-stream replay override). See the consumer-construction
+// validation for the exact rejection messages.
+type StreamMissingHook func(streamName string) error
+```
+
+Wire into:
+- `durable.WorkerConsumerConfig.StreamMissingHook`
+- `consumer.DynamicConfig` (+ `WithStreamMissingHook` option)
+
+The plumbing target inside `partition_consumer.go` is
+`pc.config.StreamMissingHook`; `partitionConsumerConfig` grows the
+field.
+
+**Validation — required recovery strategy (v7 — v5-P1.1 + v6-P1.2 fix):**
+The library's stream-missing recovery flow relies on
+`recovery.Controller` for `HandleStreamRecreated` and
+`RebuildAfterStreamRecreated`. The current
+`recovery.NewController` returns nil when strategy is
+`RecoveryDisabled` (the default). A nil controller cannot perform
+either operation.
+
+Additionally, the recreated-stream `BuildConfig` override (which
+produces `DeliverAllPolicy` when `recreatedSinceLastBuild=true` AND
+checkpoint==0) only lives in the `FromLastProcessed` branch.
+`RecoverFromNew` would skip the override and use `DeliverNewPolicy`,
+which means messages published after a fresh-stream recreate but
+before the consumer is bound would be silently skipped — the exact
+hazard P2.3 is designed to eliminate.
+
+v9 validates a NARROWED set of allowed strategies at THREE
+public surfaces. Each layer implements its OWN package-local
+validation function (v9 — v8-P1 fix: no shared helper, because
+`internal/durable/` cannot import `consumer/`; duplicating ~15
+lines avoids cross-package coupling that would require a new
+shared package or an interface dance):
+
+```go
+// consumer/dynamic.go (package-local helper):
+func validateStreamMissingHookStrategy(hookConfigured bool, strategy RecoveryStrategy) error {
+    if !hookConfigured {
+        return nil
+    }
+    switch strategy {
+    case RecoverFromLastProcessed, RecoverFromBeginning:
+        return nil // OK — both implement the recreated-stream replay correctly.
+    case RecoveryDisabled:
+        return fmt.Errorf(
+            "consumer: StreamMissingHook requires a non-disabled RecoveryStrategy; " +
+            "use WithRecoveryStrategy(RecoverFromLastProcessed) or " +
+            "WithRecoveryStrategy(RecoverFromBeginning) to enable the " +
+            "stream-missing recovery path")
+    case RecoverFromNew:
+        return fmt.Errorf(
+            "consumer: StreamMissingHook is incompatible with RecoverFromNew " +
+            "because the recreated-stream replay override only applies to " +
+            "FromLastProcessed and FromBeginning. RecoverFromNew would silently " +
+            "skip messages published after a fresh-stream recreate. " +
+            "Use WithRecoveryStrategy(RecoverFromLastProcessed) for at-least-once " +
+            "semantics, or WithRecoveryStrategy(RecoverFromBeginning) for replay-from-zero.")
+    default:
+        return fmt.Errorf(
+            "consumer: StreamMissingHook with unknown RecoveryStrategy %v", strategy)
+    }
+}
+
+// internal/durable/config.go (package-local helper — IDENTICAL logic,
+// error messages use "durable:" prefix instead of "consumer:"):
+func validateStreamMissingHookStrategy(hookConfigured bool, strategy RecoveryStrategy) error {
+    if !hookConfigured {
+        return nil
+    }
+    switch strategy {
+    case RecoverFromLastProcessed, RecoverFromBeginning:
+        return nil
+    case RecoveryDisabled:
+        return fmt.Errorf(
+            "durable: StreamMissingHook requires a non-disabled RecoveryStrategy; " +
+            "use RecoveryStrategy: RecoverFromLastProcessed or RecoverFromBeginning")
+    case RecoverFromNew:
+        return fmt.Errorf(
+            "durable: StreamMissingHook is incompatible with RecoverFromNew " +
+            "because the recreated-stream replay override only applies to " +
+            "FromLastProcessed and FromBeginning. RecoverFromNew would silently " +
+            "skip messages published after a fresh-stream recreate. " +
+            "Set RecoveryStrategy: RecoverFromLastProcessed or RecoverFromBeginning.")
+    default:
+        return fmt.Errorf(
+            "durable: StreamMissingHook with unknown RecoveryStrategy %v", strategy)
+    }
+}
+```
+
+Called from THREE entry points (v9 — v8-P1 fix):
+
+1. **`consumer.NewDynamic`** option-validation step (after applying
+   options, before constructing the inner `durable.WorkerConsumer`).
+   Calls the `consumer/` package-local helper.
+2. **`consumer.DynamicConfig.Validate`** method (public, separately
+   callable — applications using `cfg.Validate()` directly must
+   see the rejection too). Calls the same helper.
+3. **`durable.WorkerConsumerConfig.Validate`** method (public,
+   separately callable — for callers that bypass the
+   `consumer.Dynamic` wrapper and use the durable package directly).
+   Calls the `durable/` package-local helper.
+
+**Why duplicated, not shared:** moving the helper to a shared
+package (`types/`, `internal/recovery/`, or a new
+`internal/streamhook/`) would either require those packages to
+import `RecoveryStrategy` (which already lives in `internal/recovery`)
+plus the typed hook signature, OR add an interface dance. The
+~15-line duplication is contained — both helpers reject the same
+strategies and accept the same strategies; if they ever diverge, a
+test would catch it (see v9 cross-package consistency test below).
+
+**v10 cross-package consistency test (v9-P1 fix)** —
+`consumer/streamhook_validation_consistency_test.go` (in
+`package consumer_test`):
+
+The v9 spec proposed a helper-level cross-package test, but Go's
+package-privacy rules make it impossible to call two
+unexported package-local helpers from one test file. v10 rewrites
+the requirement to compare **public Validate surfaces** —
+`consumer.DynamicConfig.Validate()` and
+`durable.WorkerConsumerConfig.Validate()` — which are both
+importable from a `consumer_test` package. The test runs a
+table-driven matrix of `(strategy, hookConfigured)` inputs and
+asserts both surfaces produce equivalent accept/reject outcomes
+(error vs nil — the exact error text differs by prefix, that's
+fine).
+
+```go
+// consumer/streamhook_validation_consistency_test.go (sketch)
+package consumer_test
+
+import (
+    "testing"
+    "github.com/arloliu/parti/v2/consumer"
+    "github.com/arloliu/parti/v2/internal/durable"
+)
+
+func TestStreamMissingHookStrategy_ConsistentAcrossPublicSurfaces(t *testing.T) {
+    cases := []struct{
+        name        string
+        strategy    consumer.RecoveryStrategy // alias for durable.RecoveryStrategy
+        expectError bool
+    }{
+        {"disabled", consumer.RecoveryDisabled, true},
+        {"from-new", consumer.RecoverFromNew, true},
+        {"from-last-processed", consumer.RecoverFromLastProcessed, false},
+        {"from-beginning", consumer.RecoverFromBeginning, false},
+    }
+    hook := func(string) error { return nil }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            // DynamicConfig surface
+            dc := consumer.DynamicConfig{
+                /* ... required fields ... */
+                StreamMissingHook: hook,
+                RecoveryStrategy:  tc.strategy,
+            }
+            dErr := dc.Validate()
+            // WorkerConsumerConfig surface
+            wc := durable.WorkerConsumerConfig{
+                /* ... required fields ... */
+                StreamMissingHook: hook,
+                RecoveryStrategy:  tc.strategy,
+            }
+            wErr := wc.Validate()
+            // Equivalent outcomes (error vs nil); exact text differs.
+            if (dErr == nil) != (wErr == nil) {
+                t.Fatalf("inconsistent: DynamicConfig.Validate=%v, WorkerConsumerConfig.Validate=%v", dErr, wErr)
+            }
+            if tc.expectError && dErr == nil {
+                t.Fatalf("expected error for strategy %s, got nil from DynamicConfig.Validate", tc.name)
+            }
+        })
+    }
+}
+```
+
+This pins the cross-package consistency without violating Go's
+privacy rules. If a future change adds a new `RecoveryStrategy`
+enum value to one surface's validation without updating the
+other, the test fails because one returns nil while the other
+returns an error.
+
+The hook godoc states the allowed strategies explicitly: callers
+configuring `StreamMissingHook` must use `RecoverFromLastProcessed`
+(common case, at-least-once) or `RecoverFromBeginning` (replay-all,
+intentional duplicate processing).
+
+**Required regression tests (v9 — v7-P1 + v8-P2 fix; full
+matrix across all three surfaces × all four strategy variants):**
+
+- `consumer/dynamic_test.go` (`NewDynamic` surface):
+  - `TestNewDynamic_StreamMissingHook_RecoverFromNew_Rejected`
+  - `TestNewDynamic_StreamMissingHook_RecoveryDisabled_Rejected`
+  - `TestNewDynamic_StreamMissingHook_RecoverFromLastProcessed_OK`
+  - `TestNewDynamic_StreamMissingHook_RecoverFromBeginning_OK`
+- `consumer/dynamic_test.go` (`DynamicConfig.Validate` surface):
+  - `TestDynamicConfig_Validate_StreamMissingHook_RecoverFromNew_Rejected`
+  - `TestDynamicConfig_Validate_StreamMissingHook_RecoveryDisabled_Rejected`
+  - `TestDynamicConfig_Validate_StreamMissingHook_RecoverFromLastProcessed_OK`
+  - `TestDynamicConfig_Validate_StreamMissingHook_RecoverFromBeginning_OK`
+- `internal/durable/config_test.go` (`WorkerConsumerConfig.Validate` surface):
+  - `TestWorkerConsumerConfig_Validate_StreamMissingHook_RecoverFromNew_Rejected`
+  - `TestWorkerConsumerConfig_Validate_StreamMissingHook_RecoveryDisabled_Rejected`
+  - `TestWorkerConsumerConfig_Validate_StreamMissingHook_RecoverFromLastProcessed_OK`
+  - `TestWorkerConsumerConfig_Validate_StreamMissingHook_RecoverFromBeginning_OK`
+- Plus the cross-package consistency test (above):
+  - `TestStreamMissingHookStrategy_ConsistentAcrossPublicSurfaces`
+    (in `consumer/streamhook_validation_consistency_test.go`,
+    package `consumer_test` — compares the public
+    `DynamicConfig.Validate` and `WorkerConsumerConfig.Validate`
+    surfaces).
+
+Total: 12 strategy-validation tests + 1 consistency test = 13.
+Each test asserts the specific error type or message-substring so
+implementations cannot silently weaken the rejection.
+
+### Mechanism 1b — Public no-hook readiness route (NEW in v2)
+
+The v1 spec assumed "envelope exhaustion → OnPermanentFailure →
+existing degraded-mode wiring trips readiness". The v1 plan-review
+found that NO such wiring exists today: `consumer.Dynamic` does not
+set `WorkerConsumerConfig.OnPermanentFailure`, and `Manager` has no
+way to inject callbacks into an externally-created `*Dynamic`. T4
+cannot pass as written.
+
+v2 added the surface; v3 fixes the construction-order bug the v2
+plan-review identified (v2-P0.1). The bug: `NewDynamic` constructs
+`WorkerConsumerConfig` (copying the user-supplied
+`OnPermanentFailure` into the durable layer) BEFORE `parti.Manager`
+has a chance to call `SetOnStreamMissingError`. A later swap can't
+affect the already-copied callback.
+
+v3 fixes this with an **indirection slot owned by `*Dynamic`** that
+the durable callback ALWAYS reads at fire time:
+
+```go
+// consumer/dynamic.go (v3 fields)
+type Dynamic struct {
+    // ... existing fields ...
+    // userOnPermanentFailure is the application-supplied
+    // OnPermanentFailure callback (from WithOnPermanentFailure).
+    // Nil if not configured.
+    userOnPermanentFailure func(subject string, err error)
+    // managerOnStreamMissing is the manager-installed closure
+    // registered via SetOnStreamMissingError. Read at fire time
+    // through the atomic.Pointer so a Manager.Start call after
+    // NewDynamic correctly reaches the durable layer.
+    managerOnStreamMissing atomic.Pointer[func(streamName string, err error)]
+}
+
+// NewDynamic always installs THIS closure as WorkerConsumerConfig.OnPermanentFailure
+// (regardless of whether the user supplied OnPermanentFailure). The
+// closure dispatches at fire time:
+func (d *Dynamic) onPermanentFailure(subject string, err error) {
+    // Application-supplied callback wins if present.
+    if d.userOnPermanentFailure != nil {
+        d.userOnPermanentFailure(subject, err)
+        return
+    }
+    // Otherwise route stream-missing errors through the
+    // manager-installed observer if any. Generic exhaustion
+    // (non-stream-missing) flows through unchanged — the
+    // partition_consumer's OnPermanent log line already records it
+    // at WARN (P2.4d). No new typed-error wrapper is introduced
+    // for the generic case (v3-P1.3 resolution: types.ErrConsumerRecoveryExhausted
+    // dropped from v2; the existing log + metric path is the
+    // operator-visible signal for generic exhaustion).
+    if fn := d.managerOnStreamMissing.Load(); fn != nil {
+        if errors.Is(err, types.ErrStreamMissing) {
+            (*fn)(d.streamName, err)
+        }
+    }
+}
+```
+
+`SetOnStreamMissingError` is the public method on `*Dynamic`:
+
+```go
+// SetOnStreamMissingError stores a callback invoked when a stream-
+// missing-classified permanent failure surfaces from the durable
+// layer. Called by Manager.Start (or any wiring layer) AFTER
+// NewDynamic. Safe for concurrent use.
+func (d *Dynamic) SetOnStreamMissingError(fn func(streamName string, err error)) {
+    if fn == nil {
+        d.managerOnStreamMissing.Store(nil)
+        return
+    }
+    d.managerOnStreamMissing.Store(&fn)
+}
+```
+
+The `recovery.StreamMissingObserver` interface (one method:
+`SetOnStreamMissingError`) is implemented by `*Dynamic`.
+`Manager.Start` (specifically: at the end of `prepareStart` in
+`manager_setup.go:18-25`, after `m.ctx` is initialized but before
+any worker-consumer interaction) type-asserts the registered
+updater and installs the observer:
+
+```go
+// manager_setup.go (v5 — concrete addition; the actual field name
+// is m.consumerUpdater, not m.workerUpdater — v5 fix for v4-P1.3).
+//
+// CompositeConsumerUpdater forwarding: when the registered updater
+// is a CompositeConsumerUpdater wrapping one or more child updaters,
+// we must forward the SetOnStreamMissingError call to each child
+// that implements the StreamMissingObserver interface. The composite
+// itself does NOT implement the interface directly; instead, v5
+// adds a small forwarding method on CompositeConsumerUpdater (see
+// composite_updater.go edit below).
+if obs, ok := m.consumerUpdater.(recovery.StreamMissingObserver); ok {
+    obs.SetOnStreamMissingError(m.onStreamMissingError)
+}
+
+// onStreamMissingError is the manager's observer closure. Defined
+// as a method so it closes over m and has access to m.ctx,
+// m.logError, m.enterDegraded.
+func (m *Manager) onStreamMissingError(streamName string, cause error) {
+    // m.logError preserves the existing manager.wg + Hooks.OnError
+    // tracking (see manager.go:918-947); using m.logError instead
+    // of direct hooks.OnError invocation also gives consistent log
+    // formatting and uses m.ctx implicitly.
+    m.logError(
+        fmt.Sprintf("dynamic-consumer stream %q recovery exhausted", streamName),
+        "stream", streamName,
+        "error", cause,
+    )
+    // Trip readiness. The reason string is the operator-facing
+    // signal that distinguishes stream-missing from KV-bucket-loss
+    // (see "Cross-feature contract preservation" below).
+    m.enterDegraded("stream-missing-recovery-exhausted")
+}
+```
+
+**`composite_updater.go` edit (v6 — v4-P1.3 + v5-P1.2 fixes):**
+
+The composite must:
+1. Forward `SetOnStreamMissingError` to all CURRENT children that
+   implement `recovery.StreamMissingObserver`.
+2. Remember the registered observer so a LATER `Add()` call also
+   forwards to the newly-added child (v5-P1.2: the manager
+   registers the observer once during prepareStart; `Add()` is
+   public and can be called afterward — without this fix, late-
+   added children would miss the observer).
+3. Be race-free between concurrent `Add` and observer-related
+   reads.
+
+```go
+// composite_updater.go (v6 additions)
+type CompositeConsumerUpdater struct {
+    updaters     []WorkerConsumerUpdater // existing field (NOT "children")
+    mu           sync.Mutex              // new: protects updaters slice + currentObserver
+    currentObserver func(streamName string, err error) // new: last registered observer
+}
+
+// SetOnStreamMissingError records the callback and forwards it
+// to all current updaters that implement
+// recovery.StreamMissingObserver. Children that do not implement
+// the interface are skipped silently. Subsequent Add() calls
+// forward the recorded observer to newly-added children.
+//
+// Calling SetOnStreamMissingError(nil) clears both the stored
+// observer and any installed observer on current children.
+func (c *CompositeConsumerUpdater) SetOnStreamMissingError(fn func(streamName string, err error)) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    c.currentObserver = fn
+    for _, u := range c.updaters {
+        if obs, ok := u.(recovery.StreamMissingObserver); ok {
+            obs.SetOnStreamMissingError(fn)
+        }
+    }
+}
+
+// Add (existing public method) — v6 wraps it so newly added
+// observer-capable children inherit the currently-registered
+// stream-missing observer.
+func (c *CompositeConsumerUpdater) Add(updaters ...WorkerConsumerUpdater) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    for _, u := range updaters {
+        if u == nil {
+            continue
+        }
+        c.updaters = append(c.updaters, u)
+        if c.currentObserver != nil {
+            if obs, ok := u.(recovery.StreamMissingObserver); ok {
+                obs.SetOnStreamMissingError(c.currentObserver)
+            }
+        }
+    }
+}
+
+// UpdateWorkerConsumer, Capabilities, Len — v6 also takes the mutex
+// around their reads of c.updaters (existing code did unsynchronized
+// reads; v5-P1.2 noted the race surface). This is a minor adjustment
+// to the existing methods.
+```
+
+`CompositeConsumerUpdater` itself satisfies
+`recovery.StreamMissingObserver` (because it has the required
+method); the manager's type-assertion succeeds and the composite
+forwards to its children. Tests in `composite_updater_test.go`
+pin:
+- Children present at construction receive the observer when
+  `SetOnStreamMissingError` is called.
+- Children added LATER via `Add()` after observer registration
+  also receive the observer (v5-P1.2 regression pin).
+- `SetOnStreamMissingError(nil)` clears the stored observer and
+  the children's observers.
+- Non-observer-implementing children are silently skipped.
+
+The closure uses `m.ctx` implicitly through `m.logError`; that
+function already runs the registered `Hooks.OnError` under the
+manager's wait group, so the bridge gets the full lifecycle
+semantics without re-implementing them.
+
+**Construction order, explicitly:**
+1. Application calls `consumer.NewDynamic(...)`. The Dynamic
+   constructs `WorkerConsumerConfig` with `OnPermanentFailure =
+   d.onPermanentFailure` (the indirection closure — ALWAYS, regardless
+   of user-supplied option).
+2. `durable.NewWorkerConsumer` copies this closure into its config.
+3. Application calls `parti.NewManager(..., WithWorkerConsumerUpdater(dynamic))`.
+4. `Manager.Start` (or the constructor) type-asserts and calls
+   `dynamic.SetOnStreamMissingError(managerClosure)`. The closure is
+   stored in `dynamic.managerOnStreamMissing.atomic.Pointer`.
+5. When permanent failure fires later, the durable callback (=
+   `d.onPermanentFailure`) reads `d.managerOnStreamMissing` AT
+   THAT MOMENT and dispatches.
+
+The bug the v2 plan-review found is closed: no copy of a
+nil-at-the-time callback ever reaches the durable layer.
+
+**Cross-feature contract preservation:** `types.ErrStreamMissing` is
+the unambiguous carrier. It is distinct from
+`natsutil.IsDegradingJetStreamError` (which treats raw
+`jetstream.ErrStreamNotFound` as degrading and would otherwise
+route through `recordKVError`). T4 asserts
+`errors.Is(receivedErr, types.ErrStreamMissing)`.
+
+**v4 — explicit `recordKVError` short-circuit (v3-P1.3 fix):**
+the v3 spec claimed `recordKVError` short-circuits on
+`types.ErrStreamMissing`, but the v3 plan-review found that no
+such short-circuit exists in source. v4 adds the explicit edit to
+the file plan:
+
+```go
+// manager_degraded.go (v4 — add at the top of recordKVError, before
+// any other classification):
+func (m *Manager) recordKVError(err error) {
+    if err == nil {
+        return
+    }
+    // Stream-missing errors are routed through Dynamic's permanent-
+    // failure observer to enterDegraded("stream-missing-recovery-exhausted"),
+    // NOT through the generic KV error threshold path. Short-circuit
+    // here so that a stream-missing error which incidentally wraps
+    // jetstream.ErrStreamNotFound (a degrading-JetStream error per
+    // natsutil) does not double-count or trip the KV threshold.
+    if errors.Is(err, types.ErrStreamMissing) {
+        return
+    }
+    // ... existing classification (connectivity / degrading JS) ...
+}
+```
+
+T4 asserts the route is `stream-missing-recovery-exhausted`, NOT
+`"KV error threshold exceeded"`. This preserves the cross-feature
+contract that whole-bucket loss (Parti's own KV buckets) is the
+only path through `recordKVError → enterDegraded("KV error threshold exceeded")`.
+
+### Mechanism 2 — Checkpoint reset (`internal/recovery/checkpoint.go`)
+
+```go
+// ResetForStreamRecreate clears the checkpoint to zero. Unlike Seed,
+// this is NON-monotonic. It is only legal after the caller has
+// confirmed (via the OnStreamMissing hook returning nil) that the
+// stream is a new identity. The Controller.HandleStreamRecreated
+// path is the only legitimate caller; direct use elsewhere will
+// silently drop progress.
+func (cp *Checkpoint) ResetForStreamRecreate() {
+    cp.maxAckedStreamSeq.Store(0)
+}
+```
+
+No other Checkpoint method changes.
+
+### Mechanism 3 — Stream-epoch generation fence (`internal/recovery/controller.go`)
+
+```go
+// Controller (added field, alongside checkpoint)
+streamEpoch atomic.Uint64
+```
+
+```go
+// internal/recovery/tracking_msg.go
+type trackingMsg struct {
+    jetstream.Msg
+    controller *Controller
+    epoch      uint64 // captured from controller.streamEpoch at WrapForTracking time
+}
+
+func (m *trackingMsg) Ack() error {
+    err := m.Msg.Ack()
+    if err == nil {
+        m.controller.AdvanceCheckpoint(m.Msg, m.epoch)
+    }
+    return err
+}
+
+// (DoubleAck analogous)
+```
+
+```go
+// internal/recovery/controller.go
+func (c *Controller) WrapForTracking(msg jetstream.Msg) jetstream.Msg {
+    if c == nil || c.strategy != FromLastProcessed {
+        return msg
+    }
+    return &trackingMsg{
+        Msg:        msg,
+        controller: c,
+        epoch:      c.streamEpoch.Load(), // captured at dispatch time
+    }
+}
+
+// Signature widened: epoch parameter is the message's dispatch-time
+// epoch. AdvanceCheckpoint silently no-ops when the captured epoch
+// does not match the current streamEpoch.
+func (c *Controller) AdvanceCheckpoint(msg jetstream.Msg, epoch uint64) {
+    if c == nil {
+        return
+    }
+    if epoch != c.streamEpoch.Load() {
+        return // late ack from a prior stream generation
+    }
+    c.checkpoint.Advance(msg)
+}
+```
+
+The non-manual-ack path (`Dispatch` with `manualAck=false`,
+`controller.go:190-194`) is implicitly fenced (synchronous Ack on
+the dispatch goroutine, so it cannot outlive a `HandleStreamRecreated`
+that ran on the recovery goroutine), but the fence still applies:
+`Dispatch` captures the current epoch at dispatch time and passes
+it to `AdvanceCheckpoint`. Document the invariant:
+**`AdvanceCheckpoint` MUST be called with the epoch captured at
+message dispatch time, never at ack time.** This invariant survives
+any future async-dispatch addition.
+
+### `HandleStreamRecreated` — the load-bearing ordering
+
+```go
+// HandleStreamRecreated is called by the partition consumer's
+// recovery detour after OnStreamMissing returns nil. It performs
+// the steps in this exact order; reversing bump↔reset opens a
+// race where an old-epoch ack landing between reset and bump can
+// re-raise the (just-zeroed) checkpoint past zero, after which the
+// fresh-stream consumer skips messages.
+//
+//  1. Bump streamEpoch. Any in-flight trackingMsg captured before
+//     this point is now from a prior epoch; its late ack will
+//     no-op via the fence.
+//  2. ResetForStreamRecreate. Drop the stale checkpoint to zero.
+//  3. SeedCheckpoint(ctx, infoFn). If the new stream / restored
+//     consumer's AckFloor > 0, the seed picks it up; if AckFloor
+//     is 0 (fresh stream), the checkpoint stays at 0.
+//  4. Set recreatedSinceLastBuild so the next BuildConfig knows
+//     to choose DeliverAllPolicy when checkpoint is still 0.
+//
+// (v5: there was a step 5 "set bypass token" in v2/v3 designs;
+// v4 removed the token entirely because Site A/B both call
+// RebuildAfterStreamRecreated synchronously after the hook —
+// see "Cooldown handling" below.)
+//
+// onStep is a private test seam. When non-nil, it is invoked
+// between each ordered step with the step name. Tests use it to
+// inject an old-epoch ack between steps and verify the ordering
+// contract deterministically (see T2c-ordering below). Production
+// callers always pass nil.
+func (c *Controller) HandleStreamRecreated(ctx context.Context, infoFn InfoFunc) {
+    c.handleStreamRecreatedWithSteps(ctx, infoFn, nil)
+}
+
+func (c *Controller) handleStreamRecreatedWithSteps(
+    ctx context.Context,
+    infoFn InfoFunc,
+    onStep func(step string),
+) {
+    if c == nil {
+        return
+    }
+    c.streamEpoch.Add(1)
+    if onStep != nil { onStep("after_bump") }
+
+    c.checkpoint.ResetForStreamRecreate()
+    if onStep != nil { onStep("after_reset") }
+
+    c.SeedCheckpoint(ctx, infoFn)
+    if onStep != nil { onStep("after_seed") }
+
+    c.recreatedSinceLastBuild.Store(true)
+    if onStep != nil { onStep("after_flag") }
+}
+```
+
+The exported `HandleStreamRecreated` does NOT expose `onStep`. The
+private `handleStreamRecreatedWithSteps` is package-internal and
+the test seam used by the ordering test.
+
+**T2c-ordering deterministic test** (added in v2 to replace the
+v1 fragile sleep/log-based test): the test calls
+`handleStreamRecreatedWithSteps` with an `onStep` callback. The
+callback, when invoked with `"after_reset"`, runs:
+
+```go
+// Inject an old-epoch ack between reset and bump (this is the
+// race window for reset-before-bump). In the correct ordering
+// (bump-before-reset), this inject point is "after_reset" and
+// the epoch has ALREADY been bumped, so the held tracking msg
+// (captured at epoch=1) acks against current epoch=2 and the
+// fence drops it. In the broken ordering (reset-before-bump),
+// the epoch is still 1 at "after_reset" and the ack passes the
+// fence, advancing the checkpoint past zero.
+heldMsg.Ack()
+```
+
+Test asserts: after `handleStreamRecreatedWithSteps` returns,
+`Checkpoint.Value() == seedValue` (not the held msg's seq). On a
+hypothetical reset-before-bump implementation, the value would
+equal the held msg's stream seq. This test is deterministic — no
+sleeps, no scheduling assumptions.
+
+### `BuildConfig` override
+
+**v4 locked signature:** `BuildConfig` is widened to accept the
+`recreatedSinceLastBuild` flag as a fourth parameter. (v3 left this
+"optional"; the v3 plan-review correctly noted this was inconsistent
+with `RebuildAfterStreamRecreated`'s 4-argument call.)
+
+```go
+// internal/recovery/config.go (v4 signature)
+func BuildConfig(
+    base jetstream.ConsumerConfig,
+    strategy Strategy,
+    checkpoint uint64,
+    recreatedSinceLastBuild bool,
+) (jetstream.ConsumerConfig, string) {
+```
+
+Spec-level contract:
+
+> After stream recreate, the first post-hook `BuildConfig` call
+> with `recreatedSinceLastBuild=true` and `checkpoint==0` produces
+> `DeliverAllPolicy`, not `DeliverNewPolicy`. Subsequent calls (with
+> the flag cleared by `RebuildAfterStreamRecreated`'s Swap) use the
+> existing rules.
+
+Existing callers of `BuildConfig` (currently `Controller.recover`)
+pass `false` for the new parameter; their behavior is unchanged.
+
+```go
+// Inside BuildConfig (FromLastProcessed branch):
+switch {
+case checkpoint > 0:
+    cfg.DeliverPolicy = jetstream.DeliverByStartSequencePolicy
+    cfg.OptStartSeq = checkpoint + 1
+case recreatedSinceLastBuild:
+    cfg.DeliverPolicy = jetstream.DeliverAllPolicy
+    return cfg, "stream_recreated_replay_from_start"
+default:
+    cfg.DeliverPolicy = jetstream.DeliverNewPolicy
+    return cfg, "fallback_no_checkpoint"
+}
+```
+
+**FromBeginning branch:** unchanged from the existing implementation.
+`RecoverFromBeginning` already produces `DeliverAllPolicy`
+unconditionally (`internal/recovery/config.go:30-31`), so the
+recreated-flag override is a no-op in that branch — the replay
+contract is satisfied by the base behavior. The `recreatedSinceLastBuild`
+flag is still consumed (via Swap-and-clear) inside
+`RebuildAfterStreamRecreated` regardless of strategy, so the flag's
+one-shot semantics hold across strategy choices.
+
+**FromNew branch:** intentionally NOT modified. The validation at
+consumer construction rejects `StreamMissingHook` + `RecoverFromNew`
+(see "Validation — required recovery strategy" above), so no
+production code path can reach the FromNew branch with
+`recreatedSinceLastBuild=true`. Tests pin this rejection.
+
+### Metrics — no public-interface change (v2 resolution of P1.4)
+
+The v1 spec proposed three new metric methods
+(`IncrementWorkerConsumerStreamRecreateSuccess/Error` and
+`IncrementWorkerConsumerStreamRecreate`). Per the v1 plan-review's
+P1.4 finding, adding methods to `types.WorkerConsumerMetrics` is a
+breaking change for external implementers.
+
+v2 uses the existing
+`types.WorkerConsumerMetrics.IncrementWorkerConsumerIteratorRestart(reason string)`
+method (already in the public interface) with new reason labels:
+
+- `"stream_missing_no_hook"` — hook absent; stream-missing detected
+- `"stream_recreate_error"` — hook returned a non-nil error
+- `"stream_recreate_success"` — hook returned nil; HandleStreamRecreated ran
+
+The exported-symbol audit at the end of this spec reflects this:
+no new methods on `types.WorkerConsumerMetrics`.
+
+### Stream-missing detection — wire shape
+
+**Public typed error (resolved in v2 per P1.1 finding):**
+`types.ErrStreamMissing` lives in `types/errors.go` (the existing
+public-errors file). `parti.ErrStreamMissing` is a top-level alias
+following the existing convention (`parti.ErrClaimLost`,
+`parti.ErrInvalidConfig`, etc).
+
+```go
+// types/errors.go (new sentinel)
+//
+// ErrStreamMissing indicates that the library's stream-missing
+// recovery flow encountered a failure that prevented the dynamic
+// consumer from resuming. Despite the name, this is an UMBRELLA
+// for the entire stream-missing recovery episode — not just
+// "stream object absent". Wrapped causes include:
+//
+//   - The underlying JetStream stream is absent
+//     (jetstream.ErrStreamNotFound).
+//   - The StreamMissingHook returned a non-nil error.
+//   - After a successful hook, RebuildAfterStreamRecreated failed
+//     for any reason (stream still missing, restored consumer has
+//     incompatible config such as a different DeliverPolicy or
+//     AckPolicy, etc).
+//
+// This unification means an application's
+// errors.Is(err, parti.ErrStreamMissing) check in Hooks.OnError
+// returns true for every operator-actionable stream-recovery
+// failure mode, not just the literal stream-not-found case. The
+// wrapped cause carries the precise underlying NATS error and the
+// stream name so the operator can diagnose.
+//
+// Distinguishing whole-bucket-loss from stream-missing:
+//
+//   - Whole-bucket loss (a NATS KV bucket configured by Parti for
+//     its own internal state, e.g. assignment, heartbeat) flows
+//     through Manager.recordKVError → enterDegraded("KV error
+//     threshold exceeded"). The cross-feature contract (AGENTS.md)
+//     pins this path; ErrStreamMissing MUST NOT route there.
+//
+//   - Stream missing (the JetStream stream the application's
+//     dynamic consumer reads from) flows through the F2 envelope's
+//     OnPermanentFailure → ErrStreamMissing → Hooks.OnError +
+//     enterDegraded("stream-missing-recovery-exhausted").
+//
+// callers SHOULD use errors.Is(err, parti.ErrStreamMissing) for
+// branching; the wrapped cause (the underlying NATS error and the
+// stream name) is preserved.
+var ErrStreamMissing = errors.New("parti: stream missing")
+```
+
+The internal recovery package wraps `jetstream.ErrStreamNotFound`
+WITH `types.ErrStreamMissing`. No internal `recovery.ErrStreamMissing`
+exists — the v1 spec's internal sentinel is replaced by the public
+one.
+
+The wire shape for the stream-missing signal:
+
+**Signature contract (v3 — locked):**
+- `Controller.recover` returns `(jetstream.Consumer, error)`. The
+  `bool` from the v1-era contract is dropped; the existing two
+  success/failure variants become: nil-consumer + nil-error =
+  "backoff this attempt"; non-nil-consumer + nil-error = "success,
+  use this consumer"; nil-consumer + non-nil-error = "stream
+  missing or fatal" (caller inspects with errors.Is).
+- `Controller.Classify` returns `(Action, jetstream.Consumer, error)`.
+  Error is non-nil iff Action == ActionStreamMissing AND the
+  error wraps `types.ErrStreamMissing`.
+
+1. **Inside `recover()`**: `recreate()` is called at
+   `internal/recovery/controller.go:294`. If it returns an error
+   wrapping `jetstream.ErrStreamNotFound`, `recover()` returns
+   `(nil, fmt.Errorf("%w: %w", types.ErrStreamMissing, err))` and
+   **does NOT** update `lastRecoveryTime`, `burst`, `checkpoint`,
+   or `inProgress`.
+
+```go
+// internal/recovery/controller.go (inside recover, after recreate call)
+//
+// v4 signature contract (locked): recover returns
+// (jetstream.Consumer, error). Two-value, no bool. The previous
+// bool was redundant with err == nil semantics.
+//   - non-nil consumer + nil error = success
+//   - nil consumer + nil error    = backoff this attempt (no state advance)
+//   - nil consumer + non-nil error = fatal or stream-missing (use errors.Is to inspect)
+newCons, err := recreate(ctx, recoverCfg)
+if err != nil {
+    if natsutil.IsStreamNotFound(err) {
+        // Bail without advancing checkpoint, burst, or
+        // lastRecoveryTime; surface to the caller (partition
+        // consumer detour) so the hook can recreate the stream.
+        return nil, fmt.Errorf("%w: %w", types.ErrStreamMissing, err)
+    }
+    c.logger.Warn("consumer recovery failed", "error", err)
+    return nil, nil  // backoff path; lastRecoveryTime stays unset
+}
+```
+
+**Classify signature change (resolved in v2 per P1.2 finding):**
+the current `Classify` signature is
+`(Action, jetstream.Consumer)`. v2 widens to
+`(Action, jetstream.Consumer, error)`. The error is non-nil iff
+the action is `ActionStreamMissing` (and wraps
+`types.ErrStreamMissing`).
+
+The new `Action`:
+```go
+// internal/recovery/action.go
+ActionStreamMissing Action = iota_next_value
+```
+
+**File-by-file caller contract** (v3 — every caller of
+`recovery.Controller.Classify` updated; the v2 spec's "surfaces to
+OnError sink" claim was wrong — non-Dynamic callers don't have one
+today. v3 explicitly states "log + backoff" for them):
+
+| Caller | File | v3 contract |
+|---|---|---|
+| Dynamic partition consumer (P2.3 target) | `internal/durable/partition_consumer.go:294` | Handles ActionStreamMissing via the `handleStreamMissing` detour (hook + RebuildAfterStreamRecreated) |
+| Queue consumer | `consumer/queue.go:398-412` | Maps ActionStreamMissing → log at WARN with stream name + the wrapped error, then ActionBackoff. Queue does not own stream lifecycle and intentionally does not surface the typed error to any callback (no existing OnError sink). |
+| Broadcast consumer | `internal/durable/broadcast_consumer.go:331-350` | Same as Queue: log + backoff. |
+| Internal partition consumer | `internal/ipartition/consumer.go:291-310` | Same as Queue: log + backoff. |
+
+Each non-Dynamic caller adds the `ActionStreamMissing` switch case
+with an explicit comment that this consumer does not own stream
+lifecycle, so the typed error is logged for operator
+observability but NOT surfaced to any callback. A new test in each
+file pins this mapping (action == ActionBackoff after the case
+runs; the log line is emitted). This prevents the new action
+silently falling through to the default branch.
+
+`Classify` returns `(ActionStreamMissing, nil, wrappedErr)` where
+`wrappedErr` is the stream-missing error wrapping
+`types.ErrStreamMissing`. The Dynamic caller's `switch action`
+includes a `case ActionStreamMissing` that inspects the error via
+`errors.Is(err, types.ErrStreamMissing)`; non-Dynamic callers may
+ignore the error or log it.
+
+### `partition_consumer.go` detour — TWO call sites
+
+Stream-not-found originates at TWO call sites in
+`partition_consumer.go` today, and the v1 review found that wiring
+the hook only into `handleIteratorFailure` (the iter-runtime path)
+misses the more common case. Both sites must route through the same
+`handleStreamMissing` helper.
+
+**Site A — iterator-creation path inside the F2 envelope.**
+`runIteratorEnvelope` calls `pc.iterFactory(cons, batch, expiry)`
+at `partition_consumer.go:222-225` (v2.4d code). The actual
+stream-missing signal originates one level deeper: when
+`iterFactory` returns an error, the envelope's Work calls
+`maybeEscalateIteratorFailures` → `ensureConsumer` →
+`js.CreateOrUpdateConsumer`. Inside `ensureConsumer`, the
+`natsutil.IsStreamNotFound(err)` check at
+`partition_consumer.go:533-535` recognizes the condition but
+discards the error.
+
+v3 fix (resolves v2-P0.2):
+
+The Site A detour must do TWO things on a successful hook:
+1. Invoke `pc.recovery.HandleStreamRecreated` (resets checkpoint,
+   bumps epoch, sets recreated flag, consumes bypass token).
+2. **Explicitly rebuild the consumer using the recovery package's
+   config-aware path**, NOT the static `ensureConsumer` config.
+   Otherwise the next `iterFactory` call uses the old consumer
+   handle (or `ensureConsumer` uses `pc.consumerConfig` with the
+   static `DeliverAllPolicy` from `dynamicbuild` — bypassing the
+   reset checkpoint + `BuildConfig` override).
+
+This is mechanised through a new `recovery.Controller` method:
+
+```go
+// RebuildAfterStreamRecreated builds a post-recreate consumer
+// config from the (now-reset) checkpoint, the one-shot recreated
+// flag, and the strategy; calls recreate(ctx, cfg) to create the
+// new consumer on the freshly-restored stream; returns the new
+// consumer. Mirrors the success path of recover() but:
+//   - reads-and-clears recreatedSinceLastBuild (so BuildConfig
+//     produces DeliverAllPolicy when checkpoint==0);
+//   - updates lastRecoveryTime and burst on success (same as
+//     recover);
+//   - does NOT observe the cooldown — Site A/B call this directly
+//     after the hook returns nil, and this is the single
+//     immediate post-hook rebuild attempt. (The cooldown bypass
+//     token from earlier v3 design was dropped in v4; see
+//     "Cooldown handling" below.)
+//
+// On error, wraps the underlying cause with types.ErrStreamMissing
+// regardless of whether the underlying error is jetstream.ErrStreamNotFound
+// or a consumer-config-mismatch / NATS API error. v4 design
+// (v3-P0.2 fix): any failure during post-hook recovery is part of
+// the stream-missing recovery flow, so the typed-error class
+// surfaces consistently up to the manager observer. The operator
+// godoc on StreamMissingHook spells this out.
+//
+// Called by partitionConsumer.handleStreamMissing AFTER
+// HandleStreamRecreated has run successfully.
+func (c *Controller) RebuildAfterStreamRecreated(
+    ctx context.Context,
+    baseCfg jetstream.ConsumerConfig,
+    recreate RecreateFunc,
+) (jetstream.Consumer, error) {
+    if c == nil {
+        return nil, errors.New("recovery: nil controller")
+    }
+    checkpoint := c.checkpoint.Value()
+    recreated := c.recreatedSinceLastBuild.Swap(false) // read-and-clear
+    cfg, fallback := BuildConfig(baseCfg, c.strategy, checkpoint, recreated)
+    if fallback != "" {
+        c.logger.Info("rebuild post-recreate", "fallback", fallback)
+    }
+    newCons, err := recreate(ctx, cfg)
+    if err != nil {
+        // All errors during post-hook recovery wrap types.ErrStreamMissing
+        // so the manager observer route is consistent. Includes
+        // both still-missing-stream and incompatible-restored-consumer-config.
+        return nil, fmt.Errorf("%w: %w", types.ErrStreamMissing, err)
+    }
+    c.burst.Reset()
+    c.mu.Lock()
+    c.lastRecoveryTime = time.Now()
+    c.mu.Unlock()
+    return newCons, nil
+}
+```
+
+**Cooldown handling (v4 — v3-P1.4 fix):** the v3 design used a
+one-shot `postHookBypassPending` atomic.Bool consumed by CAS in
+`recover()` so the post-hook re-entry into `recover` could skip
+the 500ms cooldown. The v3 plan-review found this token leaks
+when `RebuildAfterStreamRecreated` is called from Site A (which
+does NOT re-enter `recover` — it has its own rebuild path).
+
+v4 drops the bypass token entirely. Both Site A and Site B call
+`RebuildAfterStreamRecreated` synchronously after the hook returns
+nil; the cooldown is irrelevant for that single immediate rebuild.
+The normal cooldown (`minRecoveryInterval` in `Controller.recover`)
+continues to apply to subsequent unrelated recoveries, but those
+won't be back-to-back with the post-hook rebuild because the
+rebuild's `lastRecoveryTime` update gives the cooldown a fresh
+baseline.
+
+`HandleStreamRecreated`'s step list is reduced accordingly:
+
+```go
+func (c *Controller) handleStreamRecreatedWithSteps(
+    ctx context.Context,
+    infoFn InfoFunc,
+    onStep func(step string),
+) {
+    if c == nil {
+        return
+    }
+    c.streamEpoch.Add(1)
+    if onStep != nil { onStep("after_bump") }
+
+    c.checkpoint.ResetForStreamRecreate()
+    if onStep != nil { onStep("after_reset") }
+
+    c.SeedCheckpoint(ctx, infoFn)
+    if onStep != nil { onStep("after_seed") }
+
+    c.recreatedSinceLastBuild.Store(true)
+    if onStep != nil { onStep("after_flag") }
+    // v4: no token set. Caller proceeds directly to RebuildAfterStreamRecreated.
+}
+```
+
+The Site A detour inside the envelope's `Work` closure:
+
+**v5 fix for v4-P1.1 (stale captured `cons`):** the envelope's Work
+closure re-loads `pc.consumer` at the START of each attempt rather
+than closing over a fixed `cons` value. This is required so that a
+mid-envelope rebuild (Site A success path stores a new consumer)
+is visible to the next Work attempt. Implementation either:
+(a) re-reads `pc.consumer` under `consumerMu.RLock` at the top of
+the closure, OR (b) the outer `runIteratorEnvelope` mutates a
+closure-local `cons` variable to `newCons` after the rebuild
+succeeds. Either works; the sketch below uses (a) for clarity.
+
+```go
+// sketch — production code in runIteratorEnvelope's Work closure
+// v5: re-load pc.consumer per attempt so post-rebuild attempts use newCons.
+pc.consumerMu.RLock()
+cons := pc.consumer
+pc.consumerMu.RUnlock()
+
+i, err := pc.iterFactory(cons, batch, expiry)
+if err == nil {
+    iter = i
+    return nil
+}
+// iter-factory failed. Try escalation/remediation; this may surface
+// a stream-missing classification.
+escErr := pc.maybeEscalateIteratorFailures(workCtx)
+if escErr != nil && natsutil.IsStreamNotFound(escErr) {
+    // Stream-missing on the iter-creation path. Detour:
+    if hookErr := pc.handleStreamMissing(workCtx); hookErr != nil {
+        // Hook absent or returned error; the envelope counts this
+        // attempt and either retries or exhausts.
+        return fmt.Errorf("%w: %w", types.ErrStreamMissing, hookErr)
+    }
+    // Hook succeeded; HandleStreamRecreated was called inside
+    // handleStreamMissing. Explicitly rebuild the consumer through
+    // the recovery config path so the next iter creation uses the
+    // post-recreate policy.
+    newCons, rebuildErr := pc.recovery.RebuildAfterStreamRecreated(
+        workCtx, pc.consumerConfig, pc.recreateFn())
+    if rebuildErr != nil {
+        // Already wrapped with types.ErrStreamMissing by
+        // RebuildAfterStreamRecreated (v4 — handles both still-missing
+        // and incompatible-restored-config). Counts against envelope budget.
+        return rebuildErr
+    }
+    pc.consumerMu.Lock()
+    pc.consumer = newCons
+    pc.consumerMu.Unlock()
+    // v4 fix for v3-P0.1: create the iterator from the new consumer
+    // BEFORE returning nil. Returning nil with iter unset would have
+    // passed a nil iterator into processIterator after the envelope
+    // Run returns.
+    newIter, iterErr := pc.iterFactory(newCons, batch, expiry)
+    if iterErr != nil {
+        // Iterator creation failed against the freshly rebuilt
+        // consumer. Counts as one envelope attempt. The NEXT
+        // attempt's Work re-reads pc.consumer at the top (v5 fix
+        // for v4-P1.1) and uses newCons, so the retry stays on the
+        // fresh handle — handles transient post-recreate
+        // iter-creation flakiness without re-running the hook.
+        return iterErr
+    }
+    iter = newIter
+    return nil
+}
+return err
+```
+
+`maybeEscalateIteratorFailures` is refactored to return
+`(error)` — non-nil on stream-not-found (passed through from
+`ensureConsumer`), nil otherwise. The existing escalation behavior
+(re-bind durable on transient failures, return the success/no-op
+case) is preserved.
+
+**Final-attempt budget edge fix (also v2-P0.2):** the v2 spec's
+"return original error after successful hook" pattern would, on
+the envelope's last allowed attempt, fire `OnPermanent` before any
+post-hook create attempt ran. v3 fixes this because Work returns
+`nil` after `RebuildAfterStreamRecreated` succeeds — the envelope's
+Run exits with success, not exhaustion. If `RebuildAfterStreamRecreated`
+itself fails with stream-still-missing, that error counts as one
+attempt (correct behavior — a "hook lied" attempt is real).
+
+**Site B — iterator-runtime path via `handleIteratorFailure`.**
+After `processIterator` returns a non-nil iterErr,
+`handleIteratorFailure` calls `pc.recovery.Classify` which may call
+`recover` → `recreate` → `js.CreateOrUpdateConsumer`. If the stream
+has been deleted mid-session and `CreateOrUpdateConsumer` returns
+stream-not-found, `recover` bails with `ActionStreamMissing`. The
+detour:
+
+```go
+// handleIteratorFailure (modified):
+action, newCons, classifyErr := pc.recovery.Classify(ctx, iterErr,
+    pc.consumerInfoFn(), pc.consumerConfig, pc.recreateFn())
+switch action {
+case recovery.ActionExit:
+    return true
+case recovery.ActionContinue:
+    // unchanged from P2.4d shape (assign newCons + reset counters + SeedCheckpoint)
+case recovery.ActionBackoff:
+    // unchanged
+case recovery.ActionStreamMissing:
+    // classifyErr wraps types.ErrStreamMissing
+    if hookErr := pc.handleStreamMissing(ctx); hookErr != nil {
+        // Hook absent / errored. Log + backoff; the next iteration's
+        // envelope eventually exhausts → OnPermanentFailure.
+        return pc.delayWithBackoffOrExit(ctx, "iterate")
+    }
+    // v5 fix for v4-P0: Site B must ALSO perform the reset-aware
+    // rebuild after the hook returns nil (was previously only in
+    // Site A). Otherwise the next iteration starts with the stale
+    // pc.consumer and either uses it directly or falls into legacy
+    // ensureConsumer with the static pc.consumerConfig — bypassing
+    // BuildConfig's recreated-flag override.
+    newCons, rebuildErr := pc.recovery.RebuildAfterStreamRecreated(
+        ctx, pc.consumerConfig, pc.recreateFn())
+    if rebuildErr != nil {
+        // RebuildAfterStreamRecreated wraps non-success errors with
+        // types.ErrStreamMissing (v4 umbrella). Loop continues to a
+        // fresh envelope which will retry; eventual exhaustion fires
+        // OnPermanentFailure with the wrapped error → manager observer.
+        pc.logger.Warn("post-hook rebuild failed",
+            "subject", pc.subject, "error", rebuildErr)
+        return pc.delayWithBackoffOrExit(ctx, "iterate")
+    }
+    pc.consumerMu.Lock()
+    pc.consumer = newCons
+    pc.consumerMu.Unlock()
+    // Reset the per-subject iterator-escalation counters so the
+    // legacy escalation doesn't fire spuriously on the fresh
+    // consumer (mirrors the ActionContinue branch).
+    pc.iterEscMu.Lock()
+    pc.iterFailureTimes = pc.iterFailureTimes[:0]
+    pc.lastEscalation = time.Time{}
+    pc.iterEscMu.Unlock()
+    return false // outer loop iterates → fresh envelope uses pc.consumer = newCons
+}
+```
+
+**The shared `pc.handleStreamMissing` helper:**
+
+```go
+// handleStreamMissing invokes the configured StreamMissingHook
+// and, on success, drives the post-hook recovery sequence:
+// HandleStreamRecreated + compat-check reset signal. Returns:
+//   - nil if the hook ran and the post-hook sequence completed
+//     successfully (caller should retry the recovery work).
+//   - a wrapped types.ErrStreamMissing if the hook is absent, the
+//     hook returned an error, or the post-hook sequence failed.
+//     The caller's envelope/loop counts this against its budget.
+func (pc *partitionConsumer) handleStreamMissing(ctx context.Context) error {
+    hook := pc.config.StreamMissingHook
+    if hook == nil {
+        pc.logger.Warn("stream-missing detected; no hook configured",
+            "subject", pc.subject, "stream", pc.streamName)
+        if pc.config.Metrics != nil {
+            pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_missing_no_hook")
+        }
+        return fmt.Errorf("%w: stream %q", types.ErrStreamMissing, pc.streamName)
+    }
+    pc.logger.Info("invoking stream-missing hook",
+        "subject", pc.subject, "stream", pc.streamName)
+    hookErr := hook(pc.streamName)
+    if hookErr != nil {
+        pc.logger.Warn("stream-missing hook returned error",
+            "subject", pc.subject, "stream", pc.streamName,
+            "error", hookErr)
+        if pc.config.Metrics != nil {
+            pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_recreate_error")
+        }
+        return fmt.Errorf("%w: stream %q: %w", types.ErrStreamMissing, pc.streamName, hookErr)
+    }
+    // Hook signalled success; perform the recovery-side reset.
+    pc.recovery.HandleStreamRecreated(ctx, pc.consumerInfoFn())
+    if pc.config.OnStreamRecreated != nil {
+        pc.config.OnStreamRecreated()
+    }
+    if pc.config.Metrics != nil {
+        pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_recreate_success")
+    }
+    return nil
+}
+```
+
+Note: metric reason labels (`stream_missing_no_hook`,
+`stream_recreate_error`, `stream_recreate_success`) are new
+operator-facing observability values. The `IncrementWorkerConsumerIteratorRestart`
+method itself is unchanged; only the documented set of reason
+strings grows.
+
+The "notify Dynamic" step uses `pc.config.OnStreamRecreated func()`
+— a new callback on `partitionConsumerConfig`, forwarded from
+`WorkerConsumerConfig`, which the `consumer.Dynamic` wrapper wires
+to its own `resetCompatCheck` method. This avoids a circular
+package import (recovery → durable → consumer would not compile)
+and keeps the recovery package isolated.
+
+### Compat re-arm in `consumer.Dynamic` — single atomic Pointer
+
+The v1 spec used two separate atomics (`workQueueCheckedAt` +
+`workQueueErr`), which the v1 plan-review correctly identified as
+having a publication race: a reader could observe `checkedAt`
+non-nil but `workQueueErr` still old, returning nil when the
+checker was about to publish a non-nil error. v2 fixes this by
+publishing a single immutable result through ONE `atomic.Pointer`:
+
+```go
+// compatCheckResult is the immutable outcome of one compat-check
+// run. A nil *compatCheckResult means "not yet checked, or reset
+// after a stream recreate".
+type compatCheckResult struct {
+    err error // non-nil iff the check failed
+}
+
+// Was:
+//   workQueueOnce sync.Once
+//   workQueueErr  error
+//
+// Becomes:
+type Dynamic struct {
+    // ... existing fields ...
+    workQueueResult atomic.Pointer[compatCheckResult]
+    workQueueMu     sync.Mutex // serializes the once-style check
+}
+```
+
+```go
+// In Update AND UpdateWorkerConsumer (both paths run the check;
+// this is the v2 fix for the bug that UpdateWorkerConsumer
+// bypassed CheckWorkQueueRecoveryCompat entirely):
+if err := d.ensureCompatChecked(ctx); err != nil {
+    return err
+}
+return d.inner.Update(...) // or UpdateWorkerConsumer
+```
+
+```go
+// ensureCompatChecked runs the compat check at most once per
+// (un)reset cycle. The fast path is a single atomic load; the
+// result struct is immutable once published, so there is no
+// publication race between the "is it checked" flag and the
+// error value (they are one pointer).
+func (d *Dynamic) ensureCompatChecked(ctx context.Context) error {
+    if r := d.workQueueResult.Load(); r != nil {
+        return r.err
+    }
+    d.workQueueMu.Lock()
+    defer d.workQueueMu.Unlock()
+    if r := d.workQueueResult.Load(); r != nil {
+        // another goroutine published while we waited
+        return r.err
+    }
+    err := CheckWorkQueueRecoveryCompat(ctx, d.js, d.streamName, d.recoveryStrategy)
+    d.workQueueResult.Store(&compatCheckResult{err: err})
+    return err
+}
+
+// resetCompatCheck clears the cached result so the next
+// Update/UpdateWorkerConsumer re-runs the check. Takes the
+// workQueueMu mutex (v3 fix for the v2-P0.3 stale-store race) so
+// it cannot interleave with an in-flight slow-path check that is
+// about to store its now-stale result.
+func (d *Dynamic) resetCompatCheck() {
+    d.workQueueMu.Lock()
+    defer d.workQueueMu.Unlock()
+    d.workQueueResult.Store(nil)
+}
+```
+
+v3 fix for v2-P0.3 (stale-store interleaving): the slow path in
+`ensureCompatChecked` is mutex-held from "compute" through
+"publish":
+
+```go
+func (d *Dynamic) ensureCompatChecked(ctx context.Context) error {
+    if r := d.workQueueResult.Load(); r != nil {
+        return r.err
+    }
+    d.workQueueMu.Lock()
+    defer d.workQueueMu.Unlock()
+    if r := d.workQueueResult.Load(); r != nil {
+        return r.err
+    }
+    err := CheckWorkQueueRecoveryCompat(ctx, d.js, d.streamName, d.recoveryStrategy)
+    d.workQueueResult.Store(&compatCheckResult{err: err})
+    return err
+}
+```
+
+Race analysis (v3, mutex-fenced):
+- Slow path holds `workQueueMu` from "I'm running the check" through
+  "result published". `resetCompatCheck` also takes `workQueueMu`,
+  so it cannot interleave between an in-flight check's compute and
+  publish — it waits.
+- Possible interleavings between A (in-progress slow-path check) and
+  B (reset):
+  1. A loads nil → A locks → A computes → A publishes →
+     A unlocks → B locks → B clears → B unlocks. Reader sees A's
+     result briefly then nil. Correct.
+  2. B locks first → B clears → B unlocks → A loads nil → A locks
+     → A computes → A publishes → A unlocks. Reader sees A's fresh
+     result. Correct.
+  3. (Pre-fix v2 bug, now impossible): A loads nil → A holds the
+     lock → B does Store(nil) WITHOUT the lock → A's still-running
+     CheckWorkQueueRecoveryCompat completes → A publishes its now-
+     stale result → reader sees stale "compatible" while the stream
+     has been recreated. v3 closes this by making B take the lock.
+- Concurrent readers on the fast path see either (a) an old result
+  that was published before any reset, (b) nil (in which case they
+  fall into the slow path and serialise with the in-flight check),
+  or (c) a fresh result. All three are acceptable.
+
+`resetCompatCheck` is invoked via the `OnStreamRecreated` callback
+the partition consumer fires after `HandleStreamRecreated` returns.
+`Dynamic` registers a closure during construction that calls its
+own `resetCompatCheck`.
+
+The T3 test in v3 is split into two:
+
+- **T3a (deterministic stale-store interleaving — v2-P0.3 pin).**
+  Use a `CheckWorkQueueRecoveryCompat` seam (e.g., inject a
+  function whose body blocks on a test-controlled channel).
+  Goroutine A starts `ensureCompatChecked`; the seam blocks. Test
+  swaps the seam to a "compatible" result on resume. Goroutine B
+  calls `resetCompatCheck` — it must BLOCK until A unblocks and
+  publishes. Test releases A's seam → A publishes "compatible".
+  Then B's reset takes the lock → clears. Reader sees nil →
+  forces a fresh check on the next call. Without v3's mutex in
+  `resetCompatCheck`, A would publish its stale result AFTER B's
+  reset, and the reader would see stale "compatible".
+- **T3b (concurrent stress — race-detector).** Spawn N goroutines
+  each calling `Update`/`UpdateWorkerConsumer`/`resetCompatCheck`
+  in a loop for ~2s under `-race`. Assert no detector triggers.
+  Complements T3a (which is deterministic about the bug but does
+  not exercise the broader race surface).
+
+## Reproducer tests
+
+### Unit tests (`internal/recovery/`)
+
+- **T2c (epoch fence)** — `internal/recovery/controller_epoch_fence_test.go`.
+  Prime `Checkpoint.Seed(100)`. Set `streamEpoch=1`. Wrap a tracking
+  msg at seq 80 via `WrapForTracking` (captures epoch=1). Call
+  `HandleStreamRecreated` (bumps epoch to 2, resets checkpoint to
+  0, seeds with a stub infoFn that returns AckFloor=0). Then call
+  `Ack()` on the held tracking msg. Assert `Checkpoint.Value() == 0`.
+  Without the fence, `AdvanceCheckpoint` would re-raise the
+  checkpoint to 80; with it, the late ack is dropped. THIS IS THE
+  TIGHTEST INVARIANT — pin first.
+
+- **T2 (fresh-stream replay)** — `internal/recovery/controller_recreated_replay_test.go`.
+  Prime `Checkpoint.Seed(100)`. Strategy=`FromLastProcessed`. Call
+  `HandleStreamRecreated` with a stub infoFn returning AckFloor=0
+  (fresh stream). Then call `BuildConfig` (or `recover` with a spy
+  RecreateFunc capturing the config). Assert
+  `DeliverPolicy == DeliverAllPolicy`, `OptStartSeq == 0`.
+
+- **T2b (restored-backup variant)** — same file.
+  Prime `Checkpoint.Seed(100)`. Strategy=`FromLastProcessed`. Call
+  `HandleStreamRecreated` with a stub infoFn returning AckFloor=50.
+  Then call `BuildConfig`. Assert
+  `DeliverPolicy == DeliverByStartSequencePolicy`,
+  `OptStartSeq == 51`.
+
+- **T2d (restored-consumer incompatible config — v4 updated)** —
+  same file. Set up the partition consumer with strategy
+  `FromLastProcessed` and a Parti-generated consumer config of
+  `AckPolicy=AckExplicit, AckWait=30s`. The hook recreates the
+  stream with a same-name consumer but with
+  `AckPolicy=AckAll` (incompatible). Spy `RecreateFunc` returns
+  `nats consumer-config-mismatch` (or the NATS-specific error code
+  10094). Assert:
+  - `RebuildAfterStreamRecreated` returns an error that wraps
+    `types.ErrStreamMissing` (v4: all post-hook recovery errors
+    wrap the typed-error class so the Dynamic→manager observer
+    route fires consistently).
+  - The envelope counts the attempt; permanent failure eventually
+    fires after exhaustion.
+  - The manager observer DOES receive the wrapped error (verified
+    via spy on `SetOnStreamMissingError`), even though the
+    underlying cause is consumer-config-mismatch (not stream-not-found).
+  - `enterDegraded` is called with reason
+    `"stream-missing-recovery-exhausted"`, NOT
+    `"KV error threshold exceeded"`.
+  This pins the operator contract: incompatible restored consumer
+  config is treated as a stream-recovery failure and surfaces
+  through the same observer/degraded route as a true stream-missing
+  case.
+
+- **T-SiteA-iter (v4 — v3-P0.1 pin) — post-hook iter creation** —
+  `internal/durable/partition_consumer_stream_missing_test.go`.
+  Drive the iter-creation path into stream-missing detection;
+  hook returns nil; `RebuildAfterStreamRecreated` succeeds with a
+  fresh consumer. Assert:
+  - `pc.iterFactory` is called AGAIN with the new consumer before
+    Work returns nil (verified via spy iterFactory counting calls
+    with the new consumer reference).
+  - The envelope's Run returns nil (success).
+  - `iter` returned by `runIteratorEnvelope` is non-nil.
+  - `processIterator` receives the new iterator (NOT nil) and
+    processes at least one message from the rebuilt consumer
+    (verified by publishing a message after the rebuild).
+  This pins v3-P0.1: a hypothetical implementation that returns
+  nil from Work without setting `iter` would pass a nil iterator
+  to `processIterator` and panic on `iter.Next()`.
+
+- **T-SiteA-iter-retry (v6 — v5-P1.4 pin) — fresh-consumer retry uses newCons** —
+  same file. Subcase of T-SiteA-iter that pins the v4-P1.1 fix
+  (re-read pc.consumer per attempt). Spy iterFactory behavior:
+  - First call (before rebuild): returns iter-creation error
+    (drives stream-missing detection).
+  - Second call (against newCons, immediately after rebuild):
+    returns iter-creation error (transient post-recreate flakiness).
+  - Third call (next envelope attempt): also against newCons —
+    must NOT be against the pre-rebuild consumer.
+  Assert that all three calls to iterFactory after the rebuild
+  use the SAME consumer reference (newCons), proving the Work
+  closure re-reads pc.consumer per attempt. A broken implementation
+  that captures cons once before the envelope would invoke the
+  third call against the old (deleted/stale) consumer.
+
+- **T-SiteB-rebuild (v7 — v5-P1.3 + v6-P1.1 pin) — Site B hook-success
+  reset-aware rebuild** —
+  `internal/durable/partition_consumer_stream_missing_site_b_test.go`.
+  Drive processIterator into the recovery path that reaches
+  ActionStreamMissing. The realistic flow when a JetStream stream
+  is deleted is:
+  1. The contained consumer is deleted too (NATS behavior).
+  2. `iter.Next()` returns `jetstream.ErrConsumerDeleted`
+     (NOT direct ErrStreamNotFound — `recovery.ClassifyError` only
+     maps consumer-gone/heartbeat to recovery actions).
+  3. handleIteratorFailure → `Classify(ErrConsumerDeleted)` →
+     `ErrorConsumerGone` → `recover()`.
+  4. `recover()` calls `recreate()` = `pc.recreateFn()` =
+     `js.CreateOrUpdateConsumer`.
+  5. `CreateOrUpdateConsumer` returns `ErrStreamNotFound`
+     (the stream is gone).
+  6. `recover()` bails with `ActionStreamMissing` + wrapped error.
+
+  Test setup:
+  - Inject `iter.Next` returning `jetstream.ErrConsumerDeleted`
+    (use the existing `errorOnNextIter` mock from
+    `partition_consumer_test.go`).
+  - Spy `RecreateFunc` is called via `pc.recreateFn()`. First call
+    (during recover): returns `jetstream.ErrStreamNotFound` to
+    simulate the stream-gone state. Second call (during
+    RebuildAfterStreamRecreated after hook returns nil): returns
+    a fresh consumer mock.
+  - Hook returns nil.
+
+  Assert:
+  - `RebuildAfterStreamRecreated` is called with checkpoint = 0
+    AND `recreatedSinceLastBuild = true` (verified via Controller
+    state inspection or by capturing the value passed to BuildConfig).
+  - The config captured by the SECOND RecreateFunc call has
+    `DeliverPolicy == DeliverAllPolicy` (the recreated-flag
+    override fired).
+  - `pc.consumer` is updated to the new consumer returned by
+    RebuildAfterStreamRecreated.
+  - handleIteratorFailure returns false (don't exit; outer loop
+    iterates with fresh envelope using the new consumer).
+  - The next envelope iteration's runIteratorEnvelope.Work reads
+    pc.consumer and sees the NEW consumer (via the v6 re-read pattern).
+
+  Original v6 assertions retained below:
+  - `RebuildAfterStreamRecreated` is called with the (now-reset)
+    checkpoint = 0 and recreatedSinceLastBuild = true.
+  - The captured config has `DeliverPolicy == DeliverAllPolicy`
+    (the v3 fresh-stream replay invariant via BuildConfig's
+    one-shot recreated-flag override).
+  - `pc.consumer` is updated to the new consumer returned by
+    RebuildAfterStreamRecreated.
+  - handleIteratorFailure returns false (don't exit; outer loop
+    iterates with fresh envelope using the new consumer).
+  - The next envelope iteration's runIteratorEnvelope.Work reads
+    pc.consumer and sees the NEW consumer (via the v6 re-read pattern).
+  This pins v4-P0 + v5-P1.3: a hypothetical Site B implementation
+  that only calls handleStreamMissing without RebuildAfterStreamRecreated
+  would either keep using the stale consumer OR fall through to
+  legacy ensureConsumer with the static (DeliverAllPolicy from
+  dynamicbuild but without the reset-aware checkpoint integration)
+  config — either way, the captured config assertion would fail.
+
+- **T6 (recreated flag is one-shot)** — same file. The v1 spec made
+  this test non-load-bearing by advancing the checkpoint > 0
+  before the second recovery: in BuildConfig, `checkpoint > 0`
+  wins before the flag is read, so a stuck flag is masked. v2
+  fixes this by driving the second recovery with `checkpoint == 0`:
+  1. Trigger the recreate path once (sets the flag); spy
+     BuildConfig captures `DeliverAllPolicy` on the first
+     post-hook build (consumes the flag).
+  2. Reset the checkpoint back to 0 directly (test seam — calls
+     `Checkpoint.ResetForStreamRecreate()` to simulate "no
+     progress since recreate").
+  3. Invoke `recover()` again on an unrelated transient
+     classification (`ErrConsumerDeleted`) with the SAME strategy.
+  4. Assert the second BuildConfig output uses `DeliverNewPolicy`
+     (the `default` branch — flag cleared, no checkpoint), NOT
+     `DeliverAllPolicy`.
+
+  On a stuck-flag implementation, the second build would emit
+  `DeliverAllPolicy` and replay everything in the (current,
+  unrelated) stream from sequence 1 — a real production hazard.
+
+- **T6b (direct read-and-clear primitive)** — same file. Sibling
+  unit test that directly exercises the flag's read-and-clear
+  semantics, independent of BuildConfig. `controller.recreatedSinceLastBuild`
+  is exposed via a private package test helper (e.g.,
+  `consumeRecreatedFlag()` returns the old value AND clears the
+  flag atomically). Test: set flag → first call returns true and
+  clears → second call returns false. Pins the primitive
+  separately from the BuildConfig assertion.
+
+- **`HandleStreamRecreated` ordering — deterministic step seam** —
+  `internal/recovery/controller_recreated_ordering_test.go`. The
+  test uses the private `handleStreamRecreatedWithSteps(ctx,
+  infoFn, onStep)` helper (defined under "HandleStreamRecreated"
+  above). The `onStep` callback, when invoked at `"after_reset"`,
+  calls `Ack()` on a held tracking msg captured at the prior
+  epoch. Assert that on return `Checkpoint.Value() == 0` (the
+  ack was dropped by the epoch fence). In a hypothetical
+  reset-before-bump implementation, `"after_reset"` would mean the
+  epoch is still the prior value, the ack would pass the fence,
+  and the checkpoint would advance to the held msg's seq —
+  deterministically failing this test. No sleeps, no scheduling
+  assumptions.
+
+### Unit test (`consumer/`)
+
+- **T3 (compat re-arm both paths)** —
+  `consumer/dynamic_compat_rearm_test.go`. Construct a `Dynamic`
+  with a mock `js` that returns a stream with
+  `LimitsPolicy + FromLastProcessed` (compat-OK) on first
+  `StreamInfo` call. Call `Update`; assert compat check ran. Call
+  `UpdateWorkerConsumer`; assert compat check **did NOT** re-run
+  (it's still cached from Update). Invoke
+  `d.resetCompatCheck()` (via the new `OnStreamRecreated`
+  callback). Switch the mock `js` to return
+  `WorkQueuePolicy + FromLastProcessed` (compat fail). Call
+  `UpdateWorkerConsumer`; assert compat check ran and returned
+  `ErrInvalidConfig`. Also assert the inverse direction: today
+  `UpdateWorkerConsumer` bypasses the check entirely (the test
+  fails on parent with the inverse assertion).
+
+### Integration tests (`test/integration/failure/`)
+
+- **T1 (hook fires)** —
+  `test/integration/failure/stream_missing_hook_test.go`. Real
+  embedded NATS. Configure manager with `StreamMissingHook` that
+  records its invocation. Start manager, drive an assignment that
+  spins up a partition consumer. Delete the dynamic-consumer
+  stream via `js.DeleteStream`. Assert the hook fires within
+  one recovery-controller cycle, with the correct stream name.
+
+- **T4 (no hook → OnError + readiness flip)** —
+  `test/integration/failure/stream_missing_no_hook_test.go`. Same
+  setup, no hook configured. Use a SPY js (wrapping the real
+  embedded NATS js) that counts `CreateOrUpdateConsumer` calls.
+  Delete the stream. Assert (all):
+  - F2 envelope exhausts within `MaxAttempts * MaxBackoff` window.
+  - `OnPermanentFailure` (P2.4d's callback) fires once.
+  - The manager-level `Hooks.OnError` fires with an error
+    satisfying `errors.Is(err, parti.ErrStreamMissing)`. NOT
+    classified as KV-bucket-loss (`recordKVError` is not invoked
+    with this error — verified by spying on `enterDegraded`'s
+    `reason` argument: it equals `"stream-missing-recovery-exhausted"`,
+    NOT `"KV error threshold exceeded"`).
+  - State transitions to degraded.
+  - **Post-exhaustion silence**: from the spy's perspective, the
+    count of `CreateOrUpdateConsumer` calls is monotonic after
+    permanent failure fires — i.e., zero additional calls in the
+    1 second following the OnError signal. This pins the
+    no-retry-storm contract specifically for the no-hook path
+    (T5 already pins it for the hook-error path; v1 spec had this
+    gap per P1.5).
+
+- **T5 (hook returns error → no retry storm)** —
+  `test/integration/failure/stream_missing_hook_error_test.go`.
+  Same setup, hook returns a non-nil error every call. Delete the
+  stream. Assert:
+  - The hook fires multiple times (up to MaxAttempts).
+  - F2 envelope eventually exhausts.
+  - **After exhaustion, no further `CreateOrUpdateConsumer`
+    calls are issued** — verifiable via a spy js.
+
+## Verification gates
+
+- `make lint && make test && make test-race && make test-integration`
+  green.
+- `make pre-pr` chained gate passes (lint + test + test-integration).
+- Docs: `docs/CONSUMERS.md` documents `StreamMissingHook` with a
+  worked `provision`-based recreate example.
+- New exported-symbol audit (v3):
+  - `types.ErrStreamMissing` (sentinel `error`); `parti.ErrStreamMissing`
+    alias.
+  - `types.StreamMissingHook` (`func(streamName string) error`) in
+    `types/stream_hooks.go`; `parti.StreamMissingHook` alias.
+  - `durable.WorkerConsumerConfig.StreamMissingHook` field.
+  - `durable.WorkerConsumerConfig.OnPermanentFailure` was added by
+    P2.4d (already exported).
+  - `consumer.DynamicConfig.StreamMissingHook` field +
+    `consumer.WithStreamMissingHook(StreamMissingHook) DynamicOption`.
+    The option's godoc (NOT just the underlying type's godoc) MUST
+    document the allowed-strategy restriction and point readers
+    to `StreamMissingHook` for the full hook contract. v8 — v7-P2
+    fix: option-level godoc is required to prevent drift between
+    the option and the underlying type's contract (parallel
+    convention to `WithRecoveryStrategy` whose godoc lives on
+    the option, not the type).
+  - `consumer.DynamicConfig.OnPermanentFailure` field +
+    `consumer.WithOnPermanentFailure(...) DynamicOption`.
+  - `consumer.Dynamic.SetOnStreamMissingError(func(streamName string, err error))`
+    method on `*consumer.Dynamic` (v3 — replaces v2's
+    `StreamMissingObserver` interface; the public Dynamic method
+    is the wiring surface).
+  - `recovery.StreamMissingObserver` interface (one method:
+    `SetOnStreamMissingError(...)`) — implemented by
+    `*consumer.Dynamic`. `Manager.Start` type-asserts the
+    registered updater against this interface.
+  - **No new methods on `types.WorkerConsumerMetrics`** — the
+    existing `IncrementWorkerConsumerIteratorRestart(reason string)`
+    is reused with new reason labels (see "Metrics" subsection).
+  - **No new generic-exhaustion typed error** (v3: dropped v2's
+    `types.ErrConsumerRecoveryExhausted`; generic exhaustion uses
+    the existing log + metric path).
+  - `internal/retry`, `internal/recovery`, `internal/durable` stay
+    internal. The new `recovery.Controller.RebuildAfterStreamRecreated`
+    and `recovery.Controller.handleStreamRecreatedWithSteps` are
+    internal-package methods; only `Controller.HandleStreamRecreated`
+    is the exported-by-package wrapper.
+  - **`manager_degraded.go:recordKVError` is edited** (v4 — v3-P1.3
+    fix) to short-circuit on `errors.Is(err, types.ErrStreamMissing)`
+    so stream-missing errors do not double-count in the KV error
+    threshold. This is an in-tree edit, not a new export.
+  - **`manager_setup.go:prepareStart`** (v4 — v3-P1.2 fix) gains
+    the type-assertion + `SetOnStreamMissingError` wiring at the
+    end of the function. No new exports.
+  - **`CompositeConsumerUpdater.SetOnStreamMissingError`** (v5 —
+    v4-P1.3 fix) is a new public method on the existing
+    `parti.CompositeConsumerUpdater` type that forwards the
+    observer registration to each child updater implementing
+    `recovery.StreamMissingObserver`. Added so the manager bridge
+    works correctly when the registered updater is a composite
+    wrapping a `*consumer.Dynamic`.
+  - **`Manager.onStreamMissingError`** (v5) is an unexported
+    method holding the observer closure; not part of the public
+    API.
+- Cross-feature contract regression check (AGENTS.md § Cross-feature
+  contracts):
+  - `TestManager_LiveNATSBucketLoss*` (whole-bucket loss → all
+    workers degraded via `recordKVError`) still green; the
+    stream-missing path does NOT route through `recordKVError`.
+  - `TestStableID_StaleKeyTakeover_Reclaim` (peer claim takeover →
+    only that worker) still green.
+  - `TestManager_LiveNATSBucketLoss_OnDegradedHook` (one-shot
+    OnDegraded per Degraded entry) still green.
+- Concurrency stress test for the new monitor-shaped surface (T2c
+  race scenario above) executes under `-race`.
+
+## How this trips readiness
+
+Two paths (same as the high-level spec):
+1. **Hook present, recreate succeeds.** No readiness trip; consumer
+   resumes from AckFloor of the fresh stream (or replays from
+   sequence 1 if AckFloor==0).
+2. **Hook absent OR hook returns error.** After F2 envelope-bounded
+   retries the consumer enters permanent failure →
+   `OnPermanentFailure` fires (P2.4d's hook) → the manager's
+   degraded-mode wiring (existing) trips readiness → pod rotation.
+
+A pod restart alone does NOT restore the stream
+(`Manager.Start` ensures only KV buckets, not message streams).
+
+## Dependencies & sequencing
+
+**Depends on P2.4d** — already merged at `2c359b0`. The F2 envelope
+on `partition_consumer.go`'s recovery loop is what turns T4/T5's
+"no hook = `OnError` + readiness flip" and "hook returns error =
+no retry storm" into observable behavior.
+
+Phase 2 sequence: P2.1 → P2.2 → P2.4a → P2.4b → P2.4c → P2.4d →
+**P2.3** → P2.5. P2.3 is the second-to-last self-healing PR.
+
+## Open questions / decisions
+
+All v1 open questions were resolved by the v1 plan-review process.
+
+1. **Error type for OnError in T4.** RESOLVED: public sentinel
+   `types.ErrStreamMissing` (with `parti.ErrStreamMissing` alias);
+   wraps the underlying NATS error and the stream name. See
+   "Public typed error" subsection above.
+2. **`StreamMissingHook` placement.** RESOLVED: lives in
+   `types/stream_hooks.go` (a new file, not in `types/hooks.go`).
+   `types.Hooks` is a manager-lifecycle struct of callbacks; the
+   stream-missing hook is a consumer-config callback used at a
+   different boundary. Separating the file keeps each boundary's
+   documentation surface focused.
+3. **HandleStreamRecreated ordering test design.** RESOLVED:
+   private `handleStreamRecreatedWithSteps(ctx, infoFn, onStep)`
+   helper with deterministic test seam; production callers use the
+   exported `HandleStreamRecreated` wrapper. See "T2c-ordering
+   deterministic test" subsection above.
+
+## Out of scope
+
+- Library auto-recreating the stream (category B forbidden).
+- The retry envelope itself (F2's territory — landed in P2.4a/b/c/d).
+- The recovery-controller consolidation (separate, future effort).
+- Manager-side stream-missing telemetry beyond the new reason
+  labels enumerated above.
+- Re-routing existing stream-missing detection in
+  `provision/apply_stream.go` or `consumer/static.go` (the spec
+  scope is the Dynamic consumer's recovery loop only).
+
+## Revision log
+
+### v2 (2026-05-24)
+
+Addresses all 11 v1 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v1.md`, verdict "revise — 6 P0 +
+5 P1"):
+
+- **P0.1 (hook detour wrong path):** Routed stream-missing from
+  BOTH the iter-creation site (inside `runIteratorEnvelope`'s
+  Work closure) AND the iter-runtime site
+  (`handleIteratorFailure` → `Classify` → `ActionStreamMissing`)
+  through a shared `pc.handleStreamMissing` helper.
+- **P0.2 (no-hook readiness wiring missing):** Added explicit
+  manager-facing wiring via new public surface
+  (`consumer.DynamicConfig.OnPermanentFailure`,
+  `recovery.StreamMissingObserver` interface implemented by
+  `*Dynamic`, manager-side closure registration in
+  `Manager.Start`). T4 can now assert
+  `errors.Is(err, parti.ErrStreamMissing)` and degraded state.
+- **P0.3 (T6 non-load-bearing):** Restructured T6 to use
+  checkpoint==0 for the second recovery; assert second build is
+  `DeliverNewPolicy`, not `DeliverAllPolicy`. Added T6b that
+  exercises the read-and-clear primitive directly.
+- **P0.4 (ordering test fragile):** Added private
+  `handleStreamRecreatedWithSteps(ctx, infoFn, onStep)` helper
+  with deterministic test seam; the ordering test injects an
+  old-epoch ack between "after_reset" and the implicit "after_bump"
+  (which, in the correct ordering, has already happened) and
+  asserts the checkpoint is unchanged regardless of scheduling.
+- **P0.5 (compat re-arm publication race):** Replaced two atomics
+  with a single `atomic.Pointer[compatCheckResult]` whose
+  `compatCheckResult` is immutable once published. T3 extended
+  with a concurrent stress test under `-race`.
+- **P0.6 (unsafe cooldown bypass):** Replaced unconditional
+  clearing of `lastRecoveryTime` with a bounded one-shot
+  `postHookBypassPending` token consumed via CAS in `recover()`.
+  At most one cooldown skip per `HandleStreamRecreated` call.
+- **P1.1 (OnError public typed error):** Defined
+  `types.ErrStreamMissing` + `parti.ErrStreamMissing` alias.
+  Internal recovery package wraps `jetstream.ErrStreamNotFound`
+  with this public sentinel.
+- **P1.2 (Classify caller under-scope):** Audited all four callers
+  (Dynamic, Queue, Broadcast, internal/ipartition); each updated
+  to handle `ActionStreamMissing` (mapped to `ActionBackoff` for
+  non-Dynamic callers that don't own stream lifecycle).
+- **P1.3 (restored-consumer same-durable-name rule):** Hook
+  godoc explicitly states the same-name requirement and the
+  fallback semantics when a different name is supplied.
+- **P1.4 (new metrics break public interface):** Dropped the
+  proposed new metric methods. Reused
+  `IncrementWorkerConsumerIteratorRestart(reason string)` with
+  three new reason labels.
+- **P1.5 (T4 post-exhaustion silence):** T4 now uses a spy js
+  and asserts zero `CreateOrUpdateConsumer` calls in the 1s
+  window following permanent-failure firing, plus asserts the
+  degraded reason is `"stream-missing-recovery-exhausted"`,
+  NOT `"KV error threshold exceeded"` (cross-feature contract
+  preservation).
+- **P2.1 (hook placement):** Committed to `types/stream_hooks.go`
+  (new file) rather than expanding `types/hooks.go`.
+
+### v10 (2026-05-24)
+
+Addresses the single v9 plan-review finding
+(`tmp/09-pr9-spec_plan_review_v9.md`, verdict "revise — 0 P0 +
+1 P1"):
+
+- **v9-P1 (cross-package consistency test references unexported
+  helpers):** the v9 test could not compile because Go forbids
+  cross-package access to unexported helpers. v10 rewrites the
+  test to compare the PUBLIC `consumer.DynamicConfig.Validate`
+  and `durable.WorkerConsumerConfig.Validate` surfaces instead.
+  The test lives in `package consumer_test` (which can import
+  both `consumer` and `internal/durable`) and asserts equivalent
+  accept/reject outcomes across a 4-strategy matrix. The intent
+  (catch future divergence) is preserved; the implementation
+  shape (compare public surfaces, not helpers) is correctly
+  expressible in Go.
+
+### v9 (2026-05-24)
+
+Addresses all v8 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v8.md`, verdict "revise — 0 P0 +
+1 P1 + 1 P2"):
+
+- **v8-P1 (shared helper crosses package boundary):** v9 replaces
+  the cross-package "shared helper" with two PACKAGE-LOCAL helpers
+  (one in `consumer/dynamic.go`, one in `internal/durable/config.go`).
+  Both implement IDENTICAL strategy-checking logic with minor
+  error-message prefix differences. A new cross-package
+  consistency test (`TestValidateStreamMissingHookStrategy_ConsistentAcrossPackages`)
+  pins that both helpers accept and reject the same set of
+  strategies; future divergence is caught by the test.
+- **v8-P2 (incomplete test coverage for OK cases):** v9 adds the
+  `_OK` test cases for all three Validate surfaces ×
+  RecoverFromLastProcessed/RecoverFromBeginning. Total
+  validation coverage is now 12 tests (4 strategies × 3 surfaces)
+  + 1 cross-package consistency test = 13.
+
+### v8 (2026-05-24)
+
+Addresses all v7 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v7.md`, verdict "revise — 0 P0 +
+1 P1 + 1 P2"):
+
+- **v7-P1 (RecoverFromNew rejection under-specified):** v8 names
+  THREE public validation surfaces (`consumer.NewDynamic`,
+  `consumer.DynamicConfig.Validate`,
+  `durable.WorkerConsumerConfig.Validate`) and factors the
+  rejection logic into a shared `validateStreamMissingHook`
+  helper. Lists 8 named regression tests across two test files
+  covering all three surfaces × the four strategy variants
+  (RecoverFromNew rejected, RecoveryDisabled rejected,
+  RecoverFromLastProcessed accepted, RecoverFromBeginning
+  accepted).
+- **v7-P2 (WithStreamMissingHook option godoc missing):** v8
+  adds an explicit requirement in the exported-symbol audit that
+  the option's godoc documents the allowed-strategy restriction
+  and points to the underlying type — parallel to the existing
+  convention where `WithRecoveryStrategy` carries the trade-off
+  documentation on the option.
+
+### v7 (2026-05-24)
+
+Addresses all v6 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v6.md`, verdict "revise — 0 P0 +
+2 P1"):
+
+- **v6-P1.1 (T-SiteB-rebuild iter error can't reach
+  ActionStreamMissing):** v7 rewrites the T-SiteB-rebuild test
+  setup to drive `iter.Next()` returning `ErrConsumerDeleted`
+  (the realistic NATS behavior when a stream is deleted — the
+  contained consumer goes with it). The spy `RecreateFunc`
+  returns `ErrStreamNotFound` on the recover() call, surfacing
+  ActionStreamMissing through the existing classification path.
+  The test now exercises the actual code path the implementation
+  uses, not a fictional direct-stream-not-found classification.
+- **v6-P1.2 (`RecoverFromNew` validation guidance contradicts
+  fresh-stream replay contract):** v7 narrows the allowed
+  recovery strategies for `StreamMissingHook`. Only
+  `RecoverFromLastProcessed` and `RecoverFromBeginning` are
+  accepted; `RecoverFromNew` is explicitly rejected with a
+  message explaining the message-skip hazard. The hook godoc
+  documents the allowed strategies. BuildConfig's FromNew branch
+  is intentionally NOT modified — the validation makes the unsafe
+  path unreachable. A regression test pins the rejection.
+
+### v6 (2026-05-24)
+
+Addresses all v5 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v5.md`, verdict "revise — 0 P0 +
+4 P1"):
+
+- **v5-P1.1 (StreamMissingHook + RecoveryDisabled undefined):**
+  v6 validates the combination at consumer construction:
+  `NewDynamic` (and `WorkerConsumerConfig.Validate`) rejects
+  `StreamMissingHook != nil` paired with `RecoveryDisabled` with
+  a clear error message. The library documents that the minimal
+  enabling strategy is `RecoverFromNew`.
+- **v5-P1.2 (composite forwarding not implementation-ready):**
+  v6 corrects the field name (`updaters`, not `children`), adds
+  a `sync.Mutex` to serialize observer-related reads/writes, and
+  threads the registered observer through `Add()` so late-added
+  observer-capable children inherit the manager-installed
+  observer. Composite_updater tests pin both the
+  construction-time and Add-time forwarding paths.
+- **v5-P1.3 (Site B reset-aware rebuild lacks regression test):**
+  v6 adds T-SiteB-rebuild that drives processIterator into
+  iter-runtime stream-missing classification (mid-session
+  stream deletion) and asserts the post-hook config passed to
+  the spy RecreateFunc has `DeliverAllPolicy` AND that
+  pc.consumer is updated to the new consumer.
+- **v5-P1.4 (Site A fresh-consumer retry lacks test):**
+  v6 adds T-SiteA-iter-retry subcase: spy iterFactory fails on
+  the first call against newCons, then asserts subsequent calls
+  in the same envelope episode are also against newCons (not
+  the pre-rebuild consumer). Pins v4-P1.1's "re-read pc.consumer
+  per attempt" invariant.
+
+### v5 (2026-05-24)
+
+Addresses all v4 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v4.md`, verdict "revise — 1 P0 +
+4 P1"):
+
+- **v4-P0 (Site B hook success skips reset-aware rebuild):**
+  Site B's `ActionStreamMissing` success branch now calls
+  `pc.recovery.RebuildAfterStreamRecreated`, stores the new
+  consumer under `consumerMu`, and resets the per-subject
+  iterator-escalation counters. Mirrors Site A's behavior.
+- **v4-P1.1 (Site A retry uses stale captured `cons`):** the
+  envelope's Work closure now re-reads `pc.consumer` at the start
+  of each attempt (under `consumerMu.RLock`) rather than closing
+  over a fixed `cons` value. Post-rebuild retries use the fresh
+  consumer.
+- **v4-P1.2 (ErrStreamMissing contradictory contracts):** the
+  godoc for `types.ErrStreamMissing` now explicitly states it is
+  an UMBRELLA covering the full stream-missing recovery episode —
+  including post-hook restored-config failures — not just literal
+  "stream absent". The `StreamMissingHook` godoc removes the
+  v3-era "invoked AGAIN" wording and instead states the operator's
+  responsibility (reconcile or delete the restored consumer).
+- **v4-P1.3 (manager wiring uses wrong field name + missing
+  Composite forwarding):** the wiring snippet now uses
+  `m.consumerUpdater` (the actual Manager field name). The
+  manager closure is extracted as `m.onStreamMissingError` for
+  reuse. `parti.CompositeConsumerUpdater` gains a
+  `SetOnStreamMissingError` method that forwards to children
+  implementing the observer interface.
+- **v4-P1.4 (stale `setBypassToken` text in
+  `HandleStreamRecreated` section):** removed the step-5 token
+  reference from the first `HandleStreamRecreated` section. The
+  step list is now bump → reset → seed → flag. All
+  `setBypassToken` / `after_token` text outside the v3-revision
+  history is removed.
+
+### v4 (2026-05-24)
+
+Addresses all v3 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v3.md`, verdict "revise — 2 P0 +
+4 P1"):
+
+- **v3-P0.1 (Site A returns nil iterator):** v4 adds the iter-
+  creation step inside Site A's success branch — after
+  `RebuildAfterStreamRecreated` stores the new consumer,
+  `iterFactory(newCons, batch, expiry)` runs and the result is
+  assigned to `iter` before Work returns nil. If iterFactory fails
+  against the freshly rebuilt consumer, that error counts as one
+  envelope attempt (retried on the next iteration). New test
+  T-SiteA-iter pins this.
+- **v3-P0.2 (incompatible restored-config has no route):**
+  `RebuildAfterStreamRecreated` now wraps ALL post-hook recovery
+  errors with `types.ErrStreamMissing` (not just stream-not-found
+  variants). The Dynamic→manager observer route now fires for
+  both true stream-missing and incompatible-restored-config
+  cases. T2d updated to assert the observer fires + the
+  `enterDegraded` reason is `stream-missing-recovery-exhausted`.
+- **v3-P1.1 (signature contract stale in sketches):** v4 locks
+  `recover` to `(Consumer, error)` (no bool), removes the
+  "optional" language for `BuildConfig`'s 4-arg signature, and
+  updates all sketches to use `types.ErrStreamMissing` (not
+  unqualified `ErrStreamMissing`).
+- **v3-P1.2 (manager wiring under-specified):** v4 includes a
+  concrete `manager_setup.go` snippet showing exactly where the
+  type-assertion goes (end of `prepareStart`, after `m.ctx` is
+  initialized), what closure is installed, and that it uses
+  `m.logError` (not a direct `Hooks.OnError` call) so the manager's
+  wait-group and lifecycle context are correctly tracked.
+- **v3-P1.3 (`recordKVError` short-circuit doesn't exist):** v4
+  adds the explicit `manager_degraded.go:recordKVError` edit to
+  the file plan with the short-circuit code:
+  `if errors.Is(err, types.ErrStreamMissing) { return }`.
+- **v3-P1.4 (cooldown bypass token leak):** v4 drops the bypass
+  token entirely. Site A/B both call `RebuildAfterStreamRecreated`
+  synchronously after the hook; the immediate post-hook rebuild
+  doesn't observe the cooldown anyway. `HandleStreamRecreated` no
+  longer sets a token; the `setBypassToken` method and
+  `postHookBypassPending` field are removed.
+
+### v3 (2026-05-24)
+
+Addresses all v2 plan-review findings
+(`tmp/09-pr9-spec_plan_review_v2.md`, verdict "revise — 3 P0 +
+4 P1 + 2 P2"):
+
+- **v2-P0.1 (no-hook Dynamic callback bridge):** `*consumer.Dynamic`
+  owns a `userOnPermanentFailure` field + a `managerOnStreamMissing
+  atomic.Pointer[func]` slot. `NewDynamic` ALWAYS wires
+  `WorkerConsumerConfig.OnPermanentFailure` to `d.onPermanentFailure`,
+  an indirection closure that reads both at fire time.
+  `SetOnStreamMissingError` is a public method on `*Dynamic` that
+  swaps the atomic pointer — a `Manager.Start` call after
+  `NewDynamic` correctly reaches the durable layer.
+- **v2-P0.2 (Site A success doesn't rebuild via reset-aware
+  config):** added `Controller.RebuildAfterStreamRecreated(ctx,
+  baseCfg, recreate)` which reads-and-clears `recreatedSinceLastBuild`,
+  calls `BuildConfig` against the (now-reset) checkpoint, and
+  invokes `recreate` to construct the new consumer. Site A's
+  detour calls this method after `handleStreamMissing` returns nil,
+  then stores the new consumer under `consumerMu`. Work returns
+  nil on success → envelope's Run exits successfully → no final-
+  attempt-budget edge.
+- **v2-P0.3 (compat re-arm reset race):** `resetCompatCheck` takes
+  `workQueueMu` (v2 only took it in the slow path of
+  `ensureCompatChecked`, allowing a stale-store interleaving).
+  T3 split into T3a (deterministic stale-store interleaving) and
+  T3b (concurrent race-detector stress).
+- **v2-P1.1 (recover/Classify signature inconsistent):** v3 locks
+  the signature: `Controller.recover` → `(Consumer, error)`;
+  `Controller.Classify` → `(Action, Consumer, error)`. All sketches
+  updated.
+- **v2-P1.2 (non-Dynamic ActionStreamMissing claims absent sink):**
+  v3 explicitly states "log + backoff" for Queue, Broadcast,
+  internal/ipartition — no surfacing to any callback. Each adds
+  a log line and a test pinning the mapping.
+- **v2-P1.3 (`ErrConsumerRecoveryExhausted` not audited):** dropped.
+  Generic exhaustion flows through unchanged (log + metric, no
+  typed wrapper). v3 scope is `ErrStreamMissing` only.
+- **v2-P1.4 (same-durable-name incompatible config undefined):**
+  hook godoc explicitly states the compatible-config rule. New
+  T2d pins the incompatible-restored-config behavior:
+  `RebuildAfterStreamRecreated` returns a non-stream-missing error;
+  envelope retries until exhaustion.
+- **v2-P2.1 (stale TBD ordering test wording):** ordering test
+  block in the reproducer-test list rewritten to reference the
+  deterministic `handleStreamRecreatedWithSteps` seam. No sleeps,
+  no logs.
+- **v2-P2.2 (`consumeBypassToken_locked` name/lock contract):**
+  renamed `setBypassToken` (atomic; no lock).
+
+### v2 (2026-05-24)
+
+Addressed all 11 v1 plan-review findings. Verdict from v2 review:
+revise — 3 new P0 + 4 new P1 + 2 P2 findings.
+
+### v1 (2026-05-24)
+
+Initial draft. Verdict: revise — 6 P0 + 5 P1 findings.

--- a/docs/plans/self-healing/STATUS.md
+++ b/docs/plans/self-healing/STATUS.md
@@ -1,12 +1,12 @@
 # Self-Healing Implementation Status
 
-This file tracks per-PR delivery state. Updated 2026-05-23
-(post-`KVBuckets.Replicas` follow-up).
+This file tracks per-PR delivery state. Updated 2026-05-24
+(post-stream-missing-detour P2.3 + P2.4d).
 
 See [`README.md`](./README.md) for the plan overview and
 [`00-fix-plan.md`](./00-fix-plan.md) for the per-PR specs.
 
-## Delivered (9 of 13 in-scope PRs + 1 follow-up)
+## Delivered (12 of 13 in-scope PRs + 1 follow-up)
 
 All branches below have been pushed to `origin`. Each PR is branched
 off `main`, not stacked — see "Merge ordering" below for the conflict
@@ -24,12 +24,18 @@ zones.
 | P2.4a | F2 | `self-healing-p24a-f2-retry-envelope` | [08](./08-pr8-spec.md) | `908f181` | Retry envelope + restartWatcher wiring |
 | P2.2 | F6-B | `self-healing-p22-f6b-partition-floor` | (in plan) | `8c072dc` | Calculator empty/shrunk floor |
 | F/U  | —     | `self-healing-kvbuckets-replicas`              | (this STATUS) | `399dfb1` | `Config.KVBuckets.Replicas` + warn-on-mismatch helper |
+| P2.4b | F2 | (on `main`) | (in plan) | `0d454be` | Envelope reuse on `claim_resolver` supervise loop |
+| P2.4c | F2 | (on `main`) | (in plan) | `31f2da9` | Envelope reuse on `monitorAssignmentChanges` + named degraded entry |
+| P2.4d | F2 | `self-healing-p23-stream-gone-hook` | (in plan) | `2c359b0` | Envelope reuse on `partition_consumer.go` recovery loop (P2.3 prerequisite) |
+| P2.3 | F5 | `self-healing-p23-stream-gone-hook` | [09](./09-pr9-spec.md) | `51bcaac` | Stream-missing hook + checkpoint reset + epoch fence + Site A/B detours + bounded exhaustion |
 
-Phase 0 (P0.1-P0.3) and Phase 1 (P1.1-P1.3) are complete. Phase 2
-has the **three dominant fixes**: P2.1 (eliminates leadership-churn),
+Phase 0 (P0.1-P0.3) and Phase 1 (P1.1-P1.3) are complete. Phase 2's
+**three dominant fixes** are P2.1 (eliminates leadership-churn),
 P2.4a (bounds the source watcher's infinite retry loop), and P2.2
 (prevents reassign-to-zero thundering herd on a transient empty
-partition observation).
+partition observation). The full F2 envelope sweep (P2.4a/b/c/d)
+also landed, and P2.3 layers the operator-driven stream-missing
+recovery flow on top of P2.4d.
 
 ### Follow-up: `Config.KVBuckets.Replicas`
 
@@ -57,17 +63,37 @@ the migration runbook should get a one-line addendum mentioning the
 new config option as an alternative to pre-creating with
 `--replicas=3`.
 
-## Remaining (4 of 13 in-scope PRs)
-
-Each needs its own session — none is mechanical reuse:
+## Remaining (1 of 13 in-scope PRs)
 
 | Order | ID | Status | Reason |
 |---|---|---|---|
-| P2.4b | F2 | Not started | Envelope reuse on `claim_resolver` supervise loop. Site has nested supervisor + restart-reason classification — read carefully. |
-| P2.4c | F2 | Not started | Envelope reuse on `monitorAssignmentChanges`. Different stop semantics; exhaustion must call `enterDegraded("assignment-watcher-exhausted")` per plan. |
-| P2.4d | F2 | Not started | Envelope reuse on `partition_consumer.go` recovery loop. Larger surface; **P2.3's prerequisite**. |
-| P2.3 | F5 | Not started | Stream-gone hook + checkpoint reset + stream-epoch generation fence. **HIGH risk** (three coordinated mechanisms; manual-ack late-ack defense). Depends on P2.4d. |
 | P2.5 | F10-A | Not started | **Chaos reproducer first** (hard gate). Truncated `Keys()` defense + worker-set floor. |
+
+### P2.3 follow-up — manager-side wiring (deferred from `self-healing-p23-stream-gone-hook`)
+
+P2.3 ships the durable layer's bind point but not the manager-side
+observer that consumes it. The spec's "out of scope" items listed at
+[`09-pr9-spec.md`](./09-pr9-spec.md) (under each Mechanism heading)
+form the next focused PR:
+
+- `manager_setup.go`: type-assert the registered consumer updater
+  against `recovery.StreamMissingObserver` and install
+  `m.onStreamMissingError` via `SetOnStreamMissingError`.
+- `CompositeConsumerUpdater.SetOnStreamMissingError`: forward the
+  observer to current and later-`Add`-ed observer-capable children
+  under a mutex.
+- `consumer.Dynamic.SetOnStreamMissingError`: indirection slot read
+  by the existing `OnPermanentFailure` closure so a `Manager.Start`
+  call after `NewDynamic` reaches the durable layer.
+- `manager_degraded.go:recordKVError`: short-circuit when
+  `errors.Is(err, types.ErrStreamMissing)` so stream-missing does
+  not double-count against the KV error threshold (cross-feature
+  contract preservation per AGENTS.md).
+- Integration tests T1/T4/T5 under `test/integration/failure/` —
+  hook fires, no-hook → readiness flip, hook-returns-error → no
+  retry storm.
+- `docs/CONSUMERS.md`: worked example with `parti.Provision`-based
+  stream recreate.
 
 Deferred to Phase 3 (post-promotion gated):
 - P3.1 (F9-B) Lease-aware leader

--- a/errors.go
+++ b/errors.go
@@ -24,4 +24,12 @@ var (
 	ErrIDClaimFailed              = types.ErrIDClaimFailed
 	ErrAssignmentFailed           = types.ErrAssignmentFailed
 	ErrInvalidPreset              = types.ErrInvalidPreset
+	// ErrStreamMissing is the operator-actionable umbrella error surfaced
+	// when the dynamic partition consumer's recovery flow determines that
+	// the underlying JetStream stream is absent (or post-hook recovery
+	// fails for any reason — restored consumer config mismatch, etc.).
+	// Callers branch via errors.Is(err, parti.ErrStreamMissing) inside
+	// their Hooks.OnError handler. See [types.ErrStreamMissing] for the
+	// full contract.
+	ErrStreamMissing = types.ErrStreamMissing
 )

--- a/internal/durable/broadcast_consumer.go
+++ b/internal/durable/broadcast_consumer.go
@@ -328,7 +328,7 @@ func (bc *BroadcastConsumer) runLoop(ctx context.Context) {
 		consumerConfig := bc.consumerConfig
 		bc.consumerMu.RUnlock()
 
-		action, newCons := bc.recovery.Classify(ctx, iterErr, bc.consumerInfoFn(), consumerConfig, bc.recreateFn())
+		action, newCons, classifyErr := bc.recovery.Classify(ctx, iterErr, bc.consumerInfoFn(), consumerConfig, bc.recreateFn())
 		switch action {
 		case recovery.ActionExit:
 			return
@@ -343,6 +343,17 @@ func (bc *BroadcastConsumer) runLoop(ctx context.Context) {
 			bc.recovery.SeedCheckpoint(ctx, bc.consumerInfoFn())
 
 			continue
+		case recovery.ActionStreamMissing:
+			// Broadcast does not own stream lifecycle; log for operator
+			// observability and backoff. No callback surface today.
+			bc.logger.Warn("broadcast consumer recovery classified stream missing",
+				"op", "broadcast_stream_missing",
+				"stream", bc.config.StreamName,
+				"error", classifyErr,
+			)
+			if bc.delayOrExit(ctx) {
+				return
+			}
 		case recovery.ActionBackoff:
 			if bc.delayOrExit(ctx) {
 				return

--- a/internal/durable/broadcast_stream_missing_test.go
+++ b/internal/durable/broadcast_stream_missing_test.go
@@ -1,0 +1,130 @@
+package durable
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	partitesting "github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// captureWarnLogger records WARN-level messages so a test can assert that a
+// specific log line was emitted by a production code path. Optional t enables
+// pass-through to the test log for diagnosis.
+type captureWarnLogger struct {
+	mu    sync.Mutex
+	warns []string
+	t     *testing.T
+}
+
+var _ types.Logger = (*captureWarnLogger)(nil)
+
+func (l *captureWarnLogger) Debug(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("DEBUG: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Info(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("INFO: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Warn(msg string, kv ...any) {
+	l.mu.Lock()
+	l.warns = append(l.warns, msg)
+	l.mu.Unlock()
+	if l.t != nil {
+		l.t.Logf("WARN: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Error(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("ERROR: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Fatal(msg string, _ ...any) {
+	panic("captureWarnLogger.Fatal: " + msg)
+}
+
+func (l *captureWarnLogger) hasWarn(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, w := range l.warns {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestBroadcastConsumer_ActionStreamMissing_LogsAndBacksOff pins the spec-
+// required mapping for Broadcast's non-Dynamic ActionStreamMissing branch
+// (docs/plans/self-healing/09-pr9-spec.md § "File-by-file caller contract"):
+// Broadcast does not own stream lifecycle, so the stream-missing
+// classification is logged for operator observability and folded into a
+// backoff — it must NOT fall through to the default branch or cause the
+// loop to exit silently.
+func TestBroadcastConsumer_ActionStreamMissing_LogsAndBacksOff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const streamName = "BROADCAST_STREAM_MISSING"
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{"bcsm.>"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.MemoryStorage,
+		MaxMsgs:   -1,
+	})
+	require.NoError(t, err)
+
+	log := &captureWarnLogger{t: t}
+	cfg := BroadcastConsumerConfig{
+		StreamName:       streamName,
+		ConsumerPrefix:   "bcsm",
+		ConsumerID:       "worker-1",
+		WildcardFilter:   "bcsm.>",
+		BatchSize:        1,
+		FetchTimeout:     1500 * time.Millisecond,
+		Logger:           log,
+		RecoveryStrategy: RecoverFromBeginning,
+	}
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	bc, err := NewBroadcastConsumer(js, cfg, handler)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bc.Close(context.Background()) })
+
+	parts := []types.Partition{{Keys: []string{"region", "us-east"}}}
+	require.NoError(t, bc.UpdateWorkerConsumer(ctx, "worker-1", parts))
+
+	durable := bc.durableName()
+	require.Eventually(t, func() bool {
+		_, infoErr := js.Consumer(ctx, streamName, durable)
+		return infoErr == nil
+	}, 5*time.Second, 25*time.Millisecond, "broadcast consumer must bind before stream deletion")
+
+	require.NoError(t, js.DeleteStream(ctx, streamName))
+
+	require.Eventually(t, func() bool {
+		return log.hasWarn("broadcast consumer recovery classified stream missing")
+	}, 10*time.Second, 50*time.Millisecond,
+		"Broadcast's ActionStreamMissing case must emit the expected WARN log line; absence implies the case is unwired or fell through")
+}

--- a/internal/durable/config.go
+++ b/internal/durable/config.go
@@ -1,6 +1,7 @@
 package durable
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -306,10 +307,61 @@ type WorkerConsumerConfig struct {
 	// Default: RecoveryDisabled (no auto-recovery).
 	RecoveryStrategy RecoveryStrategy
 
+	// StreamMissingHook fires when the partition consumer cannot create
+	// a consumer because the underlying JetStream stream is absent. The
+	// hook is the escalation path for operator-driven stream recreation;
+	// the library does not recreate streams itself.
+	//
+	// Returning a nil error indicates the caller has recreated the stream;
+	// the library will then bump the recovery controller's stream-epoch,
+	// reset its checkpoint, re-seed, and rebuild the consumer against
+	// the freshly-restored stream. Returning a non-nil error (or omitting
+	// the hook) surfaces the loss via the F2 envelope's exhaustion path:
+	// OnPermanentFailure fires with the error wrapped in
+	// types.ErrStreamMissing, and the manager routes that to enterDegraded.
+	//
+	// Requires RecoveryStrategy in {RecoverFromLastProcessed,
+	// RecoverFromBeginning}. RecoveryDisabled (default) and
+	// RecoverFromNew are rejected at Validate time. See
+	// types.StreamMissingHook godoc for the full operator contract.
+	StreamMissingHook types.StreamMissingHook
+
 	// IteratorFactory optionally overrides the iterator creation logic for testing or
 	// advanced customization. When nil, a default factory is used that configures
 	// heartbeat and expiry based on BatchSize and FetchTimeout.
 	IteratorFactory func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error)
+}
+
+// validateStreamMissingHookStrategy enforces the recovery-strategy
+// pre-conditions for StreamMissingHook at the durable/ surface. Identical
+// in spirit to the consumer/ helper of the same name; intentionally
+// duplicated rather than moved to a shared package because internal/durable
+// cannot import consumer/ and a new shared package would just be coupling
+// for ~15 lines. The cross-package consistency is pinned by a test in
+// package consumer_test that runs both public Validate surfaces over the
+// same matrix and asserts equivalent accept/reject outcomes.
+func validateStreamMissingHookStrategy(hookConfigured bool, strategy RecoveryStrategy) error {
+	if !hookConfigured {
+		return nil
+	}
+	switch strategy { //nolint:exhaustive // explicit branches; default catches the rest.
+	case RecoverFromLastProcessed, RecoverFromBeginning:
+		return nil
+	case RecoveryDisabled:
+		return errors.New(
+			"durable: StreamMissingHook requires a non-disabled RecoveryStrategy; " +
+				"set RecoveryStrategy to RecoverFromLastProcessed (at-least-once) or " +
+				"RecoverFromBeginning (replay-all) to enable the stream-missing recovery path")
+	case RecoverFromNew:
+		return errors.New(
+			"durable: StreamMissingHook is incompatible with RecoverFromNew " +
+				"because the recreated-stream replay override only applies to " +
+				"RecoverFromLastProcessed and RecoverFromBeginning; " +
+				"RecoverFromNew would silently skip messages published after a fresh-stream recreate")
+	default:
+		return fmt.Errorf(
+			"durable: StreamMissingHook with unknown RecoveryStrategy %v", strategy)
+	}
 }
 
 // DefaultWorkerConsumerConfig returns a WorkerConsumerConfig with sensible defaults.
@@ -395,5 +447,5 @@ func (c *WorkerConsumerConfig) Validate() error {
 		return fmt.Errorf("subject template is invalid: %w", err)
 	}
 
-	return nil
+	return validateStreamMissingHookStrategy(c.StreamMissingHook != nil, c.RecoveryStrategy)
 }

--- a/internal/durable/config.go
+++ b/internal/durable/config.go
@@ -307,6 +307,18 @@ type WorkerConsumerConfig struct {
 	// Default: RecoveryDisabled (no auto-recovery).
 	RecoveryStrategy RecoveryStrategy
 
+	// OnStreamRecreated is invoked on the consumption loop's goroutine
+	// after the partition consumer's stream-missing detour has driven
+	// the recovery controller through HandleStreamRecreated (post-hook
+	// success). Wiring layers (currently consumer.Dynamic) use it to
+	// reset transient per-stream-identity caches such as the WorkQueue
+	// compatibility check. Optional; nil is safe.
+	//
+	// The callback runs synchronously; it must be non-blocking. Heavy
+	// work should be offloaded to a goroutine inside the callback so
+	// the partition consumer can resume the rebuild promptly.
+	OnStreamRecreated func()
+
 	// StreamMissingHook fires when the partition consumer cannot create
 	// a consumer because the underlying JetStream stream is absent. The
 	// hook is the escalation path for operator-driven stream recreation;

--- a/internal/durable/config_streamhook_test.go
+++ b/internal/durable/config_streamhook_test.go
@@ -1,0 +1,82 @@
+package durable
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the recovery-strategy pre-conditions enforced by
+// WorkerConsumerConfig.Validate when StreamMissingHook is set. The
+// cross-package consistency test in consumer/ proves DynamicConfig.Validate
+// agrees with this surface on the same matrix.
+
+func baseWorkerConfigForStreamHook() WorkerConsumerConfig {
+	return WorkerConsumerConfig{
+		StreamName:      "TEST_STREAM",
+		ConsumerPrefix:  "wc",
+		SubjectTemplate: "events.{{.PartitionID}}",
+	}
+}
+
+func TestWorkerConsumerConfig_Validate_NoHook_AnyStrategyAccepted(t *testing.T) {
+	cases := []struct {
+		name     string
+		strategy RecoveryStrategy
+	}{
+		{"disabled", RecoveryDisabled},
+		{"from_new", RecoverFromNew},
+		{"from_last_processed", RecoverFromLastProcessed},
+		{"from_beginning", RecoverFromBeginning},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseWorkerConfigForStreamHook()
+			cfg.RecoveryStrategy = tc.strategy
+			require.NoError(t, cfg.Validate(),
+				"without StreamMissingHook, every RecoveryStrategy must remain accepted")
+		})
+	}
+}
+
+func TestWorkerConsumerConfig_Validate_Hook_RecoveryDisabled_Rejected(t *testing.T) {
+	cfg := baseWorkerConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoveryDisabled
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	err := cfg.Validate()
+	require.Error(t, err,
+		"StreamMissingHook + RecoveryDisabled must be rejected; without the controller the hook-success path cannot rebuild")
+	require.Contains(t, err.Error(), "RecoveryStrategy",
+		"the rejection message must name RecoveryStrategy so operators can fix the config")
+}
+
+func TestWorkerConsumerConfig_Validate_Hook_RecoverFromNew_Rejected(t *testing.T) {
+	cfg := baseWorkerConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoverFromNew
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	err := cfg.Validate()
+	require.Error(t, err,
+		"StreamMissingHook + RecoverFromNew must be rejected; the recreated-stream replay override does not apply, so messages published after a fresh-stream recreate would be silently skipped")
+	require.Contains(t, err.Error(), "RecoverFromNew")
+}
+
+func TestWorkerConsumerConfig_Validate_Hook_RecoverFromLastProcessed_Accepted(t *testing.T) {
+	cfg := baseWorkerConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoverFromLastProcessed
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	require.NoError(t, cfg.Validate(),
+		"StreamMissingHook + RecoverFromLastProcessed is the canonical at-least-once configuration")
+}
+
+func TestWorkerConsumerConfig_Validate_Hook_RecoverFromBeginning_Accepted(t *testing.T) {
+	cfg := baseWorkerConfigForStreamHook()
+	cfg.RecoveryStrategy = RecoverFromBeginning
+	cfg.StreamMissingHook = types.StreamMissingHook(func(string) error { return nil })
+
+	require.NoError(t, cfg.Validate(),
+		"StreamMissingHook + RecoverFromBeginning (replay-all) is an accepted intentional-duplicate-processing configuration")
+}

--- a/internal/durable/partition_consumer.go
+++ b/internal/durable/partition_consumer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/natsutil"
@@ -36,6 +37,20 @@ type partitionConsumerConfig struct {
 	// OnPermanentFailure is fired exactly once when the iterator-creation
 	// envelope exhausts its attempt budget. See WorkerConsumerConfig.
 	OnPermanentFailure func(subject string, err error)
+
+	// StreamMissingHook is the operator-supplied escalation invoked when
+	// the partition consumer's recovery flow detects the underlying
+	// JetStream stream is absent. Nil means "no hook configured" — the
+	// detour logs and surfaces the loss via the F2 envelope's exhaustion
+	// path. See WorkerConsumerConfig.StreamMissingHook for the full
+	// operator contract.
+	StreamMissingHook types.StreamMissingHook
+
+	// OnStreamRecreated is invoked after a successful post-hook
+	// HandleStreamRecreated. Used by the consumer.Dynamic wiring layer
+	// to reset its WorkQueue compat cache so the next Update re-runs
+	// the check against the fresh stream identity.
+	OnStreamRecreated func()
 
 	// Metrics
 	Metrics types.WorkerConsumerMetrics
@@ -75,6 +90,20 @@ type partitionConsumer struct {
 	iterFailureTimes []time.Time
 	lastEscalation   time.Time
 	iterEscMu        sync.Mutex
+
+	// streamMissingFailures is the consecutive Site B stream-missing detour
+	// failure count (hook absent, hook returned error, or post-hook rebuild
+	// failed). The Site A path is already bounded by the F2 envelope;
+	// Site B (iter-runtime classification via Next() → ErrConsumerDeleted)
+	// lives outside the iter-creation envelope, because nats.go's
+	// Consumer.Messages() does not validate the remote stream up front
+	// (it returns a MessagesContext eagerly and only surfaces consumer-gone
+	// later via Next()), so a fresh outer-loop envelope construction would
+	// succeed at iter creation, hit the same Next() error, and re-enter
+	// Site B forever. This counter bounds that loop: it increments on every
+	// Site B detour failure, is reset to zero on success, and triggers
+	// OnPermanentFailure + loop exit when it reaches RecoveryRetry.MaxAttempts.
+	streamMissingFailures atomic.Int32
 
 	// Info lock
 	consInfoMu sync.Mutex
@@ -220,26 +249,50 @@ func (pc *partitionConsumer) runIteratorEnvelope(
 	var iter jetstream.MessagesContext
 	env := retry.New(retry.Config{
 		Work: func(workCtx context.Context) error {
-			pc.consInfoMu.Lock()
-			i, err := pc.iterFactory(cons, batch, expiry)
-			pc.consInfoMu.Unlock()
-			if err != nil {
-				pc.logger.Warn("iterator creation failed", "subject", pc.subject, "error", err)
-				if pc.config.Metrics != nil {
-					pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("transient")
-				}
-				// Iterator creation failures (from cons.Messages()) are distinct from
-				// iterator consumption failures (from iter.Next()): consumer deletion
-				// is detected on Next() errors, not creation. The legacy per-subject
-				// escalation handles creation failures (rebind the durable) regardless
-				// of recovery strategy, so it runs inside the envelope.
-				pc.maybeEscalateIteratorFailures(workCtx)
-
-				return err
+			// Re-read pc.consumer at the start of every attempt so a
+			// mid-envelope Site A rebuild (which stores a fresh consumer
+			// under consumerMu) is visible to subsequent attempts in the
+			// same envelope episode. Closing over the outer `cons` would
+			// pin retries to the pre-rebuild consumer handle.
+			pc.consumerMu.RLock()
+			attemptCons := pc.consumer
+			pc.consumerMu.RUnlock()
+			if attemptCons == nil {
+				attemptCons = cons
 			}
-			iter = i
 
-			return nil
+			pc.consInfoMu.Lock()
+			i, err := pc.iterFactory(attemptCons, batch, expiry)
+			pc.consInfoMu.Unlock()
+			if err == nil {
+				iter = i
+				return nil
+			}
+
+			pc.logger.Warn("iterator creation failed", "subject", pc.subject, "error", err)
+			if pc.config.Metrics != nil {
+				pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("transient")
+			}
+			// Legacy per-subject escalation runs inside the envelope regardless
+			// of recovery strategy (creation failures are distinct from Next()
+			// failures and don't go through recovery.Classify). It surfaces a
+			// non-nil stream-not-found error only when ensureConsumer failed —
+			// the Site A signal that the underlying stream is gone.
+			escErr := pc.maybeEscalateIteratorFailures(workCtx)
+			if escErr != nil && natsutil.IsStreamNotFound(escErr) {
+				newIter, detourErr := pc.runStreamMissingDetour(workCtx, batch, expiry)
+				if detourErr != nil {
+					// Counts as the current attempt; the envelope keeps
+					// retrying until MaxAttempts, then OnPermanentFailure
+					// fires with the wrapped types.ErrStreamMissing.
+					return detourErr
+				}
+				iter = newIter
+
+				return nil
+			}
+
+			return err
 		},
 		OnPermanent: func(err error) {
 			pc.logger.Warn("partition consumer iterator-creation budget exhausted; entering permanent failure",
@@ -286,15 +339,40 @@ func (pc *partitionConsumer) handleIteratorFailure(ctx context.Context, iterErr 
 				pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("transient")
 			}
 		}
-		pc.maybeEscalateIteratorFailures(ctx)
+		// Recovery is disabled, so HandleStreamRecreated / rebuild
+		// machinery is unavailable. The hook would also have been
+		// rejected at construction time by the strategy validator, so
+		// there is nothing to "recreate". But a stream-not-found signal
+		// from the escalation IS the spec's Site B exhaustion trigger;
+		// routing it through handleStreamMissingFailure bounds the
+		// otherwise-infinite retry loop using the same
+		// RecoveryRetry.MaxAttempts cap as the recovery-enabled path.
+		// (v2 P0-A fix.)
+		if escErr := pc.maybeEscalateIteratorFailures(ctx); escErr != nil && natsutil.IsStreamNotFound(escErr) {
+			wrapped := fmt.Errorf("%w: stream %q: %w", types.ErrStreamMissing, pc.streamName, escErr)
+			return pc.handleStreamMissingFailure(ctx, iterErr, wrapped)
+		}
 
 		return pc.delayWithBackoffOrExit(ctx, "iterate")
 	}
 
-	action, newCons := pc.recovery.Classify(ctx, iterErr, pc.consumerInfoFn(), pc.consumerConfig, pc.recreateFn())
+	action, newCons, classifyErr := pc.recovery.Classify(ctx, iterErr, pc.consumerInfoFn(), pc.consumerConfig, pc.recreateFn())
 	switch action {
 	case recovery.ActionExit:
 		return true
+	case recovery.ActionStreamMissing:
+		// Site B detour: classifyErr already wraps types.ErrStreamMissing.
+		// The shared rebuild swaps pc.consumer with one built via the
+		// recreated-flag override (DeliverAllPolicy + reset checkpoint).
+		// Failures are bounded by handleStreamMissingFailure (see field
+		// comment on streamMissingFailures): consecutive failures up to
+		// RecoveryRetry.MaxAttempts back off, then OnPermanentFailure
+		// fires once and the loop exits.
+		if _, err := pc.rebuildAfterStreamMissing(ctx); err != nil {
+			return pc.handleStreamMissingFailure(ctx, classifyErr, err)
+		}
+
+		return false // outer loop iterates → fresh envelope uses the rebuilt pc.consumer
 	case recovery.ActionContinue:
 		pc.consumerMu.Lock()
 		pc.consumer = newCons
@@ -304,6 +382,12 @@ func (pc *partitionConsumer) handleIteratorFailure(ctx context.Context, iterErr 
 		pc.iterFailureTimes = pc.iterFailureTimes[:0]
 		pc.lastEscalation = time.Time{}
 		pc.iterEscMu.Unlock()
+		// Reset the Site B stream-missing failure counter on any successful
+		// normal recovery so a prior partial-failure burst from a now-resolved
+		// stream-missing episode doesn't shorten the next episode's budget
+		// below RecoveryRetry.MaxAttempts. (v2 P0-B fix — the
+		// RecoveryRetryConfig per-episode reset contract.)
+		pc.streamMissingFailures.Store(0)
 		// SeedCheckpoint on a freshly created consumer is typically a no-op:
 		// the new consumer's ack floor is 0 and the checkpoint monotonically
 		// advances, so it will not regress. Called here as a best-effort update
@@ -442,9 +526,18 @@ func (pc *partitionConsumer) startIterStopper(ctx context.Context, iter jetstrea
 	return stopperCh
 }
 
-// maybeEscalateIteratorFailures records an iterator failure timestamp and attempts per-subject
-// remediation (recreate/bind the durable) when a burst occurs within the configured window.
-func (pc *partitionConsumer) maybeEscalateIteratorFailures(ctx context.Context) {
+// maybeEscalateIteratorFailures records an iterator failure timestamp and
+// attempts per-subject remediation (recreate/bind the durable) when a burst
+// occurs within the configured window.
+//
+// Returns a non-nil error only when remediation surfaced a stream-not-found
+// classification from the underlying `ensureConsumer` call — this is the
+// signal the iterator-creation envelope (Site A) uses to enter the
+// stream-missing detour. All other remediation outcomes — no escalation,
+// healthy consumer info, transient ensureConsumer error, or successful
+// rebind — return nil; the original iterator-creation error is what the
+// envelope counts against its budget.
+func (pc *partitionConsumer) maybeEscalateIteratorFailures(ctx context.Context) error {
 	pc.iterEscMu.Lock()
 	defer pc.iterEscMu.Unlock()
 
@@ -464,7 +557,7 @@ func (pc *partitionConsumer) maybeEscalateIteratorFailures(ctx context.Context) 
 	lastEsc := pc.lastEscalation
 	canEscalate := count >= threshold && (lastEsc.IsZero() || now.Sub(lastEsc) >= window)
 	if !canEscalate {
-		return
+		return nil
 	}
 
 	if pc.config.Metrics != nil {
@@ -490,7 +583,13 @@ func (pc *partitionConsumer) maybeEscalateIteratorFailures(ctx context.Context) 
 		_, err := cons.Info(ctx)
 		pc.consInfoMu.Unlock()
 		if err == nil {
-			return
+			// Consumer is healthy — any prior Site B stream-missing
+			// failure count (incremented by handleStreamMissingFailure
+			// in either recovery-enabled or nil-recovery branches) is
+			// no longer load-bearing, so a later episode receives the
+			// full RecoveryRetry.MaxAttempts budget. (v3 P1 fix.)
+			pc.streamMissingFailures.Store(0)
+			return nil
 		}
 	}
 
@@ -501,8 +600,15 @@ func (pc *partitionConsumer) maybeEscalateIteratorFailures(ctx context.Context) 
 			"durable", pc.durableName,
 			"error", err,
 		)
+		// Stream-not-found is the ONLY remediation error the Site A
+		// caller must learn about — other failures are transient and
+		// the envelope's per-attempt budget already accounts for them
+		// via the original iterFactory error.
+		if natsutil.IsStreamNotFound(err) {
+			return err
+		}
 
-		return
+		return nil
 	}
 
 	// Update loop reference under lock
@@ -510,7 +616,13 @@ func (pc *partitionConsumer) maybeEscalateIteratorFailures(ctx context.Context) 
 	pc.consumer = newCons
 	pc.consumerMu.Unlock()
 
+	// Legacy remediation succeeded — same per-episode reset contract
+	// applies as in the Info-healthy branch above. (v3 P1 fix.)
+	pc.streamMissingFailures.Store(0)
+
 	pc.logger.Info("per-subject consumer remediated", "subject", pc.subject, "durable", pc.durableName)
+
+	return nil
 }
 
 // ensureConsumer creates or updates the durable consumer.
@@ -584,4 +696,187 @@ func (pc *partitionConsumer) recreateFn() recovery.RecreateFunc {
 	return func(ctx context.Context, cfg jetstream.ConsumerConfig) (jetstream.Consumer, error) {
 		return pc.js.CreateOrUpdateConsumer(ctx, pc.streamName, cfg)
 	}
+}
+
+// rebuildAfterStreamMissing runs the shared post-detection sequence used by
+// both Site A (iter-creation envelope) and Site B (iter-runtime failure):
+// invoke the StreamMissingHook, drive recovery.Controller.RebuildAfterStreamRecreated,
+// swap pc.consumer under consumerMu, and reset the per-subject iterator-
+// escalation counters so the legacy escalation doesn't fire spuriously on
+// the freshly-rebuilt consumer.
+//
+// Returns the rebuilt consumer on success, or an error wrapped with
+// types.ErrStreamMissing on hook absence / hook failure / rebuild failure.
+// The Site A caller follows up with iterFactory; the Site B caller returns
+// to the outer loop which constructs the next envelope.
+func (pc *partitionConsumer) rebuildAfterStreamMissing(ctx context.Context) (jetstream.Consumer, error) {
+	if err := pc.handleStreamMissing(ctx); err != nil {
+		return nil, err
+	}
+
+	// RebuildAfterStreamRecreated already wraps the underlying cause
+	// with types.ErrStreamMissing (covering both still-missing-stream
+	// and incompatible-restored-consumer-config cases) so the manager
+	// observer route fires consistently on exhaustion.
+	newCons, err := pc.recovery.RebuildAfterStreamRecreated(ctx, pc.consumerConfig, pc.recreateFn())
+	if err != nil {
+		return nil, err
+	}
+
+	pc.consumerMu.Lock()
+	pc.consumer = newCons
+	pc.consumerMu.Unlock()
+
+	pc.iterEscMu.Lock()
+	pc.iterFailureTimes = pc.iterFailureTimes[:0]
+	pc.lastEscalation = time.Time{}
+	pc.iterEscMu.Unlock()
+
+	// Reset the Site B failure counter on any successful rebuild — once a
+	// fresh consumer is bound, prior detour failures are no longer
+	// load-bearing toward exhaustion. Site A's failure path counts via
+	// the F2 envelope and does not consume this counter; resetting here
+	// is still correct for Site A because a successful rebuild proves the
+	// stream is back regardless of which detour drove it.
+	pc.streamMissingFailures.Store(0)
+
+	return newCons, nil
+}
+
+// handleStreamMissingFailure is the Site B failure-handler. Site B's
+// detour failures (hook absent, hook returned error, post-hook rebuild
+// failed) are bounded by RecoveryRetry.MaxAttempts because the outer-loop
+// envelope cannot catch them — see streamMissingFailures field doc for the
+// nats.go Messages() semantics that make Site B failures invisible to the
+// F2 envelope's iter-creation counter.
+//
+// Returns true to exit the consumer loop when exhaustion fires
+// OnPermanentFailure; otherwise backs off and returns false so the outer
+// loop iterates and re-enters Site B for the next attempt. The cause
+// passed to OnPermanentFailure is wrapped with types.ErrStreamMissing
+// (rebuildAfterStreamMissing's contract preserves the wrap), so the
+// downstream manager observer route fires consistently.
+func (pc *partitionConsumer) handleStreamMissingFailure(ctx context.Context, classifyErr, detourErr error) bool {
+	count := pc.streamMissingFailures.Add(1)
+	maxAttempts := pc.config.RecoveryRetry.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultRecoveryMaxAttempts
+	}
+
+	pc.logger.Warn("stream-missing detour failed on iter-runtime path",
+		"op", "stream_missing_site_b_failed",
+		"subject", pc.subject,
+		"stream", pc.streamName,
+		"attempt", count,
+		"max_attempts", maxAttempts,
+		"classify_error", classifyErr,
+		"detour_error", detourErr,
+	)
+
+	if int(count) >= maxAttempts {
+		pc.logger.Warn("stream-missing detour exhausted; entering permanent failure",
+			"op", "stream_missing_site_b_exhausted",
+			"subject", pc.subject,
+			"stream", pc.streamName,
+			"attempts", count,
+			"error", detourErr,
+		)
+		if pc.config.Metrics != nil {
+			pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_missing_exhausted")
+		}
+		if pc.config.OnPermanentFailure != nil {
+			pc.config.OnPermanentFailure(pc.subject, detourErr)
+		}
+
+		return true // exit the consumer loop
+	}
+
+	return pc.delayWithBackoffOrExit(ctx, "iterate")
+}
+
+// runStreamMissingDetour is the Site A wrapper around rebuildAfterStreamMissing:
+// after the shared rebuild succeeds, it creates a fresh iterator from the new
+// consumer so the envelope's Work attempt can return success with a usable iter.
+//
+// A nil error means pc.consumer has been swapped AND the returned iter is
+// pinned for the envelope to drain. Any non-nil error counts against the
+// envelope's attempt budget; exhaustion routes through OnPermanentFailure
+// to the manager observer. Post-rebuild iter-creation flakiness retries on
+// the next attempt — Work re-reads pc.consumer (now = newCons) at the top.
+func (pc *partitionConsumer) runStreamMissingDetour(
+	ctx context.Context,
+	batch int,
+	expiry time.Duration,
+) (jetstream.MessagesContext, error) {
+	newCons, err := pc.rebuildAfterStreamMissing(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pc.consInfoMu.Lock()
+	newIter, iterErr := pc.iterFactory(newCons, batch, expiry)
+	pc.consInfoMu.Unlock()
+	if iterErr != nil {
+		return nil, iterErr
+	}
+
+	return newIter, nil
+}
+
+// handleStreamMissing invokes the operator-supplied StreamMissingHook and,
+// on success, drives the recovery controller's post-hook reset sequence
+// (HandleStreamRecreated + the OnStreamRecreated callback). The reset runs
+// BEFORE the upstream callback so the compat-check cache resets only after
+// the controller has bumped the epoch — preventing a racing Update from
+// caching a stale "compatible" result keyed against the previous stream.
+//
+// Returns nil when the hook returned nil; the caller's detour is then
+// expected to call RebuildAfterStreamRecreated. Returns a wrapped
+// types.ErrStreamMissing when the hook is absent or returned an error.
+func (pc *partitionConsumer) handleStreamMissing(ctx context.Context) error {
+	hook := pc.config.StreamMissingHook
+	if hook == nil {
+		pc.logger.Warn("stream-missing detected; no hook configured",
+			"op", "stream_missing_no_hook",
+			"subject", pc.subject,
+			"stream", pc.streamName,
+		)
+		if pc.config.Metrics != nil {
+			pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_missing_no_hook")
+		}
+
+		return fmt.Errorf("%w: stream %q", types.ErrStreamMissing, pc.streamName)
+	}
+
+	pc.logger.Info("invoking stream-missing hook",
+		"op", "stream_missing_hook_invoke",
+		"subject", pc.subject,
+		"stream", pc.streamName,
+	)
+	hookErr := hook(pc.streamName)
+	if hookErr != nil {
+		pc.logger.Warn("stream-missing hook returned error",
+			"op", "stream_missing_hook_error",
+			"subject", pc.subject,
+			"stream", pc.streamName,
+			"error", hookErr,
+		)
+		if pc.config.Metrics != nil {
+			pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_recreate_error")
+		}
+
+		return fmt.Errorf("%w: stream %q: %w", types.ErrStreamMissing, pc.streamName, hookErr)
+	}
+
+	// Hook succeeded — drive the post-hook reset (controller first, then
+	// the upstream OnStreamRecreated callback; see docstring for ordering rationale).
+	pc.recovery.HandleStreamRecreated(ctx, pc.consumerInfoFn())
+	if pc.config.OnStreamRecreated != nil {
+		pc.config.OnStreamRecreated()
+	}
+	if pc.config.Metrics != nil {
+		pc.config.Metrics.IncrementWorkerConsumerIteratorRestart("stream_recreate_success")
+	}
+
+	return nil
 }

--- a/internal/durable/partition_consumer_stream_missing_site_b_test.go
+++ b/internal/durable/partition_consumer_stream_missing_site_b_test.go
@@ -1,0 +1,603 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestPartitionConsumer_SiteB_StreamMissing_HookSuccess_ResetAwareRebuild
+// is the T-SiteB-rebuild reproducer (per docs/plans/self-healing/09-pr9-spec.md
+// § Reproducer tests). It pins the v5-P1.3 invariant: when handleIteratorFailure
+// classifies the iterator error as ActionStreamMissing (the iter-runtime path —
+// stream deleted while the consumer was running), the post-hook success branch
+// MUST drive recovery.Controller.RebuildAfterStreamRecreated so that:
+//
+//   - The recreated stream consumer is built with DeliverAllPolicy (the
+//     one-shot recreated-flag override), not the static dynamicbuild config.
+//   - pc.consumer is swapped under consumerMu.
+//   - The outer loop's next iteration uses the freshly-rebuilt consumer.
+//
+// A broken implementation that only calls handleStreamMissing without
+// RebuildAfterStreamRecreated would either keep using the stale consumer
+// or fall through to legacy ensureConsumer with the static config —
+// either way the captured DeliverPolicy assertion fails.
+func TestPartitionConsumer_SiteB_StreamMissing_HookSuccess_ResetAwareRebuild(t *testing.T) {
+	originalCons := &streamMissingConsumer{id: "before"}
+	rebuiltCons := &streamMissingConsumer{id: "after"}
+
+	js := &streamMissingJS{
+		plan: []consumerOutcome{
+			// 1) recover() calls recreate(ctx, recoverCfg) → stream gone.
+			{cons: nil, err: jetstream.ErrStreamNotFound},
+			// 2) RebuildAfterStreamRecreated calls recreate(ctx, postHookCfg).
+			//    The captured cfg.DeliverPolicy MUST be DeliverAllPolicy.
+			{cons: rebuiltCons, err: nil},
+		},
+	}
+
+	var hookCalls atomic.Int32
+	hookCalledStream := make(chan string, 1)
+	hook := types.StreamMissingHook(func(stream string) error {
+		hookCalls.Add(1)
+		select {
+		case hookCalledStream <- stream:
+		default:
+		}
+		return nil
+	})
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	})
+
+	var iterMu sync.Mutex
+	var iterCalls []jetstream.Consumer
+	iterFactory := func(cons jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		iterMu.Lock()
+		iterCalls = append(iterCalls, cons)
+		iterMu.Unlock()
+		if cons == jetstream.Consumer(originalCons) {
+			// Drive Site B's iter-runtime classification: an iterator that
+			// returns ErrConsumerDeleted on Next() trips ClassifyError →
+			// ErrorConsumerGone → recover() → recreate() → ErrStreamNotFound
+			// → ActionStreamMissing.
+			return &errorOnNextIter{err: jetstream.ErrConsumerDeleted}, nil
+		}
+
+		// Post-rebuild: return a healthy iterator that blocks until shutdown.
+		return &blockingIter{stopCh: stopCh}, nil
+	}
+
+	cfg := partitionConsumerConfig{
+		BatchSize:        1,
+		FetchTimeout:     50 * time.Millisecond,
+		RecoveryStrategy: RecoverFromLastProcessed,
+		Retry: RetryConfig{
+			Backoff:    5 * time.Millisecond,
+			Base:       5 * time.Millisecond,
+			Multiplier: 1.0,
+			Max:        10 * time.Millisecond,
+		},
+		// High threshold so Site A's escalation path is disabled — we're
+		// pinning Site B exclusively.
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1000,
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: 10,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+			Jitter:      0,
+		},
+		StreamMissingHook: hook,
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       originalCons,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// Wait for the hook to fire.
+	select {
+	case stream := <-hookCalledStream:
+		require.Equal(t, "STREAM", stream, "hook must receive the stream name")
+	case <-time.After(5 * time.Second):
+		js.mu.Lock()
+		reqs := len(js.requests)
+		js.mu.Unlock()
+		iterMu.Lock()
+		ic := len(iterCalls)
+		iterMu.Unlock()
+		t.Fatalf("StreamMissingHook never fired; Site B detour did not trigger. iterCalls=%d, js.requests=%d", ic, reqs)
+	}
+
+	// After the detour, the outer loop must reach the post-rebuild
+	// blockingIter (built from rebuiltCons). Wait until iterFactory has
+	// been called against rebuiltCons.
+	require.Eventually(t, func() bool {
+		iterMu.Lock()
+		defer iterMu.Unlock()
+		for _, c := range iterCalls {
+			if c == jetstream.Consumer(rebuiltCons) {
+				return true
+			}
+		}
+
+		return false
+	}, 5*time.Second, 10*time.Millisecond,
+		"Site B success path must cause the outer loop to construct a fresh envelope against the rebuilt consumer")
+
+	pc.consumerMu.RLock()
+	got := pc.consumer
+	pc.consumerMu.RUnlock()
+	require.Same(t, jetstream.Consumer(rebuiltCons), got,
+		"pc.consumer must be swapped to the rebuilt consumer after Site B's reset-aware rebuild")
+
+	// The recreate request captured during RebuildAfterStreamRecreated
+	// (js.requests[1]) MUST carry DeliverAllPolicy. The recreated-flag
+	// override fires only when checkpoint==0 AND recreatedSinceLastBuild==true;
+	// asserting the second request's DeliverPolicy pins both invariants.
+	js.mu.Lock()
+	require.GreaterOrEqual(t, len(js.requests), 2,
+		"expected at least two CreateOrUpdateConsumer calls (recover-fail + post-hook rebuild)")
+	rebuildReq := js.requests[1]
+	js.mu.Unlock()
+	require.Equal(t, jetstream.DeliverAllPolicy, rebuildReq.DeliverPolicy,
+		"post-hook rebuild config must use DeliverAllPolicy via the recreated-flag override (BuildConfig); "+
+			"a stale-flag or legacy-ensureConsumer path would emit a different policy")
+
+	require.Equal(t, int32(1), hookCalls.Load(),
+		"hook must fire exactly once per Site B stream-missing episode")
+
+	cancel()
+	close(stopCh)
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("partition consumer did not exit on ctx cancel")
+	}
+}
+
+// TestPartitionConsumer_SiteB_StreamMissing_NoHook_BoundsAndFiresPermanent
+// pins the P0-1 fix from post-impl review v1: when Site B's stream-missing
+// detour fails repeatedly (here, no hook configured), the failure count is
+// bounded by RecoveryRetry.MaxAttempts and OnPermanentFailure fires exactly
+// once with a wrapped types.ErrStreamMissing — the consumer loop then exits.
+//
+// Without the bound, nats.go's Consumer.Messages() returns a MessagesContext
+// eagerly (no remote stream validation), so a fresh outer-loop envelope
+// succeeds at iter creation, hits the same ErrConsumerDeleted on Next(),
+// re-enters Site B, and loops forever generating CreateOrUpdateConsumer
+// traffic from Classify→recover. The streamMissingFailures counter +
+// handleStreamMissingFailure helper turn that into a bounded retry that
+// surfaces via the same OnPermanentFailure path as the F2 envelope.
+func TestPartitionConsumer_SiteB_StreamMissing_NoHook_BoundsAndFiresPermanent(t *testing.T) {
+	const maxAttempts = 3
+
+	originalCons := &streamMissingConsumer{id: "before"}
+
+	// Every CreateOrUpdateConsumer call (from recover()) returns ErrStreamNotFound.
+	// The detour can never succeed because there is no hook to recreate the stream.
+	js := &streamMissingJS{}
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	})
+
+	var iterMu sync.Mutex
+	var iterCalls int
+	iterFactory := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		iterMu.Lock()
+		iterCalls++
+		iterMu.Unlock()
+		// Every iter returns ErrConsumerDeleted on Next() — drives Site B
+		// classification on every outer-loop iteration.
+		return &errorOnNextIter{err: jetstream.ErrConsumerDeleted}, nil
+	}
+
+	var permanentCalls atomic.Int32
+	var permanentErr atomic.Pointer[error]
+	cfg := partitionConsumerConfig{
+		BatchSize:        1,
+		FetchTimeout:     50 * time.Millisecond,
+		RecoveryStrategy: RecoverFromLastProcessed,
+		Retry: RetryConfig{
+			Backoff:    5 * time.Millisecond,
+			Base:       5 * time.Millisecond,
+			Multiplier: 1.0,
+			Max:        10 * time.Millisecond,
+		},
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1000, // disabled — Site A path not exercised
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: maxAttempts,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+			Jitter:      0,
+		},
+		// StreamMissingHook deliberately unset — the no-hook path is what
+		// drives detour failure.
+		OnPermanentFailure: func(_ string, err error) {
+			permanentCalls.Add(1)
+			e := err
+			permanentErr.Store(&e)
+		},
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       originalCons,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// The loop must EXIT ON ITS OWN once the Site B failure counter reaches
+	// MaxAttempts — without ctx cancellation. Without the P0-1 fix, this
+	// would time out because the loop spins forever.
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("partition consumer did not exit after Site B exhaustion; "+
+			"permanentCalls=%d, iterCalls=%d (expected exactly 1 OnPermanentFailure)",
+			permanentCalls.Load(),
+			func() int { iterMu.Lock(); defer iterMu.Unlock(); return iterCalls }(),
+		)
+	}
+
+	require.Equal(t, int32(1), permanentCalls.Load(),
+		"OnPermanentFailure must fire exactly once on Site B exhaustion")
+
+	ptr := permanentErr.Load()
+	require.NotNil(t, ptr, "OnPermanentFailure must receive a non-nil error")
+	require.ErrorIs(t, *ptr, types.ErrStreamMissing,
+		"permanent-failure error must wrap types.ErrStreamMissing so the manager observer routes via the documented contract")
+}
+
+// TestPartitionConsumer_SiteB_StreamMissing_RecoveryDisabled_BoundsAndFiresPermanent
+// pins the v2-P0-A fix: when RecoveryStrategy is the default (RecoveryDisabled),
+// the nil-recovery branch of handleIteratorFailure must STILL route a
+// stream-not-found signal from maybeEscalateIteratorFailures through
+// handleStreamMissingFailure so the loop is bounded by RecoveryRetry.MaxAttempts
+// and fires OnPermanentFailure with a wrapped types.ErrStreamMissing.
+//
+// Without the fix, the nil-recovery branch ignored the stream-not-found
+// remediation error and the loop spun indefinitely calling EnsureConsumer
+// from maybeEscalateIteratorFailures — the same exhaustion gap v1 P0-1
+// flagged for the recovery-enabled path, but for the default
+// RecoveryDisabled shape.
+func TestPartitionConsumer_SiteB_StreamMissing_RecoveryDisabled_BoundsAndFiresPermanent(t *testing.T) {
+	const maxAttempts = 3
+
+	// infoErr is required: maybeEscalateIteratorFailures short-circuits
+	// when cons.Info() succeeds (consumer still healthy → no remediation
+	// needed). To drive the stream-not-found path, the stale consumer
+	// must surface an Info() failure first; then escalation calls
+	// ensureConsumer which returns ErrStreamNotFound from the mock js.
+	originalCons := &streamMissingConsumer{id: "before", infoErr: errors.New("consumer gone")}
+
+	// Every CreateOrUpdateConsumer call (from ensureConsumer in
+	// maybeEscalateIteratorFailures) returns ErrStreamNotFound. The
+	// fix routes that signal through handleStreamMissingFailure even
+	// without recovery.
+	js := &streamMissingJS{}
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	})
+
+	var iterMu sync.Mutex
+	var iterCalls int
+	iterFactory := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		iterMu.Lock()
+		iterCalls++
+		iterMu.Unlock()
+		// Each iterator immediately errors on Next() with
+		// ErrConsumerDeleted; the nil-recovery branch's escalation
+		// path calls ensureConsumer which then surfaces stream-missing.
+		return &errorOnNextIter{err: jetstream.ErrConsumerDeleted}, nil
+	}
+
+	var permanentCalls atomic.Int32
+	var permanentErr atomic.Pointer[error]
+	cfg := partitionConsumerConfig{
+		BatchSize:    1,
+		FetchTimeout: 50 * time.Millisecond,
+		// RecoveryStrategy intentionally unset (zero = RecoveryDisabled).
+		// This is the default shape v1 P0-1's fix did NOT cover.
+		Retry: RetryConfig{
+			Backoff:    5 * time.Millisecond,
+			Base:       5 * time.Millisecond,
+			Multiplier: 1.0,
+			Max:        10 * time.Millisecond,
+		},
+		// Threshold 1 → first iter-failure triggers escalation →
+		// ensureConsumer → ErrStreamNotFound → routed through
+		// handleStreamMissingFailure.
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1,
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: maxAttempts,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+			Jitter:      0,
+		},
+		OnPermanentFailure: func(_ string, err error) {
+			permanentCalls.Add(1)
+			e := err
+			permanentErr.Store(&e)
+		},
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       originalCons,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	// Recovery controller must be nil with the default strategy — confirm
+	// the test setup actually exercises the nil-recovery branch.
+	require.Nil(t, pc.recovery,
+		"test must drive the nil-recovery branch; got non-nil recovery (check default strategy semantics)")
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// The loop MUST exit on its own once Site B's counter reaches MaxAttempts.
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("partition consumer did not exit after RecoveryDisabled Site B exhaustion; "+
+			"permanentCalls=%d, iterCalls=%d",
+			permanentCalls.Load(),
+			func() int { iterMu.Lock(); defer iterMu.Unlock(); return iterCalls }(),
+		)
+	}
+
+	require.Equal(t, int32(1), permanentCalls.Load(),
+		"OnPermanentFailure must fire exactly once on Site B exhaustion in the RecoveryDisabled path")
+
+	ptr := permanentErr.Load()
+	require.NotNil(t, ptr, "OnPermanentFailure must receive a non-nil error")
+	require.ErrorIs(t, *ptr, types.ErrStreamMissing,
+		"permanent-failure error must wrap types.ErrStreamMissing so the application can errors.Is-route the failure")
+}
+
+// TestPartitionConsumer_SiteB_ActionContinue_ResetsStreamMissingCounter pins
+// the v2-P0-B fix: a partial Site B failure burst that is then "healed" by
+// a successful normal recovery (ActionContinue, e.g. the stream came back
+// out-of-band and the next ErrConsumerDeleted is resolved by recreating the
+// consumer) MUST clear the streamMissingFailures counter so the NEXT
+// stream-missing episode starts with the full RecoveryRetry.MaxAttempts
+// budget. Without the reset, the per-episode reset contract documented on
+// RecoveryRetryConfig is violated and a subsequent episode fires
+// OnPermanentFailure prematurely.
+func TestPartitionConsumer_SiteB_ActionContinue_ResetsStreamMissingCounter(t *testing.T) {
+	rebuiltCons := &streamMissingConsumer{id: "rebuilt"}
+
+	// js returns a fresh consumer on every CreateOrUpdateConsumer — drives
+	// recover() → ActionContinue. The test does not actually drive a
+	// stream-missing failure first; instead it pre-loads the counter and
+	// then exercises the reset branch directly.
+	js := &streamMissingJS{
+		plan: []consumerOutcome{
+			{cons: rebuiltCons, err: nil},
+		},
+	}
+
+	cfg := partitionConsumerConfig{
+		BatchSize:                   1,
+		FetchTimeout:                50 * time.Millisecond,
+		RecoveryStrategy:            RecoverFromLastProcessed,
+		Retry:                       RetryConfig{Backoff: 5 * time.Millisecond, Base: 5 * time.Millisecond, Multiplier: 1.0, Max: 10 * time.Millisecond},
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1000, // disabled
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: 3,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+		},
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       &streamMissingConsumer{id: "before"},
+			iterFactory: func(jetstream.Consumer, int, time.Duration) (jetstream.MessagesContext, error) {
+				return nil, nil //nolint:nilnil // unused stub; handleIteratorFailure is invoked directly in this test.
+			},
+		},
+	)
+
+	// Recovery must be enabled so handleIteratorFailure takes the
+	// classify+switch branch, where ActionContinue lives.
+	require.NotNil(t, pc.recovery, "recovery must be non-nil for ActionContinue branch coverage")
+
+	// Pre-load: simulate two prior Site B failures that did not exhaust
+	// the budget. Without the reset, the next stream-missing episode would
+	// fire OnPermanentFailure after a single attempt instead of three.
+	pc.streamMissingFailures.Store(2)
+
+	// Driving ErrConsumerDeleted through handleIteratorFailure runs:
+	//   Classify → ErrorConsumerGone → recover() → recreate() → success
+	//   → ActionContinue → reset branch (including streamMissingFailures.Store(0)).
+	exit := pc.handleIteratorFailure(context.Background(), jetstream.ErrConsumerDeleted)
+	require.False(t, exit, "ActionContinue must not exit the loop")
+
+	require.Equal(t, int32(0), pc.streamMissingFailures.Load(),
+		"ActionContinue success must reset the Site B stream-missing failure counter; "+
+			"non-zero count here implies stale failures will shorten the next episode's MaxAttempts budget")
+
+	// Belt-and-braces: pc.consumer must be the recovered one.
+	pc.consumerMu.RLock()
+	got := pc.consumer
+	pc.consumerMu.RUnlock()
+	require.Same(t, jetstream.Consumer(rebuiltCons), got, "ActionContinue must swap pc.consumer to the recovered one")
+}
+
+// TestPartitionConsumer_NilRecovery_RemediationSuccess_ResetsCounter pins
+// the v3 P1 fix: in the RecoveryDisabled (nil-recovery) path, when
+// maybeEscalateIteratorFailures successfully rebinds via the legacy
+// ensureConsumer path, the streamMissingFailures counter must be cleared
+// so a later stream-missing episode receives the full
+// RecoveryRetry.MaxAttempts budget. Without the reset, the v2 P0-A
+// increment (added in the nil-recovery branch) would leak across episodes
+// — the same class of cross-episode budget leak v2 P0-B fixed for
+// ActionContinue.
+func TestPartitionConsumer_NilRecovery_RemediationSuccess_ResetsCounter(t *testing.T) {
+	rebuiltCons := &streamMissingConsumer{id: "rebuilt"}
+
+	// ensureConsumer succeeds on first call — drives the legacy
+	// remediation success branch in maybeEscalateIteratorFailures.
+	js := &streamMissingJS{
+		plan: []consumerOutcome{
+			{cons: rebuiltCons, err: nil},
+		},
+	}
+
+	cfg := partitionConsumerConfig{
+		BatchSize:    1,
+		FetchTimeout: 50 * time.Millisecond,
+		// RecoveryStrategy intentionally unset (zero = RecoveryDisabled)
+		// to exercise the nil-recovery path that v2 P0-A bounded and
+		// v3 P1 fully balances with a reset.
+		Retry:                       RetryConfig{Backoff: 5 * time.Millisecond, Base: 5 * time.Millisecond, Multiplier: 1.0, Max: 10 * time.Millisecond},
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1,
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: 3,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+		},
+	}
+
+	// Stale-Info consumer so the escalation falls through to ensureConsumer.
+	originalCons := &streamMissingConsumer{id: "before", infoErr: errors.New("consumer gone")}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       originalCons,
+			iterFactory: func(jetstream.Consumer, int, time.Duration) (jetstream.MessagesContext, error) {
+				return nil, nil //nolint:nilnil // unused stub
+			},
+		},
+	)
+
+	require.Nil(t, pc.recovery, "test must exercise the nil-recovery (RecoveryDisabled) path")
+
+	// Pre-load: simulate two prior Site B stream-missing failures from
+	// the v2 P0-A counter path. Without v3 P1's reset, a subsequent
+	// stream-missing episode would fire OnPermanentFailure after one
+	// attempt instead of three.
+	pc.streamMissingFailures.Store(2)
+
+	// Drive escalation directly: stale Info + ensureConsumer success →
+	// remediation success branch.
+	escErr := pc.maybeEscalateIteratorFailures(context.Background())
+	require.NoError(t, escErr,
+		"successful remediation must NOT return an error to the caller")
+
+	require.Equal(t, int32(0), pc.streamMissingFailures.Load(),
+		"successful nil-recovery remediation must reset streamMissingFailures so the next stream-missing episode receives the full MaxAttempts budget")
+
+	pc.consumerMu.RLock()
+	got := pc.consumer
+	pc.consumerMu.RUnlock()
+	require.Same(t, jetstream.Consumer(rebuiltCons), got,
+		"successful remediation must swap pc.consumer to the rebuilt one")
+}

--- a/internal/durable/partition_consumer_stream_missing_test.go
+++ b/internal/durable/partition_consumer_stream_missing_test.go
@@ -1,0 +1,374 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// --- minimal jetstream.JetStream stub ---
+
+// streamMissingJS is a minimal jetstream.JetStream stub that only implements
+// CreateOrUpdateConsumer (the sole method partitionConsumer's ensureConsumer
+// and recreateFn call). All other methods inherit the embedded nil interface
+// and will panic if called — proving the test exercises only the intended
+// code path.
+type streamMissingJS struct {
+	jetstream.JetStream
+
+	mu       sync.Mutex
+	plan     []consumerOutcome // consumed in order
+	requests []jetstream.ConsumerConfig
+}
+
+type consumerOutcome struct {
+	cons jetstream.Consumer
+	err  error
+}
+
+func (s *streamMissingJS) CreateOrUpdateConsumer(_ context.Context, _ string, cfg jetstream.ConsumerConfig) (jetstream.Consumer, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requests = append(s.requests, cfg)
+	if len(s.plan) == 0 {
+		// Default to stream-not-found once the plan is exhausted to surface
+		// any unexpected extra calls obviously.
+		return nil, jetstream.ErrStreamNotFound
+	}
+	out := s.plan[0]
+	s.plan = s.plan[1:]
+
+	return out.cons, out.err
+}
+
+// --- minimal jetstream.Consumer stub ---
+
+// streamMissingConsumer is a minimal Consumer stub used as the "before" and
+// "after" consumer values; Info() returns a configurable result so the
+// escalation path's pre-remediation Info() call can drive the test.
+type streamMissingConsumer struct {
+	jetstream.Consumer
+	id      string
+	infoErr error
+}
+
+func (c *streamMissingConsumer) Info(_ context.Context) (*jetstream.ConsumerInfo, error) {
+	if c.infoErr != nil {
+		return nil, c.infoErr
+	}
+	return &jetstream.ConsumerInfo{}, nil
+}
+
+// --- T-SiteA-iter ---
+
+// TestPartitionConsumer_SiteA_StreamMissing_HookSuccess_RebuildsAndIterates
+// is the T-SiteA-iter reproducer (per docs/plans/self-healing/09-pr9-spec.md
+// § Reproducer tests). It pins the v3-P0.1 invariant: when the iterator-
+// creation envelope's Site A detour invokes the StreamMissingHook successfully,
+// the SAME Work attempt MUST also call RebuildAfterStreamRecreated, swap
+// pc.consumer to the new consumer, AND call iterFactory again with the new
+// consumer before returning nil — otherwise processIterator would receive
+// a nil iter and panic on iter.Next().
+func TestPartitionConsumer_SiteA_StreamMissing_HookSuccess_RebuildsAndIterates(t *testing.T) {
+	originalCons := &streamMissingConsumer{id: "before", infoErr: errors.New("consumer gone")}
+	rebuiltCons := &streamMissingConsumer{id: "after"}
+
+	js := &streamMissingJS{
+		plan: []consumerOutcome{
+			// ensureConsumer (called from escalation): stream is gone.
+			{cons: nil, err: jetstream.ErrStreamNotFound},
+			// RebuildAfterStreamRecreated (called after hook returns nil): success.
+			{cons: rebuiltCons, err: nil},
+		},
+	}
+
+	var hookCalls atomic.Int32
+	hookCalledStream := make(chan string, 1)
+	hook := types.StreamMissingHook(func(stream string) error {
+		hookCalls.Add(1)
+		select {
+		case hookCalledStream <- stream:
+		default:
+		}
+		return nil
+	})
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	})
+
+	var iterMu sync.Mutex
+	type iterCall struct {
+		cons   jetstream.Consumer
+		callID int
+	}
+	var iterCalls []iterCall
+
+	iterFactory := func(cons jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		iterMu.Lock()
+		idx := len(iterCalls)
+		iterCalls = append(iterCalls, iterCall{cons: cons, callID: idx})
+		iterMu.Unlock()
+		// First call (against originalCons): fail to drive escalation.
+		// Subsequent calls (against rebuiltCons after Site A detour):
+		// return a working iter so Work returns nil.
+		if cons == jetstream.Consumer(originalCons) {
+			return nil, errors.New("simulated iter-create failure (consumer stale)")
+		}
+
+		return &blockingIter{stopCh: stopCh}, nil
+	}
+
+	cfg := partitionConsumerConfig{
+		BatchSize:    1,
+		FetchTimeout: 50 * time.Millisecond,
+		// Use RecoverFromLastProcessed so the recovery.Controller is non-nil
+		// — RebuildAfterStreamRecreated requires it.
+		RecoveryStrategy: RecoverFromLastProcessed,
+		Retry: RetryConfig{
+			Backoff:    5 * time.Millisecond,
+			Base:       5 * time.Millisecond,
+			Multiplier: 1.0,
+			Max:        10 * time.Millisecond,
+		},
+		// Threshold 1 → first failure triggers escalation → ensureConsumer
+		// is called on the same Work attempt that just failed.
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1,
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: 5,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+			Jitter:      0,
+		},
+		StreamMissingHook: hook,
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       originalCons,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// Wait for the hook to fire — this proves Site A detected stream-missing
+	// and invoked handleStreamMissing.
+	select {
+	case stream := <-hookCalledStream:
+		require.Equal(t, "STREAM", stream, "hook must receive the stream name")
+	case <-time.After(5 * time.Second):
+		t.Fatalf("StreamMissingHook never fired; Site A detour did not trigger. iterCalls=%d, js.requests=%d",
+			func() int { iterMu.Lock(); defer iterMu.Unlock(); return len(iterCalls) }(),
+			func() int { js.mu.Lock(); defer js.mu.Unlock(); return len(js.requests) }(),
+		)
+	}
+
+	require.Eventually(t, func() bool {
+		iterMu.Lock()
+		defer iterMu.Unlock()
+		// Need at least two calls: one against originalCons (failed) and
+		// at least one against rebuiltCons (the post-rebuild iter creation
+		// inside the Site A success branch).
+		if len(iterCalls) < 2 {
+			return false
+		}
+
+		return iterCalls[len(iterCalls)-1].cons == jetstream.Consumer(rebuiltCons)
+	}, 2*time.Second, 10*time.Millisecond,
+		"iterFactory must be called with the rebuilt consumer inside the same Work attempt — proving Site A doesn't return nil with iter unset")
+
+	// pc.consumer must have been swapped to the rebuilt consumer under the lock.
+	pc.consumerMu.RLock()
+	got := pc.consumer
+	pc.consumerMu.RUnlock()
+	require.Same(t, rebuiltCons, got, "pc.consumer must point at the rebuilt consumer after the Site A success path")
+
+	require.Equal(t, int32(1), hookCalls.Load(), "hook must fire exactly once per stream-missing episode")
+
+	// Clean shutdown.
+	cancel()
+	close(stopCh)
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("partition consumer did not exit on ctx cancel")
+	}
+}
+
+// TestPartitionConsumer_SiteA_PostRebuildRetry_UsesNewConsumer is the
+// T-SiteA-iter-retry reproducer pinning the v5-P1.4 invariant: when the
+// iterFactory fails against the freshly-rebuilt consumer (transient post-
+// recreate flakiness), the NEXT envelope attempt MUST also use the rebuilt
+// consumer — never the pre-rebuild handle — because the Work closure
+// re-reads pc.consumer at the top of every attempt.
+//
+// Without the per-attempt re-read, the closure would close over the
+// original `cons` value and the retry would invoke iterFactory with the
+// stale (deleted) consumer indefinitely.
+func TestPartitionConsumer_SiteA_PostRebuildRetry_UsesNewConsumer(t *testing.T) {
+	originalCons := &streamMissingConsumer{id: "before", infoErr: errors.New("consumer gone")}
+	rebuiltCons := &streamMissingConsumer{id: "after"}
+
+	js := &streamMissingJS{
+		plan: []consumerOutcome{
+			{cons: nil, err: jetstream.ErrStreamNotFound}, // escalation -> stream missing
+			{cons: rebuiltCons, err: nil},                 // rebuild succeeds
+		},
+	}
+
+	var hookCalls atomic.Int32
+	hook := types.StreamMissingHook(func(_ string) error {
+		hookCalls.Add(1)
+		return nil
+	})
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-stopCh:
+		default:
+			close(stopCh)
+		}
+	})
+
+	var iterMu sync.Mutex
+	var iterCalls []jetstream.Consumer
+	postRebuildFailures := 0
+	const postRebuildFailuresWanted = 2 // first call against newCons after rebuild fails twice
+
+	iterFactory := func(cons jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		iterMu.Lock()
+		iterCalls = append(iterCalls, cons)
+		idx := len(iterCalls)
+		iterMu.Unlock()
+		if cons == jetstream.Consumer(originalCons) {
+			return nil, errors.New("simulated iter-create failure (consumer stale)")
+		}
+		// First two calls against rebuiltCons fail transiently, third succeeds.
+		if idx <= 1+postRebuildFailuresWanted {
+			iterMu.Lock()
+			postRebuildFailures++
+			iterMu.Unlock()
+
+			return nil, errors.New("simulated post-rebuild iter-create flakiness")
+		}
+
+		return &blockingIter{stopCh: stopCh}, nil
+	}
+
+	cfg := partitionConsumerConfig{
+		BatchSize:        1,
+		FetchTimeout:     50 * time.Millisecond,
+		RecoveryStrategy: RecoverFromLastProcessed,
+		Retry: RetryConfig{
+			Backoff:    5 * time.Millisecond,
+			Base:       5 * time.Millisecond,
+			Multiplier: 1.0,
+			Max:        10 * time.Millisecond,
+		},
+		IteratorEscalationWindow:    1 * time.Second,
+		IteratorEscalationThreshold: 1,
+		RecoveryRetry: RecoveryRetryConfig{
+			MaxAttempts: 10,
+			BaseBackoff: 5 * time.Millisecond,
+			MaxBackoff:  10 * time.Millisecond,
+			Jitter:      0,
+		},
+		StreamMissingHook: hook,
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		js,
+		cfg,
+		partitionConsumerOpts{
+			streamName:     "STREAM",
+			durableName:    "DUR",
+			subject:        "subj.p1",
+			partitionID:    "p1",
+			consumerConfig: jetstream.ConsumerConfig{Durable: "DUR_p1"},
+			consumer:       originalCons,
+			iterFactory:    iterFactory,
+		},
+	)
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		pc.Run(ctx, handler)
+	}()
+
+	// Wait until the iterator factory succeeds (third call against
+	// rebuiltCons) — proving subsequent retries also use newCons.
+	require.Eventually(t, func() bool {
+		iterMu.Lock()
+		defer iterMu.Unlock()
+		return len(iterCalls) >= 4 // 1 original + 3 against rebuilt (2 fail, 1 success)
+	}, 5*time.Second, 10*time.Millisecond,
+		"iterFactory should be invoked against newCons across multiple envelope attempts")
+
+	iterMu.Lock()
+	calls := append([]jetstream.Consumer(nil), iterCalls...)
+	iterMu.Unlock()
+
+	// First call: against originalCons (the failure that drove the detour).
+	require.Same(t, jetstream.Consumer(originalCons), calls[0],
+		"first iter-create call must use the original consumer")
+	// All subsequent calls: against rebuiltCons. A broken implementation
+	// that captures cons once before the envelope would invoke later
+	// retries against originalCons instead.
+	for i := 1; i < len(calls); i++ {
+		require.Same(t, jetstream.Consumer(rebuiltCons), calls[i],
+			"call %d after the Site A detour must use the rebuilt consumer, got %v",
+			i, calls[i])
+	}
+
+	require.Equal(t, int32(1), hookCalls.Load(),
+		"hook must fire exactly once even when post-rebuild iter creation flakes")
+
+	cancel()
+	close(stopCh)
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("partition consumer did not exit on ctx cancel")
+	}
+}

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -409,6 +409,8 @@ func (wc *WorkerConsumer) addSubjectLoop(ctx context.Context, workerID string, s
 		IteratorEscalationThreshold: wc.config.IteratorEscalationThreshold,
 		RecoveryRetry:               wc.config.RecoveryRetry,
 		OnPermanentFailure:          wc.config.OnPermanentFailure,
+		StreamMissingHook:           wc.config.StreamMissingHook,
+		OnStreamRecreated:           wc.config.OnStreamRecreated,
 		Metrics:                     wc.config.Metrics,
 	}
 

--- a/internal/ipartition/consumer.go
+++ b/internal/ipartition/consumer.go
@@ -296,7 +296,7 @@ func (c *JSConsumer) run(ctx context.Context) {
 		consumerConfig := c.consumerConfig
 		c.consumerMu.RUnlock()
 
-		action, newCons := c.rc.Classify(ctx, iterErr, c.consumerInfoFn(), consumerConfig, c.recreateFn())
+		action, newCons, classifyErr := c.rc.Classify(ctx, iterErr, c.consumerInfoFn(), consumerConfig, c.recreateFn())
 		switch action {
 		case recovery.ActionExit:
 			return
@@ -311,6 +311,17 @@ func (c *JSConsumer) run(ctx context.Context) {
 			c.rc.SeedCheckpoint(ctx, c.consumerInfoFn())
 
 			continue
+		case recovery.ActionStreamMissing:
+			// JSConsumer does not own stream lifecycle; log for operator
+			// observability and backoff. No callback surface today.
+			c.config.Logger.Warn("js consumer recovery classified stream missing",
+				"op", "js_consumer_stream_missing",
+				"stream", c.config.StreamName,
+				"error", classifyErr,
+			)
+			if !sleepWithContext(ctx) {
+				return
+			}
 		case recovery.ActionBackoff:
 			if !sleepWithContext(ctx) {
 				return

--- a/internal/ipartition/consumer.go
+++ b/internal/ipartition/consumer.go
@@ -119,7 +119,15 @@ func NewJSConsumer(
 
 		var onAck func(jetstream.Msg)
 		if c.rc != nil && c.rc.Strategy() == recovery.FromLastProcessed && !config.ManualAck {
-			onAck = c.rc.AdvanceCheckpoint
+			rc := c.rc
+			onAck = func(msg jetstream.Msg) {
+				// Static consumers never call HandleStreamRecreated, so
+				// streamEpoch is invariant and ack-time CurrentEpoch is
+				// equivalent to dispatch-time. If stream-missing recovery
+				// is ever wired into JSConsumer, plumb dispatch-time epoch
+				// through the keyDispatcher instead of capturing here.
+				rc.AdvanceCheckpoint(msg, rc.CurrentEpoch())
+			}
 		}
 
 		var wrapMsg func(jetstream.Msg) jetstream.Msg

--- a/internal/ipartition/consumer_stream_missing_test.go
+++ b/internal/ipartition/consumer_stream_missing_test.go
@@ -1,0 +1,134 @@
+package ipartition
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/internal/durable"
+	partitesting "github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/partition"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// captureWarnLogger records WARN-level messages so a test can assert that a
+// specific log line was emitted by a production code path. Optional t enables
+// pass-through to the test log for diagnosis.
+type captureWarnLogger struct {
+	mu    sync.Mutex
+	warns []string
+	t     *testing.T
+}
+
+var _ types.Logger = (*captureWarnLogger)(nil)
+
+func (l *captureWarnLogger) Debug(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("DEBUG: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Info(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("INFO: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Warn(msg string, kv ...any) {
+	l.mu.Lock()
+	l.warns = append(l.warns, msg)
+	l.mu.Unlock()
+	if l.t != nil {
+		l.t.Logf("WARN: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Error(msg string, kv ...any) {
+	if l.t != nil {
+		l.t.Logf("ERROR: %s %s", msg, fmt.Sprint(kv...))
+	}
+}
+func (l *captureWarnLogger) Fatal(msg string, _ ...any) {
+	panic("captureWarnLogger.Fatal: " + msg)
+}
+
+func (l *captureWarnLogger) hasWarn(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, w := range l.warns {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestJSConsumer_ActionStreamMissing_LogsAndBacksOff pins the spec-required
+// mapping for JSConsumer's non-Dynamic ActionStreamMissing branch
+// (docs/plans/self-healing/09-pr9-spec.md § "File-by-file caller contract"):
+// JSConsumer does not own stream lifecycle, so the stream-missing
+// classification is logged for operator observability and folded into a
+// backoff — it must NOT fall through to the default branch or cause the
+// loop to exit silently.
+func TestJSConsumer_ActionStreamMissing_LogsAndBacksOff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const streamName = "JS_STREAM_MISSING"
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{"jsm.>"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.MemoryStorage,
+		MaxMsgs:   -1,
+	})
+	require.NoError(t, err)
+
+	log := &captureWarnLogger{t: t}
+
+	c, err := NewJSConsumer(js, ConsumerConfig{
+		PartitionConfig: partition.PartitionConfig{
+			NumPartitions:  1,
+			SubjectPattern: "jsm.{{partition}}",
+		},
+		StreamName:       streamName,
+		ConsumerName:     "jsm-consumer-0",
+		Partition:        0,
+		FetchTimeout:     1500 * time.Millisecond,
+		Logger:           log,
+		RecoveryStrategy: durable.RecoverFromBeginning,
+	}, messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil }))
+	require.NoError(t, err)
+
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = c.Stop(stopCtx)
+	})
+
+	// Wait for the JS consumer to be bound on the server.
+	require.Eventually(t, func() bool {
+		_, infoErr := js.Consumer(ctx, streamName, "jsm-consumer-0")
+		return infoErr == nil
+	}, 5*time.Second, 25*time.Millisecond, "JSConsumer must bind before stream deletion")
+
+	require.NoError(t, js.DeleteStream(ctx, streamName))
+
+	require.Eventually(t, func() bool {
+		return log.hasWarn("js consumer recovery classified stream missing")
+	}, 10*time.Second, 50*time.Millisecond,
+		"JSConsumer's ActionStreamMissing case must emit the expected WARN log line; absence implies the case is unwired or fell through")
+}

--- a/internal/recovery/checkpoint.go
+++ b/internal/recovery/checkpoint.go
@@ -62,3 +62,14 @@ func (cp *Checkpoint) Advance(msg jetstream.Msg) {
 func (cp *Checkpoint) Value() uint64 {
 	return cp.maxAckedStreamSeq.Load()
 }
+
+// ResetForStreamRecreate drops the checkpoint back to zero. Called by
+// Controller.HandleStreamRecreated when the underlying stream has been
+// recreated and the prior checkpoint no longer refers to a sequence in
+// the new stream's address space. Unlike Seed and Advance, this is NOT
+// monotonic — it is the one path that lowers the checkpoint, and is
+// only safe when paired with a streamEpoch bump (so any in-flight
+// trackingMsg captured before the bump is fenced by AdvanceCheckpoint).
+func (cp *Checkpoint) ResetForStreamRecreate() {
+	cp.maxAckedStreamSeq.Store(0)
+}

--- a/internal/recovery/classify.go
+++ b/internal/recovery/classify.go
@@ -61,4 +61,12 @@ const (
 
 	// ActionExit means the loop should exit (graceful shutdown).
 	ActionExit
+
+	// ActionStreamMissing means recovery detected that the underlying
+	// JetStream stream is absent. The companion error returned by
+	// Classify wraps types.ErrStreamMissing so callers can route the
+	// signal to the operator-supplied StreamMissingHook (Dynamic
+	// partition consumer) or log + backoff (Queue, Broadcast,
+	// internal/ipartition — they do not own stream lifecycle).
+	ActionStreamMissing
 )

--- a/internal/recovery/config.go
+++ b/internal/recovery/config.go
@@ -7,9 +7,18 @@ import (
 // BuildConfig builds a fresh consumer config for recreation, overriding DeliverPolicy
 // according to strategy. The base config is never mutated.
 //
+// recreatedSinceLastBuild signals that the consumer is being rebuilt for the
+// first time after Controller.HandleStreamRecreated ran. When the flag is true
+// AND the strategy is FromLastProcessed AND the checkpoint is zero, BuildConfig
+// emits DeliverAllPolicy so the new consumer replays from sequence 1 of the
+// freshly-recreated stream — preventing the fresh-stream skip hazard where
+// messages published before the replacement consumer is bound would be missed
+// under the normal "no checkpoint → DeliverNewPolicy" fallback.
+//
 // Returns the config and a non-empty fallback string if the strategy was downgraded
-// (e.g., FromLastProcessed with no checkpoint falls back to FromNew).
-func BuildConfig(base jetstream.ConsumerConfig, strategy Strategy, checkpoint uint64) (jetstream.ConsumerConfig, string) {
+// (e.g., FromLastProcessed with no checkpoint falls back to FromNew, unless the
+// recreated override applies).
+func BuildConfig(base jetstream.ConsumerConfig, strategy Strategy, checkpoint uint64, recreatedSinceLastBuild bool) (jetstream.ConsumerConfig, string) {
 	cfg := base // copy
 
 	// Clear stale delivery-policy fields to prevent confusion when switching policies.
@@ -18,15 +27,26 @@ func BuildConfig(base jetstream.ConsumerConfig, strategy Strategy, checkpoint ui
 
 	switch strategy { //nolint:exhaustive // Disabled is handled by default.
 	case FromNew:
+		// Intentional: stream-missing hook is rejected at construction
+		// when paired with FromNew, so production code cannot reach
+		// this branch with recreatedSinceLastBuild=true. The flag is
+		// ignored here to keep the FromNew contract unconditional.
 		cfg.DeliverPolicy = jetstream.DeliverNewPolicy
 	case FromLastProcessed:
-		if checkpoint == 0 {
+		switch {
+		case checkpoint > 0:
+			cfg.DeliverPolicy = jetstream.DeliverByStartSequencePolicy
+			cfg.OptStartSeq = checkpoint + 1
+		case recreatedSinceLastBuild:
+			cfg.DeliverPolicy = jetstream.DeliverAllPolicy
+			return cfg, "stream_recreated_replay_from_start"
+		default:
 			cfg.DeliverPolicy = jetstream.DeliverNewPolicy
 			return cfg, "fallback_no_checkpoint"
 		}
-		cfg.DeliverPolicy = jetstream.DeliverByStartSequencePolicy
-		cfg.OptStartSeq = checkpoint + 1
 	case FromBeginning:
+		// FromBeginning already replays from sequence 1 unconditionally,
+		// so the recreated override is a no-op here.
 		cfg.DeliverPolicy = jetstream.DeliverAllPolicy
 	default:
 		cfg.DeliverPolicy = jetstream.DeliverNewPolicy

--- a/internal/recovery/config_test.go
+++ b/internal/recovery/config_test.go
@@ -16,7 +16,7 @@ func TestBuildConfig_RecoverFromNew(t *testing.T) {
 		OptStartSeq:   999,
 	}
 
-	cfg, fallback := BuildConfig(base, FromNew, 0)
+	cfg, fallback := BuildConfig(base, FromNew, 0, false)
 	require.Empty(t, fallback)
 	require.Equal(t, jetstream.DeliverNewPolicy, cfg.DeliverPolicy)
 	require.Equal(t, uint64(0), cfg.OptStartSeq)
@@ -27,7 +27,7 @@ func TestBuildConfig_RecoverFromNew(t *testing.T) {
 func TestBuildConfig_RecoverFromLastProcessed_WithCheckpoint(t *testing.T) {
 	base := jetstream.ConsumerConfig{Durable: "test-durable", FilterSubject: "orders.*"}
 
-	cfg, fallback := BuildConfig(base, FromLastProcessed, 100)
+	cfg, fallback := BuildConfig(base, FromLastProcessed, 100, false)
 	require.Empty(t, fallback)
 	require.Equal(t, jetstream.DeliverByStartSequencePolicy, cfg.DeliverPolicy)
 	require.Equal(t, uint64(101), cfg.OptStartSeq) // checkpoint + 1
@@ -36,7 +36,7 @@ func TestBuildConfig_RecoverFromLastProcessed_WithCheckpoint(t *testing.T) {
 func TestBuildConfig_RecoverFromLastProcessed_NoCheckpoint(t *testing.T) {
 	base := jetstream.ConsumerConfig{Durable: "test-durable"}
 
-	cfg, fallback := BuildConfig(base, FromLastProcessed, 0)
+	cfg, fallback := BuildConfig(base, FromLastProcessed, 0, false)
 	require.Equal(t, "fallback_no_checkpoint", fallback)
 	require.Equal(t, jetstream.DeliverNewPolicy, cfg.DeliverPolicy)
 	require.Equal(t, uint64(0), cfg.OptStartSeq)
@@ -45,7 +45,7 @@ func TestBuildConfig_RecoverFromLastProcessed_NoCheckpoint(t *testing.T) {
 func TestBuildConfig_RecoverFromBeginning(t *testing.T) {
 	base := jetstream.ConsumerConfig{Durable: "test", OptStartSeq: 50}
 
-	cfg, fallback := BuildConfig(base, FromBeginning, 42)
+	cfg, fallback := BuildConfig(base, FromBeginning, 42, false)
 	require.Empty(t, fallback)
 	require.Equal(t, jetstream.DeliverAllPolicy, cfg.DeliverPolicy)
 	require.Equal(t, uint64(0), cfg.OptStartSeq) // cleared
@@ -59,7 +59,7 @@ func TestBuildConfig_ClearsStaleFields(t *testing.T) {
 		OptStartTime: &now,
 	}
 
-	cfg, _ := BuildConfig(base, FromNew, 0)
+	cfg, _ := BuildConfig(base, FromNew, 0, false)
 	require.Equal(t, uint64(0), cfg.OptStartSeq)
 	require.Nil(t, cfg.OptStartTime)
 }
@@ -67,7 +67,7 @@ func TestBuildConfig_ClearsStaleFields(t *testing.T) {
 func TestBuildConfig_UnknownStrategy(t *testing.T) {
 	base := jetstream.ConsumerConfig{Durable: "test"}
 
-	cfg, fallback := BuildConfig(base, Strategy(99), 0)
+	cfg, fallback := BuildConfig(base, Strategy(99), 0, false)
 	require.Equal(t, "unsupported_strategy_fallback", fallback)
 	require.Equal(t, jetstream.DeliverNewPolicy, cfg.DeliverPolicy)
 }
@@ -75,7 +75,7 @@ func TestBuildConfig_UnknownStrategy(t *testing.T) {
 func TestBuildConfig_RecoveryDisabled(t *testing.T) {
 	base := jetstream.ConsumerConfig{Durable: "test"}
 
-	cfg, fallback := BuildConfig(base, Disabled, 0)
+	cfg, fallback := BuildConfig(base, Disabled, 0, false)
 	require.Equal(t, "unsupported_strategy_fallback", fallback)
 	require.Equal(t, jetstream.DeliverNewPolicy, cfg.DeliverPolicy)
 }

--- a/internal/recovery/controller.go
+++ b/internal/recovery/controller.go
@@ -3,6 +3,7 @@ package recovery
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -10,6 +11,17 @@ import (
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
+)
+
+// streamRecreatedStep* are the ordered step names HandleStreamRecreated
+// reports to the test seam. Exposed as package-level constants so both
+// the production code and the ordering test reference the same string,
+// preventing a silent typo-desync.
+const (
+	streamRecreatedStepAfterBump  = "after_bump"
+	streamRecreatedStepAfterReset = "after_reset"
+	streamRecreatedStepAfterSeed  = "after_seed"
+	streamRecreatedStepAfterFlag  = "after_flag"
 )
 
 // InfoFunc returns the current consumer info. Used to confirm consumer deletion
@@ -65,6 +77,22 @@ type Controller struct {
 	consInfoMu          sync.Mutex
 	lastRecoveryTime    time.Time
 	minRecoveryInterval time.Duration
+
+	// streamEpoch is bumped by HandleStreamRecreated each time the
+	// underlying stream is recreated. WrapForTracking captures the
+	// current epoch at dispatch time; AdvanceCheckpoint compares the
+	// captured epoch against the current one and silently drops the
+	// advance when they differ — fencing late acks from a prior
+	// stream incarnation that would otherwise re-raise the just-reset
+	// checkpoint.
+	streamEpoch atomic.Uint64
+
+	// recreatedSinceLastBuild is set true by HandleStreamRecreated
+	// and cleared by RebuildAfterStreamRecreated's first call (via
+	// atomic.Bool.Swap). When true, BuildConfig forces DeliverAllPolicy
+	// for the first post-hook consumer build so a fresh stream replays
+	// from sequence 1 rather than skipping pre-bind messages.
+	recreatedSinceLastBuild atomic.Bool
 
 	logger  types.Logger
 	metrics types.WorkerConsumerMetrics
@@ -165,14 +193,20 @@ func (c *Controller) Classify(
 }
 
 // WrapForTracking returns a jetstream.Msg that intercepts Ack/DoubleAck to advance
-// the checkpoint when the strategy is FromLastProcessed.
+// the checkpoint when the strategy is FromLastProcessed. The wrapper captures
+// the controller's current streamEpoch at dispatch time so a late ack landing
+// after HandleStreamRecreated can be fenced.
 // For all other strategies or a nil controller it returns msg unchanged (no allocation).
 func (c *Controller) WrapForTracking(msg jetstream.Msg) jetstream.Msg {
 	if c == nil || c.strategy != FromLastProcessed {
 		return msg
 	}
 
-	return &trackingMsg{Msg: msg, controller: c}
+	return &trackingMsg{
+		Msg:        msg,
+		controller: c,
+		epoch:      c.streamEpoch.Load(),
+	}
 }
 
 // Dispatch delivers msg to handle with the recovery-aware dispatch policy:
@@ -187,20 +221,165 @@ func (c *Controller) Dispatch(ctx context.Context, msg jetstream.Msg, manualAck 
 		_ = handle(ctx, c.WrapForTracking(msg))
 		return
 	}
+	// Capture the dispatch-time epoch (not the ack-time epoch) so the
+	// non-manual-ack path obeys the same fence invariant as the wrapped
+	// path: AdvanceCheckpoint silently drops the advance if the stream
+	// was recreated between dispatch and ack.
+	var epoch uint64
+	if c != nil {
+		epoch = c.streamEpoch.Load()
+	}
 	if err := handle(ctx, msg); err != nil {
 		_ = msg.Nak()
 	} else if err := msg.Ack(); err == nil {
-		c.AdvanceCheckpoint(msg)
+		c.AdvanceCheckpoint(msg, epoch)
 	}
 }
 
 // AdvanceCheckpoint should be called after a successful helper-owned msg.Ack()
-// when ManualAck is false. It monotonically advances the checkpoint.
-func (c *Controller) AdvanceCheckpoint(msg jetstream.Msg) {
+// when ManualAck is false. The epoch parameter is the streamEpoch captured at
+// message dispatch time (not ack time); if the controller's current streamEpoch
+// has advanced, the call is a silent no-op — the ack is from a prior stream
+// incarnation and must not re-raise the checkpoint after a HandleStreamRecreated
+// reset.
+func (c *Controller) AdvanceCheckpoint(msg jetstream.Msg, epoch uint64) {
 	if c == nil {
 		return
 	}
+	if epoch != c.streamEpoch.Load() {
+		return // late ack from a prior stream generation; fence drops it
+	}
 	c.checkpoint.Advance(msg)
+}
+
+// CurrentEpoch returns the controller's current streamEpoch. Callers that
+// dispatch and ack synchronously from the same goroutine (or that run on a
+// consumer type where HandleStreamRecreated is never called) may use this
+// to load the epoch immediately before AdvanceCheckpoint. The Dynamic
+// partition consumer must capture epoch at dispatch time instead (see
+// WrapForTracking and Dispatch).
+func (c *Controller) CurrentEpoch() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.streamEpoch.Load()
+}
+
+// HandleStreamRecreated is called by the partition consumer's recovery
+// detour after the operator-supplied StreamMissingHook returns nil.
+// It performs the following ordered steps; reversing the bump↔reset
+// opens a race where an old-epoch ack landing between reset and bump
+// could re-raise the just-zeroed checkpoint past zero, after which
+// the fresh-stream consumer would skip messages:
+//
+//  1. Bump streamEpoch. Any in-flight trackingMsg captured before
+//     this point is from a prior epoch; its late ack will be fenced
+//     by AdvanceCheckpoint.
+//  2. ResetForStreamRecreate. Drop the stale checkpoint to zero.
+//  3. SeedCheckpoint. If the recreated stream / restored consumer's
+//     AckFloor > 0, the seed picks it up; if AckFloor is 0 (fresh
+//     stream), the checkpoint stays at 0.
+//  4. Set recreatedSinceLastBuild so the next BuildConfig call (via
+//     RebuildAfterStreamRecreated) chooses DeliverAllPolicy when the
+//     checkpoint is still 0 — preventing the fresh-stream skip hazard.
+//
+// Safe to call on a nil *Controller (no-op).
+func (c *Controller) HandleStreamRecreated(ctx context.Context, infoFn InfoFunc) {
+	c.handleStreamRecreatedWithSteps(ctx, infoFn, nil)
+}
+
+// handleStreamRecreatedWithSteps is the package-internal implementation
+// of HandleStreamRecreated. The onStep callback (when non-nil) is invoked
+// between each ordered step with the step name from the streamRecreatedStep*
+// constants. Tests use it to deterministically inject events between
+// steps; production callers always pass nil.
+func (c *Controller) handleStreamRecreatedWithSteps(
+	ctx context.Context,
+	infoFn InfoFunc,
+	onStep func(step string),
+) {
+	if c == nil {
+		return
+	}
+	c.streamEpoch.Add(1)
+	if onStep != nil {
+		onStep(streamRecreatedStepAfterBump)
+	}
+
+	c.checkpoint.ResetForStreamRecreate()
+	if onStep != nil {
+		onStep(streamRecreatedStepAfterReset)
+	}
+
+	c.SeedCheckpoint(ctx, infoFn)
+	if onStep != nil {
+		onStep(streamRecreatedStepAfterSeed)
+	}
+
+	c.recreatedSinceLastBuild.Store(true)
+	if onStep != nil {
+		onStep(streamRecreatedStepAfterFlag)
+	}
+}
+
+// RebuildAfterStreamRecreated builds a post-recreate consumer config
+// from the (now-reset) checkpoint, the one-shot recreatedSinceLastBuild
+// flag, and the strategy; calls recreate(ctx, cfg) to create the new
+// consumer on the freshly-restored stream; returns the new consumer.
+//
+// Read-and-clears recreatedSinceLastBuild via atomic.Bool.Swap so the
+// flag's one-shot semantics hold even under contention; subsequent
+// rebuilds without a fresh HandleStreamRecreated see the cleared flag
+// and fall through to the normal BuildConfig branches.
+//
+// Bypasses the recover() cooldown: callers (the partition consumer's
+// stream-missing detour at Site A and Site B) call this synchronously
+// immediately after the hook returns nil; the cooldown applies to
+// subsequent unrelated recoveries, which won't be back-to-back with
+// this single immediate rebuild.
+//
+// On any recreate error, wraps the cause with types.ErrStreamMissing
+// so the manager observer route fires consistently for the entire
+// post-hook recovery flow (both still-missing-stream and
+// incompatible-restored-consumer-config cases).
+//
+// Called by partitionConsumer.handleStreamMissing AFTER
+// HandleStreamRecreated has run successfully.
+func (c *Controller) RebuildAfterStreamRecreated(
+	ctx context.Context,
+	baseCfg jetstream.ConsumerConfig,
+	recreate RecreateFunc,
+) (jetstream.Consumer, error) {
+	if c == nil {
+		return nil, errors.New("recovery: nil controller cannot rebuild after stream recreate")
+	}
+
+	checkpoint := c.checkpoint.Value()
+	recreated := c.recreatedSinceLastBuild.Swap(false) // read-and-clear
+	cfg, fallback := BuildConfig(baseCfg, c.strategy, checkpoint, recreated)
+	if fallback != "" {
+		c.logger.Info("recovery rebuild post-recreate used fallback strategy",
+			"fallback", fallback,
+			"checkpoint", checkpoint,
+			"recreated_flag_consumed", recreated,
+		)
+	}
+
+	newCons, err := recreate(ctx, cfg)
+	if err != nil {
+		// All errors during post-hook recovery wrap types.ErrStreamMissing
+		// so the manager observer route is consistent regardless of the
+		// underlying cause (still-missing-stream, incompatible-restored-
+		// consumer-config, etc.).
+		return nil, fmt.Errorf("%w: %w", types.ErrStreamMissing, err)
+	}
+
+	c.burst.Reset()
+	c.mu.Lock()
+	c.lastRecoveryTime = time.Now()
+	c.mu.Unlock()
+
+	return newCons, nil
 }
 
 // SeedCheckpoint reads the ack floor from consumer info and seeds the checkpoint.
@@ -271,7 +450,11 @@ func (c *Controller) recover(
 	defer func() { attempt.finish(success) }()
 
 	checkpoint := c.checkpoint.Value()
-	recoverCfg, fallback := BuildConfig(baseCfg, c.strategy, checkpoint)
+	// recover() is the normal consumer-deleted recovery path (e.g.,
+	// inactivity GC). It must NOT consume the recreatedSinceLastBuild
+	// flag — that flag belongs to RebuildAfterStreamRecreated's post-hook
+	// rebuild path. Pass false unconditionally here.
+	recoverCfg, fallback := BuildConfig(baseCfg, c.strategy, checkpoint, false)
 
 	if fallback != "" {
 		c.logger.Warn("recovery used fallback strategy",

--- a/internal/recovery/controller.go
+++ b/internal/recovery/controller.go
@@ -141,55 +141,70 @@ func (c *Controller) Strategy() Strategy {
 // baseCfg and recreate are used to perform recovery when needed.
 // infoFn is called only when burst threshold is reached.
 //
-// Returns ActionContinue if recovery succeeded, ActionBackoff if the caller should
-// retry with backoff, or ActionExit for graceful shutdown.
+// Returns:
+//   - (ActionContinue, newCons, nil) if recovery succeeded and the caller
+//     should adopt newCons and reset backoff state.
+//   - (ActionBackoff, nil, nil) if no recovery was needed or recovery
+//     failed transiently; the caller should backoff and retry.
+//   - (ActionExit, nil, nil) for graceful shutdown.
+//   - (ActionStreamMissing, nil, err) when recovery determined that the
+//     underlying JetStream stream is absent. The returned error wraps
+//     types.ErrStreamMissing so callers can route via errors.Is. No
+//     internal recovery state advances on this path.
 func (c *Controller) Classify(
 	ctx context.Context,
 	err error,
 	infoFn InfoFunc,
 	baseCfg jetstream.ConsumerConfig,
 	recreate RecreateFunc,
-) (Action, jetstream.Consumer) {
+) (Action, jetstream.Consumer, error) {
 	if c == nil {
-		return ActionBackoff, nil
+		return ActionBackoff, nil, nil
 	}
 
 	class := ClassifyError(err)
 
 	switch class {
 	case ErrorGracefulExit:
-		return ActionExit, nil
+		return ActionExit, nil, nil
 
 	case ErrorConsumerGone:
 		c.emitIteratorRestart("consumer_deleted")
-		newCons, ok := c.recover(ctx, "consumer_deleted", baseCfg, recreate)
-		if ok {
-			return ActionContinue, newCons
+		newCons, recErr := c.recover(ctx, "consumer_deleted", baseCfg, recreate)
+		if recErr != nil {
+			return ActionStreamMissing, nil, recErr
 		}
-		return ActionBackoff, nil
+		if newCons != nil {
+			return ActionContinue, newCons, nil
+		}
+
+		return ActionBackoff, nil, nil
 
 	case ErrorNeedsConfirm:
 		c.emitIteratorRestart("heartbeat")
 		if !c.burst.Record() {
-			return ActionBackoff, nil // not enough failures yet
+			return ActionBackoff, nil, nil // not enough failures yet
 		}
 		// Burst threshold reached — confirm via consumer.Info().
 		if !c.confirmConsumerGone(ctx, infoFn) {
-			return ActionBackoff, nil // consumer still exists, transient issue
+			return ActionBackoff, nil, nil // consumer still exists, transient issue
 		}
-		newCons, ok := c.recover(ctx, "consumer_not_found_after_burst", baseCfg, recreate)
-		if ok {
-			return ActionContinue, newCons
+		newCons, recErr := c.recover(ctx, "consumer_not_found_after_burst", baseCfg, recreate)
+		if recErr != nil {
+			return ActionStreamMissing, nil, recErr
+		}
+		if newCons != nil {
+			return ActionContinue, newCons, nil
 		}
 
-		return ActionBackoff, nil
+		return ActionBackoff, nil, nil
 
 	case ErrorTransient:
 		c.emitIteratorRestart("transient")
-		return ActionBackoff, nil
+		return ActionBackoff, nil, nil
 	}
 
-	return ActionBackoff, nil
+	return ActionBackoff, nil, nil
 }
 
 // WrapForTracking returns a jetstream.Msg that intercepts Ack/DoubleAck to advance
@@ -412,15 +427,28 @@ func (c *Controller) ResetBurst() {
 }
 
 // recover serializes recovery attempts, builds recovery config, calls recreate,
-// and re-seeds the checkpoint. Returns the new consumer and true on success.
+// and re-seeds the checkpoint. Returns:
+//   - (newCons, nil) on success.
+//   - (nil, nil) when the attempt is short-circuited (another recovery in
+//     flight, context canceled, cooldown in effect) or when recreate fails
+//     with a transient error. The caller should backoff and retry.
+//   - (nil, wrappedErr) where wrappedErr wraps types.ErrStreamMissing when
+//     recreate fails with a stream-not-found classification. The caller is
+//     expected to route this through the stream-missing detour rather than
+//     advance internal recovery state — lastRecoveryTime, burst, and
+//     checkpoint are intentionally NOT updated on this path.
 func (c *Controller) recover(
 	ctx context.Context,
 	reason string,
 	baseCfg jetstream.ConsumerConfig,
 	recreate RecreateFunc,
-) (jetstream.Consumer, bool) {
+) (jetstream.Consumer, error) {
+	// Contract: (nil, nil) is the documented "no-op, backoff" signal —
+	// Classify maps it to ActionBackoff and only ActionStreamMissing
+	// surfaces a non-nil error. The nilnil lint disables below are
+	// intentional and per-return.
 	if !c.inProgress.CompareAndSwap(false, true) {
-		return nil, false // another recovery in flight
+		return nil, nil //nolint:nilnil // another recovery in flight.
 	}
 	defer c.inProgress.Store(false)
 
@@ -428,7 +456,7 @@ func (c *Controller) recover(
 	defer c.mu.Unlock()
 
 	if ctx.Err() != nil {
-		return nil, false
+		return nil, nil //nolint:nilnil // ctx cancelled before lock acquired.
 	}
 
 	// Rate-limit consecutive recoveries to prevent a tight create-delete loop
@@ -442,7 +470,7 @@ func (c *Controller) recover(
 			"min_interval_ms", c.minRecoveryInterval.Milliseconds(),
 		)
 
-		return nil, false
+		return nil, nil //nolint:nilnil // see recover()'s contract above.
 	}
 
 	attempt := beginAttempt(c.metrics, reason)
@@ -471,17 +499,31 @@ func (c *Controller) recover(
 	)
 
 	if ctx.Err() != nil {
-		return nil, false
+		return nil, nil //nolint:nilnil // see recover()'s contract above.
 	}
 
 	newCons, err := recreate(ctx, recoverCfg)
 	if err != nil {
+		if natsutil.IsStreamNotFound(err) {
+			// Stream-missing escalation: bail without advancing
+			// lastRecoveryTime, burst, or checkpoint. The caller's
+			// detour invokes the operator-supplied hook and, on
+			// success, calls RebuildAfterStreamRecreated which has
+			// its own state-advance semantics.
+			c.logger.Warn("consumer recovery surfaced stream missing",
+				"op", "consumer_recovery",
+				"reason", reason,
+				"error", err,
+			)
+			return nil, fmt.Errorf("%w: %w", types.ErrStreamMissing, err)
+		}
 		c.logger.Warn("consumer recovery failed",
 			"op", "consumer_recovery",
 			"reason", reason,
 			"error", err,
 		)
-		return nil, false
+
+		return nil, nil //nolint:nilnil // see recover()'s contract above.
 	}
 
 	c.burst.Reset()
@@ -495,7 +537,7 @@ func (c *Controller) recover(
 
 	success = true
 
-	return newCons, true
+	return newCons, nil
 }
 
 // confirmConsumerGone calls consumer.Info() and returns true if the consumer is confirmed gone.

--- a/internal/recovery/controller_epoch_fence_test.go
+++ b/internal/recovery/controller_epoch_fence_test.go
@@ -1,0 +1,160 @@
+package recovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// stubInfo returns a stub InfoFunc that yields a ConsumerInfo with the given
+// AckFloor.Stream. Used to drive SeedCheckpoint deterministically without a
+// live NATS connection.
+func stubInfo(ackFloor uint64) InfoFunc {
+	return func(context.Context) (*jetstream.ConsumerInfo, error) {
+		return &jetstream.ConsumerInfo{
+			AckFloor: jetstream.SequenceInfo{Stream: ackFloor},
+		}, nil
+	}
+}
+
+// T2c — epoch fence. The tightest invariant in the stream-missing recovery
+// design: a tracking msg captured under one stream incarnation must NOT
+// re-raise the checkpoint when its Ack lands after HandleStreamRecreated
+// has bumped the streamEpoch.
+//
+// Scenario:
+//   - Strategy=FromLastProcessed. Checkpoint seeded to 100.
+//   - WrapForTracking(seq=80) captures the current epoch (call it E0).
+//   - HandleStreamRecreated() bumps the epoch (E0 → E1), resets the
+//     checkpoint to 0, seeds from a stub returning AckFloor=0.
+//   - The held wrapper's Ack() fires after the bump.
+//
+// Invariant: Checkpoint.Value() stays at 0. Without the fence,
+// AdvanceCheckpoint would push it back to 80 (the wrapper's captured
+// seq), which is exactly the fresh-stream skip hazard P2.3 must prevent.
+func TestController_EpochFence_LateAckDroppedAfterStreamRecreated(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+	require.Equal(t, uint64(100), c.checkpoint.Value(), "precondition: checkpoint seeded to 100")
+
+	// Wrap a message at seq 80. This captures the controller's current
+	// streamEpoch at dispatch time (the load-bearing semantic).
+	heldMsg := &mockMsg{seq: 80}
+	heldWrapped := c.WrapForTracking(heldMsg)
+	_, ok := heldWrapped.(*trackingMsg)
+	require.True(t, ok, "FromLastProcessed must produce a *trackingMsg")
+
+	// Stream is recreated. Epoch bumps; checkpoint resets to 0; seed
+	// reads AckFloor=0 (fresh stream — no replay floor).
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+	require.Equal(t, uint64(0), c.checkpoint.Value(),
+		"HandleStreamRecreated must reset checkpoint to 0 for a fresh stream")
+
+	// The held wrapper still references the OLD stream's epoch. Ack must
+	// be fenced — Msg.Ack succeeds (no error from the mock), but the
+	// checkpoint MUST NOT advance.
+	err := heldWrapped.Ack()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), c.checkpoint.Value(),
+		"epoch fence MUST drop the stale ack; checkpoint must stay at 0, not advance to 80")
+}
+
+// T2c — DoubleAck variant. Same invariant via the DoubleAck path. Both
+// Ack and DoubleAck must consult the same fence; a regression in either
+// would silently re-raise the checkpoint after stream recreation.
+func TestController_EpochFence_LateDoubleAckDroppedAfterStreamRecreated(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+
+	heldMsg := &mockMsg{seq: 80}
+	heldWrapped := c.WrapForTracking(heldMsg)
+
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+
+	err := heldWrapped.DoubleAck(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), c.checkpoint.Value(),
+		"epoch fence must drop a stale DoubleAck as well as a stale Ack")
+}
+
+// T2c — current-epoch acks still advance. The fence is generation-based,
+// not a blanket disable: a msg wrapped AFTER HandleStreamRecreated captures
+// the new epoch and its Ack must advance the checkpoint normally.
+func TestController_EpochFence_CurrentEpochAckStillAdvances(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	// Recreate first, then wrap a "new" message after the bump.
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+	require.Equal(t, uint64(0), c.checkpoint.Value())
+
+	newMsg := &mockMsg{seq: 5}
+	newWrapped := c.WrapForTracking(newMsg)
+
+	require.NoError(t, newWrapped.Ack())
+	require.Equal(t, uint64(5), c.checkpoint.Value(),
+		"a msg wrapped after the epoch bump must advance the checkpoint normally")
+}
+
+// T2c-ordering — deterministic test that bump-before-reset is the only
+// safe ordering. Replaces a v1 sleep/log-based fragile test. Uses the
+// package-internal handleStreamRecreatedWithSteps seam to inject a held
+// old-epoch Ack at the "after_reset" step.
+//
+// If the implementation does bump → reset (correct), the epoch was
+// already bumped by the time the seam fires, so the old-epoch Ack is
+// fenced and the checkpoint stays at 0.
+//
+// If the implementation did reset → bump (broken), at "after_reset" the
+// epoch would still match the held wrapper's captured value, and the
+// Ack would slip past the fence and advance the just-zeroed checkpoint
+// past zero.
+//
+// The assertion (checkpoint stays at 0 across the seam) deterministically
+// distinguishes correct vs broken ordering with no sleeps or scheduling
+// assumptions.
+func TestController_HandleStreamRecreated_BumpBeforeReset_DeterministicOrdering(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+
+	heldMsg := &mockMsg{seq: 80}
+	heldWrapped := c.WrapForTracking(heldMsg)
+
+	// onStep injects the held Ack at "after_reset". Under the correct
+	// bump-before-reset ordering, the epoch is already bumped here, so
+	// the fence drops the Ack. Under the broken reset-before-bump
+	// ordering, the epoch is still the captured one and the Ack would
+	// advance the checkpoint past zero.
+	// Track every step the implementation reports so a typo in the
+	// production step name desyncs the test rather than silently no-oping.
+	var seenSteps []string
+	c.handleStreamRecreatedWithSteps(context.Background(), stubInfo(0), func(step string) {
+		seenSteps = append(seenSteps, step)
+		if step == streamRecreatedStepAfterReset {
+			_ = heldWrapped.Ack()
+		}
+	})
+	require.Equal(t,
+		[]string{
+			streamRecreatedStepAfterBump,
+			streamRecreatedStepAfterReset,
+			streamRecreatedStepAfterSeed,
+			streamRecreatedStepAfterFlag,
+		},
+		seenSteps,
+		"the seam must report every step in the spec-locked order; a missing or renamed step would silently skip the ack-injection branch and mask a regression")
+
+	require.Equal(t, uint64(0), c.checkpoint.Value(),
+		"bump-before-reset ordering required: an old-epoch Ack injected at after_reset must be fenced; checkpoint must stay at 0")
+}

--- a/internal/recovery/controller_recreated_flag_test.go
+++ b/internal/recovery/controller_recreated_flag_test.go
@@ -1,0 +1,75 @@
+package recovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// T6 — recreatedSinceLastBuild is one-shot. The first post-hook rebuild
+// must consume the flag (emit DeliverAllPolicy when checkpoint==0). A
+// SECOND rebuild without a fresh HandleStreamRecreated must NOT re-use
+// the override; with checkpoint still 0 it must fall back to
+// DeliverNewPolicy (the existing "no checkpoint" rule).
+//
+// The v1 spec masked this by advancing checkpoint > 0 before the second
+// recovery (checkpoint > 0 wins inside BuildConfig before the flag is
+// consulted, so a stuck flag would be invisible). v2 drives the second
+// rebuild with checkpoint still at 0 to make the assertion load-bearing.
+func TestController_RecreatedFlag_OneShot_NotReusedOnSecondRebuild(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+	require.Equal(t, uint64(0), c.checkpoint.Value())
+
+	// First rebuild: consumes the flag, emits DeliverAllPolicy.
+	spy1 := &spyRecreate{}
+	_, err := c.RebuildAfterStreamRecreated(context.Background(), jetstream.ConsumerConfig{}, spy1.fn())
+	require.NoError(t, err)
+	require.Len(t, spy1.calls, 1)
+	require.Equal(t, jetstream.DeliverAllPolicy, spy1.calls[0].DeliverPolicy,
+		"first post-hook rebuild must consume the recreated flag and emit DeliverAllPolicy")
+
+	// Reset the checkpoint back to 0 to simulate "no progress since
+	// the prior rebuild" — keeps the test load-bearing on the flag,
+	// not on the checkpoint>0 branch.
+	c.checkpoint.ResetForStreamRecreate()
+	require.Equal(t, uint64(0), c.checkpoint.Value())
+
+	// Second rebuild without a fresh HandleStreamRecreated. The flag
+	// must already be cleared. With checkpoint==0 and the override
+	// gone, BuildConfig must fall into the "no checkpoint" branch.
+	spy2 := &spyRecreate{}
+	_, err = c.RebuildAfterStreamRecreated(context.Background(), jetstream.ConsumerConfig{}, spy2.fn())
+	require.NoError(t, err)
+	require.Len(t, spy2.calls, 1)
+	require.Equal(t, jetstream.DeliverNewPolicy, spy2.calls[0].DeliverPolicy,
+		"second rebuild without a fresh HandleStreamRecreated must NOT re-use DeliverAllPolicy; flag must be cleared by the first rebuild")
+}
+
+// T6b — direct read-and-clear primitive. Pins the atomic.Bool.Swap
+// semantic of recreatedSinceLastBuild independently of BuildConfig: a
+// regression that mistakenly used Load instead of Swap would still
+// emit the right policy on the first rebuild (the flag is true) but
+// leak the flag forever, breaking T6's second-call invariant. T6b
+// catches that primitive-level regression directly.
+func TestController_RecreatedFlag_ReadAndClear_Primitive(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+	require.True(t, c.recreatedSinceLastBuild.Load(),
+		"HandleStreamRecreated must set recreatedSinceLastBuild")
+
+	// First Swap must read true and clear.
+	require.True(t, c.recreatedSinceLastBuild.Swap(false))
+
+	// Second Swap must read false (cleared by the first).
+	require.False(t, c.recreatedSinceLastBuild.Swap(false),
+		"the flag must be cleared by the first read-and-clear; no leak")
+}

--- a/internal/recovery/controller_recreated_replay_test.go
+++ b/internal/recovery/controller_recreated_replay_test.go
@@ -1,0 +1,124 @@
+package recovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// errConsumerConfigMismatch simulates a NATS consumer-config-mismatch
+// returned by CreateOrUpdateConsumer when a restored same-named consumer
+// has incompatible config. Not stream-not-found; the contract under test
+// is that ANY post-hook recovery failure wraps types.ErrStreamMissing.
+var errConsumerConfigMismatch = errors.New("nats: consumer config mismatch (10094)")
+
+// spyRecreate captures the config passed to RecreateFunc on each call,
+// optionally returning an error to drive failure paths.
+type spyRecreate struct {
+	calls   []jetstream.ConsumerConfig
+	nextErr error
+}
+
+func (s *spyRecreate) fn() RecreateFunc {
+	return func(_ context.Context, cfg jetstream.ConsumerConfig) (jetstream.Consumer, error) {
+		s.calls = append(s.calls, cfg)
+		if s.nextErr != nil {
+			return nil, s.nextErr
+		}
+		return nil, nil
+	}
+}
+
+// T2 — fresh-stream replay. When the hook recreates the stream without
+// a preserved same-named consumer, the new consumer's AckFloor is 0.
+// HandleStreamRecreated must reset the checkpoint to 0; the next
+// RebuildAfterStreamRecreated must build a config that replays from
+// the start of the new stream (DeliverAllPolicy, OptStartSeq=0).
+//
+// This is the load-bearing fresh-stream invariant: without the
+// recreatedSinceLastBuild override, BuildConfig with checkpoint=0 falls
+// back to DeliverNewPolicy and skips messages published before the
+// replacement consumer is bound.
+func TestController_RebuildAfterStreamRecreated_FreshStream_ReplayFromStart(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+	require.Equal(t, uint64(100), c.checkpoint.Value())
+
+	// Hook recreates the stream without preserving the consumer.
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+	require.Equal(t, uint64(0), c.checkpoint.Value(),
+		"fresh-stream HandleStreamRecreated must reset checkpoint to 0 and seed sees AckFloor=0")
+
+	spy := &spyRecreate{}
+	_, err := c.RebuildAfterStreamRecreated(context.Background(), jetstream.ConsumerConfig{}, spy.fn())
+	require.NoError(t, err)
+	require.Len(t, spy.calls, 1, "RebuildAfterStreamRecreated must call recreate exactly once")
+
+	cfg := spy.calls[0]
+	require.Equal(t, jetstream.DeliverAllPolicy, cfg.DeliverPolicy,
+		"fresh-stream rebuild must use DeliverAllPolicy so the new consumer replays from seq 1, not skip pre-bind messages")
+	require.Equal(t, uint64(0), cfg.OptStartSeq,
+		"DeliverAllPolicy must not set OptStartSeq")
+}
+
+// T2b — restored-backup variant. When the hook recreates the stream
+// with a restored same-named consumer whose AckFloor > 0 (e.g., a
+// stream-snapshot restore preserved consumer state), HandleStreamRecreated
+// resets the checkpoint to 0 first, then SeedCheckpoint reads the
+// restored AckFloor. The next rebuild must resume from that floor +1.
+func TestController_RebuildAfterStreamRecreated_RestoredAckFloor_ResumesFromFloorPlusOne(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+
+	// Restored backup: same-named consumer has AckFloor=50.
+	c.HandleStreamRecreated(context.Background(), stubInfo(50))
+	require.Equal(t, uint64(50), c.checkpoint.Value(),
+		"restored-backup HandleStreamRecreated must reset to 0 then seed to AckFloor=50")
+
+	spy := &spyRecreate{}
+	_, err := c.RebuildAfterStreamRecreated(context.Background(), jetstream.ConsumerConfig{}, spy.fn())
+	require.NoError(t, err)
+	require.Len(t, spy.calls, 1)
+
+	cfg := spy.calls[0]
+	require.Equal(t, jetstream.DeliverByStartSequencePolicy, cfg.DeliverPolicy,
+		"with checkpoint>0, rebuild must resume by start-sequence, not replay from beginning")
+	require.Equal(t, uint64(51), cfg.OptStartSeq,
+		"OptStartSeq must be checkpoint+1; resuming at the next unprocessed sequence")
+}
+
+// T2d — restored-consumer incompatible config (v4 — v3-P0.2 pin). When
+// the restored same-named consumer has incompatible config (e.g.
+// AckPolicy mismatch), recreate returns an error that is NOT
+// stream-not-found. RebuildAfterStreamRecreated must still wrap it
+// with types.ErrStreamMissing so the manager observer route fires.
+// Pinning the typed-error class is the contract that keeps the
+// post-hook recovery flow consistent regardless of underlying cause.
+//
+// Note: the types.ErrStreamMissing constant is added by the
+// StreamMissingHook public-surface change (Task #28). This test
+// references it via the public types package.
+func TestController_RebuildAfterStreamRecreated_RecreateError_WrapsErrStreamMissing(t *testing.T) {
+	c := NewController(ControllerConfig{Strategy: FromLastProcessed, Logger: logging.NewNop()})
+	require.NotNil(t, c)
+
+	c.checkpoint.Seed(100)
+	c.HandleStreamRecreated(context.Background(), stubInfo(0))
+
+	spy := &spyRecreate{nextErr: errConsumerConfigMismatch}
+	_, err := c.RebuildAfterStreamRecreated(context.Background(), jetstream.ConsumerConfig{}, spy.fn())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errConsumerConfigMismatch,
+		"the underlying cause must remain in the error chain for diagnostics")
+	require.ErrorIs(t, err, types.ErrStreamMissing,
+		"all post-hook recovery failures must wrap types.ErrStreamMissing so the observer route fires consistently")
+}

--- a/internal/recovery/controller_test.go
+++ b/internal/recovery/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +85,7 @@ func TestNilController_SafeToCall(t *testing.T) {
 	var c *Controller
 	require.Equal(t, Disabled, c.Strategy())
 
-	action, cons := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, nil)
+	action, cons, _ := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, nil)
 	require.Equal(t, ActionBackoff, action)
 	require.Nil(t, cons)
 
@@ -99,13 +100,13 @@ func TestClassify_GracefulExit(t *testing.T) {
 		Logger:   nopLog,
 	})
 
-	action, _ := c.Classify(context.Background(), jetstream.ErrMsgIteratorClosed, nil, baseCfg, nil)
+	action, _, _ := c.Classify(context.Background(), jetstream.ErrMsgIteratorClosed, nil, baseCfg, nil)
 	require.Equal(t, ActionExit, action)
 
-	action, _ = c.Classify(context.Background(), context.Canceled, nil, baseCfg, nil)
+	action, _, _ = c.Classify(context.Background(), context.Canceled, nil, baseCfg, nil)
 	require.Equal(t, ActionExit, action)
 
-	action, _ = c.Classify(context.Background(), nil, nil, baseCfg, nil)
+	action, _, _ = c.Classify(context.Background(), nil, nil, baseCfg, nil)
 	require.Equal(t, ActionExit, action)
 }
 
@@ -117,11 +118,43 @@ func TestClassify_ConsumerDeleted_RecoverySucceeds(t *testing.T) {
 		Metrics:  metrics,
 	})
 
-	action, newCons := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysSucceedRecreate)
+	action, newCons, _ := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysSucceedRecreate)
 	require.Equal(t, ActionContinue, action)
 	require.NotNil(t, newCons)
 	require.Equal(t, []string{"consumer_deleted"}, metrics.iterRestartReasons)
 	require.Equal(t, []string{"success"}, metrics.results)
+}
+
+// TestClassify_ConsumerDeleted_RecreateStreamNotFound pins the P2.3 wire
+// contract: when the recreate function returns a stream-not-found error,
+// Classify returns ActionStreamMissing with a non-nil error wrapping
+// types.ErrStreamMissing — and does NOT advance internal recovery state
+// (lastRecoveryTime stays zero so the caller's detour can run immediately).
+func TestClassify_ConsumerDeleted_RecreateStreamNotFound(t *testing.T) {
+	metrics := &testMetrics{}
+	c := NewController(ControllerConfig{
+		Strategy: FromNew,
+		Logger:   nopLog,
+		Metrics:  metrics,
+	})
+
+	streamNotFound := func(_ context.Context, _ jetstream.ConsumerConfig) (jetstream.Consumer, error) {
+		return nil, jetstream.ErrStreamNotFound
+	}
+
+	action, newCons, err := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, streamNotFound)
+	require.Equal(t, ActionStreamMissing, action)
+	require.Nil(t, newCons)
+	require.ErrorIs(t, err, types.ErrStreamMissing,
+		"stream-not-found recreate error must surface as wrapped types.ErrStreamMissing")
+	require.ErrorIs(t, err, jetstream.ErrStreamNotFound,
+		"original cause must remain in the wrap chain so the operator can diagnose")
+
+	// State must NOT advance — the detour relies on lastRecoveryTime
+	// being unset so its immediate post-hook RebuildAfterStreamRecreated
+	// is not throttled by the cooldown.
+	require.True(t, c.lastRecoveryTime.IsZero(), "stream-missing must not advance lastRecoveryTime")
+	require.Equal(t, []string{"failure"}, metrics.results, "metric still records the failed attempt")
 }
 
 func TestClassify_ConsumerDeleted_RecoveryFails(t *testing.T) {
@@ -132,7 +165,7 @@ func TestClassify_ConsumerDeleted_RecoveryFails(t *testing.T) {
 		Metrics:  metrics,
 	})
 
-	action, newCons := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysFailRecreate)
+	action, newCons, _ := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysFailRecreate)
 	require.Equal(t, ActionBackoff, action)
 	require.Nil(t, newCons)
 	require.Equal(t, []string{"failure"}, metrics.results)
@@ -149,9 +182,9 @@ func TestClassify_NoHeartbeat_BelowThreshold(t *testing.T) {
 	})
 
 	// 2 heartbeat errors — below threshold of 3
-	action, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, nil, baseCfg, nil)
+	action, _, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, nil, baseCfg, nil)
 	require.Equal(t, ActionBackoff, action)
-	action, _ = c.Classify(context.Background(), jetstream.ErrNoHeartbeat, nil, baseCfg, nil)
+	action, _, _ = c.Classify(context.Background(), jetstream.ErrNoHeartbeat, nil, baseCfg, nil)
 	require.Equal(t, ActionBackoff, action)
 
 	require.Equal(t, []string{"heartbeat", "heartbeat"}, metrics.iterRestartReasons)
@@ -169,11 +202,11 @@ func TestClassify_NoHeartbeat_BurstConfirmedGone(t *testing.T) {
 	})
 
 	// 1st: below threshold
-	action, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysNotFoundInfo, baseCfg, alwaysSucceedRecreate)
+	action, _, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysNotFoundInfo, baseCfg, alwaysSucceedRecreate)
 	require.Equal(t, ActionBackoff, action)
 
 	// 2nd: threshold reached, Info() confirms gone, recovery succeeds
-	action, newCons := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysNotFoundInfo, baseCfg, alwaysSucceedRecreate)
+	action, newCons, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysNotFoundInfo, baseCfg, alwaysSucceedRecreate)
 	require.Equal(t, ActionContinue, action)
 	require.NotNil(t, newCons)
 	require.Equal(t, []string{"success"}, metrics.results)
@@ -187,9 +220,9 @@ func TestClassify_NoHeartbeat_BurstButConsumerStillExists(t *testing.T) {
 		Logger:         nopLog,
 	})
 
-	c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysSuccessInfo, baseCfg, nil)
+	_, _, _ = c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysSuccessInfo, baseCfg, nil)
 	// 2nd: threshold reached, but Info() says consumer exists — no recovery
-	action, newCons := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysSuccessInfo, baseCfg, nil)
+	action, newCons, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysSuccessInfo, baseCfg, nil)
 	require.Equal(t, ActionBackoff, action)
 	require.Nil(t, newCons)
 }
@@ -202,7 +235,7 @@ func TestClassify_TransientError(t *testing.T) {
 		Metrics:  metrics,
 	})
 
-	action, _ := c.Classify(context.Background(), errors.New("something"), nil, baseCfg, nil)
+	action, _, _ := c.Classify(context.Background(), errors.New("something"), nil, baseCfg, nil)
 	require.Equal(t, ActionBackoff, action)
 	require.Equal(t, []string{"transient"}, metrics.iterRestartReasons)
 }
@@ -216,7 +249,7 @@ func TestClassify_CancelledContext_NoRecovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	action, _ := c.Classify(ctx, jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysSucceedRecreate)
+	action, _, _ := c.Classify(ctx, jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysSucceedRecreate)
 	// Recovery should fail because ctx is cancelled
 	require.Equal(t, ActionBackoff, action)
 }
@@ -252,7 +285,7 @@ func TestRecovery_Serialization(t *testing.T) {
 	// Simulate in-progress recovery by setting the flag.
 	c.inProgress.Store(true)
 
-	action, newCons := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysSucceedRecreate)
+	action, newCons, _ := c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, alwaysSucceedRecreate)
 	// Recovery should be skipped because another is in progress.
 	require.Equal(t, ActionBackoff, action)
 	require.Nil(t, newCons)
@@ -295,7 +328,7 @@ func TestController_Classify_Concurrent(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, recreate)
+			_, _, _ = c.Classify(context.Background(), jetstream.ErrConsumerDeleted, nil, baseCfg, recreate)
 		}()
 	}
 
@@ -331,7 +364,7 @@ func TestController_AdvanceAndClassify_Concurrent(t *testing.T) {
 	// hitting recovery while AdvanceCheckpoint is still running).
 	wg.Go(func() {
 		for range 50 {
-			c.Classify(ctx, jetstream.ErrConsumerDeleted, nil, baseCfg,
+			_, _, _ = c.Classify(ctx, jetstream.ErrConsumerDeleted, nil, baseCfg,
 				func(_ context.Context, _ jetstream.ConsumerConfig) (jetstream.Consumer, error) {
 					return &stubConsumer{}, nil
 				},

--- a/internal/recovery/controller_test.go
+++ b/internal/recovery/controller_test.go
@@ -88,7 +88,7 @@ func TestNilController_SafeToCall(t *testing.T) {
 	require.Equal(t, ActionBackoff, action)
 	require.Nil(t, cons)
 
-	c.AdvanceCheckpoint(&mockMsg{seq: 10})
+	c.AdvanceCheckpoint(&mockMsg{seq: 10}, 0)
 	c.SeedCheckpoint(context.Background(), nil)
 	c.ResetBurst()
 }
@@ -323,7 +323,7 @@ func TestController_AdvanceAndClassify_Concurrent(t *testing.T) {
 	// Goroutine 1: advance checkpoint continuously (simulates auto-ack path).
 	wg.Go(func() {
 		for i := range 500 {
-			c.AdvanceCheckpoint(&mockMsg{seq: uint64(i + 1)})
+			c.AdvanceCheckpoint(&mockMsg{seq: uint64(i + 1)}, 0)
 		}
 	})
 

--- a/internal/recovery/tracking_msg.go
+++ b/internal/recovery/tracking_msg.go
@@ -11,16 +11,24 @@ import (
 //
 // Used exclusively when ManualAck=true and the recovery strategy is FromLastProcessed.
 // The handler receives a trackingMsg value typed as jetstream.Msg — transparent to the caller.
+//
+// epoch is the streamEpoch captured at dispatch time. AdvanceCheckpoint compares
+// the captured epoch against the controller's current streamEpoch and silently
+// drops the advance when they differ — fencing late acks from a prior stream
+// incarnation.
 type trackingMsg struct {
 	jetstream.Msg
 	controller *Controller
+	epoch      uint64
 }
 
 // Ack calls the underlying Ack and, on success, advances the checkpoint.
+// The dispatch-time epoch is passed through so the controller can fence
+// acks from a prior stream generation.
 func (m *trackingMsg) Ack() error {
 	err := m.Msg.Ack()
 	if err == nil {
-		m.controller.AdvanceCheckpoint(m.Msg)
+		m.controller.AdvanceCheckpoint(m.Msg, m.epoch)
 	}
 
 	return err
@@ -30,7 +38,7 @@ func (m *trackingMsg) Ack() error {
 func (m *trackingMsg) DoubleAck(ctx context.Context) error {
 	err := m.Msg.DoubleAck(ctx)
 	if err == nil {
-		m.controller.AdvanceCheckpoint(m.Msg)
+		m.controller.AdvanceCheckpoint(m.Msg, m.epoch)
 	}
 
 	return err

--- a/stream_missing_alias_test.go
+++ b/stream_missing_alias_test.go
@@ -1,0 +1,62 @@
+package parti_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	parti "github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRootAliases_StreamMissing pins the v10 spec's exported-symbol audit
+// for the root package (docs/plans/self-healing/09-pr9-spec.md § Verification
+// gates): callers MUST be able to write
+//
+//	errors.Is(err, parti.ErrStreamMissing)
+//
+// and
+//
+//	var hook parti.StreamMissingHook = func(string) error { return nil }
+//
+// using only the root parti package. Without the aliases below, those
+// snippets would not compile and the spec's "branching via errors.Is is
+// the documented public shape" contract would be unmet.
+func TestRootAliases_StreamMissing(t *testing.T) {
+	// Identity: the root alias and the types value must be the same
+	// sentinel — equality, not just errors.Is — so a caller that imports
+	// only parti can interoperate with libraries that import types.
+	require.Same(t, types.ErrStreamMissing, parti.ErrStreamMissing,
+		"parti.ErrStreamMissing must be the same sentinel value as types.ErrStreamMissing")
+
+	// errors.Is: a wrapped types.ErrStreamMissing must satisfy
+	// errors.Is(err, parti.ErrStreamMissing) — the documented user
+	// branching shape from types.ErrStreamMissing's godoc.
+	wrapped := fmt.Errorf("stream %q: %w", "TEST_STREAM", types.ErrStreamMissing)
+	require.True(t, errors.Is(wrapped, parti.ErrStreamMissing),
+		"errors.Is must match the root alias against a wrapped types.ErrStreamMissing")
+
+	// Hook type alias: parti.StreamMissingHook and types.StreamMissingHook
+	// must be the same underlying type. Compile-time assertion via the
+	// blank identifier proves bidirectional assignability — the explicit
+	// type on the LHS is intentional documentation that survives a
+	// future refactor that drops the alias (which would re-introduce
+	// the spec violation).
+	var hook parti.StreamMissingHook = func(stream string) error {
+		if stream == "" {
+			return errors.New("empty stream")
+		}
+
+		return nil
+	}
+	// parti → types and types → parti bidirectional assignability.
+	// Without an alias these declarations would not compile, so the
+	// explicit LHS type IS the assertion — staticcheck's QF1011 ("omit
+	// the type") would defeat the test if followed.
+	var _ types.StreamMissingHook = hook //nolint:staticcheck // QF1011: explicit type is the alias assertion
+	var typesHook types.StreamMissingHook = func(string) error { return nil }
+	var _ parti.StreamMissingHook = typesHook //nolint:staticcheck // QF1011: explicit type is the alias assertion
+	require.NoError(t, hook("ok"))
+	require.Error(t, hook(""), "hook should still be callable through the alias")
+}

--- a/types.go
+++ b/types.go
@@ -34,6 +34,13 @@ type (
 	HandoffMetricsRecorder   = types.HandoffMetricsRecorder
 	Logger                   = types.Logger
 	Hooks                    = types.Hooks
+	// StreamMissingHook is the operator-supplied escalation invoked when
+	// the dynamic partition consumer's recovery flow detects the
+	// underlying JetStream stream is absent. See
+	// [types.StreamMissingHook] for the operator contract — same-durable-
+	// name preservation, compatible-config reconciliation, and the
+	// post-hook checkpoint-reset / epoch-fence semantics.
+	StreamMissingHook = types.StreamMissingHook
 )
 
 // Re-export State constants from the internal types package.

--- a/types/stream_hooks.go
+++ b/types/stream_hooks.go
@@ -1,0 +1,69 @@
+package types
+
+import "errors"
+
+// ErrStreamMissing is the typed-error umbrella for the operator-driven
+// stream-missing recovery flow. The library wraps every failure that
+// occurs during the post-StreamMissingHook recovery episode with this
+// sentinel, regardless of the underlying cause (still-missing-stream,
+// incompatible-restored-consumer-config, etc.), so the manager
+// observer route fires consistently and enterDegraded surfaces a
+// single named reason ("stream-missing-recovery-exhausted") instead
+// of the generic "KV error threshold exceeded".
+//
+// Callers identify the umbrella via errors.Is(err, ErrStreamMissing);
+// the underlying cause remains in the error chain for diagnostics.
+var ErrStreamMissing = errors.New("stream missing (operator-driven recovery)")
+
+// StreamMissingHook fires when a dynamic consumer cannot create a
+// consumer because the underlying JetStream stream is absent.
+//
+// Contract:
+//   - The hook is the escalation path; the library does not recreate
+//     streams. Operators recreate the stream (e.g. via parti.Provision)
+//     and return nil so the library's recovery loop can rebuild the
+//     consumer against the freshly-restored stream.
+//   - Returning a nil error indicates the caller has re-created the
+//     stream. The library will then call Controller.HandleStreamRecreated
+//     and RebuildAfterStreamRecreated to bind a new consumer.
+//   - Returning a non-nil error or omitting the hook entirely surfaces
+//     the loss via the F2 envelope's exhaustion path — manager
+//     Hooks.OnError + enterDegraded — so the readiness probe can
+//     rotate the pod.
+//
+// Consumer-state restore is OPTIONAL but is bound to two rules:
+//
+//   - SAME-DURABLE-NAME. If the caller preserves the durable consumer
+//     WITH THE SAME NAME Parti was using and with non-zero AckFloor,
+//     Controller.HandleStreamRecreated picks up the AckFloor via the
+//     existing consumer handle. The next consumer build produces
+//     DeliverByStartSequencePolicy(AckFloor+1).
+//
+//   - COMPATIBLE CONFIG. If the caller preserves a same-named consumer
+//     but with INCOMPATIBLE config (different DeliverPolicy, AckPolicy,
+//     InactiveThreshold), the post-recreate consumer build invokes
+//     js.CreateOrUpdateConsumer with the Parti-derived config; NATS
+//     responds with a consumer-config-mismatch error. This surfaces as
+//     a wrapped ErrStreamMissing and the F2 envelope retries until
+//     exhaustion. The operator must either reconcile the restored
+//     consumer config OR delete the consumer so Parti can recreate it
+//     fresh on the restored stream.
+//
+//   - If the caller recreates the stream with NO consumer (or a
+//     consumer with a DIFFERENT durable name), Parti treats it as "no
+//     preserved consumer state". The checkpoint stays at 0 and the
+//     next consumer build produces DeliverAllPolicy (replay from
+//     sequence 1).
+//
+// The hook MUST be safe to call from a recovery goroutine and SHOULD
+// return promptly. A long-running hook delays the consumer rebuild
+// and keeps the F2 envelope's attempt budget ticking.
+//
+// REQUIRED RecoveryStrategy: configuring StreamMissingHook requires
+// either RecoverFromLastProcessed (at-least-once semantics) or
+// RecoverFromBeginning (replay-all, intentional duplicate processing).
+// RecoveryDisabled (the default) and RecoverFromNew are rejected at
+// construction time because they would either disable the recovery
+// controller entirely or silently skip messages published after a
+// fresh-stream recreate.
+type StreamMissingHook func(streamName string) error


### PR DESCRIPTION
## Summary

- **P2.3** — operator-driven stream-missing recovery flow for the dynamic partition consumer: a `StreamMissingHook` escalation seam, an epoch-fenced checkpoint reset, and Site A (iter-creation envelope) + Site B (iter-runtime classification) detours that bound every failure path through `OnPermanentFailure`.
- **P2.4d** — F2 retry envelope around `partition_consumer.go`'s iter-creation loop (P2.3 prerequisite, included in this branch as `2c359b0`).
- Concurrency stress tests for the P2.4a/b/c envelope monitors already merged to `main` (`92f760c`, `469eecd`, `e8f1530`).

Full spec at [`docs/plans/self-healing/09-pr9-spec.md`](docs/plans/self-healing/09-pr9-spec.md) (v10).

### What's new on the public surface

- `parti.ErrStreamMissing` and `parti.StreamMissingHook` root aliases — `errors.Is(err, parti.ErrStreamMissing)` is the documented branching shape inside `Hooks.OnError`.
- `consumer.WithStreamMissingHook(...)` — the operator hook. Rejects `RecoveryDisabled` and `RecoverFromNew` at construction time (only `RecoverFromLastProcessed` and `RecoverFromBeginning` implement the recreated-stream replay correctly).
- `consumer.WithOnPermanentFailure(...)` — the application observability seam for envelope and Site B exhaustion; the error preserves the wrap chain so applications can route stream-missing distinctly.

### Bounded exhaustion — the load-bearing fix

nats.go's `Consumer.Messages()` does not validate the remote stream up front, so the F2 iter-creation envelope cannot catch Site B (iter-runtime) failures — the loop would otherwise spin forever calling `CreateOrUpdateConsumer` through `Classify → recover`. A new `streamMissingFailures atomic.Int32` counter (capped at `RecoveryRetry.MaxAttempts`) fires `OnPermanentFailure` once and exits the consumer loop on exhaustion. Counter resets on every successful rebind so a recovered episode does not shorten the next episode's budget.

### Out of scope (deferred to a follow-up PR)

Per the per-PR spec, these land separately:
- `manager_setup.go` `SetOnStreamMissingError` type-assert wiring + `Manager.onStreamMissingError` closure
- `CompositeConsumerUpdater.SetOnStreamMissingError` forwarding
- `consumer.Dynamic.SetOnStreamMissingError` indirection slot
- `manager_degraded.go:recordKVError` short-circuit on `errors.Is(err, ErrStreamMissing)`
- Integration tests T1/T4/T5 under `test/integration/failure/`
- `docs/CONSUMERS.md` worked example with `parti.Provision`-based recreate

`docs/plans/self-healing/STATUS.md` enumerates these under the P2.3 follow-up section.

### Review trail

Post-impl review loop ran v1→v4 to reach merge verdict:
- v1: 2 P0, 1 P1 (Site B exhaustion gap; missing root aliases; missing non-Dynamic mapping tests)
- v2: 2 P0, 1 P1 (default `RecoveryDisabled` Site B exhaustion gap; counter leak across episodes; missing `WithOnPermanentFailure` API)
- v3: 1 P1, 1 P2 (nil-recovery legacy remediation counter reset gap; weak constructor smoke test)
- v4: **merge** (zero findings)

Reports under `tmp/09-pr9-spec_p2.3_post_implementation_review_v{1,2,3,4}.md` (worktree-local; not part of this PR).

## Test plan

- [ ] `make lint` clean — 0 issues.
- [ ] `make test -race` clean — full unit suite green.
- [ ] `make test-integration -race` clean — all live-NATS suites green (handoff has a known load-sensitive flake in `TestHandoffConflictStress` unrelated to this PR; re-run in isolation if it trips).
- [ ] `make pre-pr` — chained gate (lint + test + test-integration) reports `all gates passed`.
- [ ] Cross-feature contract regressions (per `AGENTS.md`):
  - `TestManager_LiveNATSBucketLoss*` — whole-bucket loss path through `recordKVError`. Stream-missing must NOT route there (asserted by inspection — the v2-P0-A fix routes stream-missing through `handleStreamMissingFailure` not `recordKVError`).
  - `TestStableID_StaleKeyTakeover_Reclaim` — peer claim takeover only that worker.
  - `TestManager_LiveNATSBucketLoss_OnDegradedHook` — one-shot OnDegraded per Degraded entry.
- [ ] Spot-check new tests by name: `TestPartitionConsumer_SiteA_*`, `TestPartitionConsumer_SiteB_*`, `TestRootAliases_StreamMissing`, `TestQueue_ActionStreamMissing_LogsAndBacksOff`, `TestBroadcastConsumer_ActionStreamMissing_LogsAndBacksOff`, `TestJSConsumer_ActionStreamMissing_LogsAndBacksOff`, `TestWithOnPermanentFailure_*`.