### PR TITLE
feat(source): recover recreated buckets, skip unchanged reconcile decodes

### DIFF
--- a/internal/partcodec/partcodec_test.go
+++ b/internal/partcodec/partcodec_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 
@@ -179,6 +180,28 @@ func TestDecode_EmptyInput(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			require.Empty(t, result)
+		})
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	for _, n := range []int{100, 10000, 100000} {
+		parts := make([]types.Partition, n)
+		for i := range parts {
+			parts[i] = types.Partition{Keys: []string{fmt.Sprintf("part-%08d", i)}, Weight: 1}
+		}
+		data, err := Encode(parts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := Decode(data); err != nil {
+					b.Fatal(err)
+				}
+			}
 		})
 	}
 }

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -75,6 +75,9 @@ type NatsKVOption func(*NatsKV)
 // line when this state is detected so the operational consequence is
 // visible at first deploy.
 //
+// Disabling the reconciler also disables bucket delete+recreate recovery:
+// see reconcileOnce for the recovery boundary.
+//
 // Parameters:
 //   - d: Reconcile interval (0 disables; default 30s)
 //
@@ -217,17 +220,39 @@ type NatsKV struct {
 	mu         sync.RWMutex
 	partitions []types.Partition
 	revision   uint64 // last observed KV revision
-	known      bool   // false only before any KV event; true once any event arrives (including delete/purge)
-	watcher    jetstream.KeyWatcher
-	ctx        context.Context    //nolint:containedctx // lifecycle context stored by design
-	cancel     context.CancelFunc //nolint:containedctx // paired with ctx
-	running    bool
-	listeners  []*natsKVListener
-	wg         sync.WaitGroup // tracks all source-owned goroutines; Stop waits on this
+	// applyGen increments under s.mu every time applyLocalLocked accepts an entry
+	// (passes the stale gate), regardless of whether content changed. It lets the
+	// reconcile reset path detect that local state advanced between its
+	// confirmatory read and the reset lock — even when the new value lands at a
+	// revision numerically equal to the old baseline (the bucket-recreate ABA),
+	// which a revision-number comparison alone cannot distinguish.
+	applyGen  uint64
+	known     bool // false only before any KV event; true once any event arrives (including delete/purge)
+	watcher   jetstream.KeyWatcher
+	ctx       context.Context    //nolint:containedctx // lifecycle context stored by design
+	cancel    context.CancelFunc //nolint:containedctx // paired with ctx
+	running   bool
+	listeners []*natsKVListener
+	wg        sync.WaitGroup // tracks all source-owned goroutines; Stop waits on this
 
 	// watchFn is the constructor used to start a KV watcher. Tests may replace
 	// this field to inject a fake watcher. Production code uses kv.Watch.
 	watchFn func(ctx context.Context) (jetstream.KeyWatcher, error)
+
+	// decodeFn decodes a KV value into a partition list. Indirected through a
+	// field (like watchFn) so tests can observe decode invocations. Production
+	// uses partcodec.Decode.
+	decodeFn func(data []byte) ([]types.Partition, error)
+
+	// Reconcile skip-guard cache. Accessed ONLY by reconcileOnce, which runs on
+	// the single reconcileLoop goroutine, so these need no mutex. They identify
+	// the last entry this loop applied so an unchanged tick can skip the decode.
+	// The pair (rev, created) — not rev alone — is required: a recreated bucket
+	// reuses revision numbers from 1, but the entry creation timestamp does not
+	// collide across a real recreate.
+	reconcileRev     uint64
+	reconcileCreated time.Time
+	reconcileKnown   bool
 
 	// onReconcileTick is called after each reconcile tick with the interval that
 	// was scheduled for that tick. It is nil in production and set by tests that
@@ -298,6 +323,7 @@ func NewNatsKV(kv jetstream.KeyValue, key string, logger types.Logger, opts ...N
 	s.watchFn = func(ctx context.Context) (jetstream.KeyWatcher, error) {
 		return s.kv.Watch(ctx, s.key)
 	}
+	s.decodeFn = partcodec.Decode
 	for _, o := range opts {
 		o(s)
 	}
@@ -756,8 +782,15 @@ func (s *NatsKV) RemovePartitions(ctx context.Context, partitions ...types.Parti
 // It sorts the incoming partitions, diffs against the current state, updates
 // s.partitions/s.revision/s.known atomically, and fans out to listeners if
 // notify is true and the state actually changed.
-func (s *NatsKV) applyLocal(partitions []types.Partition, revision uint64, notify bool) {
+//
+// It returns whether the entry was accepted (passed the stale gate and became
+// the current revision). The reconcile path uses this to update its skip cache
+// only with entries that were actually applied — recording a gate-dropped entry
+// would let the skip-guard wrongly skip a later re-read of that same identity.
+// Other callers ignore the result.
+func (s *NatsKV) applyLocal(partitions []types.Partition, revision uint64, notify bool) bool {
 	s.mu.Lock()
+	accepted := revision == 0 || revision >= s.revision
 	changed := s.applyLocalLocked(partitions, revision, true)
 	listeners := s.listeners
 	if notify && changed {
@@ -770,6 +803,126 @@ func (s *NatsKV) applyLocal(partitions []types.Partition, revision uint64, notif
 		}
 	}
 	s.mu.Unlock()
+
+	return accepted
+}
+
+// markReconcileApplied records the entry identity the reconcile loop last
+// accepted, for the next tick's skip-guard. Called ONLY after an apply that was
+// actually accepted (never after a dropped or unconfirmed entry). Reconcile-loop
+// goroutine only; no lock.
+func (s *NatsKV) markReconcileApplied(revision uint64, created time.Time) {
+	s.reconcileRev = revision
+	s.reconcileCreated = created
+	s.reconcileKnown = true
+}
+
+// applyReconcileReset accepts an entry that a confirmatory reconcile read has
+// proven belongs to a new bucket incarnation (its revision is below the baseline
+// we observed before the confirmatory read, yet it is the current latest). It
+// clears the stale-gate baseline under the lock so the lower revision is
+// accepted, then fans out exactly like applyLocal. The shared
+// watcher/Update/Start paths are unaffected.
+//
+// baseline/gen are s.revision and s.applyGen as observed before the confirmatory
+// read. The baseline clear is applied ONLY if s.applyGen is still gen — i.e. no
+// apply has been accepted in between. A revision check alone is insufficient: a
+// recreated bucket can advance back to a revision numerically equal to the old
+// baseline (the ABA case), so s.revision == baseline can hold even though local
+// state already moved to newer recreated content. If anything was accepted in
+// the window we must NOT bypass the stale gate; we fall through to a normal gated
+// apply that drops the lower revision instead of rolling state backward.
+//
+// It returns whether the entry was accepted (the reset cleared the baseline, or
+// the fall-through gated apply still accepted it), so the caller updates its skip
+// cache only on a real apply.
+func (s *NatsKV) applyReconcileReset(partitions []types.Partition, revision, baseline, gen uint64) bool {
+	s.mu.Lock()
+	if s.revision == baseline && s.applyGen == gen {
+		s.revision = 0 // confirmed incarnation reset: drop baseline so the lower revision applies
+	}
+	accepted := revision == 0 || revision >= s.revision
+	changed := s.applyLocalLocked(partitions, revision, true)
+	listeners := s.listeners
+	if changed {
+		for _, l := range listeners {
+			select {
+			case l.ch <- struct{}{}:
+			default:
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	return accepted
+}
+
+// applyReconcileEntry applies a freshly fetched reconcile entry, handling bucket
+// incarnation reset. A reconcile kv.Get returns the current latest revision, so
+// an entry revision below our cached baseline is ambiguous: a stale read racing
+// a concurrent Update (same incarnation), or a deleted+recreated bucket. We
+// disambiguate with ONE confirmatory latest read before bypassing the stale
+// gate; we never roll state back on a single possibly-stale read.
+func (s *NatsKV) applyReconcileEntry(ctx context.Context, partitions []types.Partition, entry jetstream.KeyValueEntry) {
+	s.mu.RLock()
+	cachedRev := s.revision
+	cachedGen := s.applyGen
+	s.mu.RUnlock()
+
+	if entry.Revision() == 0 || entry.Revision() >= cachedRev {
+		// Not backwards: ordinary apply (stale gate no-ops on equal/higher).
+		// Update the skip cache only if the gate accepted the entry: a concurrent
+		// writer may have advanced s.revision past it, in which case it was dropped
+		// and must not be recorded as applied.
+		if s.applyLocal(partitions, entry.Revision(), true) {
+			s.markReconcileApplied(entry.Revision(), entry.Created())
+		}
+
+		return
+	}
+
+	// Backwards revision: confirm with one authoritative latest read.
+	confirm, err := s.kv.Get(ctx, s.key)
+	if err != nil {
+		// Cannot confirm: do not guess, do not update the skip cache. The next
+		// tick re-evaluates. Mirror reconcileOnce's bucket-missing posture.
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return
+		}
+		if s.noteBucketUnavailable(err) {
+			s.logError("reconcile: confirmatory read found bucket missing", "error", err)
+		}
+
+		return
+	}
+	confirmParts, decErr := s.decodeFn(confirm.Value())
+	if decErr != nil {
+		s.logError("reconcile: failed to decode confirmatory entry", "error", decErr)
+
+		return
+	}
+
+	// Compare the confirmed latest against the pre-confirm baseline (cachedRev),
+	// NOT the live s.revision. In a single incarnation the latest revision only
+	// grows, so a confirmed latest below cachedRev can only mean the bucket was
+	// recreated. Using live s.revision here would misread a concurrent
+	// same-incarnation Update (which advances s.revision past the confirmed
+	// revision) as a reset and roll state backward.
+	var accepted bool
+	if confirm.Revision() != 0 && confirm.Revision() < cachedRev {
+		// Confirmed latest is below the prior baseline -> genuine incarnation reset.
+		accepted = s.applyReconcileReset(confirmParts, confirm.Revision(), cachedRev, cachedGen)
+	} else {
+		// First read was stale (a concurrent writer advanced the revision);
+		// apply the confirmed latest through the normal gate.
+		accepted = s.applyLocal(confirmParts, confirm.Revision(), true)
+	}
+	// Record the entry in the skip cache only if it was actually applied. A
+	// dropped confirm that is still the latest readable entry would otherwise
+	// make the next tick's skip-guard skip it forever (recovery never happens).
+	if accepted {
+		s.markReconcileApplied(confirm.Revision(), confirm.Created())
+	}
 }
 
 // applyLocalLocked applies partition state while the caller already holds s.mu.
@@ -807,6 +960,7 @@ func (s *NatsKV) applyLocalLocked(partitions []types.Partition, revision uint64,
 	}
 	s.revision = revision
 	s.known = known
+	s.applyGen++ // entry accepted: advance the apply generation (see field doc)
 
 	return changed
 }
@@ -1019,6 +1173,13 @@ func (s *NatsKV) nextReconcileInterval() time.Duration {
 // reconcileOnce performs a single reconcile pass: reads KV, decodes, and calls
 // applyLocal so that missed watcher events are recovered. If the local state
 // already matches KV, this is a no-op (no listener signal emitted).
+//
+// Bucket delete+recreate recovery is reconcile-driven. After an operator
+// deletes and recreates the source bucket, its revision namespace resets to 1;
+// the watcher may transiently drop that recreated rev-1 value through the stale
+// gate, but a later reconcile tick re-applies it via applyReconcileEntry's
+// confirmatory read. With WithReconcileInterval(0) and no leadership probe the
+// reconciler is disabled, so bucket-recreate recovery does not occur.
 func (s *NatsKV) reconcileOnce(ctx context.Context) {
 	entry, err := s.kv.Get(ctx, s.key)
 	if err != nil {
@@ -1030,6 +1191,7 @@ func (s *NatsKV) reconcileOnce(ctx context.Context) {
 			// the delete event with the correct revision. Only the
 			// initial-never-written case (known=false) leaves state unchanged.
 			s.applyEmptyPreservingKnown()
+			s.reconcileKnown = false // empty state: invalidate the skip cache
 
 			return
 		}
@@ -1044,16 +1206,26 @@ func (s *NatsKV) reconcileOnce(ctx context.Context) {
 		return
 	}
 
-	partitions, err := partcodec.Decode(entry.Value())
+	// Successful kv.Get confirms the bucket is reachable.
+	s.noteBucketAvailable()
+
+	// Skip the decode when this entry is the one we last applied. Match on
+	// (revision, created): revision alone is unsafe because a recreated bucket
+	// reuses revision numbers, while the creation timestamp does not collide
+	// across a real recreate. reconcileKnown==false (first tick) never skips.
+	if s.reconcileKnown &&
+		entry.Revision() == s.reconcileRev &&
+		entry.Created().Equal(s.reconcileCreated) {
+		return
+	}
+
+	partitions, err := s.decodeFn(entry.Value())
 	if err != nil {
 		s.logError("reconcile: failed to decode partitions", "error", err)
 
 		return
 	}
-
-	// Successful kv.Get confirms the bucket is reachable.
-	s.noteBucketAvailable()
-	s.applyLocal(partitions, entry.Revision(), true)
+	s.applyReconcileEntry(ctx, partitions, entry)
 }
 
 // refreshFromKV reads the current entry from KV and updates the local revision

--- a/source/nats_kv_test.go
+++ b/source/nats_kv_test.go
@@ -1356,3 +1356,324 @@ func (e *fakeKVEntry) Revision() uint64                { return e.revision }
 func (e *fakeKVEntry) Created() time.Time              { return e.created }
 func (e *fakeKVEntry) Delta() uint64                   { return e.delta }
 func (e *fakeKVEntry) Operation() jetstream.KeyValueOp { return e.op }
+
+func TestReconcileOnce_SkipsDecodeWhenEntryUnchanged(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "partitions_reconcile_skip"})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	var decodeCalls atomic.Int64
+	src.decodeFn = func(data []byte) ([]types.Partition, error) {
+		decodeCalls.Add(1)
+		return partcodec.Decode(data)
+	}
+
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"p1"}, Weight: 1}}))
+	src.reconcileOnce(ctx) // prime cache
+	baseline := decodeCalls.Load()
+	// The priming reconcile must have decoded through the seam exactly once;
+	// otherwise reconcileOnce bypassed s.decodeFn and this test proves nothing.
+	require.Equal(t, int64(1), baseline, "priming reconcile must decode through the seam")
+
+	for range 5 {
+		src.reconcileOnce(ctx)
+	}
+	if got := decodeCalls.Load(); got != baseline {
+		t.Fatalf("expected no additional decodes across 5 unchanged ticks; baseline=%d got=%d", baseline, got)
+	}
+	parts, _ := src.List(ctx)
+	if len(parts) != 1 || parts[0].Keys[0] != "p1" {
+		t.Fatalf("state corrupted: %+v", parts)
+	}
+}
+
+func TestReconcileOnce_AppliesEqualRevisionRecreate(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	const bucket = "partitions_reconcile_recreate_eq"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	var decodeCalls atomic.Int64
+	src.decodeFn = func(data []byte) ([]types.Partition, error) {
+		decodeCalls.Add(1)
+		return partcodec.Decode(data)
+	}
+
+	// A as the FIRST and only write -> revision 1, s.revision == 1.
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A"}, Weight: 1}}))
+	src.reconcileOnce(ctx) // prime cache (rev1, createdA)
+
+	// Recreate same bucket; write B as first value -> revision 1 again, later Created.
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+	kv2, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	data, err := partcodec.Encode([]types.Partition{{Keys: []string{"B"}, Weight: 1}})
+	require.NoError(t, err)
+	rev, err := kv2.Put(ctx, "partitions", data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), rev, "precondition: want recreated first value at rev 1")
+
+	before := decodeCalls.Load()
+	// Bounded poll: the source's s.kv handle may observe the recreate with
+	// propagation delay (mirror the F6A recovery wait, not a fixed sleep).
+	require.Eventually(t, func() bool {
+		src.reconcileOnce(ctx)
+		parts, _ := src.List(ctx)
+		return len(parts) == 1 && parts[0].Keys[0] == "B"
+	}, 3*time.Second, 50*time.Millisecond, "equal-rev recreate not applied; want [B]")
+
+	if decodeCalls.Load() == before {
+		t.Fatal("reconcile skipped the recreated value (created-time guard missing)")
+	}
+}
+
+func TestReconcileOnce_RecoversRecreateWithHigherOldRevision(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	const bucket = "partitions_reconcile_recreate_hi"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	// Two writes -> s.revision == 2.
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A"}, Weight: 1}}))
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A2"}, Weight: 1}}))
+	src.reconcileOnce(ctx) // prime cache
+
+	// Recreate same bucket; B becomes revision 1 in the new incarnation.
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+	kv2, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	data, err := partcodec.Encode([]types.Partition{{Keys: []string{"B"}, Weight: 1}})
+	require.NoError(t, err)
+	rev, err := kv2.Put(ctx, "partitions", data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), rev, "precondition: want rev 1")
+
+	// Recovery tick (watcher never started -> reconcile is the only path).
+	// Bounded poll mirroring the F6A wait pattern if propagation lags.
+	require.Eventually(t, func() bool {
+		src.reconcileOnce(ctx)
+		parts, _ := src.List(ctx)
+		return len(parts) == 1 && parts[0].Keys[0] == "B"
+	}, 3*time.Second, 50*time.Millisecond, "recreate-with-higher-old-revision not recovered; want [B]")
+}
+
+func TestReconcileOnce_DoesNotRegressOnConcurrentUpdate(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "partitions_reconcile_race"})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"v1"}, Weight: 1}}))
+	// IMPORTANT: do NOT prime the reconcile skip cache here. The seeding Update
+	// leaves reconcileKnown=false (only reconcileOnce sets it), so the single
+	// reconcileOnce below does NOT take the skip-guard early return — it reaches
+	// the decode, where the seam injects the concurrent write. (Priming first
+	// would make the tick skip at the guard and the injection would never fire —
+	// the test would prove nothing.)
+	var injected atomic.Bool
+	src.decodeFn = func(data []byte) ([]types.Partition, error) {
+		// Fires during reconcileOnce, AFTER its kv.Get captured the rev-1 entry
+		// but BEFORE applyReconcileEntry reads s.revision. Simulates a concurrent
+		// writer committing v2 (advancing s.revision to 2) mid-reconcile. Runs on
+		// the reconcile goroutine, OUTSIDE s.mu (reconcileOnce calls decodeFn
+		// before taking any lock), so the reentrant Update cannot deadlock.
+		if injected.CompareAndSwap(false, true) {
+			if err := src.Update(ctx, []types.Partition{{Keys: []string{"v2"}, Weight: 1}}); err != nil {
+				t.Errorf("injected update: %v", err)
+			}
+		}
+		return partcodec.Decode(data)
+	}
+
+	src.reconcileOnce(ctx) // fetched rev1, but s.revision becomes 2 mid-flight
+
+	parts, _ := src.List(ctx)
+	if len(parts) != 1 || parts[0].Keys[0] != "v2" {
+		t.Fatalf("reconcile regressed to a stale same-incarnation read; want [v2], got %+v", parts)
+	}
+}
+
+// TestReconcileOnce_DoesNotRegressOnSecondConcurrentUpdate drives the harder
+// TOCTOU: a SECOND same-incarnation Update lands AFTER the confirmatory kv.Get
+// returns but BEFORE the reset decision. The confirmed entry (rev2) is below the
+// now-live s.revision (rev3) yet it is NOT a bucket reset — it must not roll
+// state back to rev2. The reset decision must key off the pre-confirm baseline
+// (cachedRev), not the moving live revision.
+func TestReconcileOnce_DoesNotRegressOnSecondConcurrentUpdate(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "partitions_reconcile_race2"})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"v1"}, Weight: 1}}))
+
+	// decodeFn fires twice in the backwards path: decode #1 is reconcileOnce's
+	// decode of the fetched rev1 entry; decode #2 is applyReconcileEntry's decode
+	// of the confirmatory read. Inject one Update on each, advancing s.revision to
+	// 2 then 3, both OUTSIDE s.mu (reconcile holds no lock across either decode),
+	// so the reentrant Updates cannot deadlock.
+	var n atomic.Int64
+	src.decodeFn = func(data []byte) ([]types.Partition, error) {
+		switch n.Add(1) {
+		case 1:
+			if err := src.Update(ctx, []types.Partition{{Keys: []string{"v2"}, Weight: 1}}); err != nil {
+				t.Errorf("inject v2: %v", err)
+			}
+		case 2:
+			if err := src.Update(ctx, []types.Partition{{Keys: []string{"v3"}, Weight: 1}}); err != nil {
+				t.Errorf("inject v3: %v", err)
+			}
+		}
+
+		return partcodec.Decode(data)
+	}
+
+	src.reconcileOnce(ctx)
+
+	parts, rev, _, _ := src.Snapshot(ctx)
+	if len(parts) != 1 || parts[0].Keys[0] != "v3" {
+		t.Fatalf("reconcile rolled back a newer same-incarnation update; want [v3], got %+v", parts)
+	}
+	require.Equal(t, uint64(3), rev, "revision must not regress below the latest committed update")
+}
+
+// TestReconcileOnce_DoesNotRollBackOnRecreateBaselineABA drives the ABA race in
+// the reset path: the bucket is recreated (revisions restart at 1), reconcile's
+// confirmatory read captures the recreated rev-1 value, but before the reset
+// lock is taken a concurrent Modify advances the NEW incarnation back to a
+// revision numerically equal to the old baseline and applies it locally. A
+// numeric-only baseline recheck cannot tell the new incarnation's rev-2 apart
+// from the old baseline rev-2, so it would clear the gate and roll the newer
+// recreated content back to the stale confirmed rev-1. The reset must detect
+// that local state advanced (via an apply-generation token) and decline.
+func TestReconcileOnce_DoesNotRollBackOnRecreateBaselineABA(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	const bucket = "partitions_reconcile_aba"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	// Old incarnation reaches revision 2.
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A"}, Weight: 1}}))
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A2"}, Weight: 1}}))
+	src.reconcileOnce(ctx) // prime cache at rev2
+
+	// Recreate the bucket so the new first value B is revision 1.
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+	kv2, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	data, err := partcodec.Encode([]types.Partition{{Keys: []string{"B"}, Weight: 1}})
+	require.NoError(t, err)
+	rev, err := kv2.Put(ctx, "partitions", data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), rev, "precondition: recreated first value at rev 1")
+
+	// decodeFn fires twice in the backwards path: decode #1 is reconcileOnce's
+	// decode of the fetched rev-1 entry; decode #2 is the confirmatory decode,
+	// which runs AFTER the confirmatory kv.Get captured rev 1 but BEFORE the reset
+	// lock. Injecting Modify on decode #2 advances the NEW incarnation to rev 2
+	// (== old baseline) and applies [C] locally, reproducing the ABA window.
+	var n atomic.Int64
+	src.decodeFn = func(d []byte) ([]types.Partition, error) {
+		if n.Add(1) == 2 {
+			if err := src.Modify(ctx, func(_ []types.Partition) []types.Partition {
+				return []types.Partition{{Keys: []string{"C"}, Weight: 1}}
+			}); err != nil {
+				t.Errorf("inject modify: %v", err)
+			}
+		}
+
+		return partcodec.Decode(d)
+	}
+
+	src.reconcileOnce(ctx)
+
+	parts, gotRev, _, _ := src.Snapshot(ctx)
+	if len(parts) != 1 || parts[0].Keys[0] != "C" {
+		t.Fatalf("reset rolled the recreated bucket back to a stale revision; want [C], got %+v", parts)
+	}
+	require.Equal(t, uint64(2), gotRev, "revision must reflect the newer recreated-bucket write, not the stale confirm")
+}
+
+// TestReconcileOnce_RecoversAfterNoOpApplyInResetWindow guards against skip-cache
+// poisoning. An accepted-but-no-op apply (e.g. a watcher re-delivering the old
+// baseline revision) lands in the reset window and advances the apply generation
+// without changing state, so the reset declines this tick and the confirmed
+// recreate value is gate-dropped. The reconcile skip cache must NOT record that
+// dropped value: if it did, the next tick — seeing the same (revision, created)
+// — would skip decode entirely and the source would stay permanently stuck on
+// the stale state. A subsequent reconcile tick must still recover the recreate.
+func TestReconcileOnce_RecoversAfterNoOpApplyInResetWindow(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	const bucket = "partitions_reconcile_noop_window"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(0))
+
+	// Old incarnation reaches revision 2 with content [A2].
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A"}, Weight: 1}}))
+	require.NoError(t, src.Update(ctx, []types.Partition{{Keys: []string{"A2"}, Weight: 1}}))
+	src.reconcileOnce(ctx) // prime cache at rev2 / [A2]
+
+	// Recreate so the new first value B is revision 1.
+	require.NoError(t, js.DeleteKeyValue(ctx, bucket))
+	kv2, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	data, err := partcodec.Encode([]types.Partition{{Keys: []string{"B"}, Weight: 1}})
+	require.NoError(t, err)
+	rev, err := kv2.Put(ctx, "partitions", data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), rev, "precondition: recreated first value at rev 1")
+
+	// On the confirmatory decode (call #2), inject an accepted no-op re-apply of
+	// the old baseline revision (rev 2, same [A2] content). It advances applyGen
+	// without changing state, so the reset for this tick is declined.
+	var n atomic.Int64
+	src.decodeFn = func(d []byte) ([]types.Partition, error) {
+		if n.Add(1) == 2 {
+			src.applyLocal([]types.Partition{{Keys: []string{"A2"}, Weight: 1}}, 2, true)
+		}
+
+		return partcodec.Decode(d)
+	}
+
+	src.reconcileOnce(ctx) // reset declined this tick; must not poison the skip cache
+
+	// Subsequent reconcile ticks must still recover the recreated value.
+	require.Eventually(t, func() bool {
+		src.reconcileOnce(ctx)
+		parts, _ := src.List(ctx)
+		return len(parts) == 1 && parts[0].Keys[0] == "B"
+	}, 3*time.Second, 50*time.Millisecond, "recreate recovery permanently blocked by skip-cache poisoning")
+}


