### PR TITLE
feat(assignment): guard rebalance against truncated heartbeat scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Worker-set shrink-confirmation defense.** Calculator rebalances now
+  guard against silently-truncated heartbeat-bucket scans. NATS'
+  `KeyValue.Keys()` can return `(partial-slice, nil)` when the underlying
+  watcher subscription tears down mid-scan, producing a fresh-looking
+  observation that the worker set has shrunk when in fact the workers are
+  alive. Acting on such an observation reassigns live workers' partitions
+  to the survivors, producing transient double ownership. The defense
+  composes two layers: (1) `Calculator.getActiveWorkers` treats a
+  sharply-shrunk scan as suspicious and surfaces the cached worker set
+  with `fresh=false` until a configurable confirmation window has elapsed
+  — the last-known worker baseline is never advanced on a suspicious
+  read; and (2) `Calculator.rebalance` enforces an
+  emergency-confirmation gate: even after the confirmation window
+  accepts a shrunk read, the rebalance is skipped (no commit) unless
+  `EmergencyDetector` has captured at least one confirmed death. The
+  skip surfaces as a benign no-op in the state-machine callbacks, not
+  an error. Two new `Config` fields tune the defense:
+  `WorkerShrinkConfirmationCount` (default `2` — the number of
+  consecutive suspicious scans before the defense accepts the shrink)
+  and `WorkerShrinkConfirmationThresholdPct` (default `50` — an
+  observed count below `lastKnown × Pct / 100` is suspicious). Mirrors
+  the existing `PartitionShrinkConfirmation*` doctrine for the
+  partition-source side.
 - **Kubernetes operator** — a new nested Go module at `k8s/`
   (`github.com/arloliu/parti/v2/k8s`) that reconciles a `ProvisionedPartiEnv`
   custom resource to NATS infrastructure (control-plane KV buckets,

--- a/internal/assignment/calculator.go
+++ b/internal/assignment/calculator.go
@@ -33,6 +33,28 @@ var errShuttingDown = errors.New("rebalance aborted: leader is shutting down")
 // a fleet-wide reassign-to-zero thundering herd.
 var errSuspiciousPartitionObservation = errors.New("rebalance skipped: partition observation pending confirmation")
 
+// errSuspiciousWorkerObservation is returned by rebalance() when the
+// heartbeat-bucket scan returns a sharply-shrunk worker set with no
+// emergency-confirmed deaths in c.disappearedWorkers, and the
+// confirmation window (WorkerShrinkConfirmationCount) has not yet been
+// satisfied. The candidate rebalance is skipped; the cached assignment
+// remains in effect. handleRebalance treats this sentinel like a no-op
+// (no error) because it is an explicit "keep cached assignment"
+// decision, not a failure.
+//
+// This implements the "minimum credible worker input" doctrine: a
+// single observation of a sharply-shrunk heartbeat scan is more likely
+// a transient blip (KV truncated-read race, watcher hiccup) than a
+// legitimate fleet-wide loss; the confirmation window plus the
+// emergency-detector composition prevents one bad scan from
+// reassigning every partition off live workers.
+//
+// The companion to the in-getActiveWorkers defense: that path degrades
+// the observation to cached+fresh=false; this sentinel covers the
+// rebalance-floor branch when a fresh observation arrives but
+// EmergencyDetector has not yet confirmed deaths.
+var errSuspiciousWorkerObservation = errors.New("rebalance skipped: worker observation pending confirmation")
+
 // Calculator manages partition assignment calculation and distribution.
 //
 // The calculator runs on the leader worker and orchestrates three focused components:
@@ -115,6 +137,28 @@ type Calculator struct {
 	// is needed.
 	lastKnownPartitionCount     int
 	partitionShrunkObservations int
+
+	// Minimum-credible-worker-input doctrine (see
+	// errSuspiciousWorkerObservation Godoc):
+	//
+	// lastKnownWorkerCount is the most recent worker count the
+	// calculator committed to. Only a rebalance that passes the F10-A
+	// floor advances it — that is the load-bearing safety.
+	//
+	// workerShrunkObservations is the running count of consecutive
+	// suspicious observations. Once it reaches
+	// WorkerShrinkConfirmationCount the calculator trusts the shrink;
+	// any healthy observation resets it to 0. Named distinctly from
+	// partitionShrunkObservations so the two cross-feature counters
+	// do not share a confirmation window.
+	//
+	// Both fields are touched from the getActiveWorkers path (called
+	// from rebalance under rebalanceMu and from the worker-monitor
+	// poll under pollMu — independent locks) and from the rebalance
+	// floor itself. c.mu fences those read-modify-writes without
+	// widening either of the path-specific locks.
+	lastKnownWorkerCount     int
+	workerShrunkObservations int
 }
 
 // cachedWorkerList bundles worker data with its timestamp for atomic operations.
@@ -760,6 +804,16 @@ func (c *Calculator) handlePartitionRebalance(ctx context.Context, lifecycle str
 		if errors.Is(err, errSuspiciousPartitionObservation) {
 			return err
 		}
+		// A suspicious worker observation does not need re-arming here:
+		// the worker-monitor poll loop will fire its own rebalance
+		// once the heartbeat scan heals or EmergencyDetector confirms
+		// deaths, and that rebalance will pick up any pending
+		// partition change. Swallowing avoids the spurious "partition
+		// rebalance failed" Error log a non-failure would otherwise
+		// produce.
+		if errors.Is(err, errSuspiciousWorkerObservation) {
+			return nil
+		}
 
 		return fmt.Errorf("partition rebalance failed for %s: %w", lifecycle, err)
 	}
@@ -1113,52 +1167,132 @@ func (c *Calculator) hasWorkersChangedLocked(workers map[string]bool) bool {
 
 // getActiveWorkers retrieves the list of workers with active heartbeats.
 //
-// This method implements cache fallback for degraded mode:
-//  1. Try to fetch workers from NATS KV (monitor.GetActiveWorkers)
-//  2. On connectivity error, fall back to cached worker list (fresh=false)
-//  3. Update cache on successful fetches (fresh=true)
-//  4. Return ErrDegraded if no cache available during connectivity issues
+// This method implements cache fallback for two failure shapes:
+//  1. Connectivity error from NATS KV: returns the last cached worker
+//     list with fresh=false; if no cache exists, returns ErrDegraded.
+//  2. Sharply-shrunk fresh observation (the F10-A truncated-Keys()
+//     defense, see errSuspiciousWorkerObservation Godoc): degrades to
+//     the cached set with fresh=false until the confirmation window
+//     (WorkerShrinkConfirmationCount consecutive suspicious reads) is
+//     met.
 //
-// Parameters:
-//   - ctx: Context for KV operations
+// A healthy (non-shrunk) fresh observation refreshes the cache, resets
+// workerShrunkObservations to zero, and returns fresh=true.
 //
-// Returns:
-//   - []string: List of active worker IDs
-//   - bool: true if the list was fetched fresh from KV; false if it came from
-//     the degraded-mode cache. Callers that mutate detector state on the
-//     observation must gate that mutation on fresh==true.
-//   - error: Error if fetch fails and no cache available
+// lastKnownWorkerCount is intentionally NOT advanced here — the
+// rebalance-side floor advances it only after the floor passes, so the
+// floor always compares against a baseline established by a prior
+// committed rebalance.
+//
+// Callers that mutate detector state on the observation MUST gate that
+// mutation on fresh==true (see collectRebalanceWorkers's ObserveAlive
+// gating).
 func (c *Calculator) getActiveWorkers(ctx context.Context) ([]string, bool, error) {
-	// Try to fetch from NATS KV
 	workers, err := c.monitor.GetActiveWorkers(ctx)
 	if err != nil {
-		// Check if this is a connectivity error
 		if natsutil.IsConnectivityError(err) {
-			// Try to use cached worker list
 			if cached, age, ok := c.getCachedWorkers(); ok {
 				c.Logger.Warn("using cached worker list due to connectivity error",
 					"workers", len(cached),
 					"cache_age", age,
 					"error", err)
-				// Record cache usage metrics
 				c.Metrics.RecordCacheUsage("workers", age.Seconds())
 				c.Metrics.IncrementCacheFallback("connectivity_error")
 
 				return cached, false, nil
 			}
-			// No cache available - return degraded error
 			c.Metrics.IncrementCacheFallback("no_cache")
 
 			return nil, false, fmt.Errorf("%w: no cached workers available: %w", types.ErrDegraded, err)
 		}
-		// Non-connectivity error - return as-is
+
 		return nil, false, err
 	}
 
-	// Success - update cache for future use
-	c.updateCachedWorkers(workers)
+	// F10-A defense: a sharply-shrunk fresh observation is treated as
+	// suspicious until the confirmation window is satisfied. The first
+	// such reads degrade to cached+fresh=false; once the confirmation
+	// window is satisfied the read is surfaced fresh so the
+	// rebalance-side floor can apply the emergency-confirmation gate.
+	//
+	// getActiveWorkers is called from the rebalance path
+	// (collectRebalanceWorkers, under rebalanceMu) AND from the
+	// worker-monitor poll path (collectWorkerObservation, under
+	// pollMu). Those locks are independent, so c.mu fences the F10-A
+	// counter read-modify-write here.
+	suspicious, consec, accepted, lastKnown := c.recordWorkerObservation(len(workers))
+	if suspicious && !accepted {
+		c.Logger.Warn("ignoring sharply-shrunk worker observation pending confirmation",
+			"last_known", lastKnown,
+			"observed", len(workers),
+			"threshold_pct", c.WorkerShrinkConfirmationThresholdPct,
+			"consecutive_observations", consec,
+			"required", c.WorkerShrinkConfirmationCount)
+		if cached, age, ok := c.getCachedWorkers(); ok {
+			c.Metrics.RecordCacheUsage("workers", age.Seconds())
+			c.Metrics.IncrementCacheFallback("suspicious_worker_shrink")
+
+			return cached, false, nil
+		}
+		c.Metrics.IncrementCacheFallback("no_cache")
+
+		return nil, false, fmt.Errorf("%w: %w", types.ErrDegraded, errSuspiciousWorkerObservation)
+	}
+
+	// Healthy observation: refresh the cache so future connectivity
+	// errors fall back to a trusted shape. An accepted-shrunk read is
+	// surfaced fresh but NOT cached: until the rebalance floor commits,
+	// the shrunk view is not yet trusted.
+	if !suspicious {
+		c.updateCachedWorkers(workers)
+	}
 
 	return workers, true, nil
+}
+
+// recordWorkerObservation runs the F10-A counter under c.mu. It
+// returns whether the raw observation was suspicious, the resulting
+// consecutive count, whether the observation should be surfaced as
+// accepted (suspicious but past the confirmation window), and the
+// last-known baseline (for the caller's warning log). A healthy
+// non-shrunk observation resets the counter; a suspicious observation
+// increments it. Splitting the locked read-modify-write from the
+// caller's cache-fallback / metrics path keeps c.mu's critical section
+// tight and lets the caller log without holding the lock.
+func (c *Calculator) recordWorkerObservation(observed int) (suspicious bool, consec int, accepted bool, lastKnown int) { //nolint:revive // function-result-limit: caller needs all four signals atomically under c.mu
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	lastKnown = c.lastKnownWorkerCount
+	suspicious = c.workerObservationSuspicious(observed)
+	if !suspicious {
+		c.workerShrunkObservations = 0
+		return suspicious, 0, false, lastKnown
+	}
+
+	c.workerShrunkObservations++
+	consec = c.workerShrunkObservations
+	accepted = consec >= c.WorkerShrinkConfirmationCount
+
+	return suspicious, consec, accepted, lastKnown
+}
+
+// workerObservationSuspicious returns true when a fresh worker-count
+// observation is sharply shrunk relative to the last known baseline.
+// The guard is silent until lastKnownWorkerCount > 0 — the first ever
+// scan must be trusted to establish the baseline. The threshold form
+// mirrors partitionInputCredibilityGuard's
+//
+//	observed*100 < lastKnown*Pct
+//
+// shape to avoid the intermediate-truncation surprise at small worker
+// counts that the pre-divided form (lastKnown*Pct/100) produces.
+func (c *Calculator) workerObservationSuspicious(observed int) bool {
+	if c.lastKnownWorkerCount == 0 {
+		return false
+	}
+
+	return observed*100 < c.lastKnownWorkerCount*c.WorkerShrinkConfirmationThresholdPct
 }
 
 // getActiveWorkersFiltered retrieves workers, excluding those confirmed disappeared in emergency.
@@ -1291,6 +1425,13 @@ func (c *Calculator) handleRebalance(ctx context.Context, reason string) error {
 		if errors.Is(err, errSuspiciousPartitionObservation) {
 			return nil
 		}
+		// A suspicious worker observation is the same shape: the
+		// floor explicitly chose to keep the cached assignment until
+		// EmergencyDetector confirms deaths or the heartbeat scan
+		// heals. The next poll naturally re-observes; no escalation.
+		if errors.Is(err, errSuspiciousWorkerObservation) {
+			return nil
+		}
 
 		return fmt.Errorf("rebalance failed for %s: %w", reason, err)
 	}
@@ -1316,25 +1457,41 @@ func (c *Calculator) handleRebalance(ctx context.Context, reason string) error {
 // triggers (audit_repair, scaling-timer, partition-lifecycle, manual): any
 // worker visible to this fresh KV scan has its stale tracking cleared, so a
 // subsequent disappearance starts a fresh grace period.
-func (c *Calculator) collectRebalanceWorkers(ctx context.Context, lifecycle string) ([]string, error) {
-	var disappearedWorkers []string
+//
+// Returns the worker set, plus a "deaths confirmed" flag for the F10-A
+// rebalance-side floor. The flag is true iff EmergencyDetector has
+// captured at least one death — either consumed locally on the
+// emergency lifecycle, or still resident in c.disappearedWorkers on
+// the non-emergency lifecycle. The floor's check must see the
+// pre-clear state so an emergency rebalance is never wrongly
+// suppressed by its own consumption.
+func (c *Calculator) collectRebalanceWorkers(ctx context.Context, lifecycle string) ([]string, bool, error) {
+	var (
+		disappearedWorkers []string
+		deathsConfirmed    bool
+	)
 	if lifecycle == "emergency" {
 		c.mu.Lock()
 		disappearedWorkers = c.disappearedWorkers
 		c.disappearedWorkers = nil
 		c.mu.Unlock()
+		deathsConfirmed = len(disappearedWorkers) > 0
+	} else {
+		c.mu.RLock()
+		deathsConfirmed = len(c.disappearedWorkers) > 0
+		c.mu.RUnlock()
 	}
 
 	workers, fresh, err := c.getActiveWorkersFiltered(ctx, disappearedWorkers)
 	if err != nil {
-		return nil, c.wrapStopErr(fmt.Errorf("failed to get active workers: %w", err))
+		return nil, false, c.wrapStopErr(fmt.Errorf("failed to get active workers: %w", err))
 	}
 
 	if fresh {
 		c.emergencyDetector.ObserveAlive(workers)
 	}
 
-	return workers, nil
+	return workers, deathsConfirmed, nil
 }
 
 // snapshotSource picks the best partition snapshot path for the source. If
@@ -1377,7 +1534,7 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 
 	start := time.Now()
 
-	workers, err := c.collectRebalanceWorkers(ctx, lifecycle)
+	workers, deathsConfirmed, err := c.collectRebalanceWorkers(ctx, lifecycle)
 	if err != nil {
 		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
 		return err
@@ -1413,6 +1570,37 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 		c.Metrics.RecordRebalanceAttempt(lifecycle, true)
 
 		return nil
+	}
+
+	// F10-A worker-set floor: refuse to commit a rebalance on a
+	// sharply-shrunk worker set when EmergencyDetector has not
+	// confirmed any deaths. Composes with — does not duplicate — the
+	// per-worker grace window in EmergencyDetector: once any death is
+	// confirmed (c.disappearedWorkers populated) the floor releases
+	// and the rebalance proceeds. The in-getActiveWorkers defense
+	// covers the per-poll noise filtering; the floor here is the
+	// emergency-confirmation gate that must clear before the
+	// calculator commits to a shrunk worker set. lastKnownWorkerCount
+	// is advanced ONLY when the floor passes, so it always reflects a
+	// baseline confirmed by a prior successful rebalance.
+	c.mu.Lock()
+	floorBlocks := !deathsConfirmed && c.workerObservationSuspicious(len(workers))
+	lastKnownSnapshot := c.lastKnownWorkerCount
+	if !floorBlocks {
+		c.lastKnownWorkerCount = len(workers)
+	}
+	c.mu.Unlock()
+
+	if floorBlocks {
+		c.Logger.Warn("ignoring rebalance on suspiciously-shrunk worker set; no emergency-confirmed deaths",
+			"lifecycle", lifecycle,
+			"current_count", len(workers),
+			"last_known_count", lastKnownSnapshot,
+			"threshold_pct", c.WorkerShrinkConfirmationThresholdPct)
+		c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
+		c.Metrics.RecordRebalanceAttempt(lifecycle, true)
+
+		return errSuspiciousWorkerObservation
 	}
 
 	// Minimum-credible-partition-input guard (see

--- a/internal/assignment/calculator_f10a_worker_floor_test.go
+++ b/internal/assignment/calculator_f10a_worker_floor_test.go
@@ -1,0 +1,380 @@
+package assignment
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/partitest"
+)
+
+// setupF10ACalculator wires a Calculator backed by a real heartbeat KV
+// pre-populated with seedWorkers active heartbeats, runs one seed
+// rebalance to establish lastKnownWorkerCount, and returns the
+// calculator ready for shrink-injection tests.
+//
+// Direct-call test fixture — the calculator is NOT Start()ed, mirroring
+// the F6-B fixture's discipline (see setupF6BCalculator Godoc for why
+// monitor goroutines must not race the explicit rebalance calls). The
+// race detector flags any monitor goroutine writing to
+// workerShrunkObservations while the test's explicit rebalance is
+// reading it.
+//
+//nolint:unparam // confirmCount is intentionally configurable for future tests
+func setupF10ACalculator(
+	t *testing.T,
+	ctx context.Context,
+	seedWorkers int,
+	confirmCount int,
+	thresholdPct int,
+) (*Calculator, jetstream.KeyValue) {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	assignmentKV := partitest.CreateJetStreamKV(t, nc, "test-f10a-assignment-"+t.Name())
+	heartbeatKV := partitest.CreateJetStreamKV(t, nc, "test-f10a-heartbeat-"+t.Name())
+
+	for i := range seedWorkers {
+		key := fmt.Sprintf("worker-hb.worker-%03d", i)
+		_, err := heartbeatKV.Put(ctx, key, []byte(time.Now().Format(time.RFC3339Nano)))
+		require.NoError(t, err)
+	}
+
+	src := &mutableSource{partitions: makePartitions(seedWorkers)}
+
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:                            assignmentKV,
+		HeartbeatKV:                             heartbeatKV,
+		AssignmentPrefix:                        "assignment",
+		Source:                                  src,
+		Strategy:                                &mockStrategy{},
+		HeartbeatPrefix:                         "worker-hb",
+		HeartbeatTTL:                            5 * time.Second,
+		EmergencyGracePeriod:                    1 * time.Second,
+		ColdStartWindow:                         10 * time.Millisecond,
+		PlannedScaleWindow:                      10 * time.Millisecond,
+		Cooldown:                                0,
+		WorkerShrinkConfirmationCount:           confirmCount,
+		WorkerShrinkConfirmationThresholdPct:    thresholdPct,
+		PartitionShrinkConfirmationCount:        3,
+		PartitionShrinkConfirmationThresholdPct: 50,
+	})
+	require.NoError(t, err)
+
+	// Seed rebalance so lastKnownWorkerCount tracks the heartbeat
+	// scan. The direct call avoids the monitor goroutine race.
+	require.NoError(t, calc.rebalance(ctx, "test-seed"))
+	require.Equal(t, seedWorkers, calc.lastKnownWorkerCount,
+		"sanity: seed rebalance must establish lastKnownWorkerCount")
+
+	return calc, heartbeatKV
+}
+
+// shrinkHeartbeatsToThree deletes 7 of the 10 seeded heartbeat keys
+// (003..009), leaving workers 000..002 as the only active heartbeats.
+// This simulates the calculator-visible effect of a truncated Keys()
+// read — a sharply-shrunk worker scan from 10 to 3 (70 % drop, well
+// past the 50 % threshold). The calculator cannot distinguish a real
+// shrink from a truncated read at this layer; the defense fires
+// identically. The actual nats.go truncation behavior is pinned by
+// T0 in test/integration/failure/heartbeat_truncated_keys_test.go.
+func shrinkHeartbeatsToThree(t *testing.T, ctx context.Context, kv jetstream.KeyValue) {
+	t.Helper()
+	for i := 3; i < 10; i++ {
+		key := fmt.Sprintf("worker-hb.worker-%03d", i)
+		require.NoError(t, kv.Delete(ctx, key))
+	}
+}
+
+// TestCalculator_F10A_SuspiciousShrink_DegradesToCached drives the
+// in-getActiveWorkers defense (T1 in 00-fix-plan.md §P2.5): prime
+// lastKnownWorkerCount=10, inject a 3-worker observation, assert the
+// calculator returns the cached 10-worker set with fresh=false and
+// does NOT advance lastKnownWorkerCount. On parent + T0 (no defense):
+// returns the 3-worker set with fresh=true and advances the baseline
+// to 3 — the buggy behavior the defense closes.
+func TestCalculator_F10A_SuspiciousShrink_DegradesToCached(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	calc, kv := setupF10ACalculator(t, ctx, 10, 2, 50)
+
+	// Inject a sharp shrink: 10 -> 3 (70 % drop, well past the 50 %
+	// threshold).
+	shrinkHeartbeatsToThree(t, ctx, kv)
+
+	workers, fresh, err := calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.False(t, fresh,
+		"suspicious shrink MUST surface as cached (fresh=false) so callers "+
+			"that gate state mutations on fresh do not act on the phantom shrink")
+	require.Len(t, workers, 10,
+		"suspicious shrink MUST return the cached worker set, not the shrunken read")
+	require.Equal(t, 10, calc.lastKnownWorkerCount,
+		"a suppressed observation MUST NOT advance the baseline")
+	require.Equal(t, 1, calc.workerShrunkObservations,
+		"the counter must advance once per suppressed observation")
+}
+
+// TestCalculator_F10A_SuspiciousShrink_RebalanceFloor drives the
+// rebalance-side floor (T2). The defense and floor compose: the first
+// (ConfirmCount-1) calls degrade to cached so the floor does not see
+// the shrunk count; on the ConfirmCount-th call the defense surfaces
+// the shrunk read fresh and the floor blocks because no deaths have
+// been confirmed. On parent (no defense, no floor): both calls commit
+// new assignments to the 3-worker set.
+func TestCalculator_F10A_SuspiciousShrink_RebalanceFloor(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	calc, kv := setupF10ACalculator(t, ctx, 10, 2, 50)
+
+	shrinkHeartbeatsToThree(t, ctx, kv)
+
+	// Call 1: defense degrades to cached (counter=1 < ConfirmCount=2).
+	// Rebalance receives the cached 10-worker set and proceeds
+	// harmlessly — the cached assignment is the prior trusted shape.
+	require.NoError(t, calc.rebalance(ctx, "f10a-test"),
+		"first call: defense degrades to cached so rebalance is a no-op")
+	require.Equal(t, 1, calc.workerShrunkObservations,
+		"the per-poll confirmation counter must advance once per suspicious read")
+	require.Equal(t, 10, calc.lastKnownWorkerCount,
+		"a cached-fallback rebalance MUST NOT advance the worker baseline")
+
+	// Call 2: defense accepts (counter=2 >= ConfirmCount=2); the
+	// floor receives the shrunk read fresh, sees no
+	// emergency-confirmed deaths, and blocks the commit.
+	require.ErrorIs(t, calc.rebalance(ctx, "f10a-test"), errSuspiciousWorkerObservation,
+		"second call: defense surfaces the shrunk read fresh; rebalance floor MUST block "+
+			"pending emergency confirmation")
+	require.Equal(t, 10, calc.lastKnownWorkerCount,
+		"the floor MUST NOT advance the worker baseline")
+}
+
+// TestCalculator_F10A_FloorReleasedByEmergencyConfirmation drives T3:
+// the floor must release as soon as EmergencyDetector has captured
+// confirmed deaths into c.disappearedWorkers. The emergency rebalance
+// branch consumes that buffer (calculator.go's collectRebalanceWorkers
+// only clears it on lifecycle=="emergency"); the floor's check must
+// see the pre-clear state so an emergency rebalance is never wrongly
+// suppressed.
+func TestCalculator_F10A_FloorReleasedByEmergencyConfirmation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	calc, kv := setupF10ACalculator(t, ctx, 10, 10, 50)
+
+	// Populate disappearedWorkers as if EmergencyDetector confirmed
+	// deaths for 7 of the original 10.
+	calc.mu.Lock()
+	calc.disappearedWorkers = []string{
+		"worker-003", "worker-004", "worker-005",
+		"worker-006", "worker-007", "worker-008", "worker-009",
+	}
+	calc.mu.Unlock()
+
+	shrinkHeartbeatsToThree(t, ctx, kv)
+
+	require.NoError(t, calc.rebalance(ctx, "emergency"),
+		"the floor MUST release when c.disappearedWorkers has confirmed deaths; "+
+			"emergency rebalance must proceed and commit the new assignment")
+}
+
+// TestCalculator_F10A_CounterResetOnHealedRead drives T5: a single
+// suspicious observation advances the counter; a subsequent healthy
+// observation (no shrink) must reset it to 0 and advance the baseline.
+// A later shrink then needs the FULL confirmation window again.
+func TestCalculator_F10A_CounterResetOnHealedRead(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	calc, kv := setupF10ACalculator(t, ctx, 10, 3, 50)
+
+	shrinkHeartbeatsToThree(t, ctx, kv) // suspicious
+	workers, fresh, err := calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.False(t, fresh)
+	require.Len(t, workers, 10)
+	require.Equal(t, 1, calc.workerShrunkObservations)
+	require.Equal(t, 10, calc.lastKnownWorkerCount)
+
+	// Heal: restore back to 10 active heartbeats.
+	for i := 3; i < 10; i++ {
+		key := fmt.Sprintf("worker-hb.worker-%03d", i)
+		_, err := kv.Put(ctx, key, []byte(time.Now().Format(time.RFC3339Nano)))
+		require.NoError(t, err)
+	}
+
+	workers, fresh, err = calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.True(t, fresh, "healthy observation must be fresh")
+	require.Len(t, workers, 10)
+	require.Equal(t, 0, calc.workerShrunkObservations,
+		"healthy observation must reset the counter")
+
+	// A new shrink must consume the full confirmation window again.
+	shrinkHeartbeatsToThree(t, ctx, kv)
+	workers, fresh, err = calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.False(t, fresh)
+	require.Len(t, workers, 10)
+	require.Equal(t, 1, calc.workerShrunkObservations,
+		"new suspicious sequence must start from counter=0, NOT continue the prior one")
+}
+
+// TestCalculator_F10A_LegitimateMassDeath_ProceedsAfterConfirmation
+// drives T6: a real mass-death scenario (the emergency lifecycle has
+// populated disappearedWorkers with the missing names) MUST NOT be
+// suppressed by the floor. The composition with EmergencyDetector is
+// the load-bearing guarantee that legitimate large drops still get
+// served once detection has run.
+func TestCalculator_F10A_LegitimateMassDeath_ProceedsAfterConfirmation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	// ConfirmCount=1 collapses the defense to immediate acceptance so
+	// the floor takes over on the first call; this isolates the
+	// "emergency confirmation gate" behavior under test.
+	calc, kv := setupF10ACalculator(t, ctx, 10, 1, 50)
+
+	// First: shrink WITHOUT any emergency confirmation. Defense
+	// accepts immediately (ConfirmCount=1); floor blocks because no
+	// deaths confirmed.
+	shrinkHeartbeatsToThree(t, ctx, kv)
+	require.ErrorIs(t, calc.rebalance(ctx, "f10a-test"), errSuspiciousWorkerObservation,
+		"sanity: without emergency-confirmed deaths the floor fires")
+	require.Equal(t, 10, calc.lastKnownWorkerCount,
+		"sanity: floor MUST NOT advance the baseline")
+
+	// Now EmergencyDetector confirms the 7 missing workers (simulated
+	// by populating the buffer directly). The next emergency
+	// rebalance must proceed.
+	calc.mu.Lock()
+	calc.disappearedWorkers = []string{
+		"worker-003", "worker-004", "worker-005",
+		"worker-006", "worker-007", "worker-008", "worker-009",
+	}
+	calc.mu.Unlock()
+
+	require.NoError(t, calc.rebalance(ctx, "emergency"),
+		"the legitimate mass-death rebalance MUST proceed once "+
+			"EmergencyDetector has populated c.disappearedWorkers")
+	require.Equal(t, 3, calc.lastKnownWorkerCount,
+		"the confirmed shrink MUST advance the baseline to the new (3-worker) shape")
+}
+
+// TestCalculator_F10A_CrossFeatureCounterIsolation drives T7: the
+// F10-A counter and the P2.2 F6-B counter must NOT share state on the
+// same Calculator. A partition-suspicious observation must not
+// advance workerShrunkObservations and vice versa — the bug a single
+// shared counter would create is "either lifecycle's shrink fills the
+// other's confirmation window so the other never escalates".
+func TestCalculator_F10A_CrossFeatureCounterIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	calc, kv := setupF10ACalculator(t, ctx, 10, 3, 50)
+
+	// Sanity: both counters start at 0.
+	require.Equal(t, 0, calc.workerShrunkObservations)
+	require.Equal(t, 0, calc.partitionShrunkObservations)
+
+	// Partition-suspicious observation: shrink the source from 10 -> 2
+	// (80 % drop, past the 50 % threshold). Workers are unchanged.
+	src, ok := calc.Source.(*mutableSource)
+	require.True(t, ok)
+	src.set(makePartitions(2))
+
+	err := calc.rebalance(ctx, "f10a-test")
+	require.ErrorIs(t, err, errSuspiciousPartitionObservation,
+		"partition shrink must surface the partition-side sentinel")
+	require.Equal(t, 1, calc.partitionShrunkObservations,
+		"the partition counter must advance")
+	require.Equal(t, 0, calc.workerShrunkObservations,
+		"the worker counter MUST NOT advance on a partition-side suspicion")
+
+	// Restore source so the partition guard does not interfere.
+	src.set(makePartitions(10))
+	// Run a healthy rebalance to clear partitionShrunkObservations and
+	// re-seat the partition baseline at 10. Worker baseline already 10.
+	require.NoError(t, calc.rebalance(ctx, "f10a-test"))
+	require.Equal(t, 0, calc.partitionShrunkObservations)
+
+	// Worker-suspicious observation: shrink heartbeats from 10 -> 3.
+	shrinkHeartbeatsToThree(t, ctx, kv)
+	_, fresh, err := calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.False(t, fresh)
+	require.Equal(t, 1, calc.workerShrunkObservations,
+		"the worker counter must advance")
+	require.Equal(t, 0, calc.partitionShrunkObservations,
+		"the partition counter MUST NOT advance on a worker-side suspicion")
+}
+
+// TestCalculator_F10A_NoDoubleOwnershipAcrossTruncationWindow drives
+// T4 — the user-visible severity claim. Even across several
+// suspicious polls (defense degrading then accepting then being
+// floor-blocked), the calculator MUST NOT reassign the
+// apparently-missing workers' partitions to the survivors. The
+// double-ownership the spec's review §F10-A "severity is conditional"
+// section names — two workers (the original assignee, still up but
+// invisible in the scan, and a new assignee that took the partition
+// on a phantom reassign) — would surface as a 0-key entry for one of
+// workers 003..009 in currentAssignments after a published reassign.
+//
+// Assertion: currentAssignments retains entries for all original
+// workers (0..9) across the truncation window. On parent (no defense,
+// no floor): the first rebalance with a 3-worker view publishes a
+// reassign that removes 003..009 from currentAssignments, failing the
+// assertion.
+func TestCalculator_F10A_NoDoubleOwnershipAcrossTruncationWindow(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	calc, kv := setupF10ACalculator(t, ctx, 10, 2, 50)
+
+	// Sanity: after seed, every original worker is in
+	// currentAssignments (round-robin gave each one a partition).
+	calc.mu.RLock()
+	seedAssignmentCount := len(calc.currentAssignments)
+	calc.mu.RUnlock()
+	require.Equal(t, 10, seedAssignmentCount,
+		"sanity: seed rebalance must assign at least one partition to each of the 10 workers")
+
+	shrinkHeartbeatsToThree(t, ctx, kv)
+
+	// Drive WorkerShrinkConfirmationCount + extras to cover the
+	// degradation phase, the acceptance phase, and the floor-block
+	// repeats. None should reassign worker 003..009's partitions to
+	// workers 000..002.
+	const polls = 5
+	for i := range polls {
+		err := calc.rebalance(ctx, "f10a-test")
+		if err != nil {
+			require.ErrorIs(t, err, errSuspiciousWorkerObservation,
+				"poll %d: only errSuspiciousWorkerObservation is acceptable", i)
+		}
+	}
+
+	calc.mu.RLock()
+	postAssignmentCount := len(calc.currentAssignments)
+	missing := make([]string, 0, 10)
+	for i := range 10 {
+		key := fmt.Sprintf("worker-%03d", i)
+		if _, ok := calc.currentAssignments[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	calc.mu.RUnlock()
+
+	require.Equal(t, 10, postAssignmentCount,
+		"across the truncation window, currentAssignments must retain entries for "+
+			"all 10 original workers; missing=%v", missing)
+	require.Empty(t, missing,
+		"the floor + defense MUST prevent reassigning the apparently-missing "+
+			"workers' (003..009) partitions to the survivors (000..002); a missing entry "+
+			"is the double-ownership signature this PR closes")
+}

--- a/internal/assignment/config.go
+++ b/internal/assignment/config.go
@@ -69,6 +69,29 @@ type Config struct {
 	// regardless of this threshold.
 	PartitionShrinkConfirmationThresholdPct int
 
+	// Worker-input credibility (see errSuspiciousWorkerObservation Godoc
+	// in calculator.go):
+	//
+	// WorkerShrinkConfirmationCount is the number of consecutive
+	// suspicious worker-set observations the calculator requires before
+	// trusting a sharply-shrunk heartbeat scan. Default: 2. Setting this
+	// to 1 disables the confirmation window (every observation is acted
+	// on immediately). The default is lower than
+	// PartitionShrinkConfirmationCount because heartbeat scans run on
+	// every monitor poll (~HeartbeatTTL/2) whereas partition-source
+	// observations are watcher-driven and arrive only on source change —
+	// a smaller worker window converges faster on a real shrink without
+	// stranding correctness.
+	WorkerShrinkConfirmationCount int
+
+	// WorkerShrinkConfirmationThresholdPct defines "sharply shrunk" for
+	// the heartbeat scan. A new worker count where
+	//   observed * 100 < lastKnownWorkerCount * Pct
+	// is suspicious. Default: 50 (a >=50% drop in one scan is
+	// suspicious). The defense fires only when lastKnownWorkerCount > 0
+	// (the first ever scan is always trusted).
+	WorkerShrinkConfirmationThresholdPct int
+
 	// RebalanceGraceDrainInterval is the period at which monitorPartitions
 	// checks for a partition-source update that was deferred because the
 	// leader was in recovery grace. When grace lifts, the deferred update
@@ -197,5 +220,11 @@ func (c *Config) SetDefaults() {
 	}
 	if c.PartitionShrinkConfirmationThresholdPct == 0 {
 		c.PartitionShrinkConfirmationThresholdPct = 50
+	}
+	if c.WorkerShrinkConfirmationCount == 0 {
+		c.WorkerShrinkConfirmationCount = 2
+	}
+	if c.WorkerShrinkConfirmationThresholdPct == 0 {
+		c.WorkerShrinkConfirmationThresholdPct = 50
 	}
 }

--- a/test/integration/failure/heartbeat_truncated_keys_test.go
+++ b/test/integration/failure/heartbeat_truncated_keys_test.go
@@ -46,14 +46,17 @@ import (
 // load-bearing.
 //
 // Why a loop: the per-attempt outcome is probabilistic (the cancel must
-// race in between message-delivery and marker-send), but with the
-// per-attempt parameters chosen below the truncation rate is empirically
-// ~20%. The 100-attempt loop drives P(false-negative) to ~2e-10,
-// effectively deterministic at the assertion level. If truncation is
-// never observed across all 100 attempts on the parent commit, that is
-// itself a meaningful signal — either the nats.go behavior has changed
-// or the test environment has degraded — and the failure message gives
-// the operator the diagnostic counts to triage from.
+// race in between message-delivery and marker-send). Empirical hit rates
+// on developer hardware fall in the 20–60 % range depending on scheduler
+// load and `-race` overhead; calibrating against the upper end is
+// optimistic for CI, which is typically slower and more contended.
+// Sizing for the conservative case: at a 1 % per-attempt rate the
+// 500-attempt loop drives P(false-negative) to (0.99)^500 ≈ 6.6e-3, and
+// at the realistic 5 % the bound is (0.95)^500 ≈ 7e-12. If truncation
+// is never observed across all 500 attempts that is itself a meaningful
+// signal — either the nats.go behavior has changed or the test
+// environment cannot reproduce the race — and the failure message
+// reports the per-bucket counts so the operator can triage.
 func TestHeartbeatBucket_TruncatedKeysObservable(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
@@ -82,11 +85,12 @@ func TestHeartbeatBucket_TruncatedKeysObservable(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Sweep the cancel delay across 50µs..4ms. Different delays land in
-	// different points of the scan; the spread maximises the chance of
-	// hitting the post-first-message / pre-marker window across varied
-	// scheduler conditions.
-	const attempts = 100
+	// Sweep the cancel delay across ~50µs..10ms. Different delays land
+	// in different points of the scan; the wider spread hardens the
+	// reproducer against slow/contended CI where the post-first-
+	// message / pre-marker window falls outside the optimistic
+	// developer-hardware band.
+	const attempts = 500
 	var (
 		observedTruncated  int
 		observedFull       int
@@ -98,7 +102,7 @@ func TestHeartbeatBucket_TruncatedKeysObservable(t *testing.T) {
 	)
 
 	for i := range attempts {
-		delay := time.Duration(50+(i*39)) * time.Microsecond
+		delay := time.Duration(50+(i*20)) * time.Microsecond
 
 		ctx, cancel := context.WithCancel(t.Context())
 		time.AfterFunc(delay, cancel)

--- a/test/integration/failure/heartbeat_truncated_keys_test.go
+++ b/test/integration/failure/heartbeat_truncated_keys_test.go
@@ -1,0 +1,147 @@
+package failure_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/partitest"
+)
+
+// TestHeartbeatBucket_TruncatedKeysObservable is the diagnostic reproducer
+// (T0) for F10-A. Its passing IS the empirical observation that justifies
+// the worker-set shrink-confirmation defense in Calculator.getActiveWorkers
+// and the worker-set floor in rebalance.
+//
+// What it pins: nats.go's jetstream.KeyValue.Keys() can return
+// (partial-slice, nil) — a silently truncated read — when the per-call
+// context is cancelled after at least one entry has been delivered but
+// before the watcher's initial-pending marker. The mechanism, traced
+// against nats.go v1.50.0 source:
+//
+//   - jetstream/kv.go:1372-1393: Keys() ranges over watcher.Updates()
+//     and breaks on the nil marker; if the channel CLOSES before the
+//     marker, the for-range exits with whatever has been received so far.
+//   - jetstream/kv.go:1335-1339: SetClosedHandler closes the updates
+//     channel when the underlying subscription terminates.
+//   - js.go:2052-2058: a context-cancellation goroutine fires
+//     sub.Unsubscribe() the moment the watcher's nats.Context(ctx)
+//     cancels — propagating as a CLEAN subscription close, not an error
+//     visible through Updates().
+//
+// Together: ctx cancellation mid-scan tears the subscription down, the
+// closed-handler closes Updates(), Keys() compacts what it has, and
+// returns (partial, nil) at kv.go:1391-1392 without ever surfacing the
+// ctx error. Calculator code that trusts a (workers, nil) return as
+// fresh ground truth would then act on a phantom mass-disappearance.
+//
+// This test stays in the tree as a forward-observation pin: if a future
+// nats.go release closes this gap, the test FAILS (no truncation ever
+// observed), prompting a review of whether the F10-A defense is still
+// load-bearing.
+//
+// Why a loop: the per-attempt outcome is probabilistic (the cancel must
+// race in between message-delivery and marker-send), but with the
+// per-attempt parameters chosen below the truncation rate is empirically
+// ~20%. The 100-attempt loop drives P(false-negative) to ~2e-10,
+// effectively deterministic at the assertion level. If truncation is
+// never observed across all 100 attempts on the parent commit, that is
+// itself a meaningful signal — either the nats.go behavior has changed
+// or the test environment has degraded — and the failure message gives
+// the operator the diagnostic counts to triage from.
+func TestHeartbeatBucket_TruncatedKeysObservable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	kv, err := js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{
+		Bucket:  "heartbeat_trunc_probe",
+		History: 1,
+	})
+	require.NoError(t, err)
+
+	// Pre-populate the bucket with enough heartbeat keys that the scan
+	// cannot complete inside the cancel window. 500 was calibrated
+	// empirically on an embedded NATS / localhost path; smaller counts
+	// often complete before the cancel fires, larger counts add runtime
+	// without raising the per-attempt hit rate.
+	const totalKeys = 500
+	for i := range totalKeys {
+		key := fmt.Sprintf("hb.worker-%04d", i)
+		_, err := kv.PutString(t.Context(), key, "x")
+		require.NoError(t, err)
+	}
+
+	// Sweep the cancel delay across 50µs..4ms. Different delays land in
+	// different points of the scan; the spread maximises the chance of
+	// hitting the post-first-message / pre-marker window across varied
+	// scheduler conditions.
+	const attempts = 100
+	var (
+		observedTruncated  int
+		observedFull       int
+		observedNoKeys     int
+		observedCtxErr     int
+		observedOtherErr   int
+		minObservedPartial = totalKeys
+		maxObservedPartial int
+	)
+
+	for i := range attempts {
+		delay := time.Duration(50+(i*39)) * time.Microsecond
+
+		ctx, cancel := context.WithCancel(t.Context())
+		time.AfterFunc(delay, cancel)
+
+		keys, kerr := kv.Keys(ctx)
+		cancel()
+
+		switch {
+		case kerr != nil:
+			switch {
+			case errors.Is(kerr, jetstream.ErrNoKeysFound):
+				observedNoKeys++
+			case errors.Is(kerr, context.Canceled), errors.Is(kerr, context.DeadlineExceeded):
+				observedCtxErr++
+			default:
+				observedOtherErr++
+				t.Logf("attempt %d: unexpected err=%v (delay=%v)", i, kerr, delay)
+			}
+		case len(keys) == totalKeys:
+			observedFull++
+		case len(keys) > 0 && len(keys) < totalKeys:
+			observedTruncated++
+			if len(keys) < minObservedPartial {
+				minObservedPartial = len(keys)
+			}
+			if len(keys) > maxObservedPartial {
+				maxObservedPartial = len(keys)
+			}
+		default:
+			t.Logf("attempt %d: unclassified result len=%d err=%v", i, len(keys), kerr)
+		}
+	}
+
+	t.Logf("results over %d attempts: truncated=%d full=%d no-keys=%d ctx-err=%d other-err=%d",
+		attempts, observedTruncated, observedFull, observedNoKeys, observedCtxErr, observedOtherErr)
+	if observedTruncated > 0 {
+		t.Logf("truncated read sizes: min=%d max=%d (totalKeys=%d)",
+			minObservedPartial, maxObservedPartial, totalKeys)
+	}
+
+	require.Positive(t, observedTruncated,
+		"expected to observe at least one (partial, nil) result from Keys() over %d attempts; "+
+			"if this assertion fails, the nats.go truncation behavior has changed or the "+
+			"environment cannot reproduce the race. Counts: full=%d no-keys=%d ctx-err=%d other-err=%d",
+		attempts, observedFull, observedNoKeys, observedCtxErr, observedOtherErr)
+}


### PR DESCRIPTION
## Why

`nats.go`'s `KeyValue.Keys()` can return `(partial-slice, nil)` when the
underlying watcher subscription tears down mid-scan — an ordered-consumer
drop or per-call context cancellation between the first delivered key and
the initial-pending marker propagates as a clean `SetClosedHandler` close,
not as an error. A truncated scan that looks identical to a real
fleet-wide worker disappearance lets the leader reassign live workers'
partitions to the survivors, producing transient double ownership during
the truncation window.

Empirically reproduced: at 500 pre-populated heartbeat keys + varying
ctx-cancel delays, ~58 of 100 attempts observe `(partial, nil)` under
`-race` on this nats.go version.

## What

Two composing defenses sit between the heartbeat scan and the publish step:

1. **In-getActiveWorkers defense.** A sharply-shrunk fresh scan is treated
   as suspicious for a confirmation window (`WorkerShrinkConfirmationCount`,
   default 2). The first such reads degrade to the cached worker set with
   `fresh=false`. The last-known worker baseline is never advanced on a
   suspicious read.
2. **Rebalance-side floor.** Once the defense surfaces an accepted shrink,
   `rebalance` refuses to commit unless `EmergencyDetector` has populated
   `disappearedWorkers` across its grace window. The floor and the defense
   compose with the existing partition-input guard and `EmergencyDetector`
   without duplicating either — the worker baseline advances only after the
   floor passes, anchoring future floor checks against a baseline confirmed
   by a prior successful rebalance.

State is fenced by `c.mu` because `getActiveWorkers` is called from both
the rebalance path (under `rebalanceMu`) and the worker-monitor poll path
(under `pollMu`); those locks are independent.

## Test plan

- [x] T0 chaos reproducer at `test/integration/failure/heartbeat_truncated_keys_test.go` pins the nats.go truncation behavior as a forward-observation regression gate; passes on the parent commit (58/100 truncated observed under -race).
- [x] T1..T7 unit suite at `internal/assignment/calculator_f10a_worker_floor_test.go` covers the defense/floor composition, the emergency-confirmation release, the no-double-ownership invariant across the truncation window, counter reset on healed reads, the legitimate-mass-death path, and cross-feature counter isolation from the partition-input guard.
- [x] `make lint` clean.
- [x] `go test -count=1 -race ./...` green across every package including all `test/integration/*` directories.

## Spec

`docs/plans/self-healing/00-fix-plan.md`. Post-implementation review report at `tmp/self-healing-fix-plan_P2.5_post_implementation_review_v1.md` (not committed) — verdict MERGE, zero P0/P1/P2.