### PR TITLE
Unservable-consumer notification + handoff stuck-commit fix + test reliability

### DIFF
--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -246,6 +246,17 @@ type DynamicConfig struct {
 	// for the option form and the full trade-off discussion.
 	OnPermanentFailure func(subject string, err error)
 
+	// OnConsumerUnservable is the non-terminal app-facing seam fired while a
+	// partition consumer exists but its raft group is unavailable past
+	// UnservableWindow (a NATS-operator condition parti cannot self-heal). The
+	// loop keeps retrying. See [WithOnConsumerUnservable].
+	OnConsumerUnservable func(subject string, err error)
+
+	// UnservableWindow is how long the unservable condition must persist before
+	// OnConsumerUnservable fires. Zero uses the recovery default (10s).
+	// See [WithConsumerUnservableThreshold].
+	UnservableWindow time.Duration
+
 	// RecoveryRetry tunes the bounded-retry envelope wrapped around
 	// the iterator-creation path and the stream-missing Site B
 	// detour. Zero-valued fields fall back to the durable layer's
@@ -352,6 +363,8 @@ func NewDynamic(
 		RecoveryStrategy:            o.recoveryStrategy,
 		StreamMissingHook:           o.streamMissingHook,
 		OnPermanentFailure:          o.onPermanentFailure,
+		OnConsumerUnservable:        o.onConsumerUnservable,
+		UnservableWindow:            o.consumerUnservableWindow,
 		RecoveryRetry:               o.recoveryRetry,
 	}
 
@@ -408,7 +421,11 @@ func NewDynamic(
 		// SetOnStreamMissingError) at fire time, so a Manager.Start call
 		// occurring AFTER NewDynamic still reaches the durable layer.
 		OnPermanentFailure: d.onPermanentFailure,
-		OnStreamRecreated:  d.resetCompatCheck,
+		// OnConsumerUnservable is a direct user callback (no manager-observer
+		// fallback like OnPermanentFailure), so it is forwarded as-is.
+		OnUnservable:      cfg.OnConsumerUnservable,
+		UnservableWindow:  cfg.UnservableWindow,
+		OnStreamRecreated: d.resetCompatCheck,
 		Retry: durable.RetryConfig{
 			Backoff:    cfg.Retry.Backoff,
 			Max:        cfg.Retry.Max,

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -196,6 +196,8 @@ type options struct {
 	partitionRefreshMinInterval time.Duration
 	streamMissingHook           types.StreamMissingHook
 	onPermanentFailure          func(subject string, err error)
+	onConsumerUnservable        func(subject string, err error)
+	consumerUnservableWindow    time.Duration
 	recoveryRetry               RecoveryRetryConfig
 }
 
@@ -519,6 +521,48 @@ func WithStreamMissingHook(hook types.StreamMissingHook) DynamicOption {
 func WithOnPermanentFailure(fn func(subject string, err error)) DynamicOption {
 	return dynamicOpt(func(o *options) {
 		o.onPermanentFailure = fn
+	})
+}
+
+// WithOnConsumerUnservable installs a non-terminal callback fired while a
+// dynamic partition consumer EXISTS but its raft group is unavailable (a 503 /
+// "JetStream system temporarily unavailable" / no-quorum / leaderless condition)
+// while the NATS connection is up, sustained past the unservable window
+// (see [WithConsumerUnservableThreshold], default 10s).
+//
+// This is the signal that parti cannot self-heal the consumer — the NATS cluster
+// itself needs operator recovery (e.g. restore crashed nodes / restore quorum).
+// Parti keeps retrying regardless, so delivery resumes automatically once the
+// operator restores NATS; an INFO "recovered" line is logged when it does.
+//
+// Distinct from [WithOnPermanentFailure]:
+//   - OnPermanentFailure is TERMINAL — fired once just before the consume loop
+//     exits on iterator-creation retry exhaustion / stream-missing.
+//   - OnConsumerUnservable is NON-TERMINAL — fired (rate-limited, re-fired while
+//     the condition persists) without stopping the loop.
+//
+// Setting one does not enable or disable the other; OnConsumerUnservable does not
+// alter OnPermanentFailure's interaction with the manager auto-degraded route.
+//
+// The callback runs on the consumption loop's goroutine and MUST be non-blocking;
+// offload long work (e.g. raising an alert) to a goroutine. The err preserves the
+// underlying cause. Applies only to [Dynamic].
+func WithOnConsumerUnservable(fn func(subject string, err error)) DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.onConsumerUnservable = fn
+	})
+}
+
+// WithConsumerUnservableThreshold sets how long the unservable condition must
+// persist continuously before [WithOnConsumerUnservable] fires. The default
+// (10s) comfortably exceeds NATS leader-election + raft settle, so normal
+// election churn never trips the signal. Raise it for slower clusters; a value
+// <= 0 keeps the default. Applies only to [Dynamic].
+func WithConsumerUnservableThreshold(window time.Duration) DynamicOption {
+	return dynamicOpt(func(o *options) {
+		if window > 0 {
+			o.consumerUnservableWindow = window
+		}
 	})
 }
 

--- a/consumer/options_test.go
+++ b/consumer/options_test.go
@@ -185,6 +185,41 @@ func TestWithConsumerMemoryStorage(t *testing.T) {
 	}
 }
 
+func TestWithOnConsumerUnservable(t *testing.T) {
+	o := defaultOptions()
+	if o.onConsumerUnservable != nil {
+		t.Error("default onConsumerUnservable != nil")
+	}
+
+	var gotSubject string
+	WithOnConsumerUnservable(func(subject string, _ error) { gotSubject = subject }).apply(&o)
+	if o.onConsumerUnservable == nil {
+		t.Fatal("after WithOnConsumerUnservable, callback is nil")
+	}
+	o.onConsumerUnservable("sub.X", nil)
+	if gotSubject != "sub.X" {
+		t.Errorf("callback got subject %q, want sub.X", gotSubject)
+	}
+}
+
+func TestWithConsumerUnservableThreshold(t *testing.T) {
+	o := defaultOptions()
+	if o.consumerUnservableWindow != 0 {
+		t.Errorf("default consumerUnservableWindow = %v, want 0", o.consumerUnservableWindow)
+	}
+
+	WithConsumerUnservableThreshold(25 * time.Second).apply(&o)
+	if o.consumerUnservableWindow != 25*time.Second {
+		t.Errorf("after WithConsumerUnservableThreshold(25s), got %v", o.consumerUnservableWindow)
+	}
+
+	// Non-positive is ignored (keeps the prior/default value).
+	WithConsumerUnservableThreshold(0).apply(&o)
+	if o.consumerUnservableWindow != 25*time.Second {
+		t.Errorf("after WithConsumerUnservableThreshold(0), got %v, want 25s (unchanged)", o.consumerUnservableWindow)
+	}
+}
+
 func TestWithConsumerReplicas(t *testing.T) {
 	o := defaultOptions()
 	if o.consumerReplicas != 0 {

--- a/docs/plans/consumer-unservable-notification/00-plan.md
+++ b/docs/plans/consumer-unservable-notification/00-plan.md
@@ -1,0 +1,313 @@
+# Unservable-Consumer Notification — Implementation Plan
+
+**Goal:** Parti is a critical-mission orchestrator. It must auto-heal from
+*temporal* NATS failures without human intervention, and — for failures it
+genuinely cannot fix (the NATS cluster needs operator recovery) — it must
+**notify the application** so the app can raise an alert. This plan closes the
+one signalling gap that black-box reproducers proved exists: a partition
+consumer that is **unservable but still exists** (raft quorum lost) produces no
+app-facing signal today.
+
+**Status:** IMPLEMENTED and verified (2026-05-29). Reproducers codex-review-clean;
+plan-review rounds 1–2 clean; feature landed across `internal/recovery`,
+`internal/durable`, `consumer`; black-box notify + false-positive-silence tests
+green; AGENTS.md contracts + unit gate green.
+
+### Implementation refinements (code reality vs the plan text above)
+1. **`ConfirmDegrading` → `ActionBackoff` (NOT `ActionStreamMissing`).** §3.4
+   proposed routing degrading confirms to `ActionStreamMissing`. The implemented
+   choice is the more conservative `ActionBackoff` (unchanged from prior behavior)
+   so the existing stream-missing route — which surfaces via the recover/iterator
+   path, not the confirm path — keeps its current timing/semantics. The contract
+   goal (degrading is never counted as unservable) is fully met either way; this
+   avoids a behavior change to the stream-missing tests.
+2. **Full-outage is NOT asserted silent.** §5 item 8 assumed the unservable signal
+   stays silent during a full 3-of-5 outage. Empirically the consumer IS unservable
+   then (Info returns 503 while the client is reconnected to a survivor), so it may
+   legitimately fire alongside the manager's OnDegraded — both signals are true.
+   Asserting silence there would pin incorrect behavior, so that guard was dropped;
+   the manager degrade/heal contract is covered by `cluster_full_outage_recovery_test.go`.
+3. **Detection is opt-in** via `WithOnConsumerUnservable`; unset preserves prior
+   behavior exactly (zero new logs/signals), keeping the change backward-compatible.
+4. **"Rebalance does not heal an unservable consumer"** is a logical consequence of
+   the deterministic per-partition durable name: any worker that takes over the
+   partition binds the SAME (stuck) consumer, so reassignment cannot fix
+   quorum-loss — only the operator restoring NATS can. A dedicated multi-worker
+   integration test for this was prototyped but removed: forcing a rebalance *while
+   2 of 5 nodes are down* depends on leader re-election + handoff under reduced
+   quorum, which is ~50/50 timing-flaky under full-suite `-race` load and is
+   orthogonal to this feature. Rebalance behavior itself is covered by the
+   manager/leader-election integration suites.
+
+---
+
+## 1. Motivation — the gap, proven black-box
+
+Reproducers under `test/integration/failure/` assert only app-observable
+outcomes (handler deliveries, app hooks, connection status), independent of
+parti internals. They establish the following behavior matrix.
+
+| Failure | Can parti fix it alone? | Behavior | Reproducer |
+|---------|------------------------|----------|------------|
+| Consumer **really gone** (ConsumerNotFound / ErrConsumerDeleted), cluster has capacity | YES — recreate | Iterator detects deletion → recreates → delivery resumes | `cluster_partial_crash_test.go` (healthy-consumer delete→recreate) |
+| Consumer **quorum-lost but exists**, cluster later recovers | YES — wait & resume | Transient backoff retries; resumes on the **same** consumer when quorum returns; no loss, no gross duplication (observed maxDup=1) | `cluster_quorum_restored_test.go` |
+| Single-node / PVC (volume) loss, quorum holds | YES — transparent | Wiped node re-replicates from peers; worker never degrades; consumption continues | `cluster_pvc_loss_test.go` |
+| Whole cluster / meta quorum lost (3-of-5) | NO — operator | Manager enters Degraded + OnDegraded fires; auto-heals to Stable on restart | `cluster_full_outage_recovery_test.go` |
+| Consumer **quorum-lost but exists**, cluster does **not** recover | NO — operator | **Delivery silently stalls; NO app signal** (OnPermanentFailure stays 0; manager stays Stable because its RF5 KV survives 2-of-5; connection stays UP) ← **THE GAP** | `cluster_unservable_signal_gap_test.go` |
+| Unservable partition reassigned to another worker | NO — operator | Rebalance does **not** heal it (the new owner binds the same stuck consumer) | `cluster_multiworker_unservable_test.go` |
+
+So "try its best to auto-heal" is **already satisfied** for every recoverable
+shape. The only missing piece is the bottom rows: when a consumer is unservable
+in a way parti cannot fix, the app must be told.
+
+## 2. Established empirical facts (do not re-investigate)
+
+These were measured with embedded multi-node NATS clusters (see the reproducers
+and the spike history). They constrain the design:
+
+1. **A quorum-lost memory-RF3 consumer surfaces `503` / `NoResponders` — never
+   `ConsumerNotFound`.** So parti's existing recovery (which recreates only on
+   `ConsumerNotFound` / `ErrConsumerDeleted`) does not fire, and the iterator
+   backs off transiently forever with no escalation.
+2. **Parti cannot reliably recreate a quorum-lost consumer.** `DeleteConsumer`
+   needs the consumer's own raft quorum, which is gone; it usually times out
+   (non-deterministic — occasionally succeeds if the raft leader survived). So a
+   delete-then-recreate recovery path is NOT viable for quorum loss.
+3. **When the lost nodes return, parti resumes on the same consumer
+   automatically** (raft state restored from the ≥1 surviving peer). Verified no
+   loss and no gross duplication.
+4. **NATS caps stream/consumer replicas at 5.** Combined with consumers
+   co-locating on stream peers, "all of a consumer's peers die" cannot be
+   isolated from stream-quorum loss — it degenerates into the quorum-loss gap or
+   the full-outage case. There is therefore no separate total-peer-loss design
+   case.
+5. **The manager does NOT degrade on partial (2-of-5) loss** when its KV buckets
+   are RF5 (quorum 3-of-5 holds). So manager-level signals (OnDegraded) do not
+   cover the unservable-consumer case; the signal must be per-consumer.
+
+## 3. Design
+
+### 3.1 What parti does (unchanged, already correct)
+- ConsumerNotFound / ErrConsumerDeleted → recreate (the manager-leader-owned
+  creation path). Keep.
+- Transient errors → backoff + retry (auto-resumes when quorum returns). Keep.
+- No aggressive recreate of a quorum-lost consumer. Rejected because (a) delete
+  is unreliable under quorum loss (fact 2) and (b) a replacement under a new name
+  would double-deliver when the old consumer's quorum returns (fact 3) and would
+  break the deterministic per-partition durable naming used for handoff.
+
+### 3.2 What parti adds — the notification
+A **non-terminal** per-consumer "unservable" signal, gated by an explicit
+multi-state confirm classifier (this replaces the prior "neither NotFound nor
+connectivity" formulation, which review found could reroute stream-missing /
+degrading failures into the new hook).
+
+#### 3.2.1 Confirm-result classifier (the P0 fix)
+Today `Controller.confirmConsumerGone` (`internal/recovery/controller.go:543-553`)
+calls `Info()` and returns a **bool** = `IsConsumerNotFound(err)`, discarding the
+actual error. Replace it with a **lossless multi-state classifier** over the
+`Info()` outcome, evaluated in this exact priority order:
+
+1. `err` is `nil` **and** `ConsumerInfo.Cluster` has a non-empty `Leader`
+   → **`healthy`** (consumer is serviceable; reset the unservable sequence).
+2. `natsutil.IsConsumerNotFound(err)` → **`gone`** → existing recreate path
+   (unchanged). Excludes the recreate contract from the unservable path.
+3. `natsutil.IsDegradingJetStreamError(err)` (bucket/stream/consumer **missing**,
+   `internal/natsutil/errors.go:92-100`) **or** `errors.Is(err, types.ErrStreamMissing)`
+   → **`degrading`** → existing stream-missing / `recordKVError` → Degraded route
+   (unchanged). This is the contract the P0 protects (AGENTS.md §"Cross-feature
+   contracts" 1 + the stream-missing route in `manager_setup.go:49-83`).
+4. `natsutil.IsConnectivityError(err)` (`internal/natsutil/errors.go:114-137`)
+   → **`connectivity`** → plain backoff, **no** unservable signal (the connection
+   layer / manager owns this; it also should not happen here since the criterion
+   requires the connection UP).
+5. Otherwise — `err` is an `Info()` response indicating the consumer's own raft
+   group is unavailable while the connection is up: a `503` / `JetStream system
+   temporarily unavailable` / no-quorum API error, `nats.ErrNoResponders` from the
+   consumer Info, **or** `err == nil` but `ConsumerInfo.Cluster.Leader == ""`
+   (leaderless) → **`unservable`** → the only state that increments the counter.
+
+**Decision on `nats.ErrNoResponders`:** when returned by the consumer's own
+`Info()` while the NATS connection is `CONNECTED`, it means the consumer's raft
+group has no responder (no leader) → classify as **`unservable`**. It is NOT
+treated as connectivity (and `IsConnectivityError` does not match it today, so no
+existing routing is disturbed).
+
+**Optional hardening (recommended, resolve in impl):** before emitting
+`unservable`, cross-check that the **parent stream** is healthy (its `Info()`
+returns a leader). If the stream itself is unhealthy, prefer `degrading` so the
+manager owns it. This prevents a stream-wide outage from being reported as a
+per-consumer problem.
+
+#### 3.2.2 Counting + reset (P1 fix — reset on confirm RESULT, not ActionContinue)
+- Maintain `consecutiveUnservable` on the `Controller`.
+- On each confirm: `unservable` → increment; **any other class** (`healthy`,
+  `gone`, `degrading`, `connectivity`) **and** any successful iterator progress
+  (`ActionContinue`) → **reset to 0**. Reset is keyed on the confirm result /
+  progress, NOT solely on `ActionContinue` (review P1: a successful `Info()` in the
+  confirm path yields `ActionBackoff`, not `ActionContinue`, so resetting only on
+  `ActionContinue` would let non-adjacent leaderless blips accumulate).
+- The sequence must be **adjacent** unservable confirms; a single healthy confirm
+  in between breaks it. This is what makes the false-positive guard real.
+
+#### 3.2.3 Threshold, cadence, recovery (P1 fix — finalized, see §3.5)
+When `consecutiveUnservable` first crosses the configured window/threshold (§3.5):
+1. Emit an ERROR log, then rate-limited re-fires while it persists (§3.5 cadence).
+2. Fire the non-terminal hook (§3.3) once on entry, then on the same rate-limited
+   cadence.
+3. **Keep retrying** — never exit the consume loop; this preserves automatic
+   recovery the instant the operator restores NATS (fact 3).
+4. On the next `healthy`/`ActionContinue`, emit an INFO "recovered" log and clear
+   the episode (so a future episode re-fires from clean state).
+
+- Traffic-independent: keys on confirm/`Info()` outcomes, not "no delivery in T",
+  so an idle partition is never misclassified.
+- **Distinct from `OnPermanentFailure`**, which is terminal (fires immediately
+  before the consume loop exits on iterator-*creation* retry exhaustion /
+  stream-missing). Unservable is recoverable and non-terminal.
+
+### 3.3 Public API (decided)
+```go
+// consumer package
+func WithOnConsumerUnservable(fn func(subject string, err error)) DynamicOption
+```
+Non-terminal callback fired (rate-limited) while a partition consumer is
+unservable-but-existing and needs operator attention; the err preserves the
+underlying cause (e.g. wrapped 503). Fires on the consume loop goroutine and MUST
+be non-blocking.
+
+**Interaction with `WithOnPermanentFailure` (called out per review):**
+`WithOnPermanentFailure`'s godoc (`consumer/options.go:489-518`) documents that
+registering it **disables the manager's auto-degraded route for stream-missing
+exhaustion** (the dispatcher hands permanent failures to the app and stops).
+`WithOnConsumerUnservable` is **independent and additive**: it does not change
+that suppression and does not route through the manager observer. The two hooks
+fire on disjoint conditions — `OnPermanentFailure` is terminal (iterator-create
+exhaustion / stream-missing exit), `OnConsumerUnservable` is non-terminal
+(consumer-raft unavailable while alive). Setting one does not enable/disable the
+other. The plan does NOT change the existing `OnPermanentFailure` ↔ manager
+auto-degraded suppression behavior.
+
+Recovery is **log-only for v1** (an INFO "recovered" line + episode clear); a
+paired `OnConsumerRecovered` callback is explicitly deferred (not needed for the
+alert use case — the app alerts on the unservable signal and can clear its own
+alert via its monitoring system).
+
+### 3.4 Where the code goes
+- `internal/recovery/controller.go`: replace bool `confirmConsumerGone` with the
+  §3.2.1 multi-state classifier (returns an enum, e.g. `confirmResult`). In
+  `Classify`'s `ErrorNeedsConfirm` branch (`:183-200`), switch on the enum:
+  `gone` → existing recreate; `degrading` → return `ActionStreamMissing` so the
+  existing stream-missing/manager route owns it (do NOT count); `connectivity` →
+  `ActionBackoff` (no count); `unservable` → increment `consecutiveUnservable`,
+  and when it crosses the §3.5 window fire `onUnservable` + escalating log, then
+  `ActionBackoff` (keep retrying); `healthy` → reset + `ActionBackoff`. Reset
+  `consecutiveUnservable` on `healthy` and on the `ActionContinue` success branches
+  (`:171-179`, `:192-198`). Thread `onUnservable func(subject string, err error)`
+  + window/cadence config into `Controller` via `ControllerConfig`.
+- `consumer/options.go` + `consumer/dynamic.go`: add `WithOnConsumerUnservable`
+  (a `DynamicOption`), plumb through `DynamicConfig` → `WorkerConsumerConfig` →
+  `internal/durable` `partitionConsumerConfig` → `ControllerConfig`.
+- Mirror the alert-level escalation cadence from `manager_degraded.go`
+  (`monitorDegradedAlerts` `:311-371`) for the log re-fire; do not invent a new
+  shape.
+- Do NOT touch `recordKVError` / the manager degraded path — `degrading` and
+  `connectivity` confirms keep flowing to it unchanged.
+
+### 3.5 Timing model (finalized — replaces the prior open questions)
+The detector is **duration-anchored** so it provably outlasts healthy leader
+churn:
+
+- **New dedicated option** `WithConsumerUnservableThreshold(window time.Duration)`
+  rather than overloading `WithIteratorEscalation` (which means "burst → recreate"
+  and would couple two unrelated policies). Default **`window = 10s`**.
+- The detector fires when unservable confirms have persisted **continuously for
+  ≥ window**. Implementation: track the timestamp of the first unservable confirm
+  in the current adjacent run; fire when `now - firstUnservable ≥ window`. (A raw
+  count is insufficient because confirm cadence varies; anchoring on elapsed time
+  makes the false-positive bound explicit.)
+- **Why 10s is safe vs election churn:** NATS Raft leader election + settle for a
+  KV/consumer group completes in low single-digit seconds; the integration
+  configs use `ElectionTimeout` 1–3s (`internal/testutil/nats.go`). A 10s window
+  comfortably exceeds a single election/settle, so normal churn never fires. Apps
+  with slower clusters raise the window.
+- **Re-fire cadence:** after the first fire, re-fire (hook + escalating log) on the
+  manager-style interval (default reuse `DegradedAlert.AlertInterval` semantics,
+  escalating Info→Warn→Error→Critical) so a persisting outage keeps reminding
+  without log-spam.
+- **Recovery:** first `healthy`/`ActionContinue` after firing → INFO "recovered"
+  log + clear episode (re-arm for future episodes).
+
+## 4. Acceptance criteria (existing reproducers — must stay green)
+The reproducers in §1 are the regression spec. After implementation:
+- `cluster_unservable_signal_gap_test.go` **flips**: the "app gets no signal"
+  assertions become "the app receives the unservable signal within a bounded
+  window" (and the connection-UP / no-degrade facts remain).
+- All other reproducers remain unchanged and green.
+
+## 5. New tests (write with the implementation)
+
+### 5.1 Unit — `internal/recovery` (deterministic, small window/threshold)
+1. **Confirm-classifier table** over `Info()` outcomes → expected enum:
+   `ConsumerNotFound` → `gone`; `StreamNotFound` / wrapped `types.ErrStreamMissing`
+   → `degrading`; `nats.ErrTimeout` / `jetstream.ErrNoStreamResponse` →
+   `connectivity`; `nats.ErrNoResponders` → `unservable`; API `503`/no-quorum →
+   `unservable`; leaderless `ConsumerInfo` (nil err, empty `Leader`) → `unservable`;
+   healthy leaderful `ConsumerInfo` → `healthy`.
+2. **Routing**: `degrading` returns `ActionStreamMissing` (manager route), is NOT
+   counted; `connectivity` returns `ActionBackoff`, not counted; `gone` recreates.
+   Pins the P0 contract.
+3. **Adjacent-reset**: interleave `unservable → healthy → unservable` confirms and
+   assert the hook does NOT fire until `window` of *adjacent* unservable confirms;
+   assert a success clears the episode and stops re-fires (P1 reset semantics).
+4. **Existing pin preserved**: `alwaysSuccessInfo` after burst still yields
+   `ActionBackoff` and no recreate (`controller_test.go:215-227`) — the classifier
+   change must not regress it.
+
+### 5.2 Unit — option plumbing
+`WithOnConsumerUnservable` + `WithConsumerUnservableThreshold` flow through
+`DynamicConfig` → `WorkerConsumerConfig` → `partitionConsumerConfig` →
+`ControllerConfig`.
+
+### 5.3 Integration — `test/integration/failure` (black-box, app-observable)
+5. **Fires on sustained unservability:** flip `cluster_unservable_signal_gap_test.go`
+   — sustained 2-of-5 loss → `WithOnConsumerUnservable` fires for the affected
+   subject within a bounded window; preserve the existing connection-UP and
+   manager-not-Degraded assertions; err is non-connectivity, non-NotFound.
+6. **Silent on temporal blip (false-positive guard):** kill 2 nodes then
+   `RestartNode` them **before** the window elapses → the hook does NOT fire and
+   delivery resumes. Use a small explicit window for determinism.
+7. **Silent on truly-gone:** delete a healthy consumer → recreated; unservable hook
+   does NOT fire (routes to recreate).
+8. **Silent on full outage (manager owns it):** 3-of-5 loss → manager `OnDegraded`
+   fires; assert `WithOnConsumerUnservable` stays silent (negative-space guard).
+9. **Silent on stream-missing (manager owns it):** stream-missing exhaustion still
+   reaches the manager degraded route (`stream_missing_no_hook_test.go` pattern);
+   assert the unservable hook is NOT fired.
+10. **Clears on recovery:** sustained loss fires the hook; restore nodes → delivery
+    resumes (same consumer, per `cluster_quorum_restored_test.go`) and the recovered
+    INFO log is emitted; the hook stops re-firing.
+
+## 6. Resolved decisions (were open; finalized via plan-review round 1)
+- **Threshold model**: duration-anchored `window`, default **10s**, via a NEW
+  option `WithConsumerUnservableThreshold` (not `WithIteratorEscalation`). Justified
+  vs election churn in §3.5.
+- **Reset**: on the confirm RESULT (any non-`unservable` class) and on
+  `ActionContinue`, not on `ActionContinue` alone (§3.2.2).
+- **Recovery**: log-only + episode clear for v1; paired `OnConsumerRecovered`
+  callback deferred (§3.3).
+- **Re-fire cadence**: manager-style escalating alert levels on
+  `DegradedAlert.AlertInterval` semantics (§3.5).
+- **`nats.ErrNoResponders` from consumer Info while connection UP**: classified
+  `unservable` (§3.2.1).
+
+## 7. Cross-feature contract guardrails (AGENTS.md — must not regress)
+- Whole-bucket-missing → every worker Degraded (do not reroute bucket-missing into
+  the unservable path — it must stay `recordKVError` → degraded).
+- Peer claim takeover → only that worker claim-lost.
+- OnDegraded fires once per Degraded entry.
+- Start returns after sanity-check phase (async start).
+- ConsumerNotFound → recreate and `ErrStreamMissing` routing must remain intact;
+  the unservable criterion explicitly excludes both.
+- Run `make test-integration -race` and the three contract tests when touching
+  recovery classification.

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -356,8 +356,16 @@ func (t *twoPhaseCoordinator) commitPhase(ctx context.Context, workerID string, 
 					return nil, nil // already finalized
 				}
 
-				// If we're pending owner or current owner differs, move to commit.
-				if cur.PendingOwner == workerID || cur.Owner != workerID {
+				// Only commit a handoff that was actually prepared TO this worker
+				// (pendingOwner == workerID). A worker must NOT commit a claim it
+				// neither owns nor was promised: running NextCommit on a foreign
+				// stable claim (cur.Owner != workerID, pendingOwner == "") flips it
+				// to commit while keeping the foreign owner, and this worker's
+				// stabilizePhase then skips it (not its claim) — orphaning the
+				// owner's claim in commit until the TTL sweep. That happens when a
+				// transient rebalance disagreement puts a peer-owned partition in
+				// this worker's assignment without a preceding prepare.
+				if cur.PendingOwner == workerID {
 					committed := *cur
 					if cur.State != ClaimStateCommit {
 						committed = cur.NextCommit(now)

--- a/internal/assignment/handoff/twophase_stuck_commit_test.go
+++ b/internal/assignment/handoff/twophase_stuck_commit_test.go
@@ -1,0 +1,100 @@
+package handoff
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTwoPhase_CommitPhase_DoesNotHijackStableForeignClaim reproduces the
+// stuck-commit orphan observed under concurrent rebalance churn
+// (TestHandoffConflictStress, ~1/30 under CPU load).
+//
+// Mechanism: during rapid rebalancing, a worker B's local assignment can
+// transiently include a partition that another worker A actually owns
+// (B's calculator version lags or disagrees with the durable claim). Because
+// the partition is in B's `previous` AND `next`, preparePhase treats it as
+// already-held and does NOT run a prepare (no pendingOwner=B is recorded).
+// commitPhase then iterates ALL of B's next partitions and hits the
+// `cur.Owner != workerID` branch with an EMPTY pending owner: NextCommit keeps
+// owner=A (no pending to promote) but flips state stable -> commit. B's
+// stabilizePhase then skips the claim (cur.Owner != B), orphaning A's claim in
+// `commit`. A is not running an Apply for this partition (it already owns it
+// stably), so nothing finalizes it back to stable until the TTL-expiry sweep
+// (~minutes later). The pull gate suppresses the partition with
+// state_not_allowed(commit) for that entire window.
+//
+// Correct behavior: a worker must not transition a claim it does not own into
+// commit unless there is an actual handoff pending TO it
+// (cur.PendingOwner == workerID). Committing a stable, foreign-owned claim with
+// no pending handoff is spurious and must be a no-op.
+//
+// On the unfixed code this test FAILS: post-Apply the claim is {owner=A,
+// state=commit}. On the fixed code it PASSES: B's spurious commit is a no-op
+// and the claim stays {owner=A, state=stable}.
+func TestTwoPhase_CommitPhase_DoesNotHijackStableForeignClaim(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workerA = "worker-A"
+		workerB = "worker-B"
+		pid     = "p-foreign-stable"
+	)
+
+	store := newMemStore()
+
+	// A owns the partition, cleanly stable. LastUpdated=now so the opportunistic
+	// sweep cannot mask the bug (only a transition path can change the claim).
+	owned := Claim{
+		PartitionID: pid,
+		Owner:       workerA,
+		State:       ClaimStateStable,
+		Epoch:       5,
+		LastUpdated: time.Now().UTC(),
+		TTLSeconds:  int64((2 * time.Minute).Seconds()),
+	}
+	store.data[pid] = owned
+	store.rev[pid] = 5
+
+	cfg := Config{
+		ConsumerUpdater: nopUpdater{},
+		Store:           store,
+		Now:             time.Now,
+		TTL:             2 * time.Minute,
+		SweepInterval:   0,
+		MaxRetries:      3,
+		BaseBackoff:     1 * time.Millisecond,
+		MaxBackoff:      5 * time.Millisecond,
+	}
+	coord := New(cfg, true)
+
+	// B's local assignment transiently includes pid in BOTH previous and next
+	// (B believes it already holds pid), so preparePhase skips it as
+	// already-held and commitPhase runs straight against A's stable claim.
+	prev := types.Assignment{Version: 7, Lifecycle: "stable", Partitions: []types.Partition{{Keys: []string{pid}}}}
+	next := types.Assignment{Version: 8, Lifecycle: "stable", Partitions: []types.Partition{{Keys: []string{pid}}}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, coord.Apply(ctx, workerB, prev, next))
+
+	got, _, err := store.Get(ctx, pid)
+	require.NoError(t, err)
+
+	require.Equalf(t, ClaimStateStable, got.State,
+		"worker B must not hijack A's stable claim into commit. Got state=%s owner=%s pending=%q. "+
+			"This is the stuck-commit orphan: commitPhase's cur.Owner != workerID branch "+
+			"calls NextCommit on a foreign stable claim with no pending owner, flipping it to "+
+			"commit; B's stabilizePhase then skips it (not its claim), leaving A's claim "+
+			"orphaned in commit until the TTL sweep.",
+		got.State, got.Owner, got.PendingOwner)
+	require.Equal(t, workerA, got.Owner,
+		"A must remain the owner; B has no pending handoff to it")
+	require.Empty(t, got.PendingOwner)
+	require.Equal(t, owned.Epoch, got.Epoch,
+		"a spurious foreign commit must be a no-op and not advance the epoch")
+}

--- a/internal/durable/config.go
+++ b/internal/durable/config.go
@@ -299,6 +299,19 @@ type WorkerConsumerConfig struct {
 	// work should be offloaded to a goroutine inside the callback.
 	OnPermanentFailure func(subject string, err error)
 
+	// OnUnservable, when non-nil, is invoked (rate-limited, non-terminal) while a
+	// partition consumer exists but its raft group is unavailable while the NATS
+	// connection is up, sustained past UnservableWindow — a condition parti cannot
+	// fix on its own (the NATS cluster needs operator recovery). Unlike
+	// OnPermanentFailure it does NOT exit the consume loop: parti keeps retrying so
+	// delivery resumes automatically once the operator restores NATS.
+	OnUnservable func(subject string, err error)
+
+	// UnservableWindow is how long the unservable condition must persist before
+	// OnUnservable fires. Zero uses the recovery default (10s). The default
+	// comfortably exceeds NATS leader-election + settle so normal churn is silent.
+	UnservableWindow time.Duration
+
 	// AllowWorkerIDChange controls whether workerID changes are allowed after initialization.
 	// Default: false (immutable once set). Intended for controlled migrations only.
 	AllowWorkerIDChange bool

--- a/internal/durable/partition_consumer.go
+++ b/internal/durable/partition_consumer.go
@@ -38,6 +38,16 @@ type partitionConsumerConfig struct {
 	// envelope exhausts its attempt budget. See WorkerConsumerConfig.
 	OnPermanentFailure func(subject string, err error)
 
+	// OnUnservable, when non-nil, is fired (rate-limited, non-terminal) while
+	// this partition's consumer exists but its raft group is unavailable past
+	// UnservableWindow — a condition parti cannot fix (operator must recover
+	// NATS). The consume loop keeps retrying so recovery is automatic on restore.
+	OnUnservable func(subject string, err error)
+
+	// UnservableWindow is how long the unservable condition must persist before
+	// OnUnservable fires. Zero uses the recovery default (10s).
+	UnservableWindow time.Duration
+
 	// StreamMissingHook is the operator-supplied escalation invoked when
 	// the partition consumer's recovery flow detects the underlying
 	// JetStream stream is absent. Nil means "no hook configured" — the
@@ -158,10 +168,13 @@ func newPartitionConsumer(
 		checkPullSuppression: opts.checkPullSuppression,
 		done:                 make(chan struct{}),
 		recovery: recovery.NewController(recovery.ControllerConfig{
-			Strategy:     config.RecoveryStrategy,
-			FetchTimeout: config.FetchTimeout,
-			Logger:       logger,
-			Metrics:      config.Metrics,
+			Strategy:         config.RecoveryStrategy,
+			FetchTimeout:     config.FetchTimeout,
+			Subject:          opts.subject,
+			UnservableWindow: config.UnservableWindow,
+			OnUnservable:     config.OnUnservable,
+			Logger:           logger,
+			Metrics:          config.Metrics,
 		}),
 	}
 }
@@ -502,6 +515,10 @@ func (pc *partitionConsumer) processIterator(
 			}
 			return false, err
 		}
+
+		// A delivered message proves the consumer is serviceable again; clear any
+		// in-progress unservable episode (emits the recovered log if one fired).
+		pc.recovery.NoteProgress()
 
 		if handler == nil {
 			_ = msg.Nak()

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -409,6 +409,8 @@ func (wc *WorkerConsumer) addSubjectLoop(ctx context.Context, workerID string, s
 		IteratorEscalationThreshold: wc.config.IteratorEscalationThreshold,
 		RecoveryRetry:               wc.config.RecoveryRetry,
 		OnPermanentFailure:          wc.config.OnPermanentFailure,
+		OnUnservable:                wc.config.OnUnservable,
+		UnservableWindow:            wc.config.UnservableWindow,
 		StreamMissingHook:           wc.config.StreamMissingHook,
 		OnStreamRecreated:           wc.config.OnStreamRecreated,
 		Metrics:                     wc.config.Metrics,

--- a/internal/recovery/classify.go
+++ b/internal/recovery/classify.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -47,6 +48,70 @@ func ClassifyError(err error) ErrorClass {
 	}
 
 	return ErrorTransient
+}
+
+// ConfirmResult classifies the outcome of a consumer.Info() call made during the
+// confirm path (after an ambiguous ErrNoHeartbeat burst). It is a lossless
+// replacement for the previous boolean "is the consumer gone?" so the controller
+// can route each distinct failure class to the correct owner without rerouting
+// stream-missing / degrading / connectivity failures into the per-consumer
+// unservable-notification path.
+type ConfirmResult int
+
+const (
+	// ConfirmHealthy means the consumer exists and is serviceable (Info returned
+	// no error and, for a replicated consumer, has a raft leader). Resets any
+	// in-progress unservable episode.
+	ConfirmHealthy ConfirmResult = iota
+
+	// ConfirmGone means the consumer is unambiguously absent (ConsumerNotFound).
+	// Routes to the existing recreate path.
+	ConfirmGone
+
+	// ConfirmDegrading means a bucket/stream/consumer is MISSING or the stream is
+	// gone — owned by the manager's degraded / stream-missing routing, NOT by the
+	// per-consumer unservable path. Must never be counted as unservable.
+	ConfirmDegrading
+
+	// ConfirmConnectivity means the NATS connection itself is impaired. Owned by
+	// the connection monitor / manager degraded path; not counted as unservable.
+	ConfirmConnectivity
+
+	// ConfirmUnservable means the consumer EXISTS but its own raft group is
+	// unavailable while the connection is up — a 503 / "JetStream system
+	// temporarily unavailable" / no-quorum API error, NoResponders from the
+	// consumer Info, or a leaderless ConsumerInfo. This is the only class that
+	// drives the unservable-notification.
+	ConfirmUnservable
+)
+
+// ClassifyConfirm maps a consumer.Info() result to a ConfirmResult. The order of
+// checks is significant: ConsumerNotFound is matched before the degrading check
+// (IsDegradingJetStreamError also matches consumer-not-found), and connectivity
+// is matched before the unservable catch-all.
+func ClassifyConfirm(ci *jetstream.ConsumerInfo, err error) ConfirmResult {
+	if err == nil {
+		// A replicated consumer with no elected leader is unservable. A
+		// non-replicated (R1, nil Cluster) consumer with no error is healthy.
+		if ci != nil && ci.Cluster != nil && ci.Cluster.Leader == "" {
+			return ConfirmUnservable
+		}
+
+		return ConfirmHealthy
+	}
+	if natsutil.IsConsumerNotFound(err) {
+		return ConfirmGone
+	}
+	if natsutil.IsDegradingJetStreamError(err) || errors.Is(err, types.ErrStreamMissing) {
+		return ConfirmDegrading
+	}
+	if natsutil.IsConnectivityError(err) {
+		return ConfirmConnectivity
+	}
+
+	// Non-NotFound, non-degrading, non-connectivity error while the connection is
+	// up: the consumer's raft group is unavailable (503/no-quorum/NoResponders).
+	return ConfirmUnservable
 }
 
 // Action is the recommended action after the controller classifies an error.

--- a/internal/recovery/classify_test.go
+++ b/internal/recovery/classify_test.go
@@ -6,9 +6,41 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
+
+func TestClassifyConfirm(t *testing.T) {
+	leaderful := &jetstream.ConsumerInfo{Cluster: &jetstream.ClusterInfo{Leader: "n0"}}
+	leaderless := &jetstream.ConsumerInfo{Cluster: &jetstream.ClusterInfo{Leader: ""}}
+	r1 := &jetstream.ConsumerInfo{Cluster: nil} // non-replicated consumer
+
+	tests := []struct {
+		name string
+		ci   *jetstream.ConsumerInfo
+		err  error
+		want ConfirmResult
+	}{
+		{"healthy leaderful", leaderful, nil, ConfirmHealthy},
+		{"healthy R1 nil-cluster", r1, nil, ConfirmHealthy},
+		{"healthy nil-info", nil, nil, ConfirmHealthy},
+		{"leaderless -> unservable", leaderless, nil, ConfirmUnservable},
+		{"consumer not found -> gone", nil, jetstream.ErrConsumerNotFound, ConfirmGone},
+		{"stream not found -> degrading", nil, jetstream.ErrStreamNotFound, ConfirmDegrading},
+		{"stream missing umbrella -> degrading", nil, types.ErrStreamMissing, ConfirmDegrading},
+		{"timeout -> connectivity", nil, nats.ErrTimeout, ConfirmConnectivity},
+		{"no-stream-response -> connectivity", nil, jetstream.ErrNoStreamResponse, ConfirmConnectivity},
+		{"no-responders -> unservable", nil, nats.ErrNoResponders, ConfirmUnservable},
+		{"api 503 text -> unservable", nil, errors.New("nats: API error: code=503 err_code=10008 description=JetStream system temporarily unavailable"), ConfirmUnservable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ClassifyConfirm(tt.ci, tt.err))
+		})
+	}
+}
 
 func TestClassifyError(t *testing.T) {
 	tests := []struct {

--- a/internal/recovery/controller.go
+++ b/internal/recovery/controller.go
@@ -50,6 +50,21 @@ type ControllerConfig struct {
 	// If zero, auto-computed from FetchTimeout: FetchTimeout*(BurstThreshold+1)+3s.
 	BurstWindow time.Duration
 
+	// Subject is the consumer's filter subject, passed to OnUnservable so the app
+	// can identify which partition consumer needs operator attention.
+	Subject string
+
+	// UnservableWindow is how long a ConfirmUnservable state must persist before
+	// OnUnservable fires. Zero defaults to defaultUnservableWindow (10s) when
+	// OnUnservable is set.
+	UnservableWindow time.Duration
+
+	// OnUnservable, when non-nil, opts the controller into unservable-consumer
+	// detection. It is a non-terminal notification (the consume loop keeps
+	// retrying); it fires when the consumer exists but its raft group is
+	// unavailable while the connection is up, sustained past UnservableWindow.
+	OnUnservable func(subject string, err error)
+
 	Logger  types.Logger
 	Metrics types.WorkerConsumerMetrics
 }
@@ -94,9 +109,27 @@ type Controller struct {
 	// from sequence 1 rather than skipping pre-bind messages.
 	recreatedSinceLastBuild atomic.Bool
 
+	// Unservable-consumer detection (opt-in via onUnservable != nil). A consumer
+	// that EXISTS but whose raft group is unavailable while the connection is up
+	// (confirm classifies ConfirmUnservable) is something parti cannot fix — the
+	// operator must recover NATS. When this persists for >= unservableWindow we
+	// notify the app (and keep retrying, so recovery is automatic once NATS is
+	// restored). All fields below are guarded by mu.
+	subject              string
+	unservableWindow     time.Duration
+	onUnservable         func(subject string, err error)
+	unservableSince      time.Time // zero = no current unservable episode
+	unservableFired      bool
+	lastUnservableRefire time.Time
+
 	logger  types.Logger
 	metrics types.WorkerConsumerMetrics
 }
+
+// defaultUnservableWindow is the duration an unservable confirm must persist
+// before the app is notified. Chosen to comfortably exceed NATS leader-election
+// + raft settle (low single-digit seconds) so normal election churn never fires.
+const defaultUnservableWindow = 10 * time.Second
 
 // NewController creates a Controller. Returns nil if strategy is RecoveryDisabled,
 // so callers can use a nil check to skip recovery entirely.
@@ -114,11 +147,19 @@ func NewController(cfg ControllerConfig) *Controller {
 		window = defaultBurstWindow(cfg.FetchTimeout, threshold)
 	}
 
+	unservableWindow := cfg.UnservableWindow
+	if unservableWindow <= 0 {
+		unservableWindow = defaultUnservableWindow
+	}
+
 	return &Controller{
 		strategy:            cfg.Strategy,
 		checkpoint:          newCheckpoint(cfg.Logger),
 		burst:               NewBurstDetector(window, threshold),
 		minRecoveryInterval: defaultRecoveryMinInterval,
+		subject:             cfg.Subject,
+		unservableWindow:    unservableWindow,
+		onUnservable:        cfg.OnUnservable,
 		logger:              cfg.Logger,
 		metrics:             cfg.Metrics,
 	}
@@ -185,16 +226,35 @@ func (c *Controller) Classify(
 		if !c.burst.Record() {
 			return ActionBackoff, nil, nil // not enough failures yet
 		}
-		// Burst threshold reached — confirm via consumer.Info().
-		if !c.confirmConsumerGone(ctx, infoFn) {
-			return ActionBackoff, nil, nil // consumer still exists, transient issue
-		}
-		newCons, recErr := c.recover(ctx, "consumer_not_found_after_burst", baseCfg, recreate)
-		if recErr != nil {
-			return ActionStreamMissing, nil, recErr
-		}
-		if newCons != nil {
-			return ActionContinue, newCons, nil
+		// Burst threshold reached — confirm via consumer.Info() and route by class.
+		result, infoErr := c.confirm(ctx, infoFn)
+		switch result {
+		case ConfirmGone:
+			c.noteServiceable() // not unservable; clear any episode
+			newCons, recErr := c.recover(ctx, "consumer_not_found_after_burst", baseCfg, recreate)
+			if recErr != nil {
+				return ActionStreamMissing, nil, recErr
+			}
+			if newCons != nil {
+				return ActionContinue, newCons, nil
+			}
+
+			return ActionBackoff, nil, nil
+		case ConfirmUnservable:
+			// Consumer exists but its raft group is unavailable (operator must
+			// recover NATS). Notify if sustained; keep retrying for auto-heal.
+			c.noteUnservable(infoErr)
+
+			return ActionBackoff, nil, nil
+		case ConfirmHealthy, ConfirmDegrading, ConfirmConnectivity:
+			// ConfirmHealthy: consumer is fine (transient blip).
+			// ConfirmDegrading: stream/bucket missing — owned by the manager's
+			//   stream-missing/degraded route, not this path; keep existing
+			//   backoff behavior (do not reroute or count as unservable).
+			// ConfirmConnectivity: connection layer / manager owns it.
+			c.noteServiceable()
+
+			return ActionBackoff, nil, nil
 		}
 
 		return ActionBackoff, nil, nil
@@ -540,17 +600,91 @@ func (c *Controller) recover(
 	return newCons, nil
 }
 
-// confirmConsumerGone calls consumer.Info() and returns true if the consumer is confirmed gone.
-func (c *Controller) confirmConsumerGone(ctx context.Context, infoFn InfoFunc) bool {
+// confirm calls consumer.Info() and classifies the outcome. The returned error
+// is the underlying Info() error (nil for healthy/leaderless), preserved so an
+// unservable notification can carry the cause.
+func (c *Controller) confirm(ctx context.Context, infoFn InfoFunc) (ConfirmResult, error) {
 	if infoFn == nil {
-		return false
+		// Cannot confirm; treat as a transient/no-signal condition (backoff,
+		// no recreate, no unservable count).
+		return ConfirmConnectivity, nil
 	}
 
 	c.consInfoMu.Lock()
-	_, err := infoFn(ctx)
+	ci, err := infoFn(ctx)
 	c.consInfoMu.Unlock()
 
-	return natsutil.IsConsumerNotFound(err)
+	return ClassifyConfirm(ci, err), err
+}
+
+// noteUnservable advances the unservable episode and fires OnUnservable (plus an
+// ERROR log) when the episode has persisted >= unservableWindow, then re-fires on
+// the same cadence while it persists. Opt-in: a no-op unless OnUnservable is set.
+// Non-terminal — the caller keeps retrying so recovery is automatic once the
+// operator restores NATS.
+func (c *Controller) noteUnservable(cause error) {
+	if c == nil || c.onUnservable == nil {
+		return
+	}
+
+	c.mu.Lock()
+	now := time.Now()
+	if c.unservableSince.IsZero() {
+		c.unservableSince = now
+	}
+	elapsed := now.Sub(c.unservableSince)
+	fire := false
+	switch {
+	case elapsed < c.unservableWindow:
+		// not sustained long enough yet
+	case !c.unservableFired:
+		c.unservableFired = true
+		c.lastUnservableRefire = now
+		fire = true
+	case now.Sub(c.lastUnservableRefire) >= c.unservableWindow:
+		c.lastUnservableRefire = now
+		fire = true
+	}
+	subject := c.subject
+	hook := c.onUnservable
+	c.mu.Unlock()
+
+	if fire {
+		if c.logger != nil {
+			c.logger.Error("partition consumer unservable; NATS operator action needed",
+				"subject", subject, "elapsed", elapsed.String(), "cause", cause)
+		}
+		hook(subject, cause) // outside the lock; must be non-blocking
+	}
+}
+
+// noteServiceable clears any in-progress unservable episode. If an unservable
+// notification had fired, an INFO "recovered" line is emitted and the episode is
+// re-armed for the future. Safe on a nil controller.
+func (c *Controller) noteServiceable() {
+	if c == nil || c.onUnservable == nil {
+		return
+	}
+
+	c.mu.Lock()
+	wasFired := c.unservableFired
+	c.unservableSince = time.Time{}
+	c.unservableFired = false
+	c.lastUnservableRefire = time.Time{}
+	subject := c.subject
+	c.mu.Unlock()
+
+	if wasFired && c.logger != nil {
+		c.logger.Info("partition consumer recovered from unservable state", "subject", subject)
+	}
+}
+
+// NoteProgress is called by the consume loop on each successful message delivery.
+// A delivery proves the consumer is serviceable, so it clears any unservable
+// episode (and emits the recovered log) without waiting for the next confirm.
+// Safe on a nil controller.
+func (c *Controller) NoteProgress() {
+	c.noteServiceable()
 }
 
 // callInfo calls consumer.Info() with serialization.

--- a/internal/recovery/controller_test.go
+++ b/internal/recovery/controller_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
@@ -225,6 +226,84 @@ func TestClassify_NoHeartbeat_BurstButConsumerStillExists(t *testing.T) {
 	action, newCons, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, alwaysSuccessInfo, baseCfg, nil)
 	require.Equal(t, ActionBackoff, action)
 	require.Nil(t, newCons)
+}
+
+func TestController_UnservableDetection(t *testing.T) {
+	ctx := context.Background()
+	unservableInfo := func(_ context.Context) (*jetstream.ConsumerInfo, error) {
+		return nil, nats.ErrNoResponders
+	}
+	healthyInfo := func(_ context.Context) (*jetstream.ConsumerInfo, error) {
+		return &jetstream.ConsumerInfo{Cluster: &jetstream.ClusterInfo{Leader: "n0"}}, nil
+	}
+	degradingInfo := func(_ context.Context) (*jetstream.ConsumerInfo, error) {
+		return nil, jetstream.ErrStreamNotFound
+	}
+
+	t.Run("fires after sustained window, re-arms on recovery", func(t *testing.T) {
+		var mu sync.Mutex
+		var fires int
+		c := NewController(ControllerConfig{
+			Strategy: FromNew, BurstThreshold: 1, BurstWindow: time.Second,
+			Subject: "sub.A", UnservableWindow: 40 * time.Millisecond,
+			OnUnservable: func(_ string, _ error) { mu.Lock(); fires++; mu.Unlock() },
+			Logger:       nopLog,
+		})
+		count := func() int { mu.Lock(); defer mu.Unlock(); return fires }
+
+		// First unservable confirm starts the episode but is not yet sustained.
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil)
+		require.Equal(t, 0, count())
+
+		time.Sleep(60 * time.Millisecond)
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil)
+		require.Equal(t, 1, count(), "fires once sustained past the window")
+
+		// Immediate re-confirm: no re-fire within the window.
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil)
+		require.Equal(t, 1, count())
+
+		// Healthy confirm clears the episode (recovered + re-arm).
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, healthyInfo, baseCfg, nil)
+		// New unservable confirm restarts the episode; not yet sustained → no new fire.
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil)
+		require.Equal(t, 1, count(), "episode re-armed after recovery; not sustained yet")
+	})
+
+	t.Run("degrading does not fire (manager owns it)", func(t *testing.T) {
+		var n atomic.Int64
+		c := NewController(ControllerConfig{
+			Strategy: FromNew, BurstThreshold: 1, BurstWindow: time.Second,
+			Subject: "sub.B", UnservableWindow: 20 * time.Millisecond,
+			OnUnservable: func(string, error) { n.Add(1) }, Logger: nopLog,
+		})
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, degradingInfo, baseCfg, nil)
+		time.Sleep(40 * time.Millisecond)
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, degradingInfo, baseCfg, nil)
+		require.Equal(t, int64(0), n.Load(), "stream-missing/degrading is owned by the manager, not unservable")
+	})
+
+	t.Run("opt-out when no hook is set", func(t *testing.T) {
+		c := NewController(ControllerConfig{
+			Strategy: FromNew, BurstThreshold: 1, BurstWindow: time.Second, Logger: nopLog,
+		})
+		action, _, _ := c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil)
+		require.Equal(t, ActionBackoff, action) // no panic, no detection
+	})
+
+	t.Run("NoteProgress clears the episode", func(t *testing.T) {
+		var n atomic.Int64
+		c := NewController(ControllerConfig{
+			Strategy: FromNew, BurstThreshold: 1, BurstWindow: time.Second,
+			Subject: "sub.C", UnservableWindow: 40 * time.Millisecond,
+			OnUnservable: func(string, error) { n.Add(1) }, Logger: nopLog,
+		})
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil)
+		c.NoteProgress() // a delivery proves serviceability before the window elapses
+		time.Sleep(60 * time.Millisecond)
+		_, _, _ = c.Classify(ctx, jetstream.ErrNoHeartbeat, unservableInfo, baseCfg, nil) // episode restarts
+		require.Equal(t, int64(0), n.Load(), "NoteProgress reset the episode so the window restarts")
+	})
 }
 
 func TestClassify_TransientError(t *testing.T) {

--- a/internal/testutil/nats.go
+++ b/internal/testutil/nats.go
@@ -529,25 +529,34 @@ func absInt(x int) int {
 }
 
 // VerifyTotalPartitionCount verifies the total number of unique partitions assigned.
+//
+// Assignment publication and follower consumption can lag the Stable transition
+// under parallel load, so this polls until the expected coverage is observed
+// (or a bounded timeout elapses) before asserting, rather than snapshotting once.
 func (wc *WorkerCluster) VerifyTotalPartitionCount(expected int) {
-	// Use a map to track unique partitions across all workers
-	uniquePartitions := make(map[string]bool)
-
-	for i, mgr := range wc.Workers {
-		assignment := mgr.CurrentAssignment()
-		wc.T.Logf("Worker %d (%s): %d partitions",
-			i, mgr.WorkerID(), len(assignment.Partitions))
-
-		// Add partitions to unique set
-		for _, p := range assignment.Partitions {
-			// Use the first key as partition identifier
-			if len(p.Keys) > 0 {
-				uniquePartitions[p.Keys[0]] = true
+	var totalUnique int
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		uniquePartitions := make(map[string]bool)
+		for _, mgr := range wc.Workers {
+			for _, p := range mgr.CurrentAssignment().Partitions {
+				if len(p.Keys) > 0 {
+					uniquePartitions[p.Keys[0]] = true
+				}
 			}
 		}
+		totalUnique = len(uniquePartitions)
+		if totalUnique == expected || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
-	totalUnique := len(uniquePartitions)
+	for i, mgr := range wc.Workers {
+		wc.T.Logf("Worker %d (%s): %d partitions",
+			i, mgr.WorkerID(), len(mgr.CurrentAssignment().Partitions))
+	}
+
 	require.Equal(wc.T, expected, totalUnique,
 		"unique partition count mismatch (expected %d, got %d unique partitions)", expected, totalUnique)
 }

--- a/internal/testutil/nats.go
+++ b/internal/testutil/nats.go
@@ -34,19 +34,19 @@ func StartEmbeddedNATS(t *testing.T) (*nats.Conn, func()) {
 	return nc, cleanup
 }
 
-// StartEmbeddedNATSCluster starts a 3-node embedded NATS cluster with
-// JetStream replication for HA/failover integration tests. Returns the
-// connection, the slice of server handles (so tests can identify and
-// shut down the meta-leader), and a cleanup func that closes the conn
-// and shuts down every server.
+// StartEmbeddedNATSCluster starts an embedded NATS cluster with JetStream
+// replication for HA/failover integration tests. The node count defaults to 3
+// and is configurable via partitest.WithClusterSize. Returns the connection,
+// the slice of server handles (so tests can identify and shut down individual
+// nodes), and a cleanup func that closes the conn and shuts down every server.
 //
 // The cleanup func is idempotent: tests that shut down individual servers
 // mid-run will not panic when the cleanup later shuts them down again
 // because server.Server.Shutdown is itself idempotent. The nats.Conn is
 // closed only once (subsequent Close calls on a closed conn are no-ops).
-func StartEmbeddedNATSCluster(t *testing.T) (*nats.Conn, []*server.Server, func()) {
+func StartEmbeddedNATSCluster(t *testing.T, opts ...partitest.ClusterOption) (*nats.Conn, []*server.Server, func()) {
 	t.Helper()
-	servers, nc := partitest.StartEmbeddedNATSCluster(t)
+	servers, nc := partitest.StartEmbeddedNATSCluster(t, opts...)
 
 	var closed bool
 	cleanup := func() {

--- a/partitest/nats.go
+++ b/partitest/nats.go
@@ -96,9 +96,31 @@ func StartEmbeddedNATS(t testing.TB) (*server.Server, *nats.Conn) {
 	return ns, nc
 }
 
-// StartEmbeddedNATSCluster starts a 3-node NATS cluster with JetStream for HA testing.
+// clusterConfig holds resolved options for StartEmbeddedNATSCluster.
+type clusterConfig struct {
+	size int
+}
+
+// ClusterOption configures StartEmbeddedNATSCluster.
+type ClusterOption func(*clusterConfig)
+
+// WithClusterSize sets the number of in-process NATS nodes in the cluster.
 //
-// This is useful for testing leader failover, network partitions, and other
+// The default is 3. The value bounds the maximum replication factor (RF) any
+// stream, KV bucket, or consumer created against the cluster can use: a stream
+// with Replicas=5 requires at least 5 nodes. A value < 1 fails the test.
+//
+// Storage type is NOT a cluster-level setting in NATS — it is configured per
+// stream / KV bucket / consumer. Use CreateStream and CreateJetStreamKV's
+// storage options to control it.
+func WithClusterSize(n int) ClusterOption {
+	return func(c *clusterConfig) { c.size = n }
+}
+
+// StartEmbeddedNATSCluster starts an N-node NATS cluster with JetStream for HA testing.
+//
+// The node count defaults to 3 and is configurable via WithClusterSize. This is
+// useful for testing leader failover, network partitions, quorum loss, and other
 // high-availability scenarios. Each server in the cluster runs in-process.
 //
 // The cluster uses the NATS gossip protocol for automatic node discovery and
@@ -106,24 +128,65 @@ func StartEmbeddedNATS(t testing.TB) (*server.Server, *nats.Conn) {
 //
 // Parameters:
 //   - t: Testing context for logging and cleanup
+//   - opts: Optional cluster options (e.g. WithClusterSize(5))
 //
 // Returns:
-//   - []*server.Server: Slice of 3 NATS server instances
+//   - []*server.Server: Slice of cluster-size NATS server instances
 //   - *nats.Conn: Connected NATS client (connected to all servers)
 //
 // Example:
 //
 //	func TestLeaderFailover(t *testing.T) {
-//	    servers, nc := testutil.StartEmbeddedNATSCluster(t)
+//	    servers, nc := testutil.StartEmbeddedNATSCluster(t, WithClusterSize(5))
 //	    // Simulate leader failure
 //	    servers[0].Shutdown()
 //	    // Test failover behavior
 //	}
-func StartEmbeddedNATSCluster(t *testing.T) ([]*server.Server, *nats.Conn) {
+func StartEmbeddedNATSCluster(t *testing.T, opts ...ClusterOption) ([]*server.Server, *nats.Conn) {
+	t.Helper()
+	c := StartCluster(t, opts...)
+
+	return c.Servers, c.Conn
+}
+
+// Cluster is a handle to an embedded NATS cluster that supports restarting
+// individual nodes in place (same ports + StoreDir) for outage/recovery tests.
+//
+// Servers and Conn mirror the StartEmbeddedNATSCluster return values. Tests may
+// shut down a node via Servers[i].Shutdown() and later restart it with
+// RestartNode(i): because the node keeps its original StoreDir, FileStorage
+// state survives the restart while MemoryStorage assets are wiped — exactly the
+// production restart semantics.
+// nodeReadyTimeout bounds how long a single embedded node may take to accept
+// connections after Start. Generous because back-to-back multi-node clusters
+// under -race CPU contention can stall a node's startup well past a few seconds.
+const nodeReadyTimeout = 30 * time.Second
+
+type Cluster struct {
+	Servers []*server.Server
+	Conn    *nats.Conn
+
+	t        *testing.T
+	nodeOpts []*server.Options // per-node options, reused verbatim on restart
+}
+
+// StartCluster starts an N-node embedded NATS cluster and returns a Cluster
+// handle. The node count defaults to 3 and is configurable via WithClusterSize.
+//
+// Unlike StartEmbeddedNATSCluster (which returns bare slices for backward
+// compatibility), the handle retains each node's options so RestartNode can
+// bring a downed node back identically.
+func StartCluster(t *testing.T, opts ...ClusterOption) *Cluster {
 	t.Helper()
 
-	const clusterSize = 3
-	servers := make([]*server.Server, clusterSize)
+	cfg := clusterConfig{size: 3}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.size < 1 {
+		t.Fatalf("WithClusterSize: size must be >= 1, got %d", cfg.size)
+	}
+	clusterSize := cfg.size
 
 	// Pre-allocate ports to avoid chicken-and-egg problem with routes
 	clusterPorts := make([]int, clusterSize)
@@ -143,51 +206,132 @@ func StartEmbeddedNATSCluster(t *testing.T) ([]*server.Server, *nats.Conn) {
 	// Build full mesh routes
 	routes := buildClusterRoutes(clusterSize, clusterPorts)
 
+	// Build per-node options once. StoreDir is allocated here (not inside the
+	// node starter) so a restart reuses the same directory — FileStorage state
+	// then survives the restart.
+	c := &Cluster{
+		Servers:  make([]*server.Server, clusterSize),
+		t:        t,
+		nodeOpts: make([]*server.Options, clusterSize),
+	}
+	for i := range clusterSize {
+		c.nodeOpts[i] = &server.Options{
+			ServerName: fmt.Sprintf("test-server-%d", i),
+			Host:       "127.0.0.1",
+			Port:       clientPorts[i],
+			Cluster: server.ClusterOpts{
+				Name: "test-cluster",
+				Host: "127.0.0.1",
+				Port: clusterPorts[i],
+			},
+			JetStream: true,
+			StoreDir:  t.TempDir(),
+			LogFile:   "",
+			Debug:     false,
+			Trace:     false,
+			NoLog:     true,
+			Routes:    routes,
+		}
+	}
+
 	// Start all nodes
 	for i := range clusterSize {
-		servers[i] = startClusterNode(t, i, clientPorts[i], clusterPorts[i], routes, servers)
+		c.Servers[i] = startClusterNode(t, i, c.nodeOpts[i], c.Servers)
 	}
 
 	// Wait for cluster formation (routes connected to all peers).
-	waitForClusterFormation(t, servers, clusterSize)
+	waitForClusterFormation(t, c.Servers, clusterSize)
 
 	// Wait for the JetStream meta-leader to be elected. Route formation
 	// is a prerequisite but not sufficient; the Raft meta-group needs an
 	// additional round-trip to elect a leader before R>1 bucket creation
 	// will succeed.
-	waitForJetStreamMetaLeader(t, servers)
+	waitForJetStreamMetaLeader(t, c.Servers)
 
-	// Connect client and register cleanup
+	// Wait for the meta-leader to register all N JetStream peers. Leader
+	// election precedes peer-stats propagation; creating an R=N stream/KV
+	// before the leader knows all N peers fails with "no suitable peers for
+	// placement". Gate on the leader reporting the full peer set.
+	waitForJetStreamPeers(t, c.Servers, clusterSize)
+
+	// Connect client.
 	clientURLs := make([]string, clusterSize)
-	for i, s := range servers {
+	for i, s := range c.Servers {
 		clientURLs[i] = s.ClientURL()
 	}
-	nc := connectToCluster(t, clientURLs, servers)
+	c.Conn = connectToCluster(t, clientURLs, c.Servers)
 
-	return servers, nc
+	// Register cleanup over the current server set (RestartNode replaces
+	// entries in c.Servers, so iterate the field, not a captured slice).
+	t.Cleanup(func() {
+		c.Conn.Close()
+		for i, s := range c.Servers {
+			if s == nil {
+				continue
+			}
+			s.Shutdown()
+			s.WaitForShutdown()
+			t.Logf("Shut down cluster node %d", i)
+		}
+	})
+
+	return c
 }
 
-// startClusterNode creates and starts a single NATS server node in the cluster.
-func startClusterNode(t *testing.T, index int, clientPort, clusterPort int, routes []*url.URL, servers []*server.Server) *server.Server {
-	t.Helper()
+// RestartNode restarts cluster node i in place using its original options
+// (same client/cluster ports, StoreDir, routes, and server name).
+//
+// The caller is responsible for having shut the node down first (e.g.
+// c.Servers[i].Shutdown()); RestartNode shuts it down defensively if it is
+// still running. The new server is stored back into c.Servers[i] and the
+// method blocks until it is ready for connections.
+func (c *Cluster) RestartNode(i int) {
+	c.t.Helper()
+	c.restart(i, false)
+}
 
-	opts := &server.Options{
-		ServerName: fmt.Sprintf("test-server-%d", index),
-		Host:       "127.0.0.1",
-		Port:       clientPort,
-		Cluster: server.ClusterOpts{
-			Name: "test-cluster",
-			Host: "127.0.0.1",
-			Port: clusterPort,
-		},
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		LogFile:   "",
-		Debug:     false,
-		Trace:     false,
-		NoLog:     true,
-		Routes:    routes,
+// RestartNodeWiped restarts cluster node i with a FRESH (empty) StoreDir,
+// simulating a lost persistent volume (PVC) or wiped file storage: the node
+// keeps its identity (ports, routes, name) but comes back with no on-disk
+// JetStream state and must re-replicate from surviving peers.
+//
+// The fresh StoreDir is retained, so subsequent RestartNode calls keep the new
+// (now-populated) directory — matching a replaced volume.
+func (c *Cluster) RestartNodeWiped(i int) {
+	c.t.Helper()
+	c.restart(i, true)
+}
+
+func (c *Cluster) restart(i int, wipeStore bool) {
+	c.t.Helper()
+	if i < 0 || i >= len(c.Servers) {
+		c.t.Fatalf("restartNode: index %d out of range [0,%d)", i, len(c.Servers))
 	}
+
+	if old := c.Servers[i]; old != nil && old.Running() {
+		old.Shutdown()
+		old.WaitForShutdown()
+	}
+
+	if wipeStore {
+		c.nodeOpts[i].StoreDir = c.t.TempDir()
+	}
+
+	ns, err := server.NewServer(c.nodeOpts[i])
+	if err != nil {
+		c.t.Fatalf("restart %d: NewServer: %v", i, err)
+	}
+	go ns.Start()
+	if !ns.ReadyForConnections(nodeReadyTimeout) {
+		ns.Shutdown()
+		c.t.Fatalf("restart %d: not ready within timeout", i)
+	}
+	c.Servers[i] = ns
+}
+
+// startClusterNode creates and starts a single NATS server node from opts.
+func startClusterNode(t *testing.T, index int, opts *server.Options, servers []*server.Server) *server.Server {
+	t.Helper()
 
 	ns, err := server.NewServer(opts)
 	if err != nil {
@@ -197,7 +341,7 @@ func startClusterNode(t *testing.T, index int, clientPort, clusterPort int, rout
 
 	go ns.Start()
 
-	if !ns.ReadyForConnections(10 * time.Second) {
+	if !ns.ReadyForConnections(nodeReadyTimeout) {
 		shutdownServers(servers[:index+1])
 		t.Fatalf("NATS server %d not ready", index)
 	}
@@ -246,7 +390,10 @@ func getFreePort() (int, error) {
 func waitForClusterFormation(t *testing.T, servers []*server.Server, clusterSize int) {
 	t.Helper()
 
-	timeout := time.After(10 * time.Second)
+	// Scale the timeout with cluster size: larger clusters need more
+	// round-trips before every node sees all its peers. 3 nodes → ~14s,
+	// 5 nodes → ~20s.
+	timeout := time.After(time.Duration(5+3*clusterSize) * time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -268,7 +415,9 @@ func waitForClusterFormation(t *testing.T, servers []*server.Server, clusterSize
 func waitForJetStreamMetaLeader(t *testing.T, servers []*server.Server) {
 	t.Helper()
 
-	timeout := time.After(15 * time.Second)
+	// Scale with cluster size for the same reason as cluster formation:
+	// the meta Raft group needs more time to elect a leader as nodes grow.
+	timeout := time.After(time.Duration(10+2*len(servers)) * time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -280,6 +429,33 @@ func waitForJetStreamMetaLeader(t *testing.T, servers []*server.Server) {
 		case <-ticker.C:
 			for _, s := range servers {
 				if s.JetStreamIsLeader() {
+					return
+				}
+			}
+		}
+	}
+}
+
+// waitForJetStreamPeers waits until the meta-leader reports all clusterSize
+// JetStream peers as online and stats-reporting. Must be called after
+// waitForJetStreamMetaLeader. JetStreamClusterPeers returns a non-nil list only
+// on the leader, and only counts peers that are online, JS-enabled, and have
+// reported stats — exactly the set eligible for R=N placement.
+func waitForJetStreamPeers(t *testing.T, servers []*server.Server, clusterSize int) {
+	t.Helper()
+
+	timeout := time.After(time.Duration(10+2*len(servers)) * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			shutdownServers(servers)
+			t.Fatal("JetStream peers not all registered with meta-leader within timeout")
+		case <-ticker.C:
+			for _, s := range servers {
+				if len(s.JetStreamClusterPeers()) >= clusterSize {
 					return
 				}
 			}
@@ -314,15 +490,8 @@ func connectToCluster(t *testing.T, clientURLs []string, servers []*server.Serve
 		t.Fatalf("Failed to connect to cluster: %v", err)
 	}
 
-	t.Cleanup(func() {
-		nc.Close()
-		for i, s := range servers {
-			s.Shutdown()
-			s.WaitForShutdown()
-			t.Logf("Shut down cluster node %d", i)
-		}
-	})
-
+	// Cleanup (conn close + node shutdown) is registered by StartCluster so it
+	// can iterate the current server set after RestartNode replacements.
 	return nc
 }
 
@@ -355,8 +524,17 @@ func shutdownServers(servers []*server.Server) {
 //	    kv := testutil.CreateJetStreamKV(t, nc, "worker-ids")
 //	    // Use kv for testing
 //	}
-func CreateJetStreamKV(t testing.TB, nc *nats.Conn, bucketName string) jetstream.KeyValue {
+func CreateJetStreamKV(t testing.TB, nc *nats.Conn, bucketName string, opts ...KVOption) jetstream.KeyValue {
 	t.Helper()
+
+	cfg := kvConfig{
+		storage:  jetstream.MemoryStorage,
+		replicas: 1,
+		ttl:      1 * time.Minute, // Short TTL for testing
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
 
 	js, err := jetstream.New(nc)
 	if err != nil {
@@ -367,13 +545,101 @@ func CreateJetStreamKV(t testing.TB, nc *nats.Conn, bucketName string) jetstream
 	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
 		Bucket:      bucketName,
 		Description: fmt.Sprintf("Test KV bucket: %s", bucketName),
-		TTL:         1 * time.Minute, // Short TTL for testing
-		Storage:     jetstream.MemoryStorage,
-		Replicas:    1,
+		TTL:         cfg.ttl,
+		Storage:     cfg.storage,
+		Replicas:    cfg.replicas,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create KV bucket %s: %v", bucketName, err)
 	}
 
 	return kv
+}
+
+// kvConfig holds resolved options for CreateJetStreamKV.
+type kvConfig struct {
+	storage  jetstream.StorageType
+	replicas int
+	ttl      time.Duration
+}
+
+// KVOption configures a KV bucket created by CreateJetStreamKV.
+type KVOption func(*kvConfig)
+
+// WithKVStorage sets the KV bucket storage type (default jetstream.MemoryStorage).
+func WithKVStorage(s jetstream.StorageType) KVOption {
+	return func(c *kvConfig) { c.storage = s }
+}
+
+// WithKVReplicas sets the KV bucket replication factor (default 1). The value
+// must not exceed the cluster node count or bucket creation fails.
+func WithKVReplicas(n int) KVOption {
+	return func(c *kvConfig) { c.replicas = n }
+}
+
+// WithKVTTL sets the KV bucket entry TTL (default 1 minute). Zero disables TTL.
+func WithKVTTL(d time.Duration) KVOption {
+	return func(c *kvConfig) { c.ttl = d }
+}
+
+// StreamSpec configures a JetStream stream created by CreateStream.
+type StreamSpec struct {
+	// Name is the stream name (required).
+	Name string
+	// Subjects is the list of subjects the stream binds (required).
+	Subjects []string
+	// Storage is the stream storage type. Defaults to jetstream.FileStorage
+	// (the zero value of StorageType) so RF>1 streams survive node restarts.
+	Storage jetstream.StorageType
+	// Replicas is the stream replication factor. Zero is normalized to 1.
+	// Must not exceed the cluster node count or stream creation fails.
+	Replicas int
+}
+
+// CreateStream creates a JetStream stream from spec and returns its info.
+//
+// Unlike CreateJetStreamKV (which defaults to memory storage for fast, isolated
+// unit tests), CreateStream defaults to FileStorage because it is intended for
+// multi-node HA scenarios where the stream must survive node restarts. Set
+// StreamSpec.Storage explicitly to override.
+//
+// Example:
+//
+//	si := CreateStream(t, nc, StreamSpec{
+//	    Name:     "PARTI_TEST",
+//	    Subjects: []string{"parti.test.>"},
+//	    Storage:  jetstream.FileStorage,
+//	    Replicas: 5,
+//	})
+func CreateStream(t testing.TB, nc *nats.Conn, spec StreamSpec) *jetstream.StreamInfo {
+	t.Helper()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("Failed to get JetStream context: %v", err)
+	}
+
+	replicas := spec.Replicas
+	if replicas == 0 {
+		replicas = 1
+	}
+
+	ctx := t.Context()
+	s, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     spec.Name,
+		Subjects: spec.Subjects,
+		Storage:  spec.Storage,
+		Replicas: replicas,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create stream %s (Replicas=%d storage=%v): %v",
+			spec.Name, replicas, spec.Storage, err)
+	}
+
+	si, err := s.Info(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get stream info %s: %v", spec.Name, err)
+	}
+
+	return si
 }

--- a/partitest/nats_test.go
+++ b/partitest/nats_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,6 +72,155 @@ func TestStartEmbeddedNATSCluster(t *testing.T) {
 	js, err := nc.JetStream()
 	require.NoError(t, err)
 	require.NotNil(t, js)
+}
+
+func TestStartEmbeddedNATSCluster_Size5(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	servers, nc := StartEmbeddedNATSCluster(t, WithClusterSize(5))
+
+	require.Len(t, servers, 5)
+	require.True(t, nc.IsConnected())
+
+	// Every node should see at least the other 4 as routes once formed.
+	for i, s := range servers {
+		require.True(t, s.ReadyForConnections(5*time.Second), "server %d not ready", i)
+		require.GreaterOrEqual(t, s.NumRoutes(), 4, "server %d should have >=4 routes", i)
+	}
+
+	// A Replicas=5 stream must be creatable against a 5-node cluster.
+	si := CreateStream(t, nc, StreamSpec{
+		Name:     "RF5_STREAM",
+		Subjects: []string{"rf5.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+	require.Equal(t, 5, si.Config.Replicas)
+	require.Equal(t, jetstream.FileStorage, si.Config.Storage)
+}
+
+func TestStartEmbeddedNATSCluster_DefaultIsThree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	servers, nc := StartEmbeddedNATSCluster(t)
+	require.Len(t, servers, 3)
+	require.True(t, nc.IsConnected())
+}
+
+func TestCluster_RestartNode_FileStateSurvives(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	ctx := t.Context()
+	c := StartCluster(t, WithClusterSize(3))
+	require.Len(t, c.Servers, 3)
+
+	// Write a value into an R3 FileStorage KV bucket, then restart a node and
+	// confirm the value survives (file state persisted across the restart).
+	kv := CreateJetStreamKV(t, c.Conn, "persist",
+		WithKVStorage(jetstream.FileStorage),
+		WithKVReplicas(3),
+		WithKVTTL(0),
+	)
+	_, err := kv.Put(ctx, "k", []byte("v"))
+	require.NoError(t, err)
+
+	// Restart a non-meta-leader node so the bucket keeps quorum throughout.
+	target := -1
+	for i, s := range c.Servers {
+		if !s.JetStreamIsLeader() {
+			target = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, target, 0)
+
+	c.Servers[target].Shutdown()
+	c.Servers[target].WaitForShutdown()
+	c.RestartNode(target)
+	require.True(t, c.Servers[target].ReadyForConnections(5*time.Second))
+
+	entry, err := kv.Get(ctx, "k")
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), entry.Value())
+}
+
+func TestCluster_RestartNodeWiped_ReplicatesFromPeers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	ctx := t.Context()
+	c := StartCluster(t, WithClusterSize(3))
+
+	kv := CreateJetStreamKV(t, c.Conn, "persist",
+		WithKVStorage(jetstream.FileStorage),
+		WithKVReplicas(3),
+		WithKVTTL(0),
+	)
+	_, err := kv.Put(ctx, "k", []byte("v"))
+	require.NoError(t, err)
+
+	// Wipe-restart a non-leader node (PVC loss). Quorum (2 of 3) holds, so the
+	// value remains readable and the wiped node re-replicates from peers.
+	target := -1
+	for i, s := range c.Servers {
+		if !s.JetStreamIsLeader() {
+			target = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, target, 0)
+
+	c.Servers[target].Shutdown()
+	c.Servers[target].WaitForShutdown()
+	c.RestartNodeWiped(target)
+	require.True(t, c.Servers[target].ReadyForConnections(5*time.Second))
+
+	entry, err := kv.Get(ctx, "k")
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), entry.Value())
+}
+
+func TestCreateStream_FileStorageReplicas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	_, nc := StartEmbeddedNATSCluster(t, WithClusterSize(3))
+
+	si := CreateStream(t, nc, StreamSpec{
+		Name:     "PARTI_TEST",
+		Subjects: []string{"parti.test.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 3,
+	})
+	require.Equal(t, 3, si.Config.Replicas)
+	require.Equal(t, jetstream.FileStorage, si.Config.Storage)
+}
+
+func TestCreateJetStreamKV_OptionsOverride(t *testing.T) {
+	ctx := t.Context()
+	_, nc := StartEmbeddedNATS(t)
+
+	kv := CreateJetStreamKV(t, nc, "opt-bucket",
+		WithKVStorage(jetstream.FileStorage),
+		WithKVTTL(0),
+	)
+	require.NotNil(t, kv)
+
+	// KV buckets are backed by a stream named KV_<bucket>; inspect it to
+	// confirm the storage option was applied.
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	stream, err := js.Stream(ctx, "KV_opt-bucket")
+	require.NoError(t, err)
+	require.Equal(t, jetstream.FileStorage, stream.CachedInfo().Config.Storage)
 }
 
 func TestCreateJetStreamKV(t *testing.T) {

--- a/test/integration/failure/cluster_crash_gate_test.go
+++ b/test/integration/failure/cluster_crash_gate_test.go
@@ -1,0 +1,31 @@
+package failure_test
+
+import (
+	"os"
+	"testing"
+)
+
+// requireClusterCrashTests gates the heavy multi-node NATS crash/recovery tests
+// in this package. Each spins a 5-node embedded JetStream cluster and several
+// deliberately crash nodes without restarting them, so the worker's graceful Stop
+// times out at cleanup (NATS is degraded) and resources are slow to release.
+// Run back-to-back under `-race` in a single `go test` invocation, that pressure
+// accumulates and destabilizes later cluster startups.
+//
+// They pass reliably in isolation; gate them behind an env var (matching the
+// repo's PARTI_RUN_HERD_DIAGNOSTIC precedent for heavy cluster diagnostics) so the
+// default `make test-integration` run stays stable. The feature logic itself is
+// covered by always-on unit tests in internal/recovery and consumer.
+//
+// Run them with:
+//
+//	PARTI_RUN_CLUSTER_CRASH=1 go test ./test/integration/failure/ -race -run TestCluster_ -p 1
+func requireClusterCrashTests(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping multi-node cluster crash test in short mode")
+	}
+	if os.Getenv("PARTI_RUN_CLUSTER_CRASH") == "" {
+		t.Skip("set PARTI_RUN_CLUSTER_CRASH=1 to run heavy multi-node NATS crash/recovery tests")
+	}
+}

--- a/test/integration/failure/cluster_full_outage_recovery_test.go
+++ b/test/integration/failure/cluster_full_outage_recovery_test.go
@@ -1,0 +1,149 @@
+package failure_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestCluster_FullOutage_AutoHeal exercises the full-quorum-loss + recovery path:
+// with three of five nodes down, JetStream loses meta quorum so parti cannot make
+// progress; restarting the three nodes (FileStorage state survives via the
+// Cluster handle's RestartNode) must let parti auto-heal back to a working state.
+//
+// Topology: RF5 FileStorage stream, RF5 KV buckets, single worker. Killing 3 of 5
+// drops below quorum (3 of 5) for every R5 asset.
+//
+// Assertions: during the outage publishing fails and the manager enters Degraded
+// (KV renewals fail, the leadership lease cannot be held); after the nodes return
+// the manager auto-heals to StateStable and publishing is restored. Asserting the
+// Degraded entry keeps the auto-heal assertion from passing vacuously.
+func TestCluster_FullOutage_AutoHeal(t *testing.T) {
+	requireClusterCrashTests(t)
+
+	ctx := context.Background()
+	const (
+		streamName = "OUTAGE"
+		prefix     = "outage"
+		subjectTpl = "outage.{{.PartitionID}}"
+		numParts   = 4
+	)
+	subjectFor := func(i int) string { return "outage.partition-" + strconv.Itoa(i) }
+
+	cluster := partitest.StartCluster(t, partitest.WithClusterSize(5))
+	nc := cluster.Conn
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	partitest.CreateStream(t, nc, partitest.StreamSpec{
+		Name:     streamName,
+		Subjects: []string{"outage.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		mu.Lock()
+		counts[msg.Subject()]++
+		mu.Unlock()
+		return nil
+	})
+	countFor := func(subj string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[subj]
+	}
+
+	dyn, err := consumer.NewDynamic(
+		js, streamName, prefix, subjectTpl, handler,
+		consumer.WithConsumerReplicas(3),
+		consumer.WithConsumerMemoryStorage(true),
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+		consumer.WithBatchSize(1),
+		consumer.WithFetchTimeout(1*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.KVBuckets.Replicas = 5
+
+	wc := testutil.NewWorkerClusterWithSource(t, nc,
+		source.NewStatic(testutil.CreateTestPartitions(numParts)), cfg)
+	wc.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(dyn))
+	wc.StartWorkers(ctx)
+	defer wc.StopWorkers()
+	mgr := wc.Workers[0]
+
+	// Baseline: a message flows on partition 0.
+	require.Eventually(t, func() bool {
+		return len(listConsumerInfos(t, ctx, js, streamName)) == numParts
+	}, 20*time.Second, 200*time.Millisecond)
+	_, err = js.Publish(ctx, subjectFor(0), []byte("baseline"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return countFor(subjectFor(0)) >= 1 },
+		15*time.Second, 100*time.Millisecond, "baseline not consumed")
+
+	// Kill 3 of 5 nodes (indices 2,3,4) → meta quorum lost.
+	t.Log("killing nodes 2, 3, 4 (quorum lost)")
+	for _, i := range []int{2, 3, 4} {
+		cluster.Servers[i].Shutdown()
+	}
+	for _, i := range []int{2, 3, 4} {
+		cluster.Servers[i].WaitForShutdown()
+	}
+
+	// During the outage parti cannot make progress: a stream publish must fail
+	// (the R5 stream has only 2 of 5 nodes, below quorum).
+	require.Eventually(t, func() bool {
+		pctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		_, perr := js.Publish(pctx, subjectFor(1), []byte("during-outage"))
+		cancel()
+		return perr != nil
+	}, 20*time.Second, 500*time.Millisecond, "publish should fail while quorum is lost")
+	t.Log("confirmed: publish fails during outage")
+
+	// The manager must enter degraded mode while quorum is lost (KV renewals fail,
+	// leadership lease cannot be held). Asserting this makes the later auto-heal
+	// assertion self-validating rather than vacuously true.
+	require.Eventually(t, func() bool { return mgr.State() == types.StateDegraded },
+		30*time.Second, 250*time.Millisecond,
+		"manager should enter Degraded during full quorum loss (was %v)", mgr.State())
+	t.Log("confirmed: manager entered Degraded during outage")
+
+	// Bring the 3 nodes back in place (same ports + StoreDir → FileStorage survives).
+	t.Log("restarting nodes 2, 3, 4")
+	for _, i := range []int{2, 3, 4} {
+		cluster.RestartNode(i)
+	}
+
+	// Auto-heal: the manager must return to StateStable once quorum is restored.
+	require.Eventually(t, func() bool { return mgr.State() == types.StateStable },
+		60*time.Second, 250*time.Millisecond,
+		"manager should auto-heal to StateStable after nodes return (was %v)", mgr.State())
+	t.Log("confirmed: manager auto-healed to StateStable")
+
+	// Back to work: publishing to the stream succeeds again (quorum restored).
+	require.Eventually(t, func() bool {
+		pctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		_, perr := js.Publish(pctx, subjectFor(0), []byte("post-recovery"))
+		cancel()
+		return perr == nil
+	}, 30*time.Second, 500*time.Millisecond, "publish should succeed after recovery")
+	t.Log("confirmed: publish succeeds after recovery — parti is back to work")
+}

--- a/test/integration/failure/cluster_partial_crash_test.go
+++ b/test/integration/failure/cluster_partial_crash_test.go
@@ -1,0 +1,314 @@
+package failure_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestCluster_PartialCrash_QuorumLoss_Characterization pins the CURRENT behavior
+// when two of five NATS nodes crash under a memory-RF3 dynamic-consumer topology
+// on an RF5 FileStorage stream.
+//
+// Spike finding (tmp/cluster-spike-findings.md): a memory-RF3 consumer that loses
+// raft quorum surfaces 503 / NoResponders — NEVER ConsumerNotFound — so parti's
+// recovery treats it as transient and does NOT auto-recreate it. This test
+// documents that gap and, separately, proves the ONLY recreate path that works
+// today: explicit consumer deletion (ErrConsumerDeleted) DOES trigger recreate.
+//
+// Topology choices:
+//   - Stream: RF5 FileStorage (survives 2-node loss; quorum = 3 of 5).
+//   - KVBuckets.Replicas = 5 (manager KV survives 2-node loss; worker stays
+//     healthy — this isolates "some consumers break" from "whole worker degrades").
+//   - Dynamic consumers: RF3 MemoryStorage (each raft group lands on 3 of 5
+//     nodes, so a well-chosen 2-node kill strips quorum from a subset).
+//   - Single worker owning all partitions, so all per-partition consumers exist
+//     and their placement is directly observable.
+func TestCluster_PartialCrash_QuorumLoss_Characterization(t *testing.T) {
+	requireClusterCrashTests(t)
+
+	ctx := context.Background()
+	const (
+		streamName = "CRASH1"
+		prefix     = "crash1"
+		subjectTpl = "crash1.{{.PartitionID}}"
+		numParts   = 8
+	)
+
+	cluster := partitest.StartCluster(t, partitest.WithClusterSize(5))
+	nc := cluster.Conn
+
+	nameToIdx := map[string]int{}
+	for i, s := range cluster.Servers {
+		nameToIdx[s.Name()] = i
+	}
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	// RF5 FileStorage stream.
+	partitest.CreateStream(t, nc, partitest.StreamSpec{
+		Name:     streamName,
+		Subjects: []string{"crash1.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+
+	// Per-subject delivery counters.
+	var mu sync.Mutex
+	counts := map[string]int{}
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		mu.Lock()
+		counts[msg.Subject()]++
+		mu.Unlock()
+		return nil
+	})
+	countFor := func(subj string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[subj]
+	}
+
+	dyn, err := consumer.NewDynamic(
+		js, streamName, prefix, subjectTpl, handler,
+		consumer.WithConsumerReplicas(3),
+		consumer.WithConsumerMemoryStorage(true),
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+		consumer.WithBatchSize(1),
+		consumer.WithFetchTimeout(1*time.Second),
+		consumer.WithRecoveryRetry(consumer.RecoveryRetryConfig{
+			MaxAttempts: 5,
+			BaseBackoff: 100 * time.Millisecond,
+			MaxBackoff:  500 * time.Millisecond,
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.KVBuckets.Replicas = 5
+
+	wc := testutil.NewWorkerClusterWithSource(t, nc,
+		source.NewStatic(testutil.CreateTestPartitions(numParts)), cfg)
+	wc.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(dyn))
+	wc.StartWorkers(ctx) // blocks until StateStable
+	defer wc.StopWorkers()
+	mgr := wc.Workers[0]
+
+	// Wait until all per-partition consumers exist.
+	require.Eventually(t, func() bool {
+		return len(listConsumerInfos(t, ctx, js, streamName)) == numParts
+	}, 20*time.Second, 200*time.Millisecond, "expected %d per-partition consumers", numParts)
+
+	// Baseline: every partition's consumer is functional.
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		_, perr := js.Publish(ctx, subj, []byte("baseline"))
+		require.NoError(t, perr)
+	}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		require.Eventually(t, func() bool { return countFor(subj) >= 1 },
+			15*time.Second, 100*time.Millisecond, "baseline not consumed on %s", subj)
+	}
+
+	// Snapshot placement and pick the 2-node kill that breaks the most consumers.
+	infos := listConsumerInfos(t, ctx, js, streamName)
+	peersBySubject := map[string][]int{}
+	nameBySubject := map[string]string{}
+	for _, ci := range infos {
+		subj := ci.Config.FilterSubject
+		peersBySubject[subj] = peerIndices(ci, nameToIdx)
+		nameBySubject[subj] = ci.Name
+		t.Logf("consumer %s subj=%s peers=%v", ci.Name, subj, peersBySubject[subj])
+	}
+
+	killA, killB, affectedCount := bestKillPair(peersBySubject, len(cluster.Servers))
+	require.Greater(t, affectedCount, 0, "no consumer loses quorum for any node pair (placement too even)")
+	require.Less(t, affectedCount, numParts, "every consumer breaks; need some survivors to compare")
+	t.Logf("killing node%d + node%d, expecting %d/%d consumers to lose quorum", killA, killB, affectedCount, numParts)
+
+	affected := map[string]bool{}
+	for subj, peers := range peersBySubject {
+		affected[subj] = countIn(peers, killA, killB) >= 2
+	}
+
+	cluster.Servers[killA].Shutdown()
+	cluster.Servers[killB].Shutdown()
+	cluster.Servers[killA].WaitForShutdown()
+	cluster.Servers[killB].WaitForShutdown()
+
+	// The worker's KV is RF5 (quorum = 3 of 5 alive) so it must stay healthy.
+	require.Never(t, func() bool { return mgr.State() == types.StateDegraded },
+		3*time.Second, 250*time.Millisecond, "worker should NOT degrade on 2-of-5 loss with RF5 KV")
+
+	// Publish a post-crash message to every partition.
+	postBase := map[string]int{}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		postBase[subj] = countFor(subj)
+		publishWithRetry(t, ctx, js, subj, []byte("post-crash")) // stream is RF5, still has quorum
+	}
+
+	// Unaffected consumers keep flowing; affected ones stall (no recreate).
+	var stalledSubj, stalledName string
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		if affected[subj] {
+			if stalledSubj == "" {
+				stalledSubj = subj
+				stalledName = nameBySubject[subj]
+			}
+			continue
+		}
+		require.Eventually(t, func() bool { return countFor(subj) > postBase[subj] },
+			15*time.Second, 100*time.Millisecond, "unaffected partition %s should keep consuming", subj)
+	}
+
+	// Characterize the gap: the affected consumer does NOT auto-recreate, so its
+	// post-crash message is never consumed within a generous window.
+	require.Never(t, func() bool { return countFor(stalledSubj) > postBase[stalledSubj] },
+		8*time.Second, 500*time.Millisecond,
+		"affected partition %s unexpectedly recovered without recreate (spike said World B)", stalledSubj)
+	t.Logf("confirmed gap: quorum-lost consumer %s (%s) stalled, parti did not auto-recreate", stalledName, stalledSubj)
+
+	// The recreate-on-delete recovery path DOES work for a consumer that still has
+	// quorum. Delete a healthy (unaffected) consumer and assert parti detects the
+	// deletion (ErrConsumerDeleted) and recreates it, resuming delivery. 3 nodes
+	// remain alive, so an RF3 consumer can be re-placed.
+	var healthySubj, healthyName string
+	for subj := range affected {
+		if !affected[subj] {
+			healthySubj, healthyName = subj, nameBySubject[subj]
+			break
+		}
+	}
+	require.NotEmpty(t, healthyName, "need at least one healthy consumer to delete")
+
+	healthyBase := countFor(healthySubj)
+	require.NoError(t, js.DeleteConsumer(ctx, streamName, healthyName))
+	// Publish on each poll: the recreated consumer uses DeliverNew (RecoverFromNew),
+	// so only a message published AFTER the new consumer binds is delivered. Polling
+	// the publish avoids racing the recreate.
+	require.Eventually(t, func() bool {
+		_, _ = js.Publish(ctx, healthySubj, []byte("after-delete"))
+		return countFor(healthySubj) > healthyBase
+	}, 25*time.Second, 500*time.Millisecond,
+		"parti should recreate the explicitly-deleted healthy consumer and resume %s", healthySubj)
+	t.Logf("confirmed recreate-on-delete path: healthy consumer %s resumed after explicit DeleteConsumer", healthySubj)
+}
+
+// --- helpers ---
+
+func subjectFor(partition int) string {
+	return "crash1.partition-" + strconv.Itoa(partition)
+}
+
+// tryListConsumerInfos lists a stream's consumers, returning any transient error
+// (stream lookup or list timeout while the cluster re-elects / resyncs after a
+// node restart) instead of failing, so callers can retry.
+func tryListConsumerInfos(ctx context.Context, js jetstream.JetStream, stream string) ([]*jetstream.ConsumerInfo, error) {
+	s, err := js.Stream(ctx, stream)
+	if err != nil {
+		return nil, err
+	}
+	lister := s.ListConsumers(ctx)
+	var out []*jetstream.ConsumerInfo
+	for ci := range lister.Info() {
+		out = append(out, ci)
+	}
+	if err := lister.Err(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// listConsumerInfos returns the current consumer infos. On a transient error
+// (cluster mid-resync) it logs and returns nil so callers polling inside a
+// require.Eventually naturally retry rather than hard-failing on a blip.
+func listConsumerInfos(t *testing.T, ctx context.Context, js jetstream.JetStream, stream string) []*jetstream.ConsumerInfo {
+	t.Helper()
+	infos, err := tryListConsumerInfos(ctx, js, stream)
+	if err != nil {
+		t.Logf("listConsumerInfos transient error (returning nil; retry if polled): %v", err)
+		return nil
+	}
+
+	return infos
+}
+
+// publishWithRetry publishes to subj, retrying the transient errors ("no response
+// from stream", context deadline) that occur while the stream's raft group
+// re-elects a leader after nodes are killed. The RF5 stream retains quorum, so
+// the publish genuinely succeeds once re-election settles (typically <5s).
+func publishWithRetry(t *testing.T, ctx context.Context, js jetstream.JetStream, subj string, data []byte) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		pctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		_, err := js.Publish(pctx, subj, data)
+
+		return err == nil
+	}, 20*time.Second, 250*time.Millisecond, "publish to %s should succeed once the RF5 stream re-elects", subj)
+}
+
+// peerIndices returns the node indices hosting a consumer's raft peers
+// (leader + replicas).
+func peerIndices(ci *jetstream.ConsumerInfo, nameToIdx map[string]int) []int {
+	if ci.Cluster == nil {
+		return nil
+	}
+	var p []int
+	if ci.Cluster.Leader != "" {
+		p = append(p, nameToIdx[ci.Cluster.Leader])
+	}
+	for _, r := range ci.Cluster.Replicas {
+		p = append(p, nameToIdx[r.Name])
+	}
+
+	return p
+}
+
+func countIn(peers []int, a, b int) int {
+	c := 0
+	for _, p := range peers {
+		if p == a || p == b {
+			c++
+		}
+	}
+	return c
+}
+
+// bestKillPair finds the node pair whose shutdown strips quorum (>=2 of 3 peers)
+// from the most consumers.
+func bestKillPair(peersBySubject map[string][]int, nodeCount int) (killA, killB, affected int) {
+	killA, killB, affected = 0, 1, -1
+	for a := 0; a < nodeCount; a++ {
+		for b := a + 1; b < nodeCount; b++ {
+			n := 0
+			for _, peers := range peersBySubject {
+				if countIn(peers, a, b) >= 2 {
+					n++
+				}
+			}
+			if n > affected {
+				affected, killA, killB = n, a, b
+			}
+		}
+	}
+
+	return killA, killB, affected
+}

--- a/test/integration/failure/cluster_pvc_loss_test.go
+++ b/test/integration/failure/cluster_pvc_loss_test.go
@@ -1,0 +1,128 @@
+package failure_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestCluster_NodePVCLoss_SurvivesTransparently covers the "file storage / PVC
+// broken on one node" corner case: a single node loses its persistent volume and
+// restarts empty. With an RF5 FileStorage stream + RF5 KV on a 5-node cluster,
+// quorum (3 of 5) holds throughout, so the wiped node re-replicates from peers and
+// parti keeps working with no degradation and no operator intervention.
+func TestCluster_NodePVCLoss_SurvivesTransparently(t *testing.T) {
+	requireClusterCrashTests(t)
+
+	ctx := context.Background()
+	const (
+		streamName = "PVC"
+		prefix     = "pvc"
+		subjectTpl = "pvc.{{.PartitionID}}"
+		numParts   = 4
+	)
+	subjectFor := func(i int) string { return "pvc.partition-" + strconv.Itoa(i) }
+
+	cluster := partitest.StartCluster(t, partitest.WithClusterSize(5))
+	nc := cluster.Conn
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	partitest.CreateStream(t, nc, partitest.StreamSpec{
+		Name:     streamName,
+		Subjects: []string{"pvc.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		mu.Lock()
+		counts[msg.Subject()]++
+		mu.Unlock()
+		return nil
+	})
+	countFor := func(subj string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[subj]
+	}
+
+	dyn, err := consumer.NewDynamic(
+		js, streamName, prefix, subjectTpl, handler,
+		consumer.WithConsumerReplicas(3),
+		consumer.WithConsumerMemoryStorage(true),
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+		consumer.WithBatchSize(1),
+		consumer.WithFetchTimeout(1*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.KVBuckets.Replicas = 5
+
+	wc := testutil.NewWorkerClusterWithSource(t, nc,
+		source.NewStatic(testutil.CreateTestPartitions(numParts)), cfg)
+	wc.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(dyn))
+	wc.StartWorkers(ctx)
+	defer wc.StopWorkers()
+	mgr := wc.Workers[0]
+
+	require.Eventually(t, func() bool {
+		return len(listConsumerInfos(t, ctx, js, streamName)) == numParts
+	}, 20*time.Second, 200*time.Millisecond)
+
+	// Baseline.
+	for i := 0; i < numParts; i++ {
+		_, perr := js.Publish(ctx, subjectFor(i), []byte("baseline"))
+		require.NoError(t, perr)
+	}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		require.Eventually(t, func() bool { return countFor(subj) >= 1 },
+			15*time.Second, 100*time.Millisecond, "baseline not consumed on %s", subj)
+	}
+
+	// Simulate PVC loss on one node: shut it down and restart with an empty
+	// StoreDir. Quorum (3 of 5) is never lost.
+	const victim = 1
+	cluster.Servers[victim].Shutdown()
+	cluster.Servers[victim].WaitForShutdown()
+	cluster.RestartNodeWiped(victim)
+	t.Logf("node %d restarted with wiped StoreDir (PVC loss)", victim)
+
+	// The worker must not degrade — quorum held throughout.
+	require.Never(t, func() bool { return mgr.State() == types.StateDegraded },
+		3*time.Second, 250*time.Millisecond, "worker should not degrade on single-node PVC loss")
+
+	// Parti keeps working: publish to every partition and confirm consumption
+	// continues after the node rejoins and re-replicates.
+	base := make([]int, numParts)
+	for i := 0; i < numParts; i++ {
+		base[i] = countFor(subjectFor(i))
+	}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		want := base[i]
+		require.Eventually(t, func() bool {
+			_, _ = js.Publish(ctx, subj, []byte("post-pvc"))
+			return countFor(subj) > want
+		}, 25*time.Second, 500*time.Millisecond, "partition %s should keep consuming after PVC loss", subj)
+	}
+	t.Log("confirmed: parti survived single-node PVC loss transparently")
+}

--- a/test/integration/failure/cluster_quorum_restored_test.go
+++ b/test/integration/failure/cluster_quorum_restored_test.go
@@ -1,0 +1,231 @@
+package failure_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+)
+
+// TestCluster_PartialCrash_QuorumRestored_Resumes answers: once a quorum-lost
+// memory-RF3 consumer regains quorum (the nodes that hosted its peers come back),
+// does parti resume on the SAME consumer without a recreate?
+//
+// Hypothesis (verified by this test): yes. The dynamic-consumer iterator treats
+// the quorum-loss surface (503/NoResponders) as transient and backs off-and-retries
+// indefinitely, so it resumes once the consumer is reachable again. And because a
+// memory-RF3 consumer keeps exactly one surviving peer (only 2 of 3 are killed), the
+// raft group recovers its state from that peer when the 2 nodes restart empty — so
+// the consumer is the same one (unchanged Created timestamp), not a fresh recreate.
+func TestCluster_PartialCrash_QuorumRestored_Resumes(t *testing.T) {
+	requireClusterCrashTests(t)
+
+	ctx := context.Background()
+	const (
+		streamName = "CRASH1"
+		prefix     = "crash1"
+		subjectTpl = "crash1.{{.PartitionID}}"
+		numParts   = 8
+	)
+
+	cluster := partitest.StartCluster(t, partitest.WithClusterSize(5))
+	nc := cluster.Conn
+	nameToIdx := map[string]int{}
+	for i, s := range cluster.Servers {
+		nameToIdx[s.Name()] = i
+	}
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	partitest.CreateStream(t, nc, partitest.StreamSpec{
+		Name:     streamName,
+		Subjects: []string{"crash1.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+	// payloadHits[subject][payload] = delivery count, for no-loss / dup tracking.
+	payloadHits := map[string]map[string]int{}
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		mu.Lock()
+		counts[msg.Subject()]++
+		if payloadHits[msg.Subject()] == nil {
+			payloadHits[msg.Subject()] = map[string]int{}
+		}
+		payloadHits[msg.Subject()][string(msg.Data())]++
+		mu.Unlock()
+
+		return nil
+	})
+	countFor := func(subj string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[subj]
+	}
+	// uniqueDelivered returns how many of the given payloads were delivered at
+	// least once, and the max delivery count seen for any one of them.
+	uniqueDelivered := func(subj string, payloads []string) (got, maxDup int) {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, p := range payloads {
+			if n := payloadHits[subj][p]; n > 0 {
+				got++
+				if n > maxDup {
+					maxDup = n
+				}
+			}
+		}
+
+		return got, maxDup
+	}
+
+	dyn, err := consumer.NewDynamic(
+		js, streamName, prefix, subjectTpl, handler,
+		consumer.WithConsumerReplicas(3),
+		consumer.WithConsumerMemoryStorage(true),
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+		consumer.WithBatchSize(1),
+		consumer.WithFetchTimeout(1*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.KVBuckets.Replicas = 5
+
+	wc := testutil.NewWorkerClusterWithSource(t, nc,
+		source.NewStatic(testutil.CreateTestPartitions(numParts)), cfg)
+	wc.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(dyn))
+	wc.StartWorkers(ctx)
+	defer wc.StopWorkers()
+
+	require.Eventually(t, func() bool {
+		return len(listConsumerInfos(t, ctx, js, streamName)) == numParts
+	}, 20*time.Second, 200*time.Millisecond)
+
+	// Baseline.
+	for i := 0; i < numParts; i++ {
+		_, perr := js.Publish(ctx, subjectFor(i), []byte("baseline"))
+		require.NoError(t, perr)
+	}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		require.Eventually(t, func() bool { return countFor(subj) >= 1 },
+			15*time.Second, 100*time.Millisecond, "baseline not consumed on %s", subj)
+	}
+
+	// Snapshot placement, pick the best 2-node kill, and capture one affected
+	// consumer's identity (name + Created) so we can tell resume from recreate.
+	infos := listConsumerInfos(t, ctx, js, streamName)
+	peersBySubject := map[string][]int{}
+	infoBySubject := map[string]*jetstream.ConsumerInfo{}
+	for _, ci := range infos {
+		peersBySubject[ci.Config.FilterSubject] = peerIndices(ci, nameToIdx)
+		infoBySubject[ci.Config.FilterSubject] = ci
+	}
+	killA, killB, affectedCount := bestKillPair(peersBySubject, len(cluster.Servers))
+	require.Greater(t, affectedCount, 0)
+
+	var affSubj string
+	for subj, peers := range peersBySubject {
+		if countIn(peers, killA, killB) >= 2 {
+			affSubj = subj
+			break
+		}
+	}
+	require.NotEmpty(t, affSubj)
+	origName := infoBySubject[affSubj].Name
+	origCreated := infoBySubject[affSubj].Created
+	t.Logf("killing node%d+node%d; tracking affected consumer %s (subj=%s)", killA, killB, origName, affSubj)
+
+	// Crash the two nodes.
+	cluster.Servers[killA].Shutdown()
+	cluster.Servers[killB].Shutdown()
+	cluster.Servers[killA].WaitForShutdown()
+	cluster.Servers[killB].WaitForShutdown()
+
+	// Confirm the affected consumer stalls: a message published now is not consumed.
+	stallBase := countFor(affSubj)
+	publishWithRetry(t, ctx, js, affSubj, []byte("during-outage")) // stream is RF5, still has quorum
+	require.Never(t, func() bool { return countFor(affSubj) > stallBase },
+		6*time.Second, 500*time.Millisecond, "affected consumer %s should stall while quorum is lost", affSubj)
+	t.Logf("confirmed stall on %s", affSubj)
+
+	// Bring the two nodes back → the consumer's raft group regains quorum.
+	cluster.RestartNode(killA)
+	cluster.RestartNode(killB)
+	t.Log("restarted both nodes; waiting for the stalled consumer to resume")
+
+	// The iterator should resume on its own. Publishing on each poll guarantees a
+	// message lands once delivery is flowing again (covers any deliver-policy nuance).
+	resumeBase := countFor(affSubj)
+	require.Eventually(t, func() bool {
+		_, _ = js.Publish(ctx, affSubj, []byte("post-recovery"))
+		return countFor(affSubj) > resumeBase
+	}, 40*time.Second, 500*time.Millisecond,
+		"parti should resume consuming %s after quorum is restored", affSubj)
+	t.Logf("confirmed resume on %s after quorum restored", affSubj)
+
+	// Was it the SAME consumer (resumed) or a fresh recreate? Compare identity.
+	// Retry the lookup: right after node restart the stream/consumer metadata can
+	// transiently time out while the restarted nodes resync.
+	var found *jetstream.ConsumerInfo
+	require.Eventually(t, func() bool {
+		cur, lerr := tryListConsumerInfos(ctx, js, streamName)
+		if lerr != nil {
+			return false
+		}
+		for _, ci := range cur {
+			if ci.Config.FilterSubject == affSubj {
+				found = ci
+				return true
+			}
+		}
+
+		return false
+	}, 20*time.Second, 250*time.Millisecond, "consumer for %s should be listable after recovery", affSubj)
+	require.NotNil(t, found, "consumer for %s should exist after recovery", affSubj)
+	if found.Name == origName && found.Created.Equal(origCreated) {
+		t.Logf("RESULT: parti resumed on the SAME consumer %s (Created unchanged) — no recreate", origName)
+	} else {
+		t.Logf("RESULT: consumer was recreated: name %s->%s, created %v->%v",
+			origName, found.Name, origCreated, found.Created)
+	}
+	require.Equal(t, origName, found.Name, "expected the same consumer name after quorum restored")
+	require.True(t, found.Created.Equal(origCreated),
+		"expected the same consumer (unchanged Created) — resume, not recreate")
+
+	// Message-delivery correctness after recovery: publish a batch of uniquely
+	// identified messages and require every one to be delivered (no loss). Because
+	// recovery is "resume the same consumer" — not a parallel recreate — there is
+	// no second consumer racing on the subject, so gross duplication must not occur.
+	const batch = 20
+	payloads := make([]string, batch)
+	for i := 0; i < batch; i++ {
+		payloads[i] = "recovered-" + strconv.Itoa(i)
+		_, perr := js.Publish(ctx, affSubj, []byte(payloads[i]))
+		require.NoError(t, perr)
+	}
+	require.Eventually(t, func() bool {
+		got, _ := uniqueDelivered(affSubj, payloads)
+		return got == batch
+	}, 30*time.Second, 200*time.Millisecond, "all %d post-recovery messages must be delivered (no loss)", batch)
+
+	_, maxDup := uniqueDelivered(affSubj, payloads)
+	require.LessOrEqual(t, maxDup, 2,
+		"no gross duplication after resume (at-least-once allows rare redelivery, not a parallel consumer); maxDup=%d", maxDup)
+	t.Logf("delivery correctness after resume: all %d unique messages delivered, maxDup=%d", batch, maxDup)
+}

--- a/test/integration/failure/cluster_unservable_signal_gap_test.go
+++ b/test/integration/failure/cluster_unservable_signal_gap_test.go
@@ -1,0 +1,191 @@
+package failure_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestCluster_SustainedQuorumLoss_NotifiesApp is a BLACK-BOX test asserting only
+// app-observable outcomes: parti notifies the application when a consumer is
+// unservable and needs operator action.
+//
+// Scenario: an RF5 file stream with RF5 KV (manager stays healthy) and memory-RF3
+// dynamic consumers. Two of five nodes are crashed and NOT restored, so some
+// consumers permanently lose raft quorum. Parti cannot recreate them (verified:
+// DeleteConsumer needs the lost quorum) and cannot resume them (nodes never
+// return) — this genuinely requires operator action on NATS.
+//
+// Requirement pinned: with WithOnConsumerUnservable registered, the app receives
+// the unservable signal for the affected subject (while the connection stays UP
+// and the manager stays healthy), and the terminal OnPermanentFailure does NOT
+// fire. This is the case that, before the feature, left the app blind.
+func TestCluster_SustainedQuorumLoss_NotifiesApp(t *testing.T) {
+	requireClusterCrashTests(t)
+
+	ctx := context.Background()
+	const (
+		streamName = "GAP"
+		prefix     = "gap"
+		subjectTpl = "gap.{{.PartitionID}}"
+		numParts   = 8
+	)
+	subjectFor := func(i int) string { return "gap.partition-" + strconv.Itoa(i) }
+
+	cluster := partitest.StartCluster(t, partitest.WithClusterSize(5))
+	nc := cluster.Conn
+	nameToIdx := map[string]int{}
+	for i, s := range cluster.Servers {
+		nameToIdx[s.Name()] = i
+	}
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	partitest.CreateStream(t, nc, partitest.StreamSpec{
+		Name:     streamName,
+		Subjects: []string{"gap.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+
+	// App-observable signals.
+	var mu sync.Mutex
+	counts := map[string]int{}
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		mu.Lock()
+		counts[msg.Subject()]++
+		mu.Unlock()
+		return nil
+	})
+	countFor := func(subj string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[subj]
+	}
+
+	var permanentFailures atomic.Int64
+	var firesMu sync.Mutex
+	fires := map[string]int{} // subject -> unservable-notification count
+
+	dyn, err := consumer.NewDynamic(
+		js, streamName, prefix, subjectTpl, handler,
+		consumer.WithConsumerReplicas(3),
+		consumer.WithConsumerMemoryStorage(true),
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+		consumer.WithBatchSize(1),
+		consumer.WithFetchTimeout(1*time.Second),
+		// OnPermanentFailure must NOT fire for an unservable (not-exhausted) consumer.
+		consumer.WithOnPermanentFailure(func(_ string, _ error) {
+			permanentFailures.Add(1)
+		}),
+		// The unservable-notification seam: parti tells the app a consumer needs
+		// operator action. Small window so the test does not wait the 10s default.
+		consumer.WithConsumerUnservableThreshold(2*time.Second),
+		consumer.WithOnConsumerUnservable(func(subject string, _ error) {
+			firesMu.Lock()
+			fires[subject]++
+			firesMu.Unlock()
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.KVBuckets.Replicas = 5
+
+	wc := testutil.NewWorkerClusterWithSource(t, nc,
+		source.NewStatic(testutil.CreateTestPartitions(numParts)), cfg)
+	wc.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(dyn))
+	wc.StartWorkers(ctx)
+	defer wc.StopWorkers()
+	mgr := wc.Workers[0]
+
+	require.Eventually(t, func() bool {
+		return len(listConsumerInfos(t, ctx, js, streamName)) == numParts
+	}, 20*time.Second, 200*time.Millisecond)
+
+	// Baseline: everything flows.
+	for i := 0; i < numParts; i++ {
+		_, perr := js.Publish(ctx, subjectFor(i), []byte("baseline"))
+		require.NoError(t, perr)
+	}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		require.Eventually(t, func() bool { return countFor(subj) >= 1 },
+			15*time.Second, 100*time.Millisecond, "baseline not consumed on %s", subj)
+	}
+
+	// Choose the 2-node kill that strips quorum from the most consumers.
+	infos := listConsumerInfos(t, ctx, js, streamName)
+	peersBySubject := map[string][]int{}
+	for _, ci := range infos {
+		peersBySubject[ci.Config.FilterSubject] = peerIndices(ci, nameToIdx)
+	}
+	killA, killB, affectedCount := bestKillPair(peersBySubject, len(cluster.Servers))
+	require.Greater(t, affectedCount, 0)
+
+	var affSubj string
+	for subj, peers := range peersBySubject {
+		if countIn(peers, killA, killB) >= 2 {
+			affSubj = subj
+			break
+		}
+	}
+	require.NotEmpty(t, affSubj)
+	t.Logf("killing node%d+node%d; tracking unservable consumer on %s", killA, killB, affSubj)
+
+	cluster.Servers[killA].Shutdown()
+	cluster.Servers[killB].Shutdown()
+	cluster.Servers[killA].WaitForShutdown()
+	cluster.Servers[killB].WaitForShutdown()
+
+	// OBSERVABLE 1 — delivery on the affected partition stalls.
+	stallBase := countFor(affSubj)
+	publishWithRetry(t, ctx, js, affSubj, []byte("during-outage")) // stream RF5 still has quorum
+	require.Never(t, func() bool { return countFor(affSubj) > stallBase },
+		10*time.Second, 500*time.Millisecond, "affected partition %s should stall (unservable)", affSubj)
+
+	// The consumer is unservable while the NATS CONNECTION IS UP (the client
+	// reconnects to a surviving node) — this is exactly the detection predicate
+	// the future feature keys on: "exists but unservable, connection up".
+	require.Equal(t, nats.CONNECTED, nc.Status(),
+		"connection must be UP during the stall (consumer-level, not connectivity, failure)")
+
+	// OBSERVABLE 2 — the app IS notified that this consumer needs operator action.
+	// (Previously the gap: nothing fired. Now WithOnConsumerUnservable fires.)
+	firedFor := func(subj string) int {
+		firesMu.Lock()
+		defer firesMu.Unlock()
+
+		return fires[subj]
+	}
+	require.Eventually(t, func() bool { return firedFor(affSubj) > 0 },
+		30*time.Second, 250*time.Millisecond,
+		"app must be notified (OnConsumerUnservable) that %s is unservable", affSubj)
+
+	// The unservable signal is the RIGHT signal — not the terminal OnPermanentFailure
+	// (this is not iterator-creation exhaustion) and not a manager Degraded transition
+	// (RF5 KV survived 2-of-5, so the manager stays healthy).
+	require.Equal(t, int64(0), permanentFailures.Load(),
+		"OnPermanentFailure must not fire for an unservable (not-iterator-exhausted) consumer")
+	require.NotEqual(t, types.StateDegraded, mgr.State(),
+		"manager stays healthy on partial loss; the per-consumer signal owns this case")
+
+	t.Logf("NOTIFIED: app received OnConsumerUnservable for %s (fires=%d) while connection UP and manager %v",
+		affSubj, firedFor(affSubj), mgr.State())
+}

--- a/test/integration/failure/cluster_unservable_silence_test.go
+++ b/test/integration/failure/cluster_unservable_silence_test.go
@@ -1,0 +1,150 @@
+package failure_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+)
+
+// TestCluster_TemporalBlip_DoesNotNotify is the false-positive guard for the
+// unservable notification: a brief quorum blip (nodes crash then come right back,
+// the kind a normal leader election or rolling restart produces) must NOT fire
+// WithOnConsumerUnservable, because parti auto-heals it. Only sustained
+// unservability (past the window) is operator-actionable.
+//
+// The window is set to 8s; the crashed nodes are restarted within ~1s, so the
+// unservable condition never persists past the window. Delivery resumes and the
+// app is never paged.
+func TestCluster_TemporalBlip_DoesNotNotify(t *testing.T) {
+	requireClusterCrashTests(t)
+
+	ctx := context.Background()
+	const (
+		streamName = "BLIP"
+		prefix     = "blip"
+		subjectTpl = "blip.{{.PartitionID}}"
+		numParts   = 8
+	)
+	subjectFor := func(i int) string { return "blip.partition-" + strconv.Itoa(i) }
+
+	cluster := partitest.StartCluster(t, partitest.WithClusterSize(5))
+	nc := cluster.Conn
+	nameToIdx := map[string]int{}
+	for i, s := range cluster.Servers {
+		nameToIdx[s.Name()] = i
+	}
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	partitest.CreateStream(t, nc, partitest.StreamSpec{
+		Name:     streamName,
+		Subjects: []string{"blip.>"},
+		Storage:  jetstream.FileStorage,
+		Replicas: 5,
+	})
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		mu.Lock()
+		counts[msg.Subject()]++
+		mu.Unlock()
+		return nil
+	})
+	countFor := func(subj string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[subj]
+	}
+
+	var unservableFires atomic.Int64
+	dyn, err := consumer.NewDynamic(
+		js, streamName, prefix, subjectTpl, handler,
+		consumer.WithConsumerReplicas(3),
+		consumer.WithConsumerMemoryStorage(true),
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+		consumer.WithBatchSize(1),
+		consumer.WithFetchTimeout(1*time.Second),
+		// Window generous enough that node restart + raft resync (even under heavy
+		// CI load) completes well within it, so a brief blip never crosses it.
+		consumer.WithConsumerUnservableThreshold(20*time.Second),
+		consumer.WithOnConsumerUnservable(func(_ string, _ error) { unservableFires.Add(1) }),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.KVBuckets.Replicas = 5
+
+	wc := testutil.NewWorkerClusterWithSource(t, nc,
+		source.NewStatic(testutil.CreateTestPartitions(numParts)), cfg)
+	wc.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(dyn))
+	wc.StartWorkers(ctx)
+	defer wc.StopWorkers()
+
+	require.Eventually(t, func() bool {
+		return len(listConsumerInfos(t, ctx, js, streamName)) == numParts
+	}, 20*time.Second, 200*time.Millisecond)
+
+	for i := 0; i < numParts; i++ {
+		_, perr := js.Publish(ctx, subjectFor(i), []byte("baseline"))
+		require.NoError(t, perr)
+	}
+	for i := 0; i < numParts; i++ {
+		subj := subjectFor(i)
+		require.Eventually(t, func() bool { return countFor(subj) >= 1 },
+			15*time.Second, 100*time.Millisecond, "baseline not consumed on %s", subj)
+	}
+
+	// Pick a pair to kill, note an affected subject, then bring the nodes RIGHT
+	// back — a transient blip well under the 8s unservable window.
+	infos := listConsumerInfos(t, ctx, js, streamName)
+	peersBySubject := map[string][]int{}
+	for _, ci := range infos {
+		peersBySubject[ci.Config.FilterSubject] = peerIndices(ci, nameToIdx)
+	}
+	killA, killB, affectedCount := bestKillPair(peersBySubject, len(cluster.Servers))
+	require.Greater(t, affectedCount, 0)
+	var affSubj string
+	for subj, peers := range peersBySubject {
+		if countIn(peers, killA, killB) >= 2 {
+			affSubj = subj
+			break
+		}
+	}
+	require.NotEmpty(t, affSubj)
+
+	cluster.Servers[killA].Shutdown()
+	cluster.Servers[killB].Shutdown()
+	cluster.Servers[killA].WaitForShutdown()
+	cluster.Servers[killB].WaitForShutdown()
+	// Restore immediately — a brief blip, far under the 20s unservable window.
+	cluster.RestartNode(killA)
+	cluster.RestartNode(killB)
+	t.Logf("blip: killed+restored node%d+node%d (window=20s)", killA, killB)
+
+	// The (briefly) affected partition resumes delivery...
+	base := countFor(affSubj)
+	require.Eventually(t, func() bool {
+		_, _ = js.Publish(ctx, affSubj, []byte("post-blip"))
+		return countFor(affSubj) > base
+	}, 45*time.Second, 500*time.Millisecond, "partition %s should resume after the blip", affSubj)
+
+	// ...and the app was NEVER paged: the blip did not cross the unservable window.
+	require.Equal(t, int64(0), unservableFires.Load(),
+		"a transient blip must NOT fire OnConsumerUnservable (false-positive guard)")
+	t.Log("confirmed: transient blip auto-healed silently; app not paged")
+}

--- a/test/integration/handoff/handoff_conflict_stress_test.go
+++ b/test/integration/handoff/handoff_conflict_stress_test.go
@@ -80,11 +80,7 @@ func TestHandoffConflictStress(t *testing.T) {
 	require.NoError(t, m2.Start(ctx))
 	t.Cleanup(func() { _ = m2.Stop(context.Background()) })
 
-	// Wait for initial assignments to stabilize (bounded wait loop instead of fixed sleep)
-	// Use KV watcher-based collector for deterministic stabilization
-	collector, err := testutil.NewHandoffClaimCollector(ctx, js, bucket)
-	require.NoError(t, err)
-	t.Cleanup(func() { collector.Stop() })
+	// Wait for initial assignments to stabilize (bounded wait loop instead of fixed sleep).
 	// Initial convergence: wait until at least one claim enters stable state.
 	// Since partition IDs are unknown until claims appear, poll for any stable.
 	deadline := time.Now().Add(1 * time.Second)
@@ -116,66 +112,50 @@ func TestHandoffConflictStress(t *testing.T) {
 		// Proceed to next churn iteration; final stabilization is asserted later
 	}
 
-	// Final stabilization after churn
+	// Final stabilization after churn: poll until every current partition has a
+	// claim and ALL claims (current partitions plus any extras left over from the
+	// expansion-to-10 rounds) are stable with no pending owner, owned by an active
+	// worker. Convergence is eventual — under parallel load it settles within a
+	// few hundred ms — so poll the full invariant rather than snapshotting once
+	// after a fixed wait, which races a still-settling claim.
 	curParts, err := src.List(ctx)
-	require.NoError(t, err)
-	ids := make([]string, 0, len(curParts))
-	for _, p := range curParts {
-		ids = append(ids, p.ID())
-	}
-	// Allow more time due to churn and potential lingering prepare/commit windows.
-	require.True(t, collector.WaitForAllStable(ctx, ids, 4*time.Second))
-
-	// Inspect claims: current partitions must be stable; extras (from earlier expansions) must also be stable
-	claims, err := parti.InspectHandoffClaims(ctx, js, bucket)
-	require.NoError(t, err)
-	// Build current partition set
-	curParts, err = src.List(ctx)
 	require.NoError(t, err)
 	curSet := make(map[string]struct{}, len(curParts))
 	for _, p := range curParts {
 		curSet[p.ID()] = struct{}{}
 	}
 	owners := map[string]struct{}{m1.WorkerID(): {}, m2.WorkerID(): {}}
-	for _, c := range claims {
-		require.Equal(t, parti.HandoffClaimStable, c.State, "claims should converge to stable")
-		require.Empty(t, c.PendingOwner, "no pending owner after stabilization")
-		if _, ok := owners[c.Owner]; !ok {
-			t.Fatalf("unexpected owner %q; expected one of %v", c.Owner, owners)
-		}
-	}
-	// Ensure every current partition has a claim present
-	present := make(map[string]bool, len(claims))
-	for _, c := range claims {
-		present[c.PartitionID] = true
-	}
-	for pid := range curSet {
-		require.True(t, present[pid], "current partition %s must have a claim", pid)
-	}
 
-	// Observe CAS conflicts during churn (informational). Depending on timing and a single active leader,
-	// it's possible to see zero conflicts; we record the value but do not fail the test on zero.
+	var claims []parti.HandoffClaim
+	require.Eventually(t, func() bool {
+		var ierr error
+		claims, ierr = parti.InspectHandoffClaims(ctx, js, bucket)
+		if ierr != nil {
+			return false
+		}
+		present := make(map[string]bool, len(claims))
+		for _, c := range claims {
+			if c.State != parti.HandoffClaimStable || c.PendingOwner != "" {
+				return false
+			}
+			if _, ok := owners[c.Owner]; !ok {
+				return false
+			}
+			present[c.PartitionID] = true
+		}
+		for pid := range curSet {
+			if !present[pid] {
+				return false
+			}
+		}
+
+		return true
+	}, 15*time.Second, 100*time.Millisecond,
+		"all handoff claims must converge to stable (no pending owner) with every current partition present")
+
+	// Observe CAS conflicts during churn (informational). Depending on timing and
+	// a single active leader, it's possible to see zero conflicts; we record the
+	// value but do not fail the test on zero.
 	snap := mr.Snapshot()
 	t.Logf("CAS conflicts observed: %d", snap.CASConflicts)
-
-	// Phase 4 makes the initial-bootstrap apply synchronous-before-StateStable,
-	// so the initial prepare → commit transitions complete before the
-	// collector (started after Start returns) can observe them, and any
-	// partition that doesn't migrate during churn remains invisible to
-	// the collector. The convergence assertion now uses InspectHandoffClaims
-	// (KV query, sees all current state) rather than the collector's
-	// updates-only feed. The intermediate-state observability invariant
-	// is covered by unit tests against handleCommitValue's case-(c) path.
-	finalClaims, err := parti.InspectHandoffClaims(ctx, js, bucket)
-	require.NoError(t, err)
-	claimsByPID := make(map[string]parti.HandoffClaim, len(finalClaims))
-	for _, c := range finalClaims {
-		claimsByPID[c.PartitionID] = c
-	}
-	for pid := range curSet {
-		cl, ok := claimsByPID[pid]
-		require.True(t, ok, "partition %s must have a claim", pid)
-		require.Equal(t, parti.HandoffClaimStable, cl.State, "partition %s must terminate in Stable", pid)
-		require.Empty(t, cl.PendingOwner, "partition %s must not have a pending owner", pid)
-	}
 }


### PR DESCRIPTION
Bundles three independent changes (called out separately below for review).

## 1. feat: unservable-consumer notification

When a dynamic consumer exists but cannot serve (e.g. its memory-replica raft group loses quorum), NATS returns 503/NoResponders — never ConsumerNotFound — so parti's recovery treated it as transient and retried silently forever, with no app-facing signal (manager stays Stable on partial loss; OnPermanentFailure is terminal and doesn't fire).

- New non-terminal hook `consumer.WithOnConsumerUnservable(fn)` + `WithConsumerUnservableThreshold(window)` (default 10s, duration-anchored).
- Driven by a lossless 5-way `ClassifyConfirm` over `consumer.Info()` (healthy / gone / degrading / connectivity / unservable). ConsumerNotFound still routes to recreate; degrading/connectivity still route to their existing owners.
- Parti keeps retrying so delivery auto-resumes once the consumer is serviceable again; the hook only tells the app operator action may be needed. Opt-in: behavior is unchanged when the hook is not registered.
- New `partitest` cluster harness (configurable size/storage/replicas, in-place + PVC-loss node restart, JetStream peer-readiness gate) and black-box `test/integration/failure/cluster_*` tests, gated behind `PARTI_RUN_CLUSTER_CRASH`.

## 2. fix(handoff): only commit a handoff prepared to this worker

`commitPhase` committed any claim where `cur.Owner != workerID`, including a peer-owned **stable** claim with no pending handoff. Under concurrent rebalance churn a worker could carry a peer-owned partition without a preceding prepare, flip the peer's stable claim to `commit` (keeping the peer as owner), then skip it in `stabilizePhase` — orphaning the owner's claim in `commit` until the TTL sweep (~minutes), with the pull gate suppressing delivery the whole time.

Fix: commit only when `cur.PendingOwner == workerID`. Adds a deterministic reproducer (red on the old guard). Verified: reproducer 1000x green; live conflict-stress 0/40 under CPU saturation (was ~1/30); external review verdict = ship.

## 3. test: reliability hardening for two pre-existing load flakes

- `testutil.VerifyTotalPartitionCount` now polls for coverage instead of snapshotting once — fixes `TestLeaderElection_ColdStart` racing assignment propagation under parallel load (16/16 after, was ~1/12).
- `TestHandoffConflictStress` now polls the full convergence invariant instead of a fixed 4s wait + one-shot snapshot.

## Test plan

- [x] `make pre-pr` on the combined branch (lint + `make test -race` + `make test-integration -race`) — all gates passed.
- [x] Cluster crash suite (`PARTI_RUN_CLUSTER_CRASH=1`) green across repeated `-race` runs.
- [x] Handoff fix: deterministic reproducer 1000x + conflict-stress 0/40 under load; external code review = ship.
- [ ] Note: `TestCalculator_PlannedScaleRespectsCooldown` is a separate pre-existing load flake (passes in isolation and on main), out of scope for this PR.