### PR DESCRIPTION
## Summary

Two related changes to the NATS KV partition source's periodic reconcile path (`source/nats_kv.go`):

- **Decode-skip (behavior-preserving):** `reconcileOnce` no longer re-decodes the whole partition table on every tick when the KV entry is unchanged. The last-applied entry identity is cached as `(revision, created)` and the decode is skipped on a match. The pair is required because a recreated bucket reuses revision numbers from 1 while the creation timestamp does not collide — a revision-only guard would regress the equal-rev recreate case `main` already handles.
- **Bucket-recreate recovery:** a deleted-and-recreated source bucket restarts its revision namespace at 1, so the first new value was previously dropped by the stale gate whenever the old revision was > 1, stranding the source on stale partitions. `reconcileOnce` now confirms a backwards revision with one authoritative second `Get` before bypassing the stale gate, distinguishing a genuine recreate from a stale read racing a concurrent local write. The bypass is keyed on the pre-confirm revision baseline and an apply-generation token (so a concurrent writer — including a recreate that climbs back to the old numeric revision — cannot roll state back), and the reconcile skip cache is updated only for entries that were actually applied (so a dropped confirm can never permanently stall recovery).

The shared `applyLocalLocked` stale gate, watcher path, `Update`/`Modify`/`Start`, and bucket-missing escalation are untouched. Source-only change; no cross-feature contract impact.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` (unit, `-race`) — pass
- [x] `make test-integration` (live-NATS, `-race`) — all 11 packages pass
- [x] New white-box reconcile tests: steady-state skip, equal-rev recreate, higher-old-rev recreate recovery, two same-incarnation race regressions, recreate-baseline ABA, no-op-in-reset-window recovery
- [x] `BenchmarkDecode` quantifies the per-tick decode cost the skip-guard avoids
- [x] Recovery boundary documented on `reconcileOnce` / `WithReconcileInterval`