### PR TITLE
fix(durable): recover from quorum-loss resolver tombstones (don't poison on transient reads)

### DIFF
--- a/cmd/partictl/policy_test.go
+++ b/cmd/partictl/policy_test.go
@@ -323,7 +323,7 @@ func TestHelp_ContainsAdopt(t *testing.T) {
 
 // extractDeferredLine returns the line containing "Deferred commands" from s.
 func extractDeferredLine(s string) string {
-	for _, line := range strings.Split(s, "\n") {
+	for line := range strings.SplitSeq(s, "\n") {
 		if strings.Contains(line, "Deferred") {
 			return line
 		}

--- a/consumer/dynamic_compat_rearm_test.go
+++ b/consumer/dynamic_compat_rearm_test.go
@@ -201,10 +201,10 @@ func TestDynamic_CompatRearm_ConcurrentStress_NoRace(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(workers)
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < itersPerWorker; j++ {
+			for j := range itersPerWorker {
 				_ = d.ensureCompatChecked(ctx)
 				if (id+j)%17 == 0 {
 					d.resetCompatCheck()

--- a/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
@@ -1,10 +1,30 @@
 # Auto-Healing Quorum-Loss — Fix Plan
 
 - **Date:** 2026-05-30
-- **Status:** REVIEW-CLEAN — ready to implement. Cleared the review loop (1 `plan-review`
-  xhigh + 4 `final-plan-review` high passes; reports `tmp/00-fix-plan_*_review*.md`); final
-  verdict **"ready to implement, 0 findings"** (`tmp/00-fix-plan_precision_pass_review_v4.md`).
-  **Implementation not started** — awaiting go-ahead.
+- **Status:** PARTIALLY IMPLEMENTED. The operational fix (**F-D2a + F-D2c + the S2 regression
+  guard**) is implemented, `make pre-pr`-green, and codex-reviewed to *merge* on branch
+  `fix/quorum-loss-fd2a-resolver-tombstone`. **F-D2b was implemented, reviewed, then DROPPED as
+  dead code** (see the decision log below). **F-D1 (PR3) and F-D3 (PR4) are not started.** The
+  plan originally cleared the review loop (1 `plan-review` xhigh + 4 `final-plan-review` high
+  passes; reports `tmp/00-fix-plan_*_review*.md`) — but that review missed the F-D2b
+  reachability gap, which only surfaced during implementation.
+
+### Implementation status & decision log (2026-05-30)
+
+| Item | Status | Notes |
+|---|---|---|
+| **F-D2a** (resolver root-cause) | ✅ **Shipped** (`0dc4319`) | The actual fix. Tier 0 oracle flipped + boundary table, all non-vacuous. Codex *merge* (PR1 v1/v2). |
+| **F-D2c** (observability) | ✅ **Shipped** (`bfacb44`) | Implemented as a **LOG, not a metric** — `durable.ResolverMetrics` is structurally coupled to the **public** `consumer.ResolverMetrics`, so a metric method would break external implementers (§0 invariant 1). One aggregated `Warn` per reconcile pass. (Non-breaking metric path if ever wanted: an optional interface the resolver type-asserts its metrics impl against.) |
+| **S2 regression guard** | ✅ **Shipped** (`70ed026`) | `test/integration/failure/resolver_readfault_test.go`; asserts the consumer keeps consuming through the Keys-ok/Get-fail window and after recovery — no restart. Verified a genuine flip oracle. |
+| **F-D2b** (tombstone self-heal) | ❌ **DROPPED — dead code** | Implemented + codex-reviewed to *merge*, then removed. **Its heal branch is unreachable once F-D2a is in place.** `forceReplaceResolve`'s revision-bypass only matters when a cached tombstone's revision ≥ a live KV claim's revision. The only two cache-tombstone writers (`claim_resolver.go` watcher real-delete at D; reconcile synthetic at `e.revision+1`, only for genuinely-gone pids) always sit **below** any live re-creation (KV revisions are monotonic ⇒ re-create at `C > D > tombstone`), so the existing `>=` guard + the reconciler already heal it. The **sole** state needing the bypass was the synthetic **R+1-over-live-R** poison — which **F-D2a eliminates**. **The §1 rollout note's rolling-upgrade rationale is WRONG:** that poison is per-process in-memory and dies with the restart the upgrade performs; the new binary `warm()`s clean — there is no cross-process poison to self-heal. Excised via `git rebase --onto`. |
+| **F-D1** (PR3, classifier) | ⏸ **Not started** | Still valid — it is observability whose open question is *desirability* (flapping) not reachability; the `Degraded(kv-read-unavailable)` state plainly arises (it is the incident). |
+| **F-D3** (PR4, startup empty-diff) | ⏸ **Not started** | Still valid — its trigger was *traced* on v2.5.0 in the repro phase (not an untraced assertion like F-D2b's). |
+
+**Lesson carried forward to F-D1/F-D3:** before building, re-verify the fix's branch *does something the existing code does not already handle* at HEAD — i.e. "can the state this fix targets actually arise post-fix / at HEAD?" That discriminating question is exactly what exposed F-D2b as dead. (It is a pre-flight check, not a presumption of deadness — F-D1/F-D3 are on firmer ground.)
+
+**The sections below are the original design and are RETAINED AS THE HISTORICAL RECORD.**
+Where they describe F-D2b as load-bearing (esp. §1 F-D2b, the §4 rollout note, §4 phasing/PR2,
+§5 F-D2b tests, §4 model/effort table), read them as **SUPERSEDED by the decision log above.**
 - **Builds on:** `docs/plans/auto-healing-quorum-loss-repro/` (00–05). The reproduction +
   attribution is complete; this plan designs the fix.
 - **Attribution recap (from `…-repro/05-final-synthesis.md`):** the non-recovery is
@@ -117,6 +137,9 @@ absent-from-`Keys` and delete-op pids still tombstone. Preserves the legitimate-
 and the monotonic guard; net change local to `reconcileOnce`.
 
 ### F-D2b (defense-in-depth — self-heal a poisoned entry without restart) — REPLACEMENT, not guarded refresh
+> **⚠️ SUPERSEDED — F-D2b was DROPPED as dead code.** Its heal branch is unreachable once F-D2a
+> is in place (see the decision log at the top). The design below is retained as the historical
+> record of what was considered; it does **not** reflect the shipped code.
 **[Review P1 fix]** Confirmed against source: `ForceRefreshPartition` returns without
 updating when `existing.revision >= entry.Revision()` (`claim_resolver.go:495`). A tombstone
 at `R+1` vs a live read at `R` → `R+1 >= R` → **no-op**; the current call would NOT self-heal.
@@ -247,13 +270,18 @@ assertion that a retry after a failed initial apply re-attempts the full claim s
 Order rationale: the data-plane fix (PR1) lands first; the risky classifier change (PR3)
 lands last, when it is no longer load-bearing.
 
-**[Review P2] Rollout note — PR1 alone does NOT fully resolve a live incident.** F-D2a
-*prevents new* tombstones in **upgraded** processes only. It does **not** clear an
-**already-poisoned** in-process cache (the guarded refresh loses to `R+1`; only PR2's
-replacement re-resolve, or a restart, clears it), and during a **rolling upgrade** an
-old-version consumer can still manufacture/retain tombstones until restarted. **For the
-operational release, ship PR2 with or before PR1** so the deployed fleet both stops
-poisoning and self-heals existing poison without a restart.
+**[Review P2] Rollout note — SUPERSEDED (the reasoning here was wrong; see the decision log at
+the top).** This note argued PR1 needs PR2 (F-D2b) to clear an already-poisoned cache during a
+rolling upgrade. That is **incorrect**: the poison is per-process in-memory and dies with the
+restart the rolling upgrade itself performs — the new (F-D2a) binary `warm()`s clean, so there
+is no surviving poison for F-D2b to heal. **F-D2a alone is the operational fix.** The original
+(wrong) text is preserved below for the record:
+> F-D2a *prevents new* tombstones in **upgraded** processes only. It does **not** clear an
+> **already-poisoned** in-process cache (the guarded refresh loses to `R+1`; only PR2's
+> replacement re-resolve, or a restart, clears it), and during a **rolling upgrade** an
+> old-version consumer can still manufacture/retain tombstones until restarted. **For the
+> operational release, ship PR2 with or before PR1** so the deployed fleet both stops
+> poisoning and self-heals existing poison without a restart.
 
 ### Per-task model & effort (implementation dispatch)
 For the **implementation** sub-agent of each PR. Use a **Claude Agent** for implementation

--- a/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
@@ -1,0 +1,326 @@
+# Auto-Healing Quorum-Loss — Fix Plan
+
+- **Date:** 2026-05-30
+- **Status:** REVIEW-CLEAN — ready to implement. Cleared the review loop (1 `plan-review`
+  xhigh + 4 `final-plan-review` high passes; reports `tmp/00-fix-plan_*_review*.md`); final
+  verdict **"ready to implement, 0 findings"** (`tmp/00-fix-plan_precision_pass_review_v4.md`).
+  **Implementation not started** — awaiting go-ahead.
+- **Builds on:** `docs/plans/auto-healing-quorum-loss-repro/` (00–05). The reproduction +
+  attribution is complete; this plan designs the fix.
+- **Attribution recap (from `…-repro/05-final-synthesis.md`):** the non-recovery is
+  **Defect 2** (irreversible resolver-cache tombstone) — *load-bearing*; **Defect 1**
+  (connected-but-KV-timeout is unclassified, so the manager never degrades) — *enabler*;
+  **Defect 3-startup** (empty-diff retry self-exit) — *real, v2.5.0-applicable, latent
+  co-contributor*. All three pre-date v2.5.0 and are unfixed at HEAD.
+- **Attribution confidence:** the v2.10.29 incident-version probe re-run is done — the
+  sustained read failure is a *fault-nature* effect (PVC volume-offline / read-only
+  storage), not a NATS-version effect, and *which* fault dynamic fired (during-outage
+  window / wedged-storage / recovery-edge) is strongly-supported-not-confirmed. **This
+  does not affect the fix:** F-D2 trips on ANY `Get` error and is robust to surface
+  (`ErrNoResponders`/`DeadlineExceeded`) and timing — so the fix is correct regardless of
+  which dynamic fired.
+
+---
+
+## Root causes — why the current codebase can't auto-heal (read first)
+
+**The triggering state the codebase never modeled.** A PVC going offline / a node crashing
+on enough replicas to break **one bucket's RAFT quorum** — but not the meta-cluster's —
+leaves the client `CONNECTED` while reads to that bucket fail (`context deadline exceeded`
+/ `nats.ErrNoResponders`). Every auto-heal path keys off the wrong signal for this
+"connected-but-KV-reads-timing-out" state.
+
+**RC1 — the manager never enters Degraded (enabler → fixed by F-D1).** `recordKVError`
+counts an error only if `IsConnectivityError || IsDegradingJetStreamError`
+(`manager_degraded.go:98`); neither `context.DeadlineExceeded` nor `nats.ErrNoResponders` is
+in those classifiers (`internal/natsutil/errors.go:~119-136`), and `checkConnectionHealth`
+keys off `nats.Conn.Status()`, still `CONNECTED`. So the circuit never trips → `StateDegraded`
+is never entered → `attemptRecoveryFromDegraded` never runs. And even if it did, recovery
+only re-pulls the assignment — it never re-writes claims or touches the resolver cache. The
+manager self-heal is both *disabled* and *insufficient for the data plane*.
+
+**RC2 — the resolver manufactures an irreversible tombstone (load-bearing → fixed by F-D2).**
+In `ClaimBasedResolver.reconcileOnce` (`internal/durable/claim_resolver.go`), in the
+`Keys()`-ok / `Get()`-fail window (which real quorum loss produces, ~1 s after leader loss):
+the unreadable key is dropped from `seen` (`:995-999`), the tombstone pass synthesizes a
+delete at revision **`R+1`** (`:1021-1035`), and the `applyPendingBatch` `>=` guard (`:~865`)
+makes it **permanently beat** the live claim at `R`. After recovery the claim returns at `R`,
+but `R+1 >= R` rejects it; `GetOwner` returns `ok=false` (`:447-455`) → pull-gating suppresses
+the partition forever with `resolve_error` (`worker_consumer.go:656-659`). **Nothing in-process
+clears it:** `warm()` runs once at `Start` (`:518`/`:365`), never on watcher re-establish;
+`ForceRefreshPartition` loses to the same `>=` guard (`:491-496`); the watcher redelivers at
+`R` (also loses). **Only a process restart clears the poison.**
+
+**RC3 — startup empty-diff retry self-exit (latent → fixed by F-D3).** A worker *(re)starting
+during* the outage: `waitForAssignment` pre-advances the snapshot before claims are written
+(`manager_election.go:454`); the initial apply fails; `scheduleApplyRetry` re-applies with
+`prev = CurrentAssignment()` = the full set (`manager_assignment.go:~1435`) → empty prepare
+diff (`twophase.go:228-231`) → zero claims written → retry self-exits → claims absent until
+restart. (Only fires if a worker restarts mid-outage.)
+
+**The cross-cutting structural reasons there is no auto-heal:**
+1. **Recovery keys off connection state, not KV-read health** — the connection never drops,
+   so nothing fires (RC1).
+2. **The poison lives where the manager can't reach it** — the manager's only self-heal
+   (`scheduleApplyRetry`) re-writes *KV*; the tombstone is in the *consumer's in-memory
+   resolver cache* (different subsystem). In steady state no apply even fires (version gate
+   re-reads but doesn't re-apply), so the claim is never re-written to a revision `> R+1`.
+3. **Pull-gating is fail-closed with no active re-resolve** — a missing/tombstoned claim
+   suppresses pulls indefinitely; the ~150 ms suppression poll never force-refreshes.
+4. **A transient read failure is converted into permanent, monotonic-revision-irreversible
+   destructive state** (the `R+1` tombstone), protected against every recovery read-path.
+
+**Not the bug (red herring):** restart-time `wrong last sequence: key exists` (err 10071) is
+the expected stable-ID pool reclaim on a fresh process, not the failure.
+
+---
+
+## 0. Invariants the fix MUST NOT regress (load-bearing)
+1. **The 3 cross-feature contracts in `AGENTS.md`** — esp. (a) whole-bucket-missing →
+   every worker `StateDegraded` via `recordKVError`; (b) peer-claim-takeover → only that
+   worker enters claim-lost shutdown via `onClaimerError` (which keys off
+   `IsConnectivityError || IsDegradingJetStreamError`). **Any classifier change (F-D1)
+   touches the exact predicate these pin.** Run their regression tests + `make test-integration -race`.
+2. **Monotonic-revision cache semantics** in the resolver (`applyPendingBatch` `>=` guard)
+   — load-bearing for steady-state correctness; the F-D2 fix must not weaken it.
+3. **The repro suite is the regression oracle:** Tier 0 unit (`claim_resolver_quorumloss_test.go`),
+   the S2/S3 black-box harness, and the NATS-only probe must all still pass / now flip to
+   the fixed behavior where they previously demonstrated the bug.
+
+---
+
+## 1. F-D2 — resolver must not manufacture a tombstone from a transient READ failure (PRIMARY)
+
+**Root cause (verified, `internal/durable/claim_resolver.go`):** in `reconcileOnce`, a
+key whose `Keys()` listing SUCCEEDED but whose per-key `Get()` ERRORED is `continue`d
+(`:995-999`) → never added to `seen` → then, because it is in the pre-`Keys` snapshot but
+not in `seen`, the tombstone pass stages a synthetic delete at `R+1` (`:1021-1035`) that
+permanently beats the live claim. A *transient read failure is being treated as a deletion.*
+
+### F-D2a (root-cause, lowest-risk, highest-value) — THREE-way, not two-way
+**[Review P0 fix]** The naive "listed regardless of `Get` outcome → don't tombstone" rule
+is too broad: `reconcileOnce` today also relies on the tombstone pass for the
+**`Get`-succeeds-with-a-delete/purge-op** case (`claim_resolver.go:1000-1003` skips adding
+such a pid to `seen`). Lumping those into `listed` would leave a genuinely-deleted claim
+visible (`GetOwner` `ok=true`). So distinguish **three** outcomes per listed key:
+- **`Get` ERRORED** (transient — `DeadlineExceeded`/`ErrNoResponders`): add pid to a new
+  `unreadable` set. **Never tombstone an `unreadable` pid** — it exists, we just couldn't
+  read it this pass; a later pass re-reads it. *This is the incident fix.*
+- **`Get` OK, op = `KeyValueDelete`/`KeyValuePurge`**: a genuine delete → **still tombstone**
+  (stage an authoritative delete at the entry's real revision, or let the existing synthetic
+  path run). Not protected.
+- **`Get` OK, live claim**: `seen`, staged as upsert (unchanged).
+- **Absent from `Keys` entirely**: genuinely gone → tombstone (backstop, unchanged).
+
+Concretely: the tombstone pass skips a snapshot pid **only if it is in `unreadable`**;
+absent-from-`Keys` and delete-op pids still tombstone. Preserves the legitimate-delete path
+and the monotonic guard; net change local to `reconcileOnce`.
+
+### F-D2b (defense-in-depth — self-heal a poisoned entry without restart) — REPLACEMENT, not guarded refresh
+**[Review P1 fix]** Confirmed against source: `ForceRefreshPartition` returns without
+updating when `existing.revision >= entry.Revision()` (`claim_resolver.go:495`). A tombstone
+at `R+1` vs a live read at `R` → `R+1 >= R` → **no-op**; the current call would NOT self-heal.
+So F-D2b must be an explicit **replacement** rule, not the existing guarded refresh:
+- **The guard-bypass condition (Review P2 — how to identify a deleted entry).** A new method
+  (e.g. `forceReplaceResolve(ctx, pid)`) does the direct `Get`, then under `r.mu`: if the
+  existing cache entry has `existing.deleted == true` (the field `GetOwner` already reads at
+  `claim_resolver.go:454`; the tombstone sets `{deleted:true, revision:R+1}`) AND the fetched
+  claim is a **live, non-delete** op → **replace** that entry unconditionally (do NOT apply
+  the `existing.revision >= entry.Revision()` guard). If `existing` is **not** `deleted`, the
+  existing stale-guard applies unchanged (no regression). A fetched delete/purge op must
+  **not** resurrect (leave the tombstone). This is a *new* primitive — do NOT reuse
+  `ForceRefreshPartition` unchanged (it would no-op against `R+1`).
+- **Wiring (resolves the bridge gap, Review P1) — consumer-local, explicit mechanism.** No
+  change to `shouldSuppressPull`'s `(bool, reason)` return contract. On a `GetOwner` miss, the
+  suppression site calls `forceReplaceResolve(pid)` as a **rate-limited side-effect**
+  (existing `refreshCooldown`), then **still returns `(true, "resolve_error")` for THIS poll**.
+  Pull-gating re-polls (~150ms); once the bounded re-resolve has replaced the tombstone, the
+  **next** poll resolves `ok=true`. So suppression self-clears within ~one cooldown without
+  any manager↔consumer plumbing and without an async out-param. (Inline-bounded vs
+  fire-and-forget for the `forceReplaceResolve` call is an implementer choice; inline-bounded
+  with a short ctx is simplest and avoids a goroutine.)
+- **Decided:** event-driven re-resolve-on-suppression (consumer-local, as specified above).
+  A periodic sweep of `deleted` entries was considered and rejected — event-driven is cheaper
+  and tied to actual demand.
+
+### F-D2c (observability)
+Feed the reconcile `Get`/`Keys` error to a counter/log (today it is swallowed). This is a
+one-way **metrics/logging feed only** — NOT a manager↔consumer control bridge (that was
+dropped; see F-D1). It just surfaces resolver read failures for alerting.
+
+**Tests:** Tier 0 unit gains a case asserting F-D2a leaves a listed-but-unreadable pid
+`ok=true`; the S2 harness must now show `(b) consumer resumes = true` WITHOUT restart
+(the bug test flips to the fixed assertion). Negative-space: a genuinely-deleted key still
+tombstones.
+
+---
+
+## 2. F-D1 — classify connected-but-KV-read-unavailable as a degrading condition (SECONDARY, HIGHEST-RISK)
+
+**Why secondary:** even when the manager degrades, `attemptRecoveryFromDegraded` only
+`refreshAssignmentFromNATS` — it **never clears the resolver cache** (the resolver is a
+different subsystem). So F-D1 alone does NOT fix the data-plane suppression; F-D2 does. F-D1's
+value is (a) observability/alerting (the operator sees Degraded instead of silent stoppage)
+and (b) a hook to drive the consumer re-resolve.
+
+**Design (narrow, contract-safe) — [Review P1 fixes]:**
+- **Predicate matches ONLY `context.DeadlineExceeded` + `nats.ErrNoResponders`** — **NOT**
+  `jetstream.ErrNoStreamResponse`. Confirmed: `ErrNoStreamResponse` is already in
+  `IsConnectivityError` (`natsutil/errors.go:128`) AND is the stableID whole-bucket-loss
+  surface — `renew` wraps it as `ErrClaimLost`, and `onClaimerError` routes
+  `ErrClaimLost`+connectivity/degrading into `recordKVError` (the whole-bucket path,
+  `manager_election.go:107-115`). Including it would **steal the whole-bucket-loss route**
+  and break contract 1. Do **NOT** widen `IsConnectivityError`/`IsDegradingJetStreamError`
+  (contract 2's `onClaimerError` keys off exactly those).
+- **Call-site scoped, not global — concrete API [Review P1].** Define a sentinel
+  `ErrKVReadUnavailable` and a call-site wrapper `markKVReadUnavailable(err)` that wraps
+  `context.DeadlineExceeded`/`nats.ErrNoResponders` (and ONLY those, after excluding
+  stream-missing/bucket-missing) **applied only at the manager's handoff/assignment claim
+  read+list sites** — i.e. the sites that already feed `recordKVError` (heartbeat / election /
+  assignment-watcher / stableid-renew + the handoff claim get/list in the apply path). In
+  `recordKVError`, admit the new path via `errors.Is(err, ErrKVReadUnavailable)` → degrade
+  with a **distinct reason** `kv-read-unavailable` (NOT `"KV error threshold exceeded"`,
+  preserving that docstring contract). Because the wrapper is applied ONLY at those sites,
+  an unwrapped `DeadlineExceeded`/`ErrNoResponders` from anywhere else (or a peer-takeover
+  claim-get timeout, which flows through `onClaimerError`, not these sites) never enters the
+  new path. Do not add the raw errors to any global predicate.
+- **No manager→consumer bridge.** [Review P1] The earlier "bridge" is dropped — there is no
+  wireable surface for it (`UpdateWorkerConsumer` only takes `(workerID, partitions)`; the
+  resolver is private to `WorkerConsumer`). The data-plane self-heal lives entirely in
+  **F-D2b (consumer-local)**. F-D1 is therefore **purely manager-side observability**:
+  the operator sees `Degraded(kv-read-unavailable)` instead of a silent stall. It does NOT
+  itself fix the data plane (F-D2 does).
+
+**RISK CALLOUT for the reviewer:** this is the change AGENTS.md warns about. Mandatory:
+the 3 contract regression tests (`TestManager_LiveNATSBucketLoss*`, `TestStableID_StaleKeyTakeover_Reclaim`,
+`OnDegradedHook`) + `make test-integration -race` + a classifier/routing table test (below)
+proving stableID bucket-deletion still reaches whole-bucket-degraded, peer-takeover still
+reaches claim-lost shutdown, and handoff `Get`/`Keys` deadline/`ErrNoResponders` reach the
+new reason ONLY from the intended call-sites.
+**Open decision:** is entering Degraded on transient read timeouts desirable, or does it
+cause Degraded flapping on brief blips? Tunable via `KVErrorThreshold`/`KVErrorWindow`.
+
+---
+
+## 3. F-D3 — close the startup empty-diff retry self-exit (latent)
+
+**Root cause (verified):** `waitForAssignment` pre-advances the snapshot
+(`manager_election.go:454`/v2.5.0:428) before claims are written; the initial apply uses an
+explicit empty `prev` (so it WOULD write the full set) but fails under the KV-write fault;
+`scheduleApplyRetry` then re-applies with `prev = m.CurrentAssignment()` = the pre-advanced
+full set → empty prepare diff (`twophase.go:228-231`) → trivial success, zero claims written,
+retry self-exits.
+
+**Decision: option 3a** (more localized than 3b, which would reorder startup). **[Review P1]**
+Spec:
+- Add a manager flag `initialClaimsCommitted` (atomic bool), set `true` the first time an
+  apply successfully commits claims to the handoff bucket.
+- In `scheduleApplyRetry`, choose the retry's `prev` by that flag: **while
+  `initialClaimsCommitted == false`, retry with an explicit `Assignment{}` (empty) `prev`**
+  (bootstrap semantics → full prepare diff → claims actually written); **once `true`, revert
+  to `m.CurrentAssignment()`** (normal incremental semantics — unchanged behavior).
+- **Concurrent commit-watcher guard:** a commit-watcher apply that commits claims sets the
+  flag, so a subsequent retry sees `true` and uses `CurrentAssignment()` — it will NOT
+  re-issue a full-set write over already-committed claims. The two-phase coordinator's
+  per-claim CAS (`UpdateClaim` Create/Update) already makes a racing double-write safe
+  (loser CAS-fails); the flag just avoids the wasteful full re-prepare. The
+  concurrent-commit-watcher test (below) pins this.
+- **(3b deferred, out of scope here):** coupling snapshot-advance to claim-commit is a
+  larger startup-ordering change; 3a achieves the fix without it.
+
+**Tests:** the S3 harness `long_outage_restart_only` case must flip to self-heal; add a unit
+assertion that a retry after a failed initial apply re-attempts the full claim set.
+
+---
+
+## 4. Phasing (PR-by-PR; each independently shippable, own tests, `make pre-pr`)
+1. **PR1 — F-D2a** (resolver root-cause). Smallest, highest-value, lowest-risk. Flips the S2
+   harness to self-heal-after-read-recovery and the Tier 0 listed-but-unreadable case.
+2. **PR2 — F-D2b/c** (re-resolve self-heal + observability). Makes any residual poisoning
+   self-healing; defense-in-depth.
+3. **PR3 — F-D1** (classifier + manager-side Degraded reason; **no consumer bridge** — that
+   was dropped, the data-plane self-heal is consumer-local in PR2). HIGHEST RISK — full
+   contract + integration gate. Ship only after PR1/PR2 (which already fix the data plane),
+   so F-D1 is observability/robustness, not the sole fix.
+4. **PR4 — F-D3** (startup empty-diff). Independent; flips the S3 long-outage case.
+
+Order rationale: the data-plane fix (PR1) lands first; the risky classifier change (PR3)
+lands last, when it is no longer load-bearing.
+
+**[Review P2] Rollout note — PR1 alone does NOT fully resolve a live incident.** F-D2a
+*prevents new* tombstones in **upgraded** processes only. It does **not** clear an
+**already-poisoned** in-process cache (the guarded refresh loses to `R+1`; only PR2's
+replacement re-resolve, or a restart, clears it), and during a **rolling upgrade** an
+old-version consumer can still manufacture/retain tombstones until restarted. **For the
+operational release, ship PR2 with or before PR1** so the deployed fleet both stops
+poisoning and self-heals existing poison without a restart.
+
+### Per-task model & effort (implementation dispatch)
+For the **implementation** sub-agent of each PR. Use a **Claude Agent** for implementation
+(repo context, idiomatic Go tests, runs `make pre-pr`); use **Codex** only for the *review*
+gate (`/post-impl-review` or `/codex:review`), per the repo's external-reviewer pattern.
+"Effort" for a Claude Agent is **not a literal dial** — it is the verification rigor mandated
+in the dispatch prompt: verify-first (the ported test fails on the parent, passes with the
+fix), the §5 test tables, and the gates named below. Reserve **Opus** where a subtle error
+regresses a cross-feature contract or corrupts shared mutable state; use **Sonnet** where the
+change is localized, the spec is airtight, and an oracle test already exists.
+
+| PR | Task | Model | Effort | Why this tier |
+|---|---|---|---|---|
+| PR1 | F-D2a resolver root-cause | **Sonnet** | high | Localized `reconcileOnce` change; airtight spec (§1) + the Tier 0 boundary table is the exact oracle; lowest risk. Rigor goes on the 3-way split (errored vs delete-op vs absent) and on **flipping the existing Tier 0 cases non-vacuously** (they currently assert the bug). |
+| PR2 | F-D2b/c replacement re-resolve | **Opus** | high | Data-plane **hot path** (`shouldSuppressPull`), mutates the **shared resolver cache** under the existing `mu`/atomic-pointer model; AGENTS.md **concurrency-stress test required**. The replace-only-when-`deleted` vs keep-the-stale-guard logic is subtle. |
+| PR3 | F-D1 classifier + Degraded reason | **Opus** | **max (xhigh)** | **HIGHEST RISK.** Touches the exact classifier the 3 AGENTS.md cross-feature contracts pin; must not steal the whole-bucket route (`ErrNoStreamResponse`) or mis-route a peer-takeover (`onClaimerError`). **Mandatory gate:** the 3 contract regression tests + `make test-integration -race` + the §5 classifier/routing table. A subtle error here silently regresses a load-bearing contract. |
+| PR4 | F-D3 startup empty-diff | **Opus** | high | Apply/startup **lifecycle** (`scheduleApplyRetry`/`waitForAssignment`); the `initialClaimsCommitted` flag must be set/read correctly under **concurrent applies**, and the CAS-race with the commit-watcher must hold. |
+
+**Combined-PR note:** PR1+PR2 ship together for the operational release (rollout note above)
+and both touch the resolver — if implemented as **one** change, dispatch it on **Opus** (take
+the higher tier of the pair). PR1 as a standalone prevention-only PR is the only Sonnet task.
+
+**Per-PR loop (all four):** implement (Claude Agent, above) → `/simplify` → review gate
+(`/codex:review`, fall back to `/post-impl-review` for spec-compliance) → fix-loop to
+merge-clean. Every PR runs `make pre-pr` (all touch `manager/` / `internal/durable` /
+`internal/assignment`). Promote each scenario from `tmp/parti-repro/` into the tracked test
+tree **within its PR**, flipped to assert the fixed behavior (see "promotion = per-PR" — do
+not big-bang before or defer after).
+
+## 5. Test strategy (per AGENTS.md discipline)
+- Promote the repro harnesses to tracked regression guards as fixes land (`02-…repro` §5):
+  Tier 0 → already in `internal/durable`; S2/S3 + probe → `test/integration/failure/` + a
+  `partitest` N-node helper.
+- `make pre-pr` on every PR (all touch `manager/`/`internal/durable`/`internal/assignment`).
+- Negative-space tests (per `feedback_test_both_directions_of_boundary`): genuine delete still
+  tombstones (F-D2); peer-takeover still claim-lost (F-D1); no Degraded flapping on a single
+  blip below threshold (F-D1).
+
+**Required test tables [from review]:**
+- **F-D2a boundary** (`internal/durable` unit): {listed + live `Get`}, {listed + `Get`
+  error → NOT tombstoned}, {listed + `Get` delete-op → tombstoned}, {listed + `Get` purge-op
+  → tombstoned}, {absent from `Keys` → tombstoned}, {prefix-filtered key affects neither set}.
+- **F-D2b replacement**: {deleted cache `R+1` + live KV `R` → refreshes to `ok=true`},
+  {non-deleted cache `R+10` + KV `R` → stays unchanged (no regress)}, {direct `Get` returns
+  delete/purge → does NOT resurrect}. Plus the S2 harness flips: consumer resumes WITHOUT
+  restart from an already-poisoned cache.
+- **F-D1 classifier/routing table**: `context.DeadlineExceeded`, `nats.ErrNoResponders`,
+  `jetstream.ErrNoStreamResponse`, `ErrBucketNotFound`, `ErrStreamNotFound`, wrapped
+  `ErrClaimLost` — each asserted to route to the correct path (new `kv-read-unavailable` vs
+  whole-bucket-degraded vs claim-lost-shutdown), from the intended call-sites only.
+- **F-D3 retry** (must match the chosen 3a flag semantics): initial apply fails after partial
+  claim writes with `initialClaimsCommitted == false` → the retry uses explicit empty `prev`
+  and writes the **full** set (no zero-claim self-exit). Once any apply commits claims (the
+  retry itself OR a concurrent commit-watcher) the flag flips to `true` and subsequent applies
+  correctly revert to `m.CurrentAssignment()` semantics; assert a concurrent commit-watcher
+  racing the retry does not double-write (per-claim CAS makes the loser a no-op,
+  `kv_store.go:100/116`, `twophase.go:289/317`).
+
+## 6. Out of scope
+- F2 (read-only-filesystem) incident variant.
+- The optional v2.10.29 confirmation run (`…repro` #1) — orthogonal to the fix.
+
+## 7. Open decisions for review
+(F-D2b mechanism — event-driven, consumer-local — and F-D3 option 3a are now **decided** in
+the body above; they are no longer open.)
+1. F-D1: is auto-Degraded on transient read timeouts desirable (alerting value) vs flapping
+   risk? Default `KVErrorThreshold`/`KVErrorWindow` tuning.
+2. Should pull-gating additionally **fail-open after a bounded suppression timeout** as a
+   last-resort safety net, independent of the resolver fix? (Overlaps the known-deferred
+   "resolver fail-open" follow-up.)

--- a/docs/plans/auto-healing-quorum-loss-repro/00-repro-design.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/00-repro-design.md
@@ -1,0 +1,192 @@
+# Auto-Healing Quorum-Loss Reproduction — Design
+
+- **Date:** 2026-05-29
+- **Author:** Claude (perspective A — to be consolidated with an independent Codex investigation)
+- **Status:** DRAFT — pending Codex cross-investigation + user review
+- **Source incident:** `tmp/parti_auto_healing_issue.md`
+- **Scope of this effort:** *Reproduce + baseline + version-compare only.* Designing/implementing the fix is a separate, later step.
+
+---
+
+## 0. Discipline note (don't guess)
+
+The root-cause chain in §2 is a **hypothesis derived from reading the code**, not a
+proven fact. The entire point of the reproduction (§3) is to **prove or refute** it.
+Per the issue author's instruction, claims about *the handoff bucket specifically*
+causing the stall are treated as unverified until a test demonstrates them. Any
+statement below marked **(H)** is a hypothesis awaiting empirical confirmation.
+
+---
+
+## 1. Verified facts
+
+### Versions / lineage (verified, not guessed)
+- **parti v2.5.0** tagged `2026-05-24 20:01 +0800` (`650c7dc`). Already contains the
+  "self-healing" work (whole-bucket-missing → `StateDegraded`), per the self-healing
+  status memory (complete 2026-05-24).
+- **parti HEAD** = v2.5.0 + 39 commits (`2026-05-29`). Almost all `sim:` / `test:` /
+  `docs:`, plus a few `feat(manager/handoff/source)` (apply jitter, watcher/commit
+  debounce, handoff phase concurrency, recreated-bucket recovery), a `feat(testutil)`
+  3-node cluster helper, and a nats.go bump **v1.50.0 → v1.52.0**. None of these
+  obviously target the deadline-exceeded classification gap in §2. **(H)** HEAD likely
+  still exhibits the bug — the repro decides.
+- **FDC app:** `feat/parti-v2.5.0` branch carried the v2.5.0 bump (`85316a62`,
+  `2026-05-24 22:35`); the incident environment (2026-05-28) ran that v2.5.0 build.
+  FDC `main` has since been updated to v2.5.0 as well (confirmed `go.mod` =
+  `v2.5.0`). The report's "v2.5.0" label is therefore correct.
+- **nats.go in prod:** v1.50.0 (per report). Will be pinned to match for the released
+  version runs.
+
+### FDC parti configuration (verified from source)
+- Constructed in `shared/nats/consumer/dynamic/consumer.go`:
+  `parti.DefaultConfig()` + overrides: `HeartbeatInterval=3s`, `HeartbeatTTL=10s`,
+  `WorkerIDTTL=45s`, `ElectionTimeout=7s`, `EnableTwoPhaseHandoff=true`,
+  KV buckets prefixed `tfdc` (stableid/election/heartbeat/assignment/handoff),
+  `AssignmentTTL=0`, `HandoffTTL=0`.
+- Defaults left in place: `OperationTimeout=10s`, `StartupTimeout=60s`,
+  `KVErrorThreshold=5`, degraded `EnterThreshold=10s` / `ExitThreshold=5s` /
+  `KVErrorWindow=30s`.
+- Consumer: `particonsumer.NewDynamic(...)` with `WithPullGating(true)`,
+  `WithProcessingGate({Enabled:true})`, `WithResolver({HandoffBucketName})`,
+  `WithConsumerMemoryStorage(true)`, `WithConsumerReplicas(3)`. 2 worker consumers
+  (`defense_flow_fanout`, `controller_event`); partition source = NATS KV
+  (`partitions` bucket), ~100 partitions ("tools" / `USERxx`).
+- Hooks (`OnAssignmentChanged/OnStateChanged/OnError/OnDegraded`) are **log-only**;
+  the app does **not** self-stop or self-heal on degraded/error.
+
+### parti bucket storage (verified, fixed per bucket in `manager_setup.go`)
+- election = File, heartbeat = Memory, assignment = File, handoff = File, stableid = File.
+- Replica count: `Config.KVBuckets.Replicas` (default 0 → server normalizes to 1).
+  Applied only when `> 0`; pre-created buckets keep their own RF (get-first ensure).
+
+### Incident shape (from report)
+- NATS cluster v2.10.29, **RF=5, file storage**. KV buckets **RF=3**. Handoff bucket
+  raft group on `nats-v1-0, nats-v1-2, nats-v1-3`.
+- **F1 (volume offline):** `nats-v1-2` + `nats-v1-3` PVCs offline → handoff bucket
+  loses quorum (2/3 replicas gone) → defense **fully** stops; reads return
+  `context deadline exceeded`; NATS auto-recovers when PVCs return, but **defense
+  only recovers after a pod restart**. ← the "auto-healing" failure, **F1 is the
+  focus of this effort**.
+- **F2 (session down → read-only FS):** partial failure, JetStream "read-only file
+  system" snapshot errors; recovered after NATS pod restart. **Out of scope here.**
+
+---
+
+## 2. Failure model — hypothesis (H), to be proven by §3
+
+1. **Quorum loss, connection survives.** Handoff bucket is RF=3 on 3 of 5 nodes; 2 of
+   those die → that bucket has 1/3 replicas → **NO quorum**. Cluster *meta* still has
+   3/5 nodes, so the client stays **`CONNECTED`**. Handoff-bucket reads return
+   `context deadline exceeded`; the connection itself never drops. **(H)**
+2. **The classifier misses it.** `recordKVError` (`manager_degraded.go`) only counts an
+   error if `natsutil.IsConnectivityError || IsDegradingJetStreamError`.
+   `context.DeadlineExceeded` matches **neither** (`natsutil/errors.go` checks
+   `nats.ErrTimeout`, `i/o timeout`, `connection refused`, … but not Go's context
+   deadline) → KV-error counter never increments → manager **never enters
+   `StateDegraded`** → `attemptRecoveryFromDegraded` **never runs**. **(H)**
+3. **Claims never get written.** During the outage, `handoff apply failed: claim get …
+   context deadline exceeded` (report logs) → partition ownership claims are never
+   persisted to the handoff bucket. **(H)**
+4. **The gate latches shut.** `ClaimBasedResolver.reconcileOnce` swallows the deadline
+   error from `kv.Keys` and returns without updating its cache
+   (`claim_resolver.go`); `GetOwner` returns `!ok`; pull-gating is **fail-closed**
+   (`worker_consumer.go: shouldSuppressPull` → `resolve_error` /
+   `"partition not found"`), the partition consumer polls every 150 ms and **never
+   force-refreshes** (`partition_consumer.go`). **(H)**
+5. **No self-heal.** After quorum returns: connection was never lost, manager is still
+   `StateStable`, nothing triggers a re-apply, claims stay unwritten → gate stays shut
+   → **work stoppage until pod restart** (fresh `Start` → fresh apply → claims written
+   → gate opens). The restart-time `wrong last sequence: key exists` logs are the
+   *expected* stable-ID reclaim, **not** the bug. **(H)**
+
+### Candidate defect sites (both to be confirmed)
+- **(a) Classification gap:** "connected but KV reads timing out" (quorum-loss / slow
+  KV) is not modeled as a degrading condition; only connectivity-loss and
+  whole-bucket-missing are.
+- **(b) Fail-closed gating + no active refresh:** a missing claim suppresses pulls
+  indefinitely with no force-refresh and no re-apply trigger. Overlaps a **known
+  deferred** "resolver fail-open" follow-up already recorded in memory.
+
+---
+
+## 3. Reproduction design
+
+Two tiers in **one standalone Go module** at `tmp/parti-repro/` (own `go.mod`; harness
+depends only on `nats-server/v2` + `nats.go`, **not** on parti internals — true
+black-box). parti is consumed purely through its **public** consumer/manager API.
+
+### Tier 1 — deterministic symptom-injection (primary baseline + future regression guard)
+- Wrap the `jetstream.KeyValue` handed to the resolver so the **handoff** bucket's
+  `Get/Keys/Watch` return `context.DeadlineExceeded` **on command**, while the
+  connection stays `CONNECTED` and all other buckets keep working.
+- Drive the public API exactly as FDC does: `NewDynamic(...)` + `WithPullGating(true)`
+  + `WithProcessingGate` + `WithResolver{HandoffBucketName}`, FDC timings (HB 3s/TTL
+  10s, WorkerIDTTL 45s, Election 7s, two-phase handoff, OperationTimeout 10s).
+- **Scenario:** 2 workers + N partitions → Stable & pulling → flip handoff reads to
+  time out → **assert (i) work stops (pull suppressed) AND (ii) manager stays out of
+  `StateDegraded`** (proving the classification gap) → restore handoff reads →
+  **assert whether the worker auto-recovers without restart.**
+- **Expected on v2.5.0 (H):** stays suppressed → **FAIL** (the bug).
+- Fast, fully deterministic, CI-stable. This is the test that pins the exact path.
+
+### Tier 2 — real 5-node embedded cluster (faithful end-to-end), gated `PARTI_REPRO_CLUSTER=1`
+- 5 embedded `nats-server`s in a cluster, JetStream/file storage; client seeded with
+  **all 5 URLs** so it stays connected through node kills.
+- Create parti buckets RF=3 (handoff/election/assignment=file, heartbeat=memory),
+  consumer RF=3 memory — matching prod.
+- Bring 2 workers to Stable & pulling.
+- **Inspect the handoff bucket's actual replica placement** (stream `PeerInfo` /
+  cluster info), then **kill the 2 peer nodes that break that bucket's quorum while
+  meta-quorum survives (3/5)** → handoff reads time out, connection stays up.
+- Same assertions as Tier 1, plus: restart the 2 nodes (quorum restored) → does it
+  self-heal without a worker restart?
+- Slower; proves the **real causal chain**, not just the symptom. Note: JetStream
+  replica placement is automatic and cannot be pinned, so the harness must *read*
+  placement and *choose* which nodes to kill (avoiding a meta-quorum kill).
+
+> **Why not a 3-node total-quorum-loss shortcut:** killing 2 of 3 nodes drops the
+> meta-leader and likely the client connection, which **trips `IsConnectivityError`**
+> and routes into the *handled* Degraded path — reproducing a **different** failure
+> mode and masking the production bug. Fidelity is load-bearing here.
+
+### Version matrix (the deliverable that answers "did our refactor fix it?")
+Same tests, swap one line (`require <version>`, or `replace => /home/arlo/projects/parti`
+for HEAD); nats.go pinned to **v1.50.0** for the released versions.
+
+| version | work stops? | enters Degraded? | auto-recovers after restore? |
+|---|---|---|---|
+| **v2.4.1** (prior rollback baseline) | ? | ? | ? |
+| **v2.5.0** (incident build) | ? | ? | ? |
+| **HEAD** (v2.5.0 + 39) | ? | ? | ? |
+
+Measuring all three neutralizes any residual "which version really ran" doubt and
+isolates exactly what (if anything) changed across versions.
+
+---
+
+## 4. Deliverables (scope stops *before* the fix)
+- `tmp/parti-repro/` module with Tier 1 + Tier 2 tests.
+- Filled-in version matrix.
+- **Retrospective ("what we got wrong"):** the classification taxonomy never modeled
+  "connected but KV reads timing out" (only connectivity-loss and whole-bucket-missing);
+  recovery keys off **connection state**, not **KV-read health**; pull-gating is
+  fail-closed with no active refresh; and the self-healing test suite never exercised
+  *quorum-loss-while-connected* (only whole-bucket-missing and connectivity loss).
+- **Promotion note:** once a fix is green, lift the harness into `partitest`
+  (5-node + selective kill) and the test into `test/integration/failure/` as a
+  permanent regression guard (mirrors the existing integration-discipline rules).
+
+## 5. Out of scope
+- Designing / implementing the fix.
+- F2 (read-only-filesystem / session-down) variant.
+
+---
+
+## 6. Consolidation (pending)
+An independent Codex investigation of the same incident is being run **blind** (from
+the raw issue report + the two repos, without this document) to produce a second
+root-cause analysis + reproduction recommendation. This section will be updated to
+record: (a) where the two analyses **agree** (raises confidence), (b) where they
+**disagree** (the disagreement becomes a must-settle assertion in the repro), and
+(c) any failure modes / repro angles Codex surfaces that this draft missed. The final
+artifact is the consolidated design.

--- a/docs/plans/auto-healing-quorum-loss-repro/01-codex-investigation.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/01-codex-investigation.md
@@ -1,0 +1,94 @@
+# Independent Codex Investigation (Perspective B)
+
+> Produced by an independent **blind** `codex:codex-rescue` run (job
+> `task-mpqurj0r-o24gym`, 5m57s, model default). It did **not** read perspective A
+> (`00-repro-design.md`). Codex's sandbox was **read-only**, so it could not write its
+> intended structured report file; the genuine deliverable was its returned summary,
+> captured verbatim below in §A. §B captures one load-bearing nuance from its
+> reasoning log (clearly marked as such). Claude then independently **verified** the
+> central mechanism against the source — see §C.
+
+---
+
+## §A. Codex's returned summary (verbatim)
+
+> I completed the read-only investigation, but I could not create
+> `/home/arlo/projects/parti/tmp/codex-auto-healing-investigation.md`: the write was
+> rejected by the read-only sandbox.
+>
+> Core conclusion: the non-recovery is not just "deadline errors do not enter
+> degraded mode," although that is true. The stronger root cause is in
+> `internal/durable/claim_resolver.go`: if `Keys()` succeeds but per-key `Get()`
+> returns `context deadline exceeded`, reconcile can synthesize delete tombstones at
+> `oldRevision+1`; after quorum returns, live KV claims at `oldRevision` are treated
+> as stale and ignored. Pull gating then permanently sees `GetOwner(...)=ok false`
+> and suppresses pulls with `resolve_error` until process restart warms a fresh
+> resolver cache.
+>
+> HEAD verdict: I do not see a HEAD fix. The relevant classifier, pull-gating,
+> claim-resolver, force-refresh, and claim-store files are unchanged from `v2.5.0`;
+> post-tag changes are mostly debounce/jitter/concurrency/source-recreate/dependency
+> work and do not alter this failure path.
+>
+> Top repro recommendation: first write a deterministic `ClaimBasedResolver` test
+> that makes `Keys()` return `claims/USER21`, makes `Get()` return
+> `context.DeadlineExceeded`, runs `reconcileOnce`, then restores `Get()` to return
+> the original claim at the original revision and proves `GetOwner` remains false.
+> That directly captures the irreversible tombstone mechanism without depending on
+> real NATS replica placement.
+>
+> Codex session ID: 019e738b-3230-7333-a394-4202aa574ca3
+> Resume in Codex: codex resume 019e738b-3230-7333-a394-4202aa574ca3
+
+---
+
+## §B. The asymmetry nuance (Codex's reasoning log + Claude's code derivation)
+
+The one statement Codex made in its reasoning log (job log, not in the returned
+summary) beyond §A, **verbatim**:
+
+> "its reconciler can synthesize delete tombstones when `Keys()` succeeds but per-key
+> `Get()` times out, and those tombstones carry a higher synthetic revision than the
+> still-existing claim. That can permanently hide valid claims from pull gating until
+> a fresh process warms the cache from KV."
+
+**Claude's derivation of the implication** (verified from code, not from Codex): the
+poisoning requires the **asymmetric** state `Keys()`-succeeds **and** `Get()`-fails.
+If *both* time out (the outage peak), `reconcileOnce` hits the `Keys()` error branch
+and **early-returns without touching the cache** (`claim_resolver.go:978-984`) — the
+cache stays warm with correct owners, no poisoning. So the poison is specific to the
+partial-degradation / recovery edges, **not** the outage peak. **Repro consequence:**
+a test that blanket-times-out *every* handoff read may NOT reproduce (false negative);
+it must inject the asymmetric `Keys`-ok / `Get`-fail window. Whether real NATS
+quorum loss actually produces that asymmetric window is **unverified** (don't guess on
+NATS internals) — Tier 2 (§02) exists to check it; Tiers 0/1 engineer it directly.
+
+---
+
+## §C. Claude's independent verification of the tombstone mechanism (FACT)
+
+Read against `internal/durable/claim_resolver.go` at HEAD — the mechanism Codex
+describes is **real and irreversible**:
+
+1. `reconcileOnce` snapshots the cache, then `keys, err := r.kv.Keys(ctx)`
+   (`claim_resolver.go:977`). If `Keys()` itself errors, it **early-returns without
+   touching the cache** (`:978-984`) — the benign path (no poisoning).
+2. If `Keys()` succeeds, the per-key loop does `entry, err := r.kv.Get(ctx, k)` and on
+   error `continue`s (`:995-999`) — so that pid is **never added to `seen`**.
+3. The tombstone loop iterates the pre-`Keys` snapshot; any pid in the snapshot but
+   **not in `seen`** is staged as a synthetic delete at `e.revision + 1`
+   (`:1021-1035`).
+4. `applyPendingBatch` applies it because `existing.revision (R) >= p.revision (R+1)`
+   is false (`:859`) → cache entry becomes `{deleted:true, revision:R+1}`.
+5. **After recovery** the live claim returns at its real revision `R`. The incoming
+   upsert is rejected because now `existing.revision (R+1) >= p.revision (R)` is true
+   → `continue` (`:859-862`). The tombstone **wins permanently**.
+6. `GetOwner` returns `ok=false` for a `deleted` entry (`:447-455`), so
+   `shouldSuppressPull` logs `pull gating resolve failed: partition not found` and
+   returns `true, "resolve_error"` (`worker_consumer.go:656-659`) — **forever**.
+7. Only a process restart clears it: fresh `warm()` rebuilds the cache from live KV at
+   the correct revision, no tombstone.
+
+This is a **distinct, more specific** mechanism than perspective A's primary
+hypothesis (manager never enters Degraded because `context.DeadlineExceeded` is
+unclassified). The two are **complementary**, not competing — see `02`.

--- a/docs/plans/auto-healing-quorum-loss-repro/02-consolidated-design.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/02-consolidated-design.md
@@ -1,0 +1,311 @@
+# Auto-Healing Quorum-Loss Reproduction — Consolidated Design
+
+- **Date:** 2026-05-29
+- **Status:** DRAFT for user review — consolidates perspective A (`00-repro-design.md`,
+  Claude), perspective B (`01-codex-investigation.md`, independent blind Codex), and a
+  third mechanism surfaced during apply-path verification (Defect 3).
+- **Source incident:** `tmp/parti_auto_healing_issue.md`
+- **Scope:** reproduce + black-box baseline + version-compare. **The fix is a separate,
+  later effort.**
+
+> Supersedes `00-repro-design.md` as the working design. `00` and `01` are retained as
+> the two independent inputs; this file is the merge.
+
+---
+
+## 1. The shape of the answer (read this first)
+
+There are **three independently-verified-in-code mechanisms** that can each leave a
+worker stalled after a connected KV-timeout outage. They are **not** ranked
+root-causes competing for one slot — they are **distinct incident scenarios that
+produce the same symptom** ("work stops, only a pod restart recovers"). **The logs
+alone cannot tell us which one fired.** So the job of the reproduction is not merely to
+*reproduce a stall* — it is to **discriminate** between the mechanisms, because that is
+what tells the fix authors what to fix.
+
+The single most important structural fact, which took the whole investigation to state
+cleanly:
+
+> **The claim *resolver* (consumer-side cache, where the tombstone lives) and the
+> handoff *coordinator* (manager-side claim writer) are different subsystems.** The
+> manager's only in-process self-heal — `scheduleApplyRetry` — re-writes **KV**. The
+> tombstone poisons the **resolver's in-memory cache**. Whether the manager's KV
+> re-write reaches and repairs the resolver's cache is exactly the hinge the repro
+> must settle.
+
+### The three mechanisms (all FACT-in-code; which one fired = open)
+- **Defect 1 — manager never enters Degraded.** `context.DeadlineExceeded` is
+  classified as neither connectivity nor degrading, so the Degraded/recovery machinery
+  never engages. **Verified secondary:** the pull gate is manager-state-independent, so
+  this alone cannot close the data plane, and the Degraded-recovery path never
+  re-writes claims anyway. It is a real gap (it disables the manager's *assignment*
+  re-pull), but not by itself the restart-only cause.
+- **Defect 2 — irreversible resolver tombstone.** A `Keys()`-ok / `Get()`-fail
+  reconcile synthesizes a delete tombstone at `revision R+1` that permanently beats the
+  live claim at `R` in the resolver cache. **Load-bearing for restart-only recovery —
+  but only in the steady-state scenario** (see §2).
+- **Defect 3 — uncommitted claim + bounded retry.** An apply interrupted mid-flight
+  leaves some partitions with no claim in KV. `scheduleApplyRetry` *does* retry, so
+  this **self-heals** once KV recovers — *unless* the retry didn't outlive the outage,
+  was version-gated out, or the failure was on a path that never scheduled a retry.
+
+---
+
+## 2. Root cause — reconciled (three mechanisms, two scenarios)
+
+### Defect 1 — manager never enters Degraded — **FACT (logic); secondary (verified)**
+- `natsutil/errors.go::IsConnectivityError` matches `nats.ErrTimeout`, `i/o timeout`,
+  `connection refused`, etc. — **not** Go's `context.DeadlineExceeded`.
+- `manager_degraded.go::recordKVError` early-returns unless
+  `IsConnectivityError || IsDegradingJetStreamError`, so the KV-error counter never
+  moves → `enterDegraded` is never called from KV timeouts.
+- `checkConnectionHealth` keys off `nats.Conn.Status()`. In F1 the connection **stays
+  CONNECTED** (meta-quorum survives on 3/5 nodes; only the RF=3 handoff bucket loses
+  quorum), so it doesn't fire either.
+- **Why secondary (verified):** `shouldSuppressPull` reads *only* `resolver.GetOwner`
+  — **zero** references to Degraded/`State()` (`worker_consumer.go:641-695`). And
+  `attemptRecoveryFromDegraded` calls only `refreshAssignmentFromNATS` /
+  `recordKVSuccess` / `exitDegraded` — it **never re-writes claims**. So Defect 1
+  neither closes the gate nor, if fixed, would clear a poisoned cache. Its real cost:
+  the manager's assignment re-pull self-heal is silently disabled during the outage.
+
+### Defect 2 — irreversible resolver tombstone — **FACT (mechanism), Claude-verified against source**
+In `internal/durable/claim_resolver.go::reconcileOnce`:
+1. Snapshot cache, then `Keys()` (`:977`). If `Keys()` **errors**, early-return, cache
+   untouched (`:978-984`) — benign.
+2. If `Keys()` **succeeds** but a per-key `Get()` **fails**, the loop `continue`s
+   (`:995-999`) → that pid is **never added to `seen`**.
+3. Tombstone pass: every snapshot pid not in `seen` is staged as a synthetic delete at
+   `e.revision + 1` (`:1021-1035`).
+4. `applyPendingBatch` writes `{deleted:true, revision:R+1}` because `R >= R+1` is false
+   (`:862-868`).
+5. **After recovery**, the live claim returns at revision `R`; the upsert is rejected
+   because `R+1 >= R` is now true. The tombstone wins.
+6. `GetOwner` returns `ok=false` for a deleted entry (`:447-455`) → `shouldSuppressPull`
+   → `resolve_error`, suppressed (`worker_consumer.go:656-659`).
+7. **No read-path clears it (verified):** the reconciler stages recovered claims at `R`
+   (`:1010-1015`); the watcher stages at `upd.Revision()` = `R` (`handleWatcherUpdate`,
+   `:845`); both lose to `R+1` at the shared guard. `warm()` — the only full cache
+   *replace* (`:553`) — runs **once, in `Start()` (`:365`)**, never on watcher
+   re-establish (which goes `runWatcher` → merge, not `warm`). So **only a new process**
+   clears it.
+
+#### The one way to beat the tombstone WITHOUT a restart — and why it usually doesn't happen
+The guard is beaten only by a claim **write at a revision `> R+1`**. Claim writes go
+through `kv_store.go::UpdateClaim`: **`Create` for a brand-new claim (`currentRev==0`),
+`Update` (CAS) for every subsequent state transition** — and each `Update` bumps the KV
+revision. So a *fresh apply that re-writes the claim* (prepare→commit→stabilize) would
+push the claim to `R+2`/`R+3`…, which the watcher then delivers and which **beats the
+tombstone**.
+
+**But that re-write only happens if an apply fires.** And here is the steady-state trap:
+if the manager is **Stable on the version whose claims are already in KV at `R`**, the
+version gate (`handleAssignmentEntry`: skip when `oldVersion >= newVersion`) means the
+assignment reconcile **re-reads but never re-applies**, and `scheduleApplyRetry` has
+nothing stashed. **No apply → no claim re-write → tombstone stands until restart.**
+
+→ **This is the precise, load-bearing explanation for restart-only recovery in the
+steady-state scenario.** Defect 2 is not "latent"; it is the unique non-restart-proof
+mechanism *when poisoning happens to an already-committed-version cache during the
+recovery window*.
+
+### Defect 3 — uncommitted claim + bounded retry — **FACT (mechanism), Explore-verified; self-healing CONDITIONAL**
+
+> **UPDATE — settled by the S3 reproduction (see `04-tier1-s3-verdict.md`).** The
+> "self-heals once KV recovers" claim below holds for the **rebalance** shape but
+> is **FALSE for the initial-startup window**: the startup apply *does* schedule a
+> retry, but the retry is neutered by an **empty prepare diff** (the snapshot is
+> pre-advanced to the full set by `waitForAssignment`, `manager_election.go:454`,
+> with no claim writes), so it self-exits writing zero claims and the partitions
+> stay claim-less until restart. This is a distinct, source-verified third
+> restart-only path — not the "(a) no retry scheduled" or "(c) version-gate stash
+> drop" hypotheses guessed below.
+
+`manager_assignment.go:1248` calls `handoffCoordinator.Apply`. The two-phase coordinator
+(`twophase.go` prepare/commit/stabilize) writes claims via `UpdateClaim`; on a mid-apply
+`context deadline exceeded` it returns an error with **no rollback and no claim
+deletion** (verified: no delete/abort path; sweep only resets non-stable claims). So a
+partial apply leaves some partitions claim-less in KV.
+
+On failure, `scheduleApplyRetry` (`:1399-1454`) spawns a **robust** retry loop:
+coalesces to the highest version, exponential backoff to 30s, exits only on `ctx.Done()`
+(Stop) or success. **So Defect 3 self-heals once KV recovers** — the retry eventually
+re-runs Apply, writes the missing claims, and (because those are fresh `Create`s or
+CAS `Update`s at new revisions) the resolver picks them up via watcher.
+
+**Defect 3 explains restart-only recovery only in a narrow window:** (a) the failure was
+on a path that never called `scheduleApplyRetry` (e.g. the *initial* startup apply — to
+be checked), or (b) the retry loop exited via `ctx.Done()` without the process
+restarting (contradiction — so unlikely), or (c) a version-gate interaction dropped the
+stash. **If none of those hold, Defect 3 should NOT need a restart** — which is exactly
+why it is a *discriminating* test (§4).
+
+### The two scenarios, side by side
+| | **Scenario S2 (Defect 2)** | **Scenario S3 (Defect 3)** |
+|---|---|---|
+| Pre-outage state | Stable; claims committed at `R` | apply in-flight (rebalance / startup) |
+| What breaks | recovery-window reconcile poisons cache | partial claim writes, apply errors |
+| KV after recovery | claims present at `R` | some claims missing |
+| In-process self-heal? | **No** — no apply fires, tombstone unbeaten | **Yes (expected)** — `scheduleApplyRetry` rewrites |
+| Restart-only? | **Yes** | Only if retry didn't outlive / never fired |
+| Log fingerprint | `reconcile … list keys failed`, `resolve_error` | `handoff apply failed: claim get … deadline` |
+
+The incident logs contain **both** fingerprints, so neither scenario is excluded. The
+asymmetry risk from §0 remains: the only *direct* evidence (`list keys failed`) is the
+**benign** reconcile branch — i.e. Defect 2's required `Keys`-ok/`Get`-fail window is
+not directly witnessed. **Discriminate, don't assume.**
+
+### Restart-time `wrong last sequence: key exists` (10071) — **FACT, not the bug**
+Expected stable-ID pool re-walk on restart (`stableid/claimer.go`): `kv.Create` collides
+on the still-present key, code falls through to reclaim. A red herring.
+
+---
+
+## 3. HEAD verdict — **VERIFIED FACT**
+
+All five critical-path files for **Defect 1 + Defect 2** are **byte-identical
+between v2.5.0 and HEAD** (`git diff v2.5.0 HEAD --numstat` empty):
+`claim_resolver.go`, `worker_consumer.go`, `partition_consumer.go`,
+`natsutil/errors.go`, `manager_degraded.go`. So the resolver-tombstone and
+error-classification verdicts are HEAD-and-v2.5.0 identical.
+
+> **CORRECTION (do not repeat the original overclaim).** The apply path is **NOT**
+> unchanged: `git diff --numstat v2.5.0 HEAD` shows `manager_assignment.go`
+> **+337/−15**, `manager_election.go` **+26**, `internal/assignment/handoff/twophase.go`
+> **+3/−3**. `scheduleApplyRetry` was refactored — v2.5.0 retried via
+> `applyAssignment(*pending)`, HEAD via
+> `applyAssignmentWithPrevSkipJitter(m.CurrentAssignment(), *pending)`. **However, the
+> Defect-3 startup empty-diff finding (`04`) was traced on both versions and HOLDS on
+> v2.5.0**: v2.5.0's `applyAssignment` → `applyAssignmentWithPrev(m.CurrentAssignment(), …)`
+> uses the same `m.CurrentAssignment()` prev-source, and the pre-advance + twophase
+> empty-diff early-return are both present on v2.5.0. So the startup path **is**
+> attributable to the incident build (source-verified; reproduced on HEAD). The
+> refactor changed names/jitter, not the mechanism. Defects 1 and 2 are unaffected
+> (byte-identical files).
+
+The 39 post-tag commits are sim/test/docs + apply-jitter, watcher/commit debounce,
+handoff phase concurrency, source recreated-bucket recovery (a *different* reconcile
+path), and a nats.go v1.50→v1.52 bump.
+
+**All three mechanisms also pre-date v2.5.0 — VERIFIED.** v2.4.1 already contains the
+synthetic-tombstone reconcile (`e.revision + 1`), the fail-closed pull gate
+(`resolve_error`), the same `applyPendingBatch` `>=` guard, and the unclassified
+`context.DeadlineExceeded`. v2.5.0's self-healing work added recovery for
+whole-bucket-loss / connectivity loss and never touched these paths.
+
+**→ HEAD does NOT fix this** for Defects 1 and 2 — settled by `git diff` *before*
+any test runs: those files are byte-identical. (The apply path *did* change, so
+Defect-3 behavior must be read on the specific version — see the correction above.
+Consequence for the matrix — see §4.)
+
+---
+
+## 4. Reproduction design — discriminating, not just reproducing
+
+One standalone Go module at `tmp/parti-repro/` (own `go.mod`); parti consumed only
+through its **public** API.
+
+### Tier 0 — deterministic resolver-unit repro (PRIMARY) — pins Defect 2 + its boundary
+Exercise `ClaimBasedResolver` directly with a fake `jetstream.KeyValue`.
+
+- **Case A (the bug):** warm with `claims/USER21@R` → `Keys`-ok / `Get`-fail →
+  `reconcileOnce` → restore `Get` to `R` and also deliver via watcher → **assert
+  `GetOwner` STILL `ok=false`** through both recovery read-paths. Control: fresh
+  `warm()` returns `ok=true` (restart-fixes-it).
+- **Case A′ (fleet-wide):** `Keys`-ok / **all**-`Get`-fail in one pass → assert **all**
+  PIDs tombstoned — the mechanism for the report's "all fail."
+- **Case A″ (the heal, for the fix authors):** after Case A's tombstone at `R+1`,
+  deliver a claim **re-write at `R+2`** via the watcher → **assert `GetOwner` becomes
+  `ok=true`**. This proves a KV re-write *does* beat the tombstone — i.e. tells the fix
+  authors whether "re-write on recovery" is a viable fix and confirms the S2-vs-S3
+  distinction is real.
+- **Case B (boundary, reconciler path only):** `Keys()` **itself** fails →
+  `reconcileOnce` early-returns → **assert `GetOwner` STILL `ok=true`** (no poisoning).
+  Scope caveat: this models the *reconciler* path only; what the real nats.go watcher
+  does under quorum loss is a Tier 2 question (prior empirical finding: its `Updates()`
+  channel does *not* close on server restart).
+
+Fast, fully deterministic, no NATS, no race. A + A′ + A″ + B are the regression guard.
+
+### Tier 1 — consumer-level discriminator (symptom-injection through the public API)
+Wrap the handoff bucket's `jetstream.KeyValue` behind a fault-injecting shim while the
+connection stays `CONNECTED`. Drive `NewDynamic(...)` exactly as FDC does
+(`WithPullGating(true)`, `WithProcessingGate`, `WithResolver{HandoffBucketName}`, FDC
+timings). Two scenarios, run separately:
+
+- **S2 — steady-state poisoning:** reach Stable with claims committed → inject the
+  asymmetric `Keys`-ok/`Get`-fail window (no rebalance) → restore healthy → **assert
+  work does NOT resume without restart** (Defect 2), and manager never enters Degraded
+  (Defect 1). `Stop()/Start()` recovers.
+- **S3 — in-flight apply (THE discriminating test):** trigger a rebalance so an apply
+  is in-flight, kill handoff KV mid-apply, then restore → **assert whether
+  `scheduleApplyRetry` heals without a restart.** *If it heals, S3 is FALSIFIED as the
+  incident's cause* (production required a restart), leaving S2 (or something else).
+  This is the highest-value test in the whole effort — it is real evidence, not just a
+  reproduced bug.
+
+### Tier 2 — faithful 5-node embedded cluster (the asymmetry linchpin), gated `PARTI_REPRO_CLUSTER=1`
+The only tier that can answer **whether real quorum loss actually produces the
+`Keys`-ok/`Get`-fail window** S2 depends on (Tiers 0/1 engineer it by hand). 5 embedded
+`nats-server`s, file storage, client seeded with all 5 URLs (stays connected through
+kills). parti buckets RF=3 (handoff/election/assignment=file, heartbeat=memory),
+consumer RF=3 memory. Reach Stable, read the handoff stream's actual replica placement
+(`StreamInfo().Cluster`), kill the 2 followers that break *that bucket's* quorum while
+meta survives (3/5), assert `nc.IsConnected()` throughout, observe which mechanism
+fires, restart the 2 nodes, check self-heal. `partitest.StartEmbeddedNATSCluster` is
+hardcoded to 3 nodes with no kill API → needs a new N-node helper + `KillNode(i)`.
+Slower/flakier; fidelity + linchpin, not a CI gate.
+
+### Version handling — collapsed (per the HEAD verdict)
+`git diff` already proves v2.4.1 / v2.5.0 / HEAD are identical on every relevant path,
+so running the full repro three times proves nothing the diff doesn't. **Run the repro
+once on HEAD; cite the `git diff` as the proof for v2.4.1 and v2.5.0.** A single
+narrow confirmation run on v2.5.0 (the literal incident binary) is optional belt-and-
+suspenders, not required.
+
+| version | code on the 3 mechanisms | repro action |
+|---|---|---|
+| v2.4.1 | identical (verified) | none — cite diff |
+| v2.5.0 (incident) | identical (verified) | optional 1 confirmation run |
+| HEAD | identical (verified) | **run full Tier 0/1/2** |
+
+---
+
+## 5. Deliverables (scope stops before the fix)
+- `tmp/parti-repro/` module: Tier 0 (A/A′/A″/B) + Tier 1 (S2/S3) + Tier 2 (env-gated).
+- The **S3 discrimination verdict**: does `scheduleApplyRetry` self-heal? (falsifies or
+  keeps Defect 3 as the incident cause).
+- The **Tier 2 verdict**: does real quorum loss produce the `Keys`-ok/`Get`-fail window?
+- **Retrospective — "what we got wrong":**
+  1. The error taxonomy never modeled **connected-but-KV-reads-timing-out**; recovery
+     keys off connection state, not KV-read health.
+  2. The resolver reconcile **manufactures destructive state** (synthetic tombstones)
+     from a *read* failure, monotonic-revision **irreversible** by any in-process
+     read-path — a transient fault made permanent. Reconcile also swallows the error
+     silently (never feeds `recordKVError`).
+  3. Pull-gating is **fail-closed with no active re-resolve** on the suppression poll.
+  4. The apply path has **no rollback** on partial failure and relies on a single retry
+     loop whose non-firing (steady-state version gate) is invisible.
+  5. Coverage blind spot: the self-healing suite never exercised
+     quorum-loss-while-connected, the `Keys`-ok/`Get`-fail reconcile window, or
+     mid-apply KV death.
+  6. **The defects long pre-date the feature that hid them.** v2.5.0's "self-healing"
+     was scoped to the manager/connection layer and left the consumer/resolver data
+     plane unhealable.
+- **Promotion note:** once a fix is green, lift Tier 0 into `internal/durable` unit
+  tests, Tier 1/2 harness into `partitest`, and the integration test into
+  `test/integration/failure/` (per AGENTS.md integration-discipline rules).
+
+## 6. Out of scope
+- Designing / implementing the fix (separate effort; must address all three mechanisms
+  + a gate re-open / cache re-resolve path).
+- F2 (read-only-filesystem / session-down) variant.
+
+## 7. Open questions the repro must settle (not assumed here)
+- **S3 discrimination:** does `scheduleApplyRetry` self-heal a mid-apply KV death after
+  recovery? (Tier 1 S3.) Does the *initial startup* apply path schedule a retry at all?
+- **S2 trigger reality:** does real NATS bucket-quorum-loss produce a `Keys`-ok /
+  `Get`-fail window? (Tier 2.) What does the real nats.go KV watcher deliver under
+  quorum loss — delete / stale snapshot / nothing?
+- **Heal viability:** Case A″ confirms a KV re-write at `>R+1` beats the tombstone — is
+  forcing such a re-write (or a resolver cache re-warm) the right fix shape? (Fix phase.)

--- a/docs/plans/auto-healing-quorum-loss-repro/03-execution-model-effort.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/03-execution-model-effort.md
@@ -1,0 +1,137 @@
+# Tier 0 Execution — Model & Effort Recommendation
+
+- **Date:** 2026-05-29
+- **Status:** Recommendation for the Tier 0 dispatch (`02-consolidated-design.md` §4 Tier 0).
+- **Scope:** how to run the Tier 0 sub-agent — model, "effort", and the
+  scaffolding/controls that actually save time. Tier 1/2 get a one-line
+  forward note; they are not dispatched yet.
+
+> **The headline:** for Tier 0 the model choice is the *least* important
+> variable. The two things that decide wall-time and correctness are (a) handing
+> the sub-agent the existing harness pointers so it doesn't re-discover them, and
+> (b) the **control pairings** that stop the test from passing for the wrong
+> reason. Both are encoded in the dispatch prompt below.
+
+---
+
+## 1. Decision (Tier 0)
+
+| Knob | Recommendation | Why |
+|---|---|---|
+| **Agent** | **Claude Agent** (Agent tool), not Codex | Tier 0 is a same-package white-box Go test on a harness *we already hold context for*. A Codex dispatch re-orients blind (its prior run here was read-only and could not even write its file) — throwing away the exact context that makes Tier 0 cheap. |
+| **Model** | **Sonnet 4.6** (`model: "sonnet"`) | White-box unit test, low LOC, no NATS, no concurrency, mature reusable harness, and an exceptionally detailed spec (mechanism + line refs in `02` §2). Squarely Sonnet's competence; Opus's reasoning headroom buys little on a task this well-specified, and Sonnet is the time/cost-efficient choice — which is the goal. |
+| **"Effort"** | Rigor lives in the **prompt**, not a dial | A Claude Agent has no literal effort knob (that exists only for Codex). "Effort" here = the verification controls in §3 mandated in the prompt. Express it that way; don't leave it ambiguous. |
+
+**Escalation rule (evidence, not speculation):** if the sub-agent's first pass
+gets the revision-guard semantics wrong (e.g. asserts a tombstone that the guard
+would actually overwrite, or a control that passes vacuously), re-dispatch the
+*correction* on Opus. Don't pre-spend Opus on the first pass.
+
+---
+
+## 2. The real time-saver — scaffolding pointers (put these in the prompt)
+
+The main session already located everything a fresh sub-agent would otherwise
+spend its first minutes re-finding. Hand it these verbatim:
+
+**Placement (a correction to `02` §3/§4 — non-negotiable):**
+`reconcileOnce`, `applyPendingBatch`, `handleWatcherUpdate`, `warm` are
+**unexported**, so Tier 0 **must** be a same-package white-box test —
+`package durable`, new file e.g.
+`internal/durable/claim_resolver_quorumloss_test.go`. It **cannot** live in the
+standalone `tmp/parti-repro/` module: Go's internal-package rule forbids a
+separate module from importing `github.com/arloliu/parti/v2/internal/durable`,
+even with a `replace`. (Only Tier 1/2, which use the **public** `consumer`/
+`manager` API, belong in `tmp/parti-repro/`.) This correction also *reduces*
+Tier 0's difficulty — it means reusing the in-package harness below.
+
+**Reusable harness (already in tree — extend, don't rebuild):**
+- `internal/durable/claim_resolver_restart_test.go`
+  - `mockKVForReconcile` (`:563`), `newMockKVForReconcile` (`:570`),
+    `mockKVEntryFull` (`:602`) — a `jetstream.KeyValue` fake with `Keys()`+`Get()`.
+  - `TestClaimResolver_ReconcileDoesNotRegressLaterWatcherUpdates` (`:197`) —
+    seeds a high-revision cache entry then calls `r.reconcileOnce(ctx)` directly.
+    **This is the structural template** for every Tier 0 case. (It is a
+    *revision-guard* control, **not** the healthy-reconcile control of §3 — that
+    one must be added.)
+- `internal/durable/claim_resolver_test.go` — `marshalClaim` helper, `mockKV`,
+  direct `applyPendingBatch` / `GetOwner` usage patterns.
+- `internal/durable/claim_resolver_consistency_test.go:172` — `mockKVClient`
+  with `WatchAll`+`Keys`, if a watcher-driven delivery is needed for A″.
+
+**The one harness gap to close (~30–50 LOC):** `mockKVForReconcile.Get` has **no
+per-key error injection**. Add a `getErr map[string]error` (a key returns
+`context.DeadlineExceeded` while `Keys()` still lists it = the asymmetric window)
+and a configurable `keysErr error` (so `Keys()` itself can fail = Case B). Keep
+per-entry revisions configurable so a claim can sit at `R` while a tombstone
+lands at `R+1`.
+
+**Mechanism anchors (from `02` §2, verified; anchor on symbol names, not the
+line numbers — they drift):** tombstone synthesized at `e.revision + 1`
+(`reconcileOnce`, ~`:1021-1035`); apply guard rejects `R` once `R+1` is cached
+(`applyPendingBatch`, ~`:862-868`); `GetOwner` returns `ok=false` for a `deleted`
+entry (~`:447-455`); benign early-return when `Keys()` errors (~`:978-984`);
+per-key `Get` error → `continue`, pid never enters `seen` (~`:995-999`).
+
+---
+
+## 3. False-green defense — the controls (this is the "effort")
+
+Tier 0's assertions are mostly **absence** (`GetOwner` stays `ok=false`). Absence
+passes for many *broken* reasons (wrong prefix, claim never warmed, mock returns
+nothing). The verify-first memory doesn't map cleanly here — there is no fix, so
+no "fails-on-parent / passes-after-fix" cycle. **Controls, not verify-first, are
+what make each case meaningful.** Mandate these in the prompt:
+
+1. **Healthy-reconcile control (MISSING from `02` §4 — must be added).**
+   `Keys`-ok **and** `Get`-ok at `R` → `reconcileOnce` → assert `GetOwner` =
+   `ok=true`. Case A must differ from this control by **exactly one variable**:
+   that key's `Get` fails. This pairing is what proves the `Get`-fail is the
+   *specific* cause of the tombstone. Without it, Case A could be tombstoning for
+   an unrelated setup reason and look like a real repro. (Case B tests the
+   `Keys`-fail early-return — a *different* branch — and A″ tests the heal;
+   neither substitutes for this control.)
+2. **Case A (the bug):** healthy → asymmetric `Keys`-ok/`Get`-fail → `reconcileOnce`
+   → restore `Get` to `R` **and** deliver the live claim at `R` via the watcher
+   path → assert `GetOwner` **still** `ok=false`. Plus the restart control: a
+   fresh `warm()` over the same KV returns `ok=true` (proves restart-fixes-it).
+3. **Case A′ (fleet-wide):** `Keys`-ok / **all** `Get` fail in one pass → assert
+   **all** pids tombstoned.
+4. **Case A″ (the heal):** after Case A's `R+1` tombstone, deliver a claim
+   re-write at `R+2` via the watcher → assert `GetOwner` becomes `ok=true`
+   (proves a KV re-write beats the tombstone — input the fix authors need).
+5. **Case B (boundary):** `Keys()` **itself** returns `DeadlineExceeded` →
+   `reconcileOnce` early-returns → assert `GetOwner` **still** `ok=true` (no
+   poisoning on this branch).
+
+A/A′/A″/B **plus the healthy-reconcile control** are the regression guard.
+
+---
+
+## 4. Forward notes (not dispatched yet)
+
+- **Tier 1 / Tier 2 → Opus.** Reserve the expensive model for where it returns an
+  *unknown verdict* — Tier 1 **S3** (does `scheduleApplyRetry` self-heal a
+  mid-apply KV death? → falsifies or keeps Defect 3) and Tier 2 (does real quorum
+  loss produce the `Keys`-ok/`Get`-fail window?). Those drive the conclusions;
+  Tier 0 only makes-executable an already-code-verified mechanism.
+- **Tier 1 injection seam — RESOLVED (verified in source).** `02` §4 described
+  wrapping "the handoff bucket's `jetstream.KeyValue`", but there is **no**
+  `WithKeyValue` option — both `consumer.NewDynamic(js jetstream.JetStream, …)`
+  and `parti.NewManager(cfg, js jetstream.JetStream, …)` take a
+  `jetstream.JetStream`, and each builds the handoff KV internally
+  (`kvutil.EnsureKVBucket` / `manager_setup.go:ensureKVBucket`, both via
+  `js.KeyValue(ctx,bucket)` + `js.CreateKeyValue(ctx,cfg)`). **The correct seam
+  is therefore the `jetstream.JetStream` interface, not a KV:** embed it, override
+  `KeyValue` / `CreateKeyValue` / `CreateOrUpdateKeyValue` to return a
+  fault-injecting `jetstream.KeyValue` wrapper **only** for the handoff bucket
+  (pass-through otherwise), and hand that wrapped `js` to **both** `NewManager`
+  and `NewDynamic` so it covers the manager's claim-writer and the consumer's
+  resolver. The fault KV embeds the real `jetstream.KeyValue` and toggles
+  `Get`/`Keys`/`Watch` (reads) and `Create`/`Update`/`Put` (writes — needed for
+  the S3 mid-apply kill). Confirmed reachable through the **public** API; Tier 1
+  correctly lives in the standalone `tmp/parti-repro/` module (public API only,
+  `replace … => <local parti>` for HEAD). Embedded NATS via the **public**
+  `partitest.StartEmbeddedNATS`. Wiring templates to mirror: `examples/basic`,
+  `test/integration/failure/claim_resolver_nats_restart_test.go`,
+  `test/integration/handoff/*`.

--- a/docs/plans/auto-healing-quorum-loss-repro/04-tier1-s3-verdict.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/04-tier1-s3-verdict.md
@@ -1,0 +1,133 @@
+# Tier 1 S3 — Discrimination Verdict
+
+- **Date:** 2026-05-29
+- **Status:** FINDINGS — verified empirically (tests re-run under `-race`) **and**
+  in source (mechanism traced to specific lines).
+- **Scope:** the S3 question from `02-consolidated-design.md` §4/§7 — *does the
+  manager's apply-retry self-heal a mid-apply handoff KV-write failure, or is a
+  restart required?* — measured as a **discriminator**, not just a stall repro.
+
+## What was run
+A standalone black-box harness at `tmp/parti-repro/` (own `go.mod`, `replace …
+=> local HEAD; gitignored — see "Harness disposition" below). It drives the
+**public** API only: a `jetstream.JetStream`-interface wrapper (per `03` §4)
+faults **only the handoff bucket's writes** (`Create`/`Update`/`Put` →
+`context.DeadlineExceeded`) via deterministic call-counting, leaving reads and
+`Watch` **live**, and is handed to both `parti.NewManager` and
+`consumer.NewDynamic`. Single embedded NATS (`partitest.StartEmbeddedNATS`) —
+symptom injection, not real quorum loss (that is Tier 2). Two measured layers:
+**(a)** does the claim reappear in the handoff KV (read directly, unwrapped);
+**(b)** does the consumer resume pulling (publish → handler receipt).
+
+## Verdict table (reproduced under `-race`)
+| Scenario | (a) KV claim reappears | (b) consumer resumes | Degraded? |
+|---|---|---|---|
+| 0 — baseline (faults off) | yes | yes | no |
+| A — steady-state rebalance apply | **yes** | **yes** | no |
+| B — startup apply, short outage (~0.5s) | yes | yes | no |
+| B — startup apply, long outage (~5s) | **no** | **no** | **no** |
+| B — long outage, after fresh restart | yes | yes | n/a |
+
+Negative control held: publishing while faulted was **not** consumed within the
+bound, so `(b)=true` carries information (not a fail-open probe). The baseline
+reaching Stable + pulling through the wrapped `js` also proves **no parti code
+type-asserts `jetstream.JetStream` to a concrete type** — the seam is sound.
+
+## Discrimination conclusion
+1. **Defect 3 self-heals in the running-fleet (rebalance) shape — FALSIFIED as
+   the incident cause for a running fleet.** Scenario A heals end-to-end: a
+   rebalance apply runs with `prev = CurrentAssignment()` = the live set, so the
+   prepare diff is non-empty and `scheduleApplyRetry` re-attempts the missing
+   write until it lands.
+2. **A clean S3 (writes-faulted, reads-live) does NOT produce the tombstone
+   signature.** The killer "(a) heals / (b) stays suppressed" outcome — Defect 2
+   — did **not** appear, precisely because reads stayed live (no
+   `Keys`-ok/`Get`-fail window). So for a *running* fleet, the restart-only
+   incident still points to **Defect 2 / S2**, which needs the read-fault
+   asymmetry — a different scenario and the open Tier 2 question.
+3. **NEW: a startup-timed KV-write fault is a THIRD restart-only path** (Scenario
+   B, long outage) — distinct from both Defect 3's self-heal and Defect 2's
+   tombstone. The claim is simply **absent** in KV (not tombstoned), the manager
+   reaches Stable with claims absent, never enters Degraded, and only a restart
+   fixes it (demonstrated, not inferred: the RESTART-FIXES-IT step writes the
+   claims and the consumer resumes).
+
+## The new mechanism — source-verified **on HEAD** (v2.5.0 applicability UNCONFIRMED)
+
+> **Version note (Codex flagged the apply-path refactor; now traced and RESOLVED).**
+> The apply path *did* change between v2.5.0 and HEAD (`manager_assignment.go`
+> +337/−15, `manager_election.go` +26, `twophase.go` +3/−3) — so `02` §3's old
+> "unchanged in the relevant functions" was wrong. **But the empty-diff mechanism
+> holds on v2.5.0 too**, verified by source trace: v2.5.0's retry path
+> `scheduleApplyRetry → applyAssignment(*pending) → applyAssignmentWithPrev(m.CurrentAssignment(), *pending)`
+> (v2.5.0 `manager_assignment.go:868`) passes that `prev` straight to
+> `handoffCoordinator.Apply(..., oldAssignment, ...)` (`:931`) — the **same
+> `m.CurrentAssignment()` prev-source** as HEAD's `applyAssignmentWithPrevSkipJitter`;
+> the pre-advance (`waitForAssignment` store, v2.5.0 `manager_election.go:428`) and
+> the twophase empty-diff early-return (v2.5.0 `twophase.go:230`) are both present.
+> The HEAD refactor renamed the retry call and added jitter-skip; it did **not**
+> change the prev-source or the mechanism. So this startup restart-only path **applies
+> to the v2.5.0 incident build** (source-verified; empirically reproduced on HEAD —
+> not separately re-run against a v2.5.0 binary, but the path is structurally
+> identical). Defects 1 and 2 are unaffected (byte-identical files).
+
+The initial startup apply **does** schedule a retry (so `02` §2's "(a) maybe no
+retry is scheduled" hypothesis is **disproven**), but the retry is **neutered by
+an empty prepare diff**, which is a more precise mechanism than `02` §2's "(c)
+version-gate dropped the stash":
+1. `waitForAssignment` stores the leader's full assignment **straight into the
+   snapshot with no claim writes and no apply hook** — `m.assignment.Store(*curAssignment)`
+   (`manager_election.go:454`). Empirically: the snapshot jumps to
+   `version=1/parts=2` at ~676ms while faults are still firing and the hook trace
+   stays flat (no `asgChanged`).
+2. The one-shot initial apply (which uses an explicit empty `prev`, so it *would*
+   write the full set) fails under the write-fault and stashes a retry.
+3. `scheduleApplyRetry` reads `prev := m.CurrentAssignment()`
+   (`manager_assignment.go:1434`) — now the **full set** (from step 1).
+4. Two-phase prepare computes `toPrepare` = partitions in `next` not in `prev`;
+   full-set vs full-set → **empty** → `return nil` (`twophase.go:228-231`):
+   trivial "success" writing **zero** claims → the retry self-exits. Empirically:
+   faults freeze at 7 from ~1076ms through the entire armed window — the retry
+   stopped attempting writes.
+5. Claims stay absent until a fresh process (whose `waitForAssignment` re-runs
+   against KV that now has the leader's assignment but the worker re-applies from
+   an empty `prev`) writes them.
+
+**Defect 1 confirmed exactly as described:** mid-apply `context.DeadlineExceeded`
+never trips `recordKVError`, so the manager never enters Degraded in any scenario.
+
+## Corrections to `02-consolidated-design.md` §2
+- Defect 3's blanket "`scheduleApplyRetry` … self-heals once KV recovers" is
+  **true for the rebalance shape but FALSE for the initial-startup window.**
+- The §2 "to-be-checked" startup hypothesis is now **checked**: the initial apply
+  *does* schedule a retry; the failure is the empty-prepare-diff self-exit above,
+  not a missing retry and not the version-gate stash drop.
+
+## Incident attribution (current best reading)
+The reported incident was a **running** fleet → shape A → self-heals → so the
+restart-only behavior points to **Defect 2 / S2** (the resolver tombstone, which
+needs a read-fault asymmetry this clean write-only S3 deliberately excluded). The
+new Scenario-B finding adds a **second live hypothesis**: a worker that was
+(re)starting *during* the outage could be stuck restart-only via the empty-diff
+path. Both are consistent with the logs; discriminating them further needs the
+read-fault scenario and Tier 2.
+
+## Remains open
+- **Tier 2:** does *real* bucket quorum loss produce the `Keys`-ok/`Get`-fail
+  read asymmetry S2/Defect 2 depend on? (Single-node injection cannot answer this.)
+- **Read-fault S2 at the consumer level** (Tier 1 variant): fault handoff *reads*
+  while live, to reproduce the (a)-heals/(b)-suppressed tombstone end-to-end
+  through the public API (Tier 0 already pins the resolver-unit mechanism).
+- **Short-outage heal is timing-fragile** (recovery landing inside the ~0.5–0.7s
+  initial-apply window) — reported honestly, not as "short outages self-heal."
+- **Startup-timeout watchdog path** (fault outliving `StartupTimeout` → Degraded
+  via `startup-timeout`, distinct from Defect 1) was not exercised — restore
+  happens before the 60s timeout to keep attribution clean.
+
+## Harness disposition
+The harness lives in **gitignored** `tmp/parti-repro/` (per the design — a
+throwaway black-box). It is therefore **not version-controlled**; only this
+verdict is. Per `02` §5's promotion note, the durable home once a fix is green is
+`test/integration/failure/` (+ a `partitest` N-node helper for Tier 2). If the
+harness should be preserved before then, it must be force-added or relocated to a
+tracked path.

--- a/docs/plans/auto-healing-quorum-loss-repro/05-final-synthesis.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/05-final-synthesis.md
@@ -1,0 +1,140 @@
+# Final Synthesis — What Caused the Quorum-Loss Non-Recovery
+
+- **Date:** 2026-05-30
+- **Status:** REPRODUCTION + DISCRIMINATION COMPLETE. (Fix design remains a separate, later effort — still out of scope.)
+- **Inputs (all verified first-hand under `-race`):** Tier 0 unit test (committed), the
+  NATS-only trigger probe (Agent A), the read-fault end-to-end test (Agent B), the
+  S3 write-fault verdict (`04`), the incident timeline (`tmp/parti_auto_healing_issue.md`).
+
+## Verdict
+The v2.5.0 incident's non-recovery is **Defect 2 — the irreversible resolver-cache
+tombstone**. The reproduction now **strongly supports** the one premise that was
+previously only assumed — **real bucket quorum loss provably produces the `Keys`-ok /
+`Get`-fail window the tombstone requires** (demonstrated end-to-end on a current NATS
+server, including the incident's exact versions) — with **one named gap that remains
+open**: the incident's *sustained* read failure is not reproduced. That gap is now
+characterized (see "v2.10.29 confirmation" below): it is a **fault-nature** effect
+(PVC volume-offline / read-only storage), **not** a NATS-version effect, and a clean
+process-kill probe structurally cannot reproduce wedged storage. So the mechanism is
+proven real and reachable; *which* fault dynamic fired is strongly supported, not
+confirmed. Defect
+1 (unclassified timeout) is the enabler that keeps the manager out of its recovery
+machinery; the Defect-3 startup empty-diff path is a real, v2.5.0-applicable, but
+*not-evidenced-here* co-contributor.
+
+## The evidence chain (premise → mechanism → consequence → incident)
+1. **Trigger provably occurs — PREMISE STRONGLY SUPPORTED, one gap (Agent A, NATS-only 5-node probe).** Killing the
+   2 nodes that include the bucket's RAFT **leader** (1 replica survives) while
+   meta-quorum holds (3/5) and the client stays connected produces a genuine
+   `NoLeader` window in which **`kv.Keys()` succeeds while per-key `kv.Get()` fails**
+   — reproduced 6/6 trials, ~107 asymmetric samples, confirmed against an in-process
+   `server.Jsz` ground-truth instrument. The control (kill 2 *followers*, leader
+   survives) shows **no** asymmetry (both reads serve stale). The watcher's
+   `Updates()` channel does **not** close (confirms the prior empirical finding) —
+   so the tombstone is a *reconciler*-path artifact, not a watcher one.
+2. **Mechanism — PINNED (Tier 0, committed unit test).** A `Keys`-ok/`Get`-fail
+   `reconcileOnce` synthesizes a delete tombstone at revision `R+1` that permanently
+   beats the live claim at `R` (`existing.revision >= p.revision` guard); `GetOwner`
+   returns `ok=false`; only a fresh `warm()` (process restart) clears it.
+3. **Consequence — REPRODUCED END-TO-END (Agent B, public `NewManager`+`NewDynamic`).**
+   Injecting the asymmetric read fault through the public stack: `(a)` the claim stays
+   in the handoff KV at unchanged `R`, `(b)` the consumer stays suppressed without a
+   restart, the manager never enters Degraded, and a fresh start resumes. The live
+   watcher did **not** clear it — Tier 0's irreversibility holds at integration scale.
+4. **Incident match (timeline).** Running fleet; handoff bucket loses quorum 09:39;
+   NATS auto-recovers ~11:35; the consumer is **still** suppressed at 12:04
+   (`pull suppressed reason=resolve_error`, `pull gating resolve failed: partition not
+   found, partition USER21`); pod restart 12:24 = the fix. Claims were committed before
+   the outage and writes never failed, so a post-recovery `ok=false` = a poisoned cache.
+   This is precisely the `(a)`/`(b)` signature reproduced in step 3. (Inference, not a
+   logged fact: USER21's pre-outage `Stable` claim is not in the excerpt, but a running
+   fleet that was Stable and pulling necessarily had it resolved `ok=true`; writes never
+   failed, so a post-recovery `ok=false` is a poisoned cache, not claim-absence.)
+
+   **Trigger *timing* — an equally/more plausible variant (still Defect 2).** Because the
+   incident's reads were failing for the *whole* outage (the logged `list keys failed` is
+   the benign both-fail branch on the old server), the tombstone most likely formed at the
+   **recovery edge** (~11:35, when `Keys` recovers but `Get` briefly lags) rather than in
+   a during-outage leader-loss window. Either timing is the same defect; this just makes
+   the attribution robust to the obvious "the logs show `Keys` failing, not the asymmetry"
+   objection.
+
+## Defect 1 — the enabler (confirmed)
+`natsutil.IsConnectivityError`/`IsDegradingJetStreamError` classify **neither**
+`context.DeadlineExceeded` (the incident's logged error) **nor** `nats.ErrNoResponders`
+(the probe's error). So `recordKVError` never trips and the manager never enters
+Degraded on KV read timeouts — confirmed in code and observed `Degraded=false` in every
+S2/S3 scenario. Even if the manager *had* degraded, `attemptRecoveryFromDegraded` only
+re-pulls assignment / never re-writes claims, so it would not clear the resolver cache.
+
+## Defect 3 startup empty-diff — latent co-contributor (not evidenced here)
+A worker *(re)starting during* the outage hits a distinct restart-only path: the
+snapshot is pre-advanced (`waitForAssignment`) before claims are written, so the
+apply-retry computes an empty prepare diff and self-exits writing zero claims (`04`).
+Traced to hold on **v2.5.0** too. But the incident shows no worker restart *during* the
+outage (the only restart, 12:24, was the fix), so this is a latent risk here, not an
+evidenced contributor. (If any worker had restarted mid-outage, Defect 2 and this path
+would be co-contributors, not alternatives.)
+
+## Honest caveats (discrimination rigor — do not overclaim)
+- **Error-surface mismatch.** The probe's `Get` failed with `nats.ErrNoResponders`
+  (nats-server **v2.14.1**); the incident logged `context deadline exceeded` (nats-server
+  **v2.10.29**). Both trigger the tombstone identically (`reconcileOnce` does
+  `if err != nil { continue }` on *any* `Get` error), so the mechanism is unaffected —
+  but the **exact error surface on the incident's older server is not reproduced**.
+  Likely a server-version and/or timeout-budget difference. The asymmetry's *existence*
+  under real quorum loss is confirmed; its v2.10.29 error shape is inferred.
+- **Conditionality.** The asymmetry requires the bucket's RAFT **leader** among the
+  killed nodes and lasts only ~0.4–1.3 s (then degrades to both-ok-stale). Whether the
+  incident's surviving replica was leader or follower is unknown from the logs. The
+  short window also explains why the logs only ever show the *benign* `list keys failed`
+  branch: a reconcile pass has to land inside the window to trip the tombstone.
+- **No single test reproduces real-kill → real-parti → restart-only in one shot.** The
+  premise (A) and the consequence (B) are proven separately; the full end-to-end Tier 2
+  (below) was not run.
+
+## What is settled vs. optional
+**Settled (goal met — reproduce + discriminate):** Defect 2 is the primary cause, with
+a real trigger (A), a pinned mechanism (Tier 0), an end-to-end consequence (B), and an
+incident-log match. Defect 1 is the enabler. Defect 3-startup is a latent co-contributor.
+
+**The v2.10.29 confirmation step — DONE; it REFINED the gap rather than closing it.**
+Re-ran the probe pinned to the incident's exact versions (nats-server **v2.10.29**,
+nats.go **v1.50.0**; `tmp/nats-quorum-probe-v210/`). Result: **v2.10.29 behaves
+identically to v2.14.1** — a ~1.1 s `Get`-fail asymmetry window (surface
+`nats.ErrNoResponders`), then **stale** (both-ok, rev=1) reads for the rest of the
+outage. So **the incident's sustained `context deadline exceeded` is NOT a NATS-version
+effect.** The probe also corrected a framing point: the ground-truth `NoLeader` *state*
+is sustained the whole outage on both versions; the ~1 s figure is the *asymmetry*
+window, not leadership.
+
+The residual gap is now **precisely characterized**: the incident was a **PVC
+volume-offline → read-only/wedged-storage** fault (F1/F2), not a clean process kill.
+Wedged-but-present storage can keep the RAFT group unable to serve even *stale* reads
+(the leader can't fsync/append), sustaining `context deadline exceeded` in a way a clean
+`Shutdown()` cannot — so the clean-kill probe structurally cannot reproduce the sustained
+dynamics. Two things remain genuinely untested: (i) a **wedged-storage** fault simulation
+(read-only FS on surviving replicas), and (ii) the **recovery-edge** `Keys`-ok/`Get`-fail
+timing (the probe's sample loop stops before restore). Either could be the actual
+tombstone-formation trigger.
+
+**Bottom line:** the attribution to Defect 2 is unchanged and remains *strongly
+supported* — the mechanism is real, reachable, and (per Tier 0 / S2) trips on ANY `Get`
+error regardless of surface or timing; the asymmetry provably occurs under real
+leader-loss on the incident's exact versions. What stays open is *which* fault dynamic
+(during-outage window, sustained wedged-storage, or recovery-edge) fired in production —
+not whether the mechanism is the cause. Notably, the incident's logged
+`list keys failed: context deadline exceeded` matches the **benign `Keys`-timeout branch**
+(reproduced on v2.10.29), consistent with the Conditionality caveat above.
+
+## Deliverables produced
+- Committed: Tier 0 unit guard (`internal/durable/claim_resolver_quorumloss_test.go`),
+  plan docs `00`–`05`.
+- Gitignored harnesses (not version-controlled; promote per `02` §5 once a fix lands):
+  `tmp/parti-repro/` (S2 read-fault + S3 write-fault, public-API black-box) and
+  `tmp/nats-quorum-probe/` (NATS-only trigger probe).
+- For the fix authors: the fix must (1) re-classify connected-but-KV-timing-out as a
+  degrading condition, (2) make the resolver reconcile NOT manufacture a destructive
+  tombstone from a transient *read* failure (or provide an in-process cache re-resolve /
+  gate-reopen path), and (3) close the startup empty-diff window. Defect 2 is the
+  load-bearing one for *this* incident.

--- a/docs/plans/auto-healing-quorum-loss-repro/README.md
+++ b/docs/plans/auto-healing-quorum-loss-repro/README.md
@@ -1,0 +1,35 @@
+# Auto-Healing Quorum-Loss Reproduction
+
+Reproduce and baseline the v2.5.0 production incident where workers stopped
+entirely after the handoff KV bucket lost quorum and **did not auto-recover**
+until a pod restart. Source incident: `tmp/parti_auto_healing_issue.md`.
+
+**Scope:** reproduce + black-box baseline + version-compare (v2.4.1 / v2.5.0 /
+HEAD). Designing/implementing the fix is a separate later step.
+
+## Files
+- **`02-consolidated-design.md` — the working design (READ THIS).** Merges A + B:
+  two independent defects on the non-recovery path, the asymmetry the repro must
+  honor, the verified HEAD verdict, and the three-tier repro plan.
+- `03-execution-model-effort.md` — how to dispatch Tier 0: model (Sonnet, Claude
+  Agent), the in-tree harness pointers that save time, and the control pairings
+  that prevent a meaningless green. Corrects Tier 0's placement (same-package
+  white-box, not the standalone module). Also records the verified Tier 1
+  injection seam (wrap the `jetstream.JetStream` interface, not a KV).
+- `04-tier1-s3-verdict.md` — the Tier 1 S3 discrimination verdict (verified
+  empirically + in source): the rebalance apply self-heals (Defect 3 falsified
+  for a running fleet), and a newly-found **startup-timed** restart-only path via
+  an empty-prepare-diff retry self-exit. Corrects `02` §2's Defect 3 claim.
+- **`05-final-synthesis.md` — the capstone verdict (READ THIS for the answer).**
+  Combines the NATS-only trigger probe (real quorum loss *does* produce the
+  `Keys`-ok/`Get`-fail window), the end-to-end read-fault reproduction, and the
+  incident timeline into one attribution: **Defect 2 (resolver tombstone)** is the
+  cause, Defect 1 is the enabler, Defect 3-startup is a latent co-contributor.
+  Includes the honest caveats (probe `ErrNoResponders` vs incident deadline-exceeded;
+  nats-server v2.14.1 vs v2.10.29; leader-kill conditionality).
+- `00-repro-design.md` — perspective A (Claude). Original draft; its primary
+  hypothesis (Defect 1, manager-never-Degraded) is correct but missed the deeper
+  resolver-tombstone mechanism. Retained as an input.
+- `01-codex-investigation.md` — perspective B (independent blind Codex). Captured
+  from the job result (Codex's sandbox was read-only). Contributed the
+  resolver-tombstone root cause; Claude verified it against source.

--- a/internal/assignment/calculator_cooldown_test.go
+++ b/internal/assignment/calculator_cooldown_test.go
@@ -47,7 +47,14 @@ func waitStableVersion(t *testing.T, calc *Calculator) int64 {
 	deadline := time.Now().Add(6 * time.Second)
 	for time.Now().Before(deadline) {
 		v := calc.CurrentVersion()
-		if v == 0 {
+		// Require a published version AND that the state machine has returned
+		// to Idle. Idle gates out the window where a cold-start final rebalance
+		// is still pending (CalcStateScaling) but the version has not yet been
+		// bumped: a version-only check could otherwise capture the
+		// immediate-assignment version as "stable" under load, before the
+		// delayed stabilization timer fires — the same premature-baseline race
+		// this helper exists to prevent.
+		if v == 0 || calc.GetState() != types.CalcStateIdle {
 			time.Sleep(25 * time.Millisecond)
 			continue
 		}
@@ -55,7 +62,7 @@ func waitStableVersion(t *testing.T, calc *Calculator) int64 {
 		end := time.Now().Add(confirm)
 		for time.Now().Before(end) {
 			time.Sleep(25 * time.Millisecond)
-			if calc.CurrentVersion() != v {
+			if calc.CurrentVersion() != v || calc.GetState() != types.CalcStateIdle {
 				stable = false
 				break
 			}
@@ -523,12 +530,14 @@ func TestCalculator_Cooldown_WithPartitionRefresh(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	initialVersion := calc.CurrentVersion()
 
-	// Change partition source (add new partition)
-	source.partitions = []types.Partition{
+	// Change partition source (add new partition). Use SetPartitions: the
+	// calculator's background rebalance goroutine may be reading the source
+	// concurrently via List, so a direct field write would be a data race.
+	source.SetPartitions([]types.Partition{
 		{Keys: []string{"p1"}},
 		{Keys: []string{"p2"}},
 		{Keys: []string{"p3"}}, // New partition
-	}
+	})
 
 	// Trigger partition refresh
 	err = calc.TriggerRebalance(ctx)
@@ -539,7 +548,12 @@ func TestCalculator_Cooldown_WithPartitionRefresh(t *testing.T) {
 	require.Greater(t, firstRefreshVersion, initialVersion, "first refresh should succeed")
 
 	// Try another refresh immediately (should be blocked by cooldown)
-	source.partitions = append(source.partitions, types.Partition{Keys: []string{"p4"}})
+	source.SetPartitions([]types.Partition{
+		{Keys: []string{"p1"}},
+		{Keys: []string{"p2"}},
+		{Keys: []string{"p3"}},
+		{Keys: []string{"p4"}},
+	})
 	err = calc.TriggerRebalance(ctx)
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)

--- a/internal/assignment/calculator_initial_assignment_test.go
+++ b/internal/assignment/calculator_initial_assignment_test.go
@@ -464,14 +464,24 @@ func TestCalculator_InitialAssignment_Metrics(t *testing.T) {
 		return len(assignment.Partitions) == 1
 	}, 150*time.Millisecond, 10*time.Millisecond, "leader should get all partitions immediately")
 
-	// Wait for both phases
-	time.Sleep(200 * time.Millisecond)
+	// The final (post-stabilization) cold_start rebalance fires after the
+	// ColdStartWindow timer elapses. Under load that timer plus the rebalance
+	// itself can run well past a fixed 200ms budget, so poll for the metric
+	// instead of sleeping a fixed amount and asserting once.
+	require.Eventually(t, func() bool {
+		return metrics.GetRebalanceAttempt("cold_start") == 1
+	}, 3*time.Second, 20*time.Millisecond, "final cold_start rebalance should run exactly once")
 
-	// Verify two rebalance attempts recorded
+	// Immediate-assignment phase must have recorded exactly once.
 	require.Equal(t, 1, metrics.GetRebalanceAttempt("cold_start_immediate"),
 		"immediate assignment should be recorded exactly once")
-	require.Equal(t, 1, metrics.GetRebalanceAttempt("cold_start"),
-		"final assignment should run exactly once")
+
+	// Exactly-once guard: the final cold_start must not run again for the
+	// unchanged single-worker topology.
+	require.Never(t, func() bool {
+		return metrics.GetRebalanceAttempt("cold_start") > 1
+	}, 300*time.Millisecond, 50*time.Millisecond,
+		"cold_start must run exactly once, not repeatedly")
 
 	t.Logf("✅ Metrics correctly recorded: immediate=%d, final=%d",
 		metrics.GetRebalanceAttempt("cold_start_immediate"),

--- a/internal/assignment/calculator_partition_lifecycle_fsm_test.go
+++ b/internal/assignment/calculator_partition_lifecycle_fsm_test.go
@@ -2,6 +2,7 @@ package assignment
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -76,15 +77,13 @@ func buildFSMPartitionFixture(t *testing.T, busName string, drainInterval time.D
 func recordFSMTransitions(calc *Calculator) (*fsmRecorder, func()) {
 	ch, unsubscribe := calc.SubscribeToStateChanges()
 	r := &fsmRecorder{}
-	r.wg.Add(1)
-	go func() {
-		defer r.wg.Done()
+	r.wg.Go(func() {
 		for s := range ch {
 			r.mu.Lock()
 			r.states = append(r.states, s)
 			r.mu.Unlock()
 		}
-	}()
+	})
 
 	return r, func() {
 		unsubscribe()
@@ -107,12 +106,7 @@ func (r *fsmRecorder) snapshot() []types.CalculatorState {
 }
 
 func (r *fsmRecorder) contains(s types.CalculatorState) bool {
-	for _, x := range r.snapshot() {
-		if x == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.snapshot(), s)
 }
 
 // TestPartitionLifecycle_DrivesFSMRebalancing verifies PR-3 §5.2 — a

--- a/internal/assignment/calculator_recovery_grace_test.go
+++ b/internal/assignment/calculator_recovery_grace_test.go
@@ -54,9 +54,14 @@ func TestCalculator_RecoveryGrace_BlocksNormalRebalance(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = calc.Stop(ctx) }()
 
-	// Wait for any initial activity to settle
-	time.Sleep(150 * time.Millisecond)
-	initialVersion := calc.CurrentVersion()
+	// Capture the baseline only after the full cold-start sequence (immediate +
+	// post-window final rebalance) has settled. A fixed sleep is racy: cold
+	// start is not subject to recovery grace, so under load its final
+	// rebalance (gated by the 50ms ColdStartWindow) can land AFTER the sleep
+	// and bump the version during the measurement window below, masquerading as
+	// an unblocked planned_scale. waitStableVersion blocks until the version
+	// stops changing, so the baseline is the settled cold-start version.
+	initialVersion := waitStableVersion(t, calc)
 
 	// Add a second worker — this would normally trigger a scaling rebalance
 	_, err = heartbeatKV.Put(ctx, "worker-hb.worker-2", []byte(time.Now().Format(time.RFC3339Nano)))
@@ -115,9 +120,12 @@ func TestCalculator_RecoveryGrace_AllowsRebalanceAfterGraceExpires(t *testing.T)
 	require.NoError(t, err)
 	defer func() { _ = calc.Stop(ctx) }()
 
-	// Wait for the initial cold_start stabilization to complete before measuring
-	time.Sleep(500 * time.Millisecond)
-	initialVersion := calc.CurrentVersion()
+	// Wait for the full cold-start stabilization (immediate + post-window
+	// final rebalance) to settle before measuring. A fixed sleep is racy under
+	// load: cold start is not gated by recovery grace, so a late final
+	// rebalance would shift the baseline. waitStableVersion blocks until the
+	// version stops changing.
+	initialVersion := waitStableVersion(t, calc)
 
 	// Add worker-2 while grace is active — should be blocked
 	_, err = heartbeatKV.Put(ctx, "worker-hb.worker-2", []byte(time.Now().Format(time.RFC3339Nano)))

--- a/internal/assignment/calculator_trigger_rebalance_test.go
+++ b/internal/assignment/calculator_trigger_rebalance_test.go
@@ -39,9 +39,10 @@ func TestTriggerRebalance_NoDuplicateScaleOnNextPoll(t *testing.T) {
 	}
 	strategy := &mockStrategy{}
 
-	// Long HeartbeatTTL so the worker monitor's polling fallback (hbTTL/2) is
-	// slow enough that we can win the race against the watcher and call
-	// TriggerRebalance before the new heartbeat key is observed.
+	// Long HeartbeatTTL keeps all workers alive for the whole test. The worker
+	// monitor is stopped after the cluster settles (see below) so its watcher
+	// cannot independently observe worker-3 and race the manual
+	// TriggerRebalance.
 	calc, err := NewCalculator(&Config{
 		AssignmentKV:         assignmentKV,
 		HeartbeatKV:          heartbeatKV,
@@ -65,16 +66,18 @@ func TestTriggerRebalance_NoDuplicateScaleOnNextPoll(t *testing.T) {
 		return calc.GetState() == types.CalcStateIdle && calc.CurrentVersion() > 0
 	}, 5*time.Second, 25*time.Millisecond, "initial rebalance did not settle")
 
+	// Stop the worker monitor's background watcher so no background poll can
+	// rebalance behind our back and perturb the version during the behavioral
+	// check below. TriggerRebalance still picks up worker-3 via its own fresh
+	// KV scan (GetActiveWorkers is a direct scan, monitor-independent), and
+	// IsStarted reads a calculator-level flag, so stopping the monitor does not
+	// disable TriggerRebalance.
+	require.NoError(t, calc.monitor.Stop())
+
 	versionBeforeTrigger := calc.CurrentVersion()
 
-	// Subscribe AFTER the cluster has settled so the initial cold-start
-	// Scaling cycle does not leak into the assertion.
-	states, unsubscribe := calc.SubscribeToStateChanges()
-	defer unsubscribe()
-
-	// Add a third worker directly to KV. The watcher may or may not have
-	// observed it yet — that is irrelevant because TriggerRebalance fetches
-	// the worker set fresh inside rebalance.
+	// Add a third worker directly to KV. TriggerRebalance fetches the worker
+	// set fresh inside rebalance, so it picks up worker-3.
 	_, err = heartbeatKV.Put(ctx, "worker-hb.worker-3", []byte(time.Now().Format(time.RFC3339Nano)))
 	require.NoError(t, err)
 
@@ -83,31 +86,30 @@ func TestTriggerRebalance_NoDuplicateScaleOnNextPoll(t *testing.T) {
 	require.Greater(t, versionAfterTrigger, versionBeforeTrigger,
 		"TriggerRebalance must publish a new assignment version")
 
-	// Force a worker-set observation by calling checkForChanges (the same
-	// entry point the worker monitor uses). With the W3 fix, lastWorkers is
-	// already aligned with the post-trigger currentWorkers, so no Scaling
-	// transition should fire. Without the fix, lastWorkers is stale and
-	// checkForChanges will detect a planned_scale.
+	// Primary regression guard — deterministic, with no dependence on watcher
+	// quiescence or scaling-timer timing: TriggerRebalance must refresh
+	// lastWorkers to match the freshly-scanned worker set. This is the exact
+	// invariant the W3 fix restored. Without the refresh, lastWorkers stays
+	// {worker-1, worker-2} and the next observe cycle re-enters planned_scale
+	// for worker-3 (the duplicate scale this test guards against).
+	calc.mu.RLock()
+	lastWorkers := calc.cloneLastWorkersLocked()
+	calc.mu.RUnlock()
+	require.True(t, lastWorkers["worker-3"],
+		"TriggerRebalance must refresh lastWorkers to include the newly-scanned worker-3")
+	require.Len(t, lastWorkers, 3,
+		"lastWorkers must equal the post-trigger worker set {worker-1, worker-2, worker-3}")
+
+	// Behavioral confirmation: observing the now-unchanged topology must not
+	// start another rebalance. With lastWorkers refreshed, observeAndDecide
+	// short-circuits on "no change" before any scaling or rebalance, so the
+	// version stays put. The monitor is stopped, so this explicit
+	// checkForChanges is the only observation in flight — fully deterministic,
+	// with no draining for the absence of a state transition.
+	require.Eventually(t, func() bool {
+		return calc.GetState() == types.CalcStateIdle
+	}, 2*time.Second, 10*time.Millisecond, "calculator should return to Idle after TriggerRebalance")
 	require.NoError(t, calc.checkForChanges(ctx))
-
-	// Wait briefly for any Scaling transition to surface on the subscriber.
-	scalingObserved := false
-	drain := time.After(500 * time.Millisecond)
-drainLoop:
-	for {
-		select {
-		case s := <-states:
-			if s == types.CalcStateScaling {
-				scalingObserved = true
-				break drainLoop
-			}
-		case <-drain:
-			break drainLoop
-		}
-	}
-
-	require.False(t, scalingObserved,
-		"observed CalcStateScaling after TriggerRebalance — lastWorkers was not refreshed and the next checkForChanges re-entered planned_scale")
 	require.Equal(t, versionAfterTrigger, calc.CurrentVersion(),
 		"no further rebalance must run for an unchanged topology after TriggerRebalance")
 }

--- a/internal/assignment/config.go
+++ b/internal/assignment/config.go
@@ -205,10 +205,7 @@ func (c *Config) SetDefaults() {
 		c.PlannedScaleWindow = 10 * time.Second
 	}
 	if c.RebalanceGraceDrainInterval == 0 {
-		c.RebalanceGraceDrainInterval = min(c.Cooldown, 30*time.Second)
-		if c.RebalanceGraceDrainInterval < time.Second {
-			c.RebalanceGraceDrainInterval = time.Second
-		}
+		c.RebalanceGraceDrainInterval = max(min(c.Cooldown, 30*time.Second), time.Second)
 	}
 	if c.ApplyGracePeriod == 0 {
 		c.ApplyGracePeriod = 2 * c.HeartbeatTTL

--- a/internal/assignment/testing_helpers.go
+++ b/internal/assignment/testing_helpers.go
@@ -2,6 +2,7 @@ package assignment
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/arloliu/parti/v2/types"
@@ -31,8 +32,14 @@ func (m *mockStateProvider) SetGrace(v bool) {
 
 // mockSource implements types.PartitionSource for testing.
 //
-// Provides configurable partition lists and error simulation.
+// Provides configurable partition lists and error simulation. The partition
+// list is guarded by mu so a test can mutate it (via SetPartitions) while the
+// calculator's background rebalance goroutine reads it through List, without
+// tripping the race detector. Construct-time field initialization
+// (&mockSource{partitions: ...}) needs no lock because it happens-before the
+// calculator goroutines start.
 type mockSource struct {
+	mu         sync.RWMutex
 	partitions []types.Partition
 	err        error
 }
@@ -49,11 +56,25 @@ func (m *mockSource) Stop(_ context.Context) error {
 
 // List returns the configured partitions or error.
 func (m *mockSource) List(_ context.Context) ([]types.Partition, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.err != nil {
 		return nil, m.err
 	}
 
 	return m.partitions, nil
+}
+
+// SetPartitions replaces the partition list under the lock. Tests that change
+// the source after the calculator has started (e.g. partition-refresh
+// scenarios) must use this instead of writing the field directly, so the write
+// is synchronized against concurrent List reads. It assigns a fresh slice
+// rather than mutating in place, so a slice already returned by List stays
+// valid to iterate without the lock.
+func (m *mockSource) SetPartitions(p []types.Partition) {
+	m.mu.Lock()
+	m.partitions = p
+	m.mu.Unlock()
 }
 
 // mockStrategy implements types.AssignmentStrategy for testing.

--- a/internal/durable/claim_resolver.go
+++ b/internal/durable/claim_resolver.go
@@ -987,6 +987,13 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 
 	pendingByPID := make(map[string]pending)
 	seen := make(map[string]struct{}, len(keys))
+	// Keys we listed but could not Get this pass (transient read failure, e.g.
+	// a quorum-lost bucket returning DeadlineExceeded/ErrNoResponders while the
+	// connection stays CONNECTED). These must NOT be tombstoned: the key still
+	// exists, we just could not read it now; a later pass re-reads it. Without
+	// this set, an unreadable key would fall through to the tombstone pass below
+	// and be staged as a synthetic delete at R+1 — an irreversible poison.
+	unreadable := make(map[string]struct{})
 
 	for _, k := range keys {
 		if r.claimsPref != "" && !strings.HasPrefix(k, r.claimsPref) {
@@ -994,7 +1001,9 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 		}
 		entry, err := r.kv.Get(ctx, k)
 		if err != nil {
-			// Skip missing keys; the next reconcile pass will retry.
+			// Listed-but-unreadable: record the pid so the tombstone pass
+			// skips it. The next reconcile pass retries the read.
+			unreadable[strings.TrimPrefix(k, r.claimsPref)] = struct{}{}
 			continue
 		}
 		// Defensive: skip delete-operation entries; we tombstone separately
@@ -1023,6 +1032,13 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 			continue
 		}
 		if _, ok := seen[pid]; ok {
+			continue
+		}
+		// Listed but unreadable this pass — a transient read failure, not a
+		// deletion. Skip; the next reconcile re-reads it. (Genuine deletions —
+		// absent from Keys, or a delete/purge op — are not in `unreadable` and
+		// still tombstone below.)
+		if _, ok := unreadable[pid]; ok {
 			continue
 		}
 		// Synthetic tombstone revision: existing + 1. The shared apply

--- a/internal/durable/claim_resolver.go
+++ b/internal/durable/claim_resolver.go
@@ -994,6 +994,10 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 	// this set, an unreadable key would fall through to the tombstone pass below
 	// and be staged as a synthetic delete at R+1 — an irreversible poison.
 	unreadable := make(map[string]struct{})
+	// firstReadErr keeps one sample of the per-key Get errors for the aggregated
+	// observability log below (F-D2c). Per-key logging would be a storm during a
+	// whole-bucket read fault, so we log once per pass with the count.
+	var firstReadErr error
 
 	for _, k := range keys {
 		if r.claimsPref != "" && !strings.HasPrefix(k, r.claimsPref) {
@@ -1004,6 +1008,9 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 			// Listed-but-unreadable: record the pid so the tombstone pass
 			// skips it. The next reconcile pass retries the read.
 			unreadable[strings.TrimPrefix(k, r.claimsPref)] = struct{}{}
+			if firstReadErr == nil {
+				firstReadErr = err
+			}
 			continue
 		}
 		// Defensive: skip delete-operation entries; we tombstone separately
@@ -1022,6 +1029,17 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 			}
 		}
 		pendingByPID[pid] = pending{op: "upsert", data: entry.Value(), revision: entry.Revision()}
+	}
+
+	// Observability (F-D2c): surface the previously-swallowed per-key read
+	// failures. A non-zero count means the bucket is listing keys but failing to
+	// read some of them (the quorum-loss "Keys-ok/Get-fail" window) — the signal
+	// that, before the F-D2a fix, was silently converted into permanent
+	// tombstones. One aggregated line per pass avoids a log storm under a
+	// whole-bucket read fault.
+	if len(unreadable) > 0 && r.logger != nil {
+		r.logger.Warn("claim resolver reconcile: listed keys were unreadable this pass",
+			"unreadable_count", len(unreadable), "sample_error", firstReadErr)
 	}
 
 	// Iterate over the pre-Keys snapshot, NOT the live cache. Any

--- a/internal/durable/claim_resolver_quorumloss_test.go
+++ b/internal/durable/claim_resolver_quorumloss_test.go
@@ -1,0 +1,393 @@
+// Package durable — Tier 0 regression guard for the auto-healing quorum-loss incident.
+//
+// Incident: a KV bucket that lost quorum while the NATS connection stayed
+// CONNECTED produced a Keys()-ok / Get()-fail reconcile window. reconcileOnce
+// continued without adding the pid to `seen`, so the tombstone pass staged a
+// synthetic delete at R+1 (cache revision + 1). applyPendingBatch applied it
+// because R+1 > R. After recovery the real claim returned at R; both the
+// watcher and reconciler tried to re-apply it at R, but the guard
+// (existing.revision >= p.revision = R+1 >= R = true) rejected it. The
+// tombstone won permanently. Only a process restart (warm() re-reading KV
+// from scratch) cleared it.
+//
+// Plan: docs/plans/auto-healing-quorum-loss-repro/
+//
+//	02-consolidated-design.md  §2 Defect 2, §4 Tier 0
+//	03-execution-model-effort.md §3 control pairings
+//
+// All tests are deterministic and require no NATS server.
+package durable
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── Mock extension ───────────────────────────────────────────────────────────
+//
+// mockKVForReconcile (defined in claim_resolver_restart_test.go) is extended
+// with two nil-default fields:
+//
+//   getErrByKey map[string]error — if a key has an entry, Get returns that
+//     error while Keys() STILL lists the key (the asymmetric window).
+//   keysErr error — if set, Keys() returns this error immediately.
+//
+// Both fields are set by direct field assignment (consistent with the existing
+// afterKeys hook pattern). No existing call sites pass them, so they default
+// to nil and the behaviour of existing tests is unchanged.
+//
+// The Get() implementation in claim_resolver_restart_test.go does not check
+// getErrByKey; we shadow it here with a promoted-type wrapper so the existing
+// struct definition needs no modification. See mockKVWithKeyErr below.
+
+// mockKVWithKeyErr wraps mockKVForReconcile and adds per-key error injection
+// and a Keys-level error, while keeping the existing store/revision/afterKeys
+// fields for all other behaviour. It is the mock used in EVERY quorum-loss test.
+//
+// Invariant: getErrByKey[k] != nil → Get(k) returns that error even though
+// Keys() still lists k. This is exactly the asymmetric Keys-ok/Get-fail
+// window that reconcileOnce cannot handle.
+type mockKVWithKeyErr struct {
+	*mockKVForReconcile
+	getErrByKey map[string]error // optional per-key error override for Get
+	keysErr     error            // if set, Keys() returns this error
+}
+
+func newMockKVWithKeyErr(store map[string][]byte, revision uint64) *mockKVWithKeyErr {
+	return &mockKVWithKeyErr{
+		mockKVForReconcile: newMockKVForReconcile(store, revision),
+	}
+}
+
+// Keys overrides mockKVForReconcile.Keys so that keysErr can be returned.
+// The afterKeys hook is still honoured.
+func (m *mockKVWithKeyErr) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	if m.keysErr != nil {
+		return nil, m.keysErr
+	}
+	return m.mockKVForReconcile.Keys(ctx, opts...)
+}
+
+// Get overrides mockKVForReconcile.Get to inject per-key errors. If a key has
+// an entry in getErrByKey the error is returned instead of the store value.
+// The key deliberately stays in store (i.e. Keys() still lists it), modelling
+// the asymmetric window: Keys returns the key, but Get times out.
+func (m *mockKVWithKeyErr) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	if m.getErrByKey != nil {
+		if err, hit := m.getErrByKey[key]; hit {
+			return nil, err
+		}
+	}
+	return m.mockKVForReconcile.Get(ctx, key)
+}
+
+// ─── Shared construction helpers ─────────────────────────────────────────────
+
+const (
+	quorumTestPID      = "USER21"
+	quorumTestFullKey  = "claims/" + quorumTestPID
+	quorumTestOwner    = "worker-A"
+	quorumTestEpoch    = int64(1)
+	quorumTestRevision = uint64(5) // R = 5; tombstone will land at R+1 = 6
+)
+
+// quorumTestClaim returns marshalled bytes for the standard live claim used
+// across tests.
+func quorumTestClaim(t *testing.T) []byte {
+	t.Helper()
+	return marshalClaim(t, handoff.Claim{
+		PartitionID: quorumTestPID,
+		Owner:       quorumTestOwner,
+		State:       handoff.ClaimStateStable,
+		Epoch:       quorumTestEpoch,
+	})
+}
+
+// newHealthyKV returns a mock with a live claim at R, no error injection.
+func newHealthyKV(t *testing.T) *mockKVWithKeyErr {
+	t.Helper()
+	return newMockKVWithKeyErr(map[string][]byte{
+		quorumTestFullKey: quorumTestClaim(t),
+	}, quorumTestRevision)
+}
+
+// seedResolverCache seeds the resolver's in-memory cache directly (bypassing
+// Start/warm) with the standard single-pid live claim at quorumTestRevision.
+// This mirrors the pattern used by
+// TestClaimResolver_ReconcileDoesNotRegressLaterWatcherUpdates.
+func seedResolverCache(r *ClaimBasedResolver) {
+	m := map[string]claimEntry{
+		quorumTestPID: {
+			owner:    quorumTestOwner,
+			state:    toState(handoff.ClaimStateStable),
+			epoch:    quorumTestEpoch,
+			revision: quorumTestRevision,
+		},
+	}
+	r.cache.Store(&m)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// TestQuorumLoss_HealthyReconcile_Control is the mandatory false-green control.
+//
+// Setup: Keys-ok and Get-ok at R. After reconcileOnce the cache must retain
+// the live claim (ok=true, correct owner). Case A below DIFFERS from this
+// control by EXACTLY ONE variable: that key's Get fails. This pairing proves
+// the Get-fail is the specific cause of the tombstone — if the control passed
+// but Case A asserted ok=false for an unrelated setup reason, we would never
+// know the tombstone was from the fault and not from something else.
+func TestQuorumLoss_HealthyReconcile_Control(t *testing.T) {
+	kv := newHealthyKV(t)
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+
+	// Seed cache at R=5 (same as quorumTestRevision).
+	seedResolverCache(r)
+
+	r.reconcileOnce(context.Background())
+
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "healthy reconcile must not tombstone a live claim")
+	require.Equal(t, quorumTestOwner, owner, "owner must be unchanged after healthy reconcile")
+}
+
+// TestQuorumLoss_CaseA_GetFailCreatesUnbeatableTombstone is the primary
+// defect pin: Keys-ok / Get-fail for a single pid causes a permanent
+// tombstone that neither reconcile nor the watcher can overcome.
+//
+// Non-vacuous because:
+//   - The healthy-reconcile control above differs by exactly one variable
+//     (Get-ok vs Get-fail) and asserts ok=true. Removing getErrByKey from this
+//     test would flip the final assertion to ok=true — proven by the control.
+//   - After tombstone, both read-paths (reconcile AND watcher) are exercised
+//     and both fail to clear it: the revision guard R+1 >= R rejects both.
+//   - The restart control at the end proves warm() over a healthy KV returns
+//     ok=true — confirming process restart is the only fix.
+func TestQuorumLoss_CaseA_GetFailCreatesUnbeatableTombstone(t *testing.T) {
+	// Step 1 — fault setup: Keys returns the key, Get returns DeadlineExceeded.
+	// This is the ONLY difference from TestQuorumLoss_HealthyReconcile_Control.
+	kv := newHealthyKV(t)
+	kv.getErrByKey = map[string]error{
+		quorumTestFullKey: context.DeadlineExceeded,
+	}
+
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+
+	// Seed cache at R=5 so the resolver believes there is a live claim.
+	seedResolverCache(r)
+
+	// Step 2 — trigger the reconcile under fault conditions.
+	// reconcileOnce: Keys() ok → Get() fails → pid not in seen →
+	// tombstone staged at R+1=6 → applyPendingBatch writes {deleted:true, rev:6}.
+	r.reconcileOnce(context.Background())
+
+	// The tombstone must now be in place.
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.False(t, ok, "fault reconcile must have tombstoned the claim")
+
+	// Step 3 — simulate recovery: restore Get to return the live claim at R=5.
+	kv.getErrByKey = nil // Get is healthy again
+
+	// Step 3a — reconcile read-path: reconcileOnce now sees the live claim at
+	// R=5 via Get, but the reconcile PRE-FILTER (claim_resolver.go:1010-1014)
+	// drops it because the cached tombstone's revision (6) >= entry revision (5),
+	// so no upsert is ever staged and applyPendingBatch gets an empty batch. The
+	// tombstone persists. NOTE this is a DISTINCT guard from the applyPendingBatch
+	// guard exercised by step 3b below — Case A covers both sites.
+	r.reconcileOnce(context.Background())
+	_, _, _, ok = r.GetOwner(quorumTestPID)
+	require.False(t, ok,
+		// Non-vacuous: we just ran reconcileOnce with a healthy KV. If the
+		// reconcile pre-filter were wrong (staged R over the R+1 tombstone),
+		// this would be ok=true.
+		"reconcile read-path at R must NOT beat the tombstone at R+1",
+	)
+
+	// Step 3b — watcher read-path: deliver the live claim at R=5 via
+	// handleWatcherUpdate + applyPendingBatch. handleWatcherUpdate stages the
+	// upsert unconditionally, so here the applyPendingBatch guard (:865,
+	// existing.revision 6 >= p.revision 5) is what rejects it — the same >=
+	// semantics as 3a's pre-filter but a different code site.
+	pendingMap := make(map[string]pending)
+	watcherEntry := &mockKVEntryFull{
+		key:      quorumTestFullKey,
+		val:      quorumTestClaim(t),
+		revision: quorumTestRevision, // R=5 < tombstone R+1=6
+	}
+	r.handleWatcherUpdate(watcherEntry, pendingMap)
+	r.applyPendingBatch(pendingMap, "test-watcher-recovery")
+
+	_, _, _, ok = r.GetOwner(quorumTestPID)
+	require.False(t, ok,
+		// Non-vacuous: we just delivered the live claim via the watcher path.
+		// If the guard were wrong (accepted R over R+1), this would be ok=true.
+		"watcher read-path at R must NOT beat the tombstone at R+1",
+	)
+
+	// Step 4 — restart control: a fresh resolver calling warm() over the now-
+	// healthy KV reads KV directly (no in-memory tombstone) and returns ok=true.
+	// This proves a process restart IS the fix, as reported in the incident.
+	r2 := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	err := r2.warm(context.Background())
+	require.NoError(t, err)
+	owner, _, _, ok2 := r2.GetOwner(quorumTestPID)
+	require.True(t, ok2, "fresh warm() over healthy KV must return ok=true (restart fixes it)")
+	require.Equal(t, quorumTestOwner, owner)
+}
+
+// TestQuorumLoss_CaseAPrime_FleetWideTombstone verifies that if ALL pids' Get
+// calls fail in a single reconcile pass, ALL pids are tombstoned.
+//
+// This models the fleet-wide symptom from the incident report where all workers
+// stopped processing after a bucket quorum loss affecting all keys.
+//
+// Non-vacuous: we assert ok=true for ALL pids immediately after seeding (before
+// the fault reconcile). After the fault reconcile we assert ALL pids are ok=false.
+// Without the pre-fault presence check, the post-fault absence could pass
+// vacuously (cache never populated).
+func TestQuorumLoss_CaseAPrime_FleetWideTombstone(t *testing.T) {
+	const numPIDs = 3
+	pids := []string{"USER01", "USER02", "USER03"}
+
+	store := make(map[string][]byte, numPIDs)
+	for _, pid := range pids {
+		store["claims/"+pid] = marshalClaim(t, handoff.Claim{
+			PartitionID: pid,
+			Owner:       "worker-" + pid,
+			State:       handoff.ClaimStateStable,
+			Epoch:       1,
+		})
+	}
+
+	kv := newMockKVWithKeyErr(store, quorumTestRevision)
+
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+
+	// Seed cache with all pids at R=5.
+	seedMap := make(map[string]claimEntry, numPIDs)
+	for _, pid := range pids {
+		seedMap[pid] = claimEntry{
+			owner:    "worker-" + pid,
+			state:    toState(handoff.ClaimStateStable),
+			epoch:    1,
+			revision: quorumTestRevision,
+		}
+	}
+	r.cache.Store(&seedMap)
+
+	// Non-vacuous pre-fault check: all pids present before the fault.
+	for _, pid := range pids {
+		_, _, _, ok := r.GetOwner(pid)
+		require.True(t, ok, "pre-fault: pid %s must be present", pid)
+	}
+
+	// Inject fault: ALL pids' Get returns DeadlineExceeded.
+	kv.getErrByKey = make(map[string]error, numPIDs)
+	for _, pid := range pids {
+		kv.getErrByKey["claims/"+pid] = context.DeadlineExceeded
+	}
+
+	// Trigger the fault reconcile.
+	r.reconcileOnce(context.Background())
+
+	// Assert ALL pids are tombstoned (non-vacuous because we proved them present above).
+	for _, pid := range pids {
+		_, _, _, ok := r.GetOwner(pid)
+		require.False(t, ok, "post-fault: pid %s must be tombstoned after all-Get-fail", pid)
+	}
+}
+
+// TestQuorumLoss_CaseADoublePrime_KVRewriteBeatsTheTombstone verifies that
+// a claim re-write at revision R+2 (strictly greater than the tombstone at R+1)
+// DOES beat the tombstone and restores the gate to open.
+//
+// This tells the fix authors that forcing a claim re-write at a new revision
+// (e.g., a triggered re-apply or a handoff coordinator that re-writes on
+// recovery) is a viable fix shape — without requiring a process restart.
+//
+// Non-vacuous: we assert ok=false AFTER the tombstone (intermediate state)
+// before delivering R+2. The final ok=true can only pass because the R+2
+// write was accepted, NOT because the tombstone was absent.
+func TestQuorumLoss_CaseADoublePrime_KVRewriteBeatsTheTombstone(t *testing.T) {
+	// Step 1 — reproduce the tombstone at R+1 (same as Case A steps 1-2).
+	kv := newHealthyKV(t)
+	kv.getErrByKey = map[string]error{
+		quorumTestFullKey: context.DeadlineExceeded,
+	}
+
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	seedResolverCache(r)
+
+	r.reconcileOnce(context.Background())
+
+	// Non-vacuous intermediate check: tombstone is in place before the heal.
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.False(t, ok, "tombstone must be in place before the heal attempt")
+
+	// Step 2 — deliver a claim re-write at R+2=7 via the watcher path.
+	// R+2=7 > tombstone=6 → guard: 6 >= 7 = false → write accepted.
+	const healRevision = quorumTestRevision + 2 // R+2 = 7
+	pendingMap := make(map[string]pending)
+	rewriteEntry := &mockKVEntryFull{
+		key:      quorumTestFullKey,
+		val:      quorumTestClaim(t),
+		revision: healRevision,
+	}
+	r.handleWatcherUpdate(rewriteEntry, pendingMap)
+	r.applyPendingBatch(pendingMap, "test-rewrite-heal")
+
+	// The re-write at R+2 must beat the tombstone at R+1.
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok,
+		// Non-vacuous: we asserted ok=false immediately above (tombstone present).
+		// This ok=true can only result from the R+2 write being accepted.
+		"claim re-write at R+2 must beat the tombstone at R+1",
+	)
+	require.Equal(t, quorumTestOwner, owner)
+}
+
+// TestQuorumLoss_CaseB_KeysFailDoesNotPoison verifies the boundary between the
+// two fault branches: when Keys() ITSELF fails (not just per-key Get),
+// reconcileOnce takes the early-return path and leaves the cache untouched.
+//
+// This is the benign branch — the one the incident logs DID show
+// ("reconcile … list keys failed"). The dangerous branch is Case A (Keys-ok /
+// Get-fail). This test proves the two branches produce opposite outcomes.
+//
+// Non-vacuous: the presence assertion before reconcileOnce proves the cache was
+// genuinely populated. The post-reconcile ok=true cannot pass vacuously (it
+// would fail if reconcileOnce had poisoned the cache). Contrast with Case A:
+// identical setup, only the fault type differs (Keys-fail vs Get-fail), and the
+// outcome is the opposite (ok=true vs ok=false).
+func TestQuorumLoss_CaseB_KeysFailDoesNotPoison(t *testing.T) {
+	kv := newHealthyKV(t)
+	// Keys() returns DeadlineExceeded — the EARLY-RETURN branch in reconcileOnce.
+	// Note: must NOT use an error containing "no keys found" — that branch
+	// sets keys=nil and proceeds into the tombstone pass instead of returning.
+	kv.keysErr = context.DeadlineExceeded
+
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	seedResolverCache(r)
+
+	// Non-vacuous pre-reconcile check: cache is genuinely populated.
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "pre-reconcile: cache must be populated (non-vacuous check)")
+	require.Equal(t, quorumTestOwner, owner)
+
+	// reconcileOnce: Keys() fails → early return (lines ~978-984 in production
+	// code). The cache must be untouched.
+	r.reconcileOnce(context.Background())
+
+	owner, _, _, ok = r.GetOwner(quorumTestPID)
+	require.True(t, ok,
+		// Non-vacuous: we seeded the cache above AND confirmed it was present.
+		// If reconcileOnce had touched the tombstone pass it would be ok=false.
+		// The early-return prevents any cache modification — the claim survives.
+		"Keys() failure must take the early-return path and NOT poison the cache",
+	)
+	require.Equal(t, quorumTestOwner, owner)
+}

--- a/internal/durable/claim_resolver_quorumloss_test.go
+++ b/internal/durable/claim_resolver_quorumloss_test.go
@@ -3,17 +3,23 @@
 // Incident: a KV bucket that lost quorum while the NATS connection stayed
 // CONNECTED produced a Keys()-ok / Get()-fail reconcile window. reconcileOnce
 // continued without adding the pid to `seen`, so the tombstone pass staged a
-// synthetic delete at R+1 (cache revision + 1). applyPendingBatch applied it
-// because R+1 > R. After recovery the real claim returned at R; both the
-// watcher and reconciler tried to re-apply it at R, but the guard
-// (existing.revision >= p.revision = R+1 >= R = true) rejected it. The
-// tombstone won permanently. Only a process restart (warm() re-reading KV
-// from scratch) cleared it.
+// synthetic delete at R+1 (cache revision + 1) — turning a transient read
+// failure into a permanent, monotonic-revision-irreversible tombstone that only
+// a process restart could clear.
 //
-// Plan: docs/plans/auto-healing-quorum-loss-repro/
+// Fix (F-D2a): reconcileOnce now distinguishes a listed-but-unreadable key (Get
+// errored) from a genuinely-gone key. A read error adds the pid to an
+// `unreadable` set, and the tombstone pass skips unreadable pids — it never
+// tombstones a key it simply could not read this pass. Genuine deletions (key
+// absent from Keys, or Get returning a delete/purge op) still tombstone.
 //
-//	02-consolidated-design.md  §2 Defect 2, §4 Tier 0
-//	03-execution-model-effort.md §3 control pairings
+// These tests pin BOTH directions: the read-fault case must NOT poison (the
+// flipped reproducer), and every genuine-deletion case must STILL tombstone (so
+// the fix is not over-broad).
+//
+// Plan: docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md §1 (F-D2a)
+//
+//	docs/plans/auto-healing-quorum-loss-repro/02-consolidated-design.md §2 Defect 2, §4 Tier 0
 //
 // All tests are deterministic and require no NATS server.
 package durable
@@ -30,13 +36,16 @@ import (
 // ─── Mock extension ───────────────────────────────────────────────────────────
 //
 // mockKVForReconcile (defined in claim_resolver_restart_test.go) is extended
-// with two nil-default fields:
+// with three nil-default fields:
 //
 //   getErrByKey map[string]error — if a key has an entry, Get returns that
 //     error while Keys() STILL lists the key (the asymmetric window).
+//   getOpByKey map[string]jetstream.KeyValueOp — if a key has an entry, the
+//     entry Get returns has its Operation() overridden (surfacing a listed key
+//     as a genuine delete/purge).
 //   keysErr error — if set, Keys() returns this error immediately.
 //
-// Both fields are set by direct field assignment (consistent with the existing
+// All fields are set by direct field assignment (consistent with the existing
 // afterKeys hook pattern). No existing call sites pass them, so they default
 // to nil and the behaviour of existing tests is unchanged.
 //
@@ -53,8 +62,9 @@ import (
 // window that reconcileOnce cannot handle.
 type mockKVWithKeyErr struct {
 	*mockKVForReconcile
-	getErrByKey map[string]error // optional per-key error override for Get
-	keysErr     error            // if set, Keys() returns this error
+	getErrByKey map[string]error                // optional per-key error override for Get
+	getOpByKey  map[string]jetstream.KeyValueOp // optional per-key Operation() override for Get
+	keysErr     error                           // if set, Keys() returns this error
 }
 
 func newMockKVWithKeyErr(store map[string][]byte, revision uint64) *mockKVWithKeyErr {
@@ -72,17 +82,34 @@ func (m *mockKVWithKeyErr) Keys(ctx context.Context, opts ...jetstream.WatchOpt)
 	return m.mockKVForReconcile.Keys(ctx, opts...)
 }
 
-// Get overrides mockKVForReconcile.Get to inject per-key errors. If a key has
-// an entry in getErrByKey the error is returned instead of the store value.
-// The key deliberately stays in store (i.e. Keys() still lists it), modelling
-// the asymmetric window: Keys returns the key, but Get times out.
+// Get overrides mockKVForReconcile.Get to inject per-key errors and per-key
+// operation overrides. If a key has an entry in getErrByKey the error is
+// returned instead of the store value (the key deliberately stays in store, so
+// Keys() still lists it — the asymmetric Keys-ok/Get-fail window). If a key has
+// an entry in getOpByKey the returned entry's Operation() is overridden (so a
+// listed key can surface as a genuine delete/purge tombstone via Get).
 func (m *mockKVWithKeyErr) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
 	if m.getErrByKey != nil {
 		if err, hit := m.getErrByKey[key]; hit {
 			return nil, err
 		}
 	}
-	return m.mockKVForReconcile.Get(ctx, key)
+	entry, err := m.mockKVForReconcile.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if m.getOpByKey != nil {
+		if op, hit := m.getOpByKey[key]; hit {
+			return &mockKVEntryFull{
+				key:      entry.Key(),
+				val:      entry.Value(),
+				revision: entry.Revision(),
+				op:       op,
+			}, nil
+		}
+	}
+
+	return entry, nil
 }
 
 // ─── Shared construction helpers ─────────────────────────────────────────────
@@ -155,19 +182,23 @@ func TestQuorumLoss_HealthyReconcile_Control(t *testing.T) {
 	require.Equal(t, quorumTestOwner, owner, "owner must be unchanged after healthy reconcile")
 }
 
-// TestQuorumLoss_CaseA_GetFailCreatesUnbeatableTombstone is the primary
-// defect pin: Keys-ok / Get-fail for a single pid causes a permanent
-// tombstone that neither reconcile nor the watcher can overcome.
+// TestQuorumLoss_CaseA_GetFailDoesNotPoison is the primary F-D2a pin and the
+// flipped reproducer: a Keys-ok / Get-fail window for a single pid must NOT
+// tombstone the live claim. The transient read failure adds the pid to the
+// `unreadable` set; the tombstone pass skips it; the cached claim survives.
+//
+// This is the RED→GREEN flip: on the pre-fix code this same fault staged a
+// synthetic delete at R+1 and the final assertion would be ok=false. The fix
+// keeps it ok=true.
 //
 // Non-vacuous because:
 //   - The healthy-reconcile control above differs by exactly one variable
-//     (Get-ok vs Get-fail) and asserts ok=true. Removing getErrByKey from this
-//     test would flip the final assertion to ok=true — proven by the control.
-//   - After tombstone, both read-paths (reconcile AND watcher) are exercised
-//     and both fail to clear it: the revision guard R+1 >= R rejects both.
-//   - The restart control at the end proves warm() over a healthy KV returns
-//     ok=true — confirming process restart is the only fix.
-func TestQuorumLoss_CaseA_GetFailCreatesUnbeatableTombstone(t *testing.T) {
+//     (Get-ok vs Get-fail) and also asserts ok=true. The pairing isolates the
+//     Get-fail as the variable under test; the fix makes both outcomes equal.
+//   - Step 3 proves the claim was never lost: after Get recovers, a later
+//     reconcile still resolves ok=true with the correct owner — i.e. "we just
+//     couldn't read it this pass; a later pass re-reads it", no restart needed.
+func TestQuorumLoss_CaseA_GetFailDoesNotPoison(t *testing.T) {
 	// Step 1 — fault setup: Keys returns the key, Get returns DeadlineExceeded.
 	// This is the ONLY difference from TestQuorumLoss_HealthyReconcile_Control.
 	kv := newHealthyKV(t)
@@ -181,75 +212,41 @@ func TestQuorumLoss_CaseA_GetFailCreatesUnbeatableTombstone(t *testing.T) {
 	seedResolverCache(r)
 
 	// Step 2 — trigger the reconcile under fault conditions.
-	// reconcileOnce: Keys() ok → Get() fails → pid not in seen →
-	// tombstone staged at R+1=6 → applyPendingBatch writes {deleted:true, rev:6}.
+	// reconcileOnce: Keys() ok → Get() fails → pid added to `unreadable` →
+	// tombstone pass skips it → no synthetic delete staged → cache untouched.
 	r.reconcileOnce(context.Background())
 
-	// The tombstone must now be in place.
-	_, _, _, ok := r.GetOwner(quorumTestPID)
-	require.False(t, ok, "fault reconcile must have tombstoned the claim")
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok,
+		// Non-vacuous: the healthy control differs only in Get-ok vs Get-fail.
+		// On pre-fix code this asserted ok=false (the R+1 tombstone). The fix
+		// keeps the unreadable claim live.
+		"a listed-but-unreadable claim must NOT be tombstoned by a transient Get failure",
+	)
+	require.Equal(t, quorumTestOwner, owner, "owner must be unchanged after an unreadable-key reconcile")
 
-	// Step 3 — simulate recovery: restore Get to return the live claim at R=5.
-	kv.getErrByKey = nil // Get is healthy again
-
-	// Step 3a — reconcile read-path: reconcileOnce now sees the live claim at
-	// R=5 via Get, but the reconcile PRE-FILTER (claim_resolver.go:1010-1014)
-	// drops it because the cached tombstone's revision (6) >= entry revision (5),
-	// so no upsert is ever staged and applyPendingBatch gets an empty batch. The
-	// tombstone persists. NOTE this is a DISTINCT guard from the applyPendingBatch
-	// guard exercised by step 3b below — Case A covers both sites.
+	// Step 3 — recovery: restore Get, run another reconcile. The claim was never
+	// lost, so it still resolves ok=true at the correct owner. No restart needed.
+	kv.getErrByKey = nil
 	r.reconcileOnce(context.Background())
-	_, _, _, ok = r.GetOwner(quorumTestPID)
-	require.False(t, ok,
-		// Non-vacuous: we just ran reconcileOnce with a healthy KV. If the
-		// reconcile pre-filter were wrong (staged R over the R+1 tombstone),
-		// this would be ok=true.
-		"reconcile read-path at R must NOT beat the tombstone at R+1",
-	)
-
-	// Step 3b — watcher read-path: deliver the live claim at R=5 via
-	// handleWatcherUpdate + applyPendingBatch. handleWatcherUpdate stages the
-	// upsert unconditionally, so here the applyPendingBatch guard (:865,
-	// existing.revision 6 >= p.revision 5) is what rejects it — the same >=
-	// semantics as 3a's pre-filter but a different code site.
-	pendingMap := make(map[string]pending)
-	watcherEntry := &mockKVEntryFull{
-		key:      quorumTestFullKey,
-		val:      quorumTestClaim(t),
-		revision: quorumTestRevision, // R=5 < tombstone R+1=6
-	}
-	r.handleWatcherUpdate(watcherEntry, pendingMap)
-	r.applyPendingBatch(pendingMap, "test-watcher-recovery")
-
-	_, _, _, ok = r.GetOwner(quorumTestPID)
-	require.False(t, ok,
-		// Non-vacuous: we just delivered the live claim via the watcher path.
-		// If the guard were wrong (accepted R over R+1), this would be ok=true.
-		"watcher read-path at R must NOT beat the tombstone at R+1",
-	)
-
-	// Step 4 — restart control: a fresh resolver calling warm() over the now-
-	// healthy KV reads KV directly (no in-memory tombstone) and returns ok=true.
-	// This proves a process restart IS the fix, as reported in the incident.
-	r2 := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
-	err := r2.warm(context.Background())
-	require.NoError(t, err)
-	owner, _, _, ok2 := r2.GetOwner(quorumTestPID)
-	require.True(t, ok2, "fresh warm() over healthy KV must return ok=true (restart fixes it)")
+	owner, _, _, ok = r.GetOwner(quorumTestPID)
+	require.True(t, ok, "claim must remain resolvable after the read fault recovers")
 	require.Equal(t, quorumTestOwner, owner)
 }
 
-// TestQuorumLoss_CaseAPrime_FleetWideTombstone verifies that if ALL pids' Get
-// calls fail in a single reconcile pass, ALL pids are tombstoned.
+// TestQuorumLoss_CaseAPrime_FleetWideReadFaultDoesNotPoison verifies that if
+// ALL pids' Get calls fail in a single reconcile pass, NONE are tombstoned —
+// every pid stays resolvable.
 //
 // This models the fleet-wide symptom from the incident report where all workers
-// stopped processing after a bucket quorum loss affecting all keys.
+// stopped processing after a bucket quorum loss affecting all keys. With F-D2a
+// the whole fleet survives the transient read fault.
 //
 // Non-vacuous: we assert ok=true for ALL pids immediately after seeding (before
-// the fault reconcile). After the fault reconcile we assert ALL pids are ok=false.
-// Without the pre-fault presence check, the post-fault absence could pass
-// vacuously (cache never populated).
-func TestQuorumLoss_CaseAPrime_FleetWideTombstone(t *testing.T) {
+// the fault reconcile) AND after it. The pre-fault check proves the cache was
+// genuinely populated; on pre-fix code the post-fault assertion was ok=false for
+// every pid, so the ok=true here is a real flip, not a vacuous pass.
+func TestQuorumLoss_CaseAPrime_FleetWideReadFaultDoesNotPoison(t *testing.T) {
 	const numPIDs = 3
 	pids := []string{"USER01", "USER02", "USER03"}
 
@@ -294,10 +291,11 @@ func TestQuorumLoss_CaseAPrime_FleetWideTombstone(t *testing.T) {
 	// Trigger the fault reconcile.
 	r.reconcileOnce(context.Background())
 
-	// Assert ALL pids are tombstoned (non-vacuous because we proved them present above).
+	// Assert ALL pids survive (non-vacuous because we proved them present above
+	// and pre-fix code tombstoned every one of them).
 	for _, pid := range pids {
 		_, _, _, ok := r.GetOwner(pid)
-		require.False(t, ok, "post-fault: pid %s must be tombstoned after all-Get-fail", pid)
+		require.True(t, ok, "post-fault: pid %s must survive an all-Get-fail reconcile", pid)
 	}
 }
 
@@ -305,18 +303,22 @@ func TestQuorumLoss_CaseAPrime_FleetWideTombstone(t *testing.T) {
 // a claim re-write at revision R+2 (strictly greater than the tombstone at R+1)
 // DOES beat the tombstone and restores the gate to open.
 //
-// This tells the fix authors that forcing a claim re-write at a new revision
-// (e.g., a triggered re-apply or a handoff coordinator that re-writes on
-// recovery) is a viable fix shape — without requiring a process restart.
+// This documents the monotonic-revision guard: a re-write at a strictly greater
+// revision is the only thing that clears a tombstone in-process. The tombstone
+// here is manufactured via a GENUINE delete-op (Get returns a KeyValueDelete) —
+// the F-D2a fix only spares transient READ failures, so a real deletion still
+// tombstones, which is exactly what this test relies on.
 //
 // Non-vacuous: we assert ok=false AFTER the tombstone (intermediate state)
 // before delivering R+2. The final ok=true can only pass because the R+2
 // write was accepted, NOT because the tombstone was absent.
 func TestQuorumLoss_CaseADoublePrime_KVRewriteBeatsTheTombstone(t *testing.T) {
-	// Step 1 — reproduce the tombstone at R+1 (same as Case A steps 1-2).
+	// Step 1 — manufacture a genuine tombstone at R+1: Keys() lists the key but
+	// Get() returns a delete operation, so the reconcile tombstone pass stages a
+	// synthetic delete at R+1.
 	kv := newHealthyKV(t)
-	kv.getErrByKey = map[string]error{
-		quorumTestFullKey: context.DeadlineExceeded,
+	kv.getOpByKey = map[string]jetstream.KeyValueOp{
+		quorumTestFullKey: jetstream.KeyValueDelete,
 	}
 
 	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
@@ -326,7 +328,7 @@ func TestQuorumLoss_CaseADoublePrime_KVRewriteBeatsTheTombstone(t *testing.T) {
 
 	// Non-vacuous intermediate check: tombstone is in place before the heal.
 	_, _, _, ok := r.GetOwner(quorumTestPID)
-	require.False(t, ok, "tombstone must be in place before the heal attempt")
+	require.False(t, ok, "a genuine delete-op must tombstone the claim before the heal attempt")
 
 	// Step 2 — deliver a claim re-write at R+2=7 via the watcher path.
 	// R+2=7 > tombstone=6 → guard: 6 >= 7 = false → write accepted.
@@ -354,15 +356,15 @@ func TestQuorumLoss_CaseADoublePrime_KVRewriteBeatsTheTombstone(t *testing.T) {
 // two fault branches: when Keys() ITSELF fails (not just per-key Get),
 // reconcileOnce takes the early-return path and leaves the cache untouched.
 //
-// This is the benign branch — the one the incident logs DID show
-// ("reconcile … list keys failed"). The dangerous branch is Case A (Keys-ok /
-// Get-fail). This test proves the two branches produce opposite outcomes.
+// This is the branch the incident logs DID show ("reconcile … list keys
+// failed"). Post-F-D2a it and Case A both leave the claim live (ok=true), but by
+// DIFFERENT mechanisms: Keys-fail returns early so the tombstone pass never
+// runs, whereas Keys-ok/Get-fail runs the tombstone pass but skips the pid via
+// the `unreadable` set. This test pins the early-return mechanism specifically.
 //
 // Non-vacuous: the presence assertion before reconcileOnce proves the cache was
 // genuinely populated. The post-reconcile ok=true cannot pass vacuously (it
-// would fail if reconcileOnce had poisoned the cache). Contrast with Case A:
-// identical setup, only the fault type differs (Keys-fail vs Get-fail), and the
-// outcome is the opposite (ok=true vs ok=false).
+// would fail if reconcileOnce had poisoned the cache via the tombstone pass).
 func TestQuorumLoss_CaseB_KeysFailDoesNotPoison(t *testing.T) {
 	kv := newHealthyKV(t)
 	// Keys() returns DeadlineExceeded — the EARLY-RETURN branch in reconcileOnce.
@@ -390,4 +392,150 @@ func TestQuorumLoss_CaseB_KeysFailDoesNotPoison(t *testing.T) {
 		"Keys() failure must take the early-return path and NOT poison the cache",
 	)
 	require.Equal(t, quorumTestOwner, owner)
+}
+
+// ─── F-D2a boundary table: genuine deletions must STILL tombstone ─────────────
+//
+// These guard that the fix is not over-broad: it spares ONLY a transient read
+// failure (Get errored). Every genuine-deletion signal still tombstones. They
+// pass on pre-fix code too — they are preservation guards, not RED flips — and
+// turn red if the fix were widened to skip tombstoning for ANY non-`seen` pid.
+
+// TestQuorumLoss_Boundary_GetDeleteOpStillTombstones: Keys lists the key, Get
+// returns a KeyValueDelete op → a genuine deletion → still tombstoned.
+func TestQuorumLoss_Boundary_GetDeleteOpStillTombstones(t *testing.T) {
+	kv := newHealthyKV(t)
+	kv.getOpByKey = map[string]jetstream.KeyValueOp{
+		quorumTestFullKey: jetstream.KeyValueDelete,
+	}
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	seedResolverCache(r)
+
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "pre-reconcile: claim must be present (non-vacuous)")
+
+	r.reconcileOnce(context.Background())
+
+	_, _, _, ok = r.GetOwner(quorumTestPID)
+	require.False(t, ok, "a Get delete-op is a genuine deletion and must still tombstone")
+}
+
+// TestQuorumLoss_Boundary_GetPurgeOpStillTombstones: same as above with a
+// KeyValuePurge op.
+func TestQuorumLoss_Boundary_GetPurgeOpStillTombstones(t *testing.T) {
+	kv := newHealthyKV(t)
+	kv.getOpByKey = map[string]jetstream.KeyValueOp{
+		quorumTestFullKey: jetstream.KeyValuePurge,
+	}
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	seedResolverCache(r)
+
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "pre-reconcile: claim must be present (non-vacuous)")
+
+	r.reconcileOnce(context.Background())
+
+	_, _, _, ok = r.GetOwner(quorumTestPID)
+	require.False(t, ok, "a Get purge-op is a genuine deletion and must still tombstone")
+}
+
+// TestQuorumLoss_Boundary_AbsentFromKeysStillTombstones: the cached pid is no
+// longer listed by Keys at all → genuinely gone → tombstoned. This is the
+// backstop deletion path; the fix must not disturb it.
+func TestQuorumLoss_Boundary_AbsentFromKeysStillTombstones(t *testing.T) {
+	// Store holds a DIFFERENT live claim so Keys() returns non-empty (avoiding
+	// the "no keys found" branch) but does NOT list the seeded pid.
+	kv := newMockKVWithKeyErr(map[string][]byte{
+		"claims/OTHER99": marshalClaim(t, handoff.Claim{
+			PartitionID: "OTHER99",
+			Owner:       "worker-other",
+			State:       handoff.ClaimStateStable,
+			Epoch:       1,
+		}),
+	}, quorumTestRevision)
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	seedResolverCache(r) // seeds quorumTestPID, which is NOT in the store
+
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "pre-reconcile: seeded claim must be present (non-vacuous)")
+
+	r.reconcileOnce(context.Background())
+
+	_, _, _, ok = r.GetOwner(quorumTestPID)
+	require.False(t, ok, "a pid absent from Keys is genuinely gone and must still tombstone")
+}
+
+// TestQuorumLoss_Boundary_PrefixFilteredKeyIsInert: a key that does not match
+// the claims prefix is skipped before Get, so it enters neither `seen` nor
+// `unreadable`. This test is load-bearing against a regressed prefix filter (one
+// that stopped skipping out-of-prefix keys) on BOTH sides:
+//
+//   - seen-side: an out-of-prefix key carrying a VALID claim. If it were
+//     fetched it would be staged as an upsert and become resolvable. (A junk
+//     payload would be masked by applyPendingBatch's unmarshal-skip, so the
+//     value must be a real claim for the assertion to bite.)
+//   - unreadable-side: an out-of-prefix key whose bare name equals a cached,
+//     genuinely-gone pid and whose Get errors. If it entered `unreadable` it
+//     would wrongly suppress that gone pid's tombstone.
+func TestQuorumLoss_Boundary_PrefixFilteredKeyIsInert(t *testing.T) {
+	// An out-of-prefix key is cached (if a regression staged it) under its
+	// TrimPrefix("claims/") result, which — having no prefix to strip — is the
+	// full key string. So the seen-side assertion must query that full key.
+	const outSeenKey = "other/SEEN9" // out-of-prefix valid claim; must stay inert
+	const gonePID = "GONE7"          // cached but genuinely gone → must tombstone
+
+	kv := newHealthyKV(t) // store: claims/USER21 (live)
+	// seen-side probe: a valid claim under an out-of-prefix key.
+	kv.store[outSeenKey] = marshalClaim(t, handoff.Claim{
+		PartitionID: "SEEN9",
+		Owner:       "worker-out",
+		State:       handoff.ClaimStateStable,
+		Epoch:       1,
+	})
+	// unreadable-side probe: a bare key whose name collides with gonePID and
+	// whose Get errors. The real prefixed key (claims/GONE7) is absent, so a
+	// correct prefix filter lets gonePID tombstone; a regressed filter would
+	// route this errored Get into `unreadable[gonePID]` and suppress it.
+	kv.store[gonePID] = []byte("ignored")
+	kv.getErrByKey = map[string]error{gonePID: context.DeadlineExceeded}
+
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	// Seed cache with the live claim AND the genuinely-gone pid.
+	seed := map[string]claimEntry{
+		quorumTestPID: {
+			owner:    quorumTestOwner,
+			state:    toState(handoff.ClaimStateStable),
+			epoch:    quorumTestEpoch,
+			revision: quorumTestRevision,
+		},
+		gonePID: {
+			owner:    "worker-gone",
+			state:    toState(handoff.ClaimStateStable),
+			epoch:    1,
+			revision: quorumTestRevision,
+		},
+	}
+	r.cache.Store(&seed)
+
+	// Non-vacuous pre-reconcile presence checks.
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "pre-reconcile: live claim must be present")
+	_, _, _, ok = r.GetOwner(gonePID)
+	require.True(t, ok, "pre-reconcile: gone pid must be present before it tombstones")
+
+	r.reconcileOnce(context.Background())
+
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok, "the live claim must survive a reconcile that also saw out-of-prefix keys")
+	require.Equal(t, quorumTestOwner, owner)
+
+	// seen-side: the out-of-prefix valid claim must not have been staged. It
+	// would be cached under its full-key pid if the prefix filter regressed.
+	_, _, _, ok = r.GetOwner(outSeenKey)
+	require.False(t, ok, "an out-of-prefix key must never become a resolvable claim (seen-side)")
+
+	// unreadable-side: gonePID is genuinely gone (claims/GONE7 absent) and the
+	// bare GONE7 key was prefix-filtered, so it must still tombstone.
+	_, _, _, ok = r.GetOwner(gonePID)
+	require.False(t, ok, "an out-of-prefix errored key must not suppress a genuine tombstone (unreadable-side)")
 }

--- a/internal/durable/claim_resolver_reconcile_observability_test.go
+++ b/internal/durable/claim_resolver_reconcile_observability_test.go
@@ -1,0 +1,77 @@
+package durable
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLogger is a minimal types.Logger that records messages so a test can
+// assert a specific line was (or was not) emitted.
+type captureLogger struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+var _ types.Logger = (*captureLogger)(nil)
+
+func (c *captureLogger) record(msg string) {
+	c.mu.Lock()
+	c.msgs = append(c.msgs, msg)
+	c.mu.Unlock()
+}
+
+func (c *captureLogger) Debug(msg string, _ ...any) { c.record(msg) }
+func (c *captureLogger) Info(msg string, _ ...any)  { c.record(msg) }
+func (c *captureLogger) Warn(msg string, _ ...any)  { c.record(msg) }
+func (c *captureLogger) Error(msg string, _ ...any) { c.record(msg) }
+func (c *captureLogger) Fatal(msg string, _ ...any) { c.record(msg) }
+
+func (c *captureLogger) has(substr string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range c.msgs {
+		if strings.Contains(m, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestReconcile_LogsUnreadableKeys pins F-D2c: a reconcile pass that lists keys
+// but fails to Get some of them must surface that read failure (previously the
+// per-key Get error was silently swallowed). One aggregated line per pass.
+//
+// Non-vacuous: the healthy control below runs the same reconcile without the
+// read fault and asserts the line is NOT emitted.
+func TestReconcile_LogsUnreadableKeys(t *testing.T) {
+	kv := newHealthyKV(t)
+	kv.getErrByKey = map[string]error{quorumTestFullKey: context.DeadlineExceeded}
+	cl := &captureLogger{}
+	r := NewClaimBasedResolver(kv, "claims/", cl, WithReconcileInterval(0))
+	seedResolverCache(r)
+
+	r.reconcileOnce(context.Background())
+
+	require.True(t, cl.has("unreadable"),
+		"reconcile must surface a listed-but-unreadable read failure (F-D2c)")
+}
+
+// TestReconcile_NoUnreadableLogWhenHealthy is the F-D2c control: a healthy
+// reconcile (all Gets succeed) must not emit the unreadable-keys line.
+func TestReconcile_NoUnreadableLogWhenHealthy(t *testing.T) {
+	kv := newHealthyKV(t)
+	cl := &captureLogger{}
+	r := NewClaimBasedResolver(kv, "claims/", cl, WithReconcileInterval(0))
+	seedResolverCache(r)
+
+	r.reconcileOnce(context.Background())
+
+	require.False(t, cl.has("unreadable"),
+		"a healthy reconcile must not emit an unreadable-keys read-failure log")
+}

--- a/internal/durable/partition_consumer_envelope_test.go
+++ b/internal/durable/partition_consumer_envelope_test.go
@@ -138,7 +138,7 @@ func TestPartitionConsumer_RecoveryEnvelope_RecoveredIterationsResetBudget(t *te
 	// Pattern: fail once, succeed once, fail once, succeed once, ... ensures
 	// no two consecutive failures.
 	var failPlan []bool
-	for i := 0; i < totalEpisodes; i++ {
+	for range totalEpisodes {
 		failPlan = append(failPlan, true)  // fail
 		failPlan = append(failPlan, false) // succeed
 	}

--- a/internal/durable/partition_consumer_envelope_test.go
+++ b/internal/durable/partition_consumer_envelope_test.go
@@ -137,7 +137,7 @@ func TestPartitionConsumer_RecoveryEnvelope_RecoveredIterationsResetBudget(t *te
 	// failPlan[i] == true means: on the i-th iter-create call, return error.
 	// Pattern: fail once, succeed once, fail once, succeed once, ... ensures
 	// no two consecutive failures.
-	var failPlan []bool
+	failPlan := make([]bool, 0, 2*totalEpisodes)
 	for range totalEpisodes {
 		failPlan = append(failPlan, true)  // fail
 		failPlan = append(failPlan, false) // succeed

--- a/internal/durable/partition_consumer_stream_missing_site_b_test.go
+++ b/internal/durable/partition_consumer_stream_missing_site_b_test.go
@@ -3,6 +3,7 @@ package durable
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -152,13 +153,7 @@ func TestPartitionConsumer_SiteB_StreamMissing_HookSuccess_ResetAwareRebuild(t *
 	require.Eventually(t, func() bool {
 		iterMu.Lock()
 		defer iterMu.Unlock()
-		for _, c := range iterCalls {
-			if c == jetstream.Consumer(rebuiltCons) {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(iterCalls, jetstream.Consumer(rebuiltCons))
 	}, 5*time.Second, 10*time.Millisecond,
 		"Site B success path must cause the outer loop to construct a fresh envelope against the rebuilt consumer")
 

--- a/internal/heartbeat/publisher.go
+++ b/internal/heartbeat/publisher.go
@@ -321,9 +321,7 @@ func (p *Publisher) publishLoop() {
 				p.recordSkippedPublish()
 				continue
 			}
-			p.inFlightWG.Add(1)
-			go func() {
-				defer p.inFlightWG.Done()
+			p.inFlightWG.Go(func() {
 				defer p.inFlight.Store(false)
 
 				timeout := min(maxPublishTimeout, p.interval/2)
@@ -340,7 +338,7 @@ func (p *Publisher) publishLoop() {
 				} else {
 					p.recordMetric(true)
 				}
-			}()
+			})
 		}
 	}
 }

--- a/internal/retry/envelope_test.go
+++ b/internal/retry/envelope_test.go
@@ -181,7 +181,7 @@ func TestEnvelope_Run_JitterStaysWithinBounds(t *testing.T) {
 	const jitter = 0.3 // ± 30%
 	low := time.Duration(float64(base) * (1 - jitter))
 	high := time.Duration(float64(base) * (1 + jitter))
-	for i := 0; i < trials; i++ {
+	for range trials {
 		sl := &instantSleep{}
 		env := New(Config{
 			Work: func(context.Context) error {

--- a/manager_apply_jitter_startup_test.go
+++ b/manager_apply_jitter_startup_test.go
@@ -2,6 +2,7 @@ package parti
 
 import (
 	"context"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -158,13 +159,7 @@ func TestApplyStartJitter_StartupBudget_Negative(t *testing.T) {
 	// Wait for watchdog to fire Degraded("startup-timeout").
 	require.Eventually(t, func() bool {
 		reasons, _ := degradedReasonsAtomic.Load().([]string)
-		for _, r := range reasons {
-			if r == "startup-timeout" {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(reasons, "startup-timeout")
 	}, 2*time.Second, 10*time.Millisecond,
 		"watchdog must fire Degraded('startup-timeout') when jitter exceeds StartupTimeout budget")
 }

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -904,13 +904,7 @@ func commitContainsWorker(c *types.AssignmentCommit, workerID string) bool {
 	if c == nil {
 		return false
 	}
-	for _, w := range c.Workers {
-		if w == workerID {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(c.Workers, workerID)
 }
 
 // handleCommitValue implements §3.6 case 1 (commit-path state machine).

--- a/manager_assignment_watcher_envelope_test.go
+++ b/manager_assignment_watcher_envelope_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -422,13 +423,7 @@ func (s *assignmentWatcherReasonSpy) record(_ context.Context, reason string) er
 func (s *assignmentWatcherReasonSpy) has(reason string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, r := range s.reasons {
-		if r == reason {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(s.reasons, reason)
 }
 
 func (s *assignmentWatcherReasonSpy) snapshot() []string {

--- a/manager_startup_async_test.go
+++ b/manager_startup_async_test.go
@@ -237,7 +237,7 @@ func TestStart_EmptySliceFromNonEmptyCluster_HookFiresEmptyEmpty(t *testing.T) {
 	defer cancel()
 
 	mgrs := make([]*parti.Manager, 2)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		m, err := parti.NewManager(&cfg, js, src, assignStrat, parti.WithHooks(makeHooks(i)))
 		require.NoError(t, err)
 		require.NoError(t, m.Start(ctx))

--- a/provision/dynamic_consumers_test.go
+++ b/provision/dynamic_consumers_test.go
@@ -151,7 +151,7 @@ func TestPlanDynamicConsumers_DeterministicOrderAcrossShuffles(t *testing.T) {
 	require.NoError(t, err)
 
 	r := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic shuffle for test
-	for trial := 0; trial < 10; trial++ {
+	for trial := range 10 {
 		shuffled := make([]types.Partition, len(base))
 		copy(shuffled, base)
 		r.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })

--- a/provision/plan.go
+++ b/provision/plan.go
@@ -414,9 +414,7 @@ func mergeMarkerMetadata(live map[string]string, component, instance string) map
 	if merged == nil {
 		merged = map[string]string{}
 	}
-	for k, v := range BuildMarker(component, instance) {
-		merged[k] = v
-	}
+	maps.Copy(merged, BuildMarker(component, instance))
 	if instance == "" {
 		delete(merged, MarkerInstanceKey)
 	}

--- a/provision/plan_integration_test.go
+++ b/provision/plan_integration_test.go
@@ -275,7 +275,7 @@ func TestPlan_Deterministic_AcrossRepeats(t *testing.T) {
 
 	// Call Plan multiple more times (exploiting Go map-iteration randomness)
 	// and assert full PlanResult equality, not just name/kind tuples.
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		again, err := provision.Plan(ctx, js, cfg)
 		require.NoError(t, err)
 		require.True(t, reflect.DeepEqual(first, again),

--- a/provision/types.go
+++ b/provision/types.go
@@ -452,5 +452,5 @@ type PlannedConsumer struct {
 	StreamName string                   `json:"streamName"`
 	Subject    string                   `json:"subject"`
 	Durable    string                   `json:"durable"`
-	Config     jetstream.ConsumerConfig `json:"config,omitempty"`
+	Config     jetstream.ConsumerConfig `json:"config"`
 }

--- a/source/nats_kv_retry_envelope_test.go
+++ b/source/nats_kv_retry_envelope_test.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -88,11 +89,8 @@ func TestRestartWatcher_BoundedByEnvelope(t *testing.T) {
 	warnMu.Lock()
 	defer warnMu.Unlock()
 	var sawExhausted bool
-	for _, w := range warnLines {
-		if w == "source watcher restart attempt budget exhausted; relying on reconciler for recovery" {
-			sawExhausted = true
-			break
-		}
+	if slices.Contains(warnLines, "source watcher restart attempt budget exhausted; relying on reconciler for recovery") {
+		sawExhausted = true
 	}
 	require.True(t, sawExhausted,
 		"onWatcherRetryExhausted must emit the named WARN line at exhaustion; got %v", warnLines)

--- a/test/integration/failure/resolver_readfault_test.go
+++ b/test/integration/failure/resolver_readfault_test.go
@@ -1,0 +1,403 @@
+package failure_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	rfStreamName    = "EVENTS"
+	rfSubjectTmpl   = "events.{{.PartitionID}}"
+	rfHandoffBucket = "parti-handoff"
+	rfClaimsPrefix  = "claims/"
+)
+
+// --- READ-axis fault seam ----------------------------------------------------
+//
+// This is the trimmed READ-only port of the S2 scratch-harness seam
+// (tmp/parti-repro/seam.go). The entire WRITE axis is dropped: S2 only needs
+// the asymmetric Keys-ok / Get-fail window. The seam wraps the handoff bucket's
+// KeyValue and overrides ONLY Get to fault claim-prefix keys when armed; Keys /
+// Watch / WatchAll / Status all pass through via embedding. Every other bucket
+// and every non-KV JetStream method passes straight through to the real js.
+
+// rfFaultController is the single shared toggle+counter every wrapper references.
+type rfFaultController struct {
+	// readArmed is the READ-axis toggle. When true, a per-key Get against a
+	// claim key faults with context.DeadlineExceeded.
+	readArmed atomic.Bool
+
+	// readFaultsInjected counts how many claim-key Get calls actually returned
+	// the injected read error. Lets the test assert the asymmetric read fault
+	// genuinely fired (non-vacuous) and that a reconcile pass ran under it.
+	readFaultsInjected atomic.Int64
+}
+
+func newRFFaultController() *rfFaultController { return &rfFaultController{} }
+
+// ArmReads enables the asymmetric read fault: per-key Get on a claim key faults
+// while Keys()/WatchAll() stay live. It resets the read-fault counter so the
+// test can assert the fault fired from this point.
+func (fc *rfFaultController) ArmReads() {
+	fc.readFaultsInjected.Store(0)
+	fc.readArmed.Store(true)
+}
+
+// DisarmReads disables the read fault (simulates KV read recovery — the claim
+// becomes Get-able again at its unchanged revision R, since writes were never
+// faulted on this axis).
+func (fc *rfFaultController) DisarmReads() { fc.readArmed.Store(false) }
+
+// shouldFaultRead reports whether a claim-key Get should fault and counts the
+// injected fault. Deterministic atomic toggle — no timing race.
+func (fc *rfFaultController) shouldFaultRead() bool {
+	if !fc.readArmed.Load() {
+		return false
+	}
+	fc.readFaultsInjected.Add(1)
+
+	return true
+}
+
+// rfFaultJetStream wraps a real jetstream.JetStream. Only handoff-bucket KV
+// handles are wrapped; everything else passes through.
+type rfFaultJetStream struct {
+	jetstream.JetStream // embedded: all non-overridden methods pass through
+
+	handoffBucket string
+	fc            *rfFaultController
+}
+
+func newRFFaultJetStream(inner jetstream.JetStream, handoffBucket string, fc *rfFaultController) *rfFaultJetStream {
+	return &rfFaultJetStream{JetStream: inner, handoffBucket: handoffBucket, fc: fc}
+}
+
+func (f *rfFaultJetStream) wrap(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
+	if bucket == f.handoffBucket {
+		return &rfFaultKeyValue{KeyValue: kv, fc: f.fc, claimsPrefix: rfClaimsPrefix}
+	}
+
+	return kv
+}
+
+// KeyValue is the get-first lookup used by both manager setup and consumer
+// setup (durable.ensureGateResolver → kvutil.EnsureKVBucket → js.KeyValue).
+func (f *rfFaultJetStream) KeyValue(ctx context.Context, bucket string) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.KeyValue(ctx, bucket)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, bucket), nil
+}
+
+// CreateKeyValue is the create path used when the bucket does not yet exist.
+func (f *rfFaultJetStream) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+// CreateOrUpdateKeyValue is wrapped for completeness so a future setup change
+// cannot leak an unwrapped handoff handle.
+func (f *rfFaultJetStream) CreateOrUpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateOrUpdateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+// rfFaultKeyValue wraps the real handoff KeyValue and faults ONLY the per-key
+// claim READ path (Get of a claimsPrefix key) when the READ axis is armed.
+// Keys() and WatchAll() are NEVER overridden — they always pass through. That
+// is the whole point: it reproduces the asymmetric Keys-ok/Get-fail window, and
+// the live WatchAll lets the resolver's watcher + reconcile-triggered replay run.
+type rfFaultKeyValue struct {
+	jetstream.KeyValue // embedded: Keys/Watch/WatchAll/Status/... pass through
+	fc                 *rfFaultController
+	claimsPrefix       string
+}
+
+// Get is the per-key read primitive the resolver uses both in warm() (Start)
+// and in every reconcileOnce pass. When the READ axis is armed it faults a
+// CLAIM key (claimsPrefix) with context.DeadlineExceeded; non-claim keys and
+// all reads while disarmed pass straight through.
+func (k *rfFaultKeyValue) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	if k.claimsPrefix != "" && len(key) >= len(k.claimsPrefix) && key[:len(k.claimsPrefix)] == k.claimsPrefix {
+		if k.fc.shouldFaultRead() {
+			return nil, context.DeadlineExceeded
+		}
+	}
+
+	return k.KeyValue.Get(ctx, key)
+}
+
+// --- Minimal worker stack ----------------------------------------------------
+
+// rfWorkerStack bundles one worker's manager, its consumer.Dynamic, and the
+// consumption counter. The scenario uses a single partition, so one atomic
+// counter of consumed events.* messages is sufficient.
+type rfWorkerStack struct {
+	mgr      *parti.Manager
+	dyn      *consumer.Dynamic
+	consumed atomic.Int64
+}
+
+// rfBuildStream creates the events stream (file storage — single-node embedded
+// server so storage type does not affect symptom injection).
+func rfBuildStream(t *testing.T, ctx context.Context, realJS jetstream.JetStream) {
+	t.Helper()
+	_, err := realJS.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      rfStreamName,
+		Subjects:  []string{"events.>"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.FileStorage,
+		MaxMsgs:   -1,
+	})
+	require.NoError(t, err)
+}
+
+// rfBuildWorkerStack constructs one worker: a consumer.Dynamic (pull-gating +
+// processing gate + auto-created claim resolver reading the WRAPPED handoff KV)
+// wired into a Manager via WithWorkerConsumerUpdater. The manager runs two-phase
+// handoff. faultJS is handed to BOTH NewDynamic and NewManager.
+func rfBuildWorkerStack(
+	t *testing.T,
+	ctx context.Context,
+	faultJS jetstream.JetStream,
+	src parti.PartitionSource,
+	index int,
+) *rfWorkerStack {
+	t.Helper()
+
+	s := &rfWorkerStack{}
+
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		const prefix = "events."
+		if subj := msg.Subject(); len(subj) > len(prefix) {
+			s.consumed.Add(1)
+		}
+
+		return msg.Ack()
+	})
+
+	dyn, err := consumer.NewDynamic(
+		faultJS,
+		rfStreamName,
+		fmt.Sprintf("w%d", index),
+		rfSubjectTmpl,
+		handler,
+		consumer.WithPullGating(true),
+		consumer.WithProcessingGate(&consumer.ProcessingGateConfig{
+			Enabled:  true,
+			NakDelay: 50 * time.Millisecond,
+			AllowedStates: []types.HandoffState{
+				types.HandoffStateStable,
+				types.HandoffStateCommit,
+			},
+		}),
+		consumer.WithResolver(consumer.ResolverConfig{
+			HandoffBucketName:   rfHandoffBucket,
+			HandoffClaimsPrefix: rfClaimsPrefix,
+			// Keep the auto-created resolver's reconcile snappy so the
+			// Keys-ok/Get-fail window is hit within the test bound.
+			ReconcileInterval: 1 * time.Second,
+		}),
+	)
+	require.NoError(t, err)
+	s.dyn = dyn
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := parti.TestConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.KVBuckets.HandoffBucket = rfHandoffBucket
+	cfg.WorkerIDMax = 8
+	cfg.StartupTimeout = 60 * time.Second
+
+	mgr, err := parti.NewManager(&cfg, faultJS, src, strategy.NewConsistentHash(),
+		parti.WithWorkerConsumerUpdater(dyn),
+	)
+	require.NoError(t, err)
+	s.mgr = mgr
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	require.NoError(t, mgr.Start(ctx))
+
+	return s
+}
+
+// rfReadClaimRevision opens the REAL (unwrapped) handoff KV and returns the
+// claim's KV revision for pid, whether it exists, and whether it is Stable.
+// It MUST be called with realJS (never the wrapped faultJS) so that an armed
+// read fault cannot make the read-back observe a phantom absence.
+func rfReadClaimRevision(t *testing.T, ctx context.Context, realJS jetstream.JetStream, pid string) (revision uint64, exists bool, stable bool) {
+	t.Helper()
+	kv, err := realJS.KeyValue(ctx, rfHandoffBucket)
+	require.NoError(t, err)
+	entry, err := kv.Get(ctx, rfClaimsPrefix+pid)
+	if err != nil {
+		return 0, false, false
+	}
+	cl, err := handoff.UnmarshalClaim(entry.Value())
+	require.NoError(t, err)
+
+	return entry.Revision(), true, cl.State == handoff.ClaimStateStable
+}
+
+// rfPublish sends one message to events.<pid> via the REAL js.
+func rfPublish(t *testing.T, ctx context.Context, realJS jetstream.JetStream, pid, payload string) {
+	t.Helper()
+	_, err := realJS.Publish(ctx, "events."+pid, []byte(payload))
+	require.NoError(t, err)
+}
+
+// rfOwnsPID reports whether the worker's current assignment owns pid.
+func rfOwnsPID(s *rfWorkerStack, pid string) bool {
+	for _, p := range s.mgr.CurrentAssignment().Partitions {
+		if p.ID() == pid {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestResolverReadFault_ConsumerSurvivesQuorumLossWindow pins the resolver
+// tombstone fix end-to-end through the public NewManager + NewDynamic stack.
+//
+// The bug (Defect 2, on the parent base): a quorum-loss "Keys-ok/Get-fail"
+// window made reconcileOnce stage a synthetic delete tombstone at R+1 for a
+// claim that still sat live in KV at revision R, permanently suppressing the
+// consumer until a restart. The original scratch scenario asserted that
+// suppression as the killer signature.
+//
+// This test FLIPS those assertions to the FIXED behaviour: a listed-but-
+// unreadable claim no longer tombstones, so the consumer keeps consuming
+// THROUGHOUT the read fault and after it recovers — with NO restart.
+//
+// The oracle is purely the CONSUMER data plane. We deliberately do NOT assert
+// on the manager's Degraded state (the manager-side classifier is a separate
+// later change); no OnDegraded hook is wired.
+func TestResolverReadFault_ConsumerSurvivesQuorumLossWindow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := newRFFaultController()
+	faultJS := newRFFaultJetStream(realJS, rfHandoffBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	// Single partition, single worker — the steady-state trap. NO rebalance:
+	// the bug poisons an ALREADY-committed-version cache, so no apply must fire
+	// after Stable. Static is non-watchable, so the calculator never re-applies
+	// after Stable — that is what keeps the claim pinned at revision R.
+	const pid = "p0"
+	src := source.NewStatic([]types.Partition{{Keys: []string{pid}}})
+
+	stack := rfBuildWorkerStack(t, ctx, faultJS, src, 0)
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 30*time.Second),
+		"manager did not reach Stable")
+
+	// (1) Reach a Stable claim for p0 in KV at revision R, with the worker
+	// owning p0. Read-back uses the UNWRAPPED realJS.
+	var revR uint64
+	require.Eventually(t, func() bool {
+		rev, exists, stable := rfReadClaimRevision(t, ctx, realJS, pid)
+		if exists && stable && rfOwnsPID(stack, pid) {
+			revR = rev
+
+			return true
+		}
+
+		return false
+	}, 20*time.Second, 100*time.Millisecond, "p0 did not reach a Stable claim in KV")
+	require.Positive(t, revR, "claim revision R must be > 0")
+
+	// (2) Baseline: a steady-state publish is consumed (gate open).
+	rfPublish(t, ctx, realJS, pid, "pre-p0")
+	require.Eventually(t, func() bool { return stack.consumed.Load() >= 1 },
+		15*time.Second, 100*time.Millisecond, "p0 baseline pull failed — gate not open at steady state")
+
+	t.Logf("[%s] BASELINE: claim p0 Stable in KV at revision R=%d, baseline pull OK, state=%s",
+		t.Name(), revR, stack.mgr.State())
+
+	// (3) Arm the ASYMMETRIC read fault: Keys() stays live, Get(claims/p0)
+	// returns context.DeadlineExceeded. Writes are untouched, so the claim
+	// stays committed at R.
+	fc.ArmReads()
+
+	// (4) Force at least one reconcileOnce pass under the fault: wait until a
+	// claim-key Get has actually faulted at least twice (proves a reconcile
+	// cycle observed the Keys-ok/Get-fail window — the exact condition that
+	// tombstoned on the parent base). This ordering is load-bearing: the
+	// "during-p0" publish below MUST happen AFTER the fault has fired, or the
+	// FLIP assertion would prove nothing.
+	require.Eventually(t, func() bool { return fc.readFaultsInjected.Load() >= 2 },
+		15*time.Second, 25*time.Millisecond,
+		"the resolver never performed a faulted claim-key Get under the read fault — "+
+			"no reconcile pass observed the Keys-ok/Get-fail window")
+
+	// (5) FLIP — the key assertion. Publish AFTER faults have fired, then assert
+	// the message IS consumed within a bound comfortably above the 1s
+	// ReconcileInterval. The original asserted NOT-consumed (the bug suppressed
+	// the pull); the fix means the claim is NEVER tombstoned, so the consumer
+	// keeps working under the read fault.
+	baseDuring := stack.consumed.Load()
+	rfPublish(t, ctx, realJS, pid, "during-p0")
+	require.Eventually(t, func() bool { return stack.consumed.Load() > baseDuring },
+		10*time.Second, 100*time.Millisecond,
+		"with the fix, a listed-but-unreadable claim must NOT suppress the consumer — "+
+			"p0 was published after the Keys-ok/Get-fail window fired and must still be consumed")
+
+	// (6) The claim must STILL be present in KV at the UNCHANGED revision R while
+	// the fault is armed — proving the read fault is read-only and no tombstone
+	// or rewrite occurred (writes were never faulted). Read-back uses realJS.
+	revDuring, existsDuring, stableDuring := rfReadClaimRevision(t, ctx, realJS, pid)
+	require.True(t, existsDuring && stableDuring,
+		"claim must remain present+Stable in KV while only reads are faulted")
+	require.Equal(t, revR, revDuring,
+		"claim revision must be unchanged at R while only reads are faulted")
+
+	t.Logf("[%s] DURING read-fault: readFaults=%d during-p0 consumed claimRevInKV=%d(==R %v) state=%s",
+		t.Name(), fc.readFaultsInjected.Load(), revDuring, revDuring == revR, stack.mgr.State())
+
+	// (7) Disarm reads (simulate KV read recovery). No restart anywhere.
+	fc.DisarmReads()
+
+	// (8) Publish AFTER recovery; the consumer continues without any restart.
+	baseAfter := stack.consumed.Load()
+	rfPublish(t, ctx, realJS, pid, "post-p0")
+	require.Eventually(t, func() bool { return stack.consumed.Load() > baseAfter },
+		15*time.Second, 100*time.Millisecond,
+		"after read recovery the consumer must continue without any restart")
+
+	t.Logf("[%s] AFTER read-recovery (no restart): consumer continued; total p0 consumed=%d",
+		t.Name(), stack.consumed.Load())
+}

--- a/test/integration/manager/apply_coalescing_test.go
+++ b/test/integration/manager/apply_coalescing_test.go
@@ -745,11 +745,7 @@ func recommendedWindow(rs map[string]burstReport) time.Duration {
 	ns := int64(d)
 	stepNs := int64(step)
 	roundedNs := ((ns + stepNs - 1) / stepNs) * stepNs
-	w := time.Duration(roundedNs) + step
-
-	if w > time.Second {
-		w = time.Second
-	}
+	w := min(time.Duration(roundedNs)+step, time.Second)
 
 	return w
 }
@@ -856,13 +852,7 @@ func analyzeFleetBursts(
 			fv.Last = s.at
 		}
 		// Track distinct workers.
-		alreadySeen := false
-		for _, w := range fv.Workers {
-			if w == s.workerID {
-				alreadySeen = true
-				break
-			}
-		}
+		alreadySeen := slices.Contains(fv.Workers, s.workerID)
 		if !alreadySeen {
 			fv.WorkerCount++
 			fv.Workers = append(fv.Workers, s.workerID)
@@ -1021,16 +1011,9 @@ func recommendedApplyJitter(r fleetReport) time.Duration {
 	wsNs := int64(ws)
 	stepNs := int64(step)
 	roundedNs := int64(math.Ceil(float64(wsNs)/float64(stepNs))) * stepNs
-	rounded := time.Duration(roundedNs)
+	rounded := max(time.Duration(roundedNs), floor)
 
-	if rounded < floor {
-		rounded = floor
-	}
-
-	result := rounded + margin
-	if result > cap1s {
-		result = cap1s
-	}
+	result := min(rounded+margin, cap1s)
 
 	return result
 }

--- a/test/integration/manager/startup_async_calculator_race_test.go
+++ b/test/integration/manager/startup_async_calculator_race_test.go
@@ -114,7 +114,7 @@ func TestStartupAsync_CalculatorStateNotClobbered(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		mgr, err := parti.NewManager(&cfg, js, src, assignStrat, parti.WithHooks(makeHooks(i)))
 		require.NoError(t, err)
 		require.NoError(t, mgr.Start(ctx))

--- a/test/simulation/cmd/simulation/producer_chaos.go
+++ b/test/simulation/cmd/simulation/producer_chaos.go
@@ -121,7 +121,7 @@ func runCASStorm(ctx context.Context, js jetstream.JetStream, duration time.Dura
 		return
 	}
 
-	staleValue := []byte(fmt.Sprintf("chaos-cas-storm-%d", time.Now().UnixNano()))
+	staleValue := fmt.Appendf(nil, "chaos-cas-storm-%d", time.Now().UnixNano())
 	iteration := 0
 
 	for {

--- a/test/simulation/cmd/simulation/watcher_stall_chaos.go
+++ b/test/simulation/cmd/simulation/watcher_stall_chaos.go
@@ -123,10 +123,10 @@ func bucketFromSubjectPrefix(prefix string) string {
 		return ""
 	}
 	rest := prefix[len(kvPrefix):]
-	idx := strings.Index(rest, ".")
-	if idx < 0 {
+	before, _, ok := strings.Cut(rest, ".")
+	if !ok {
 		return rest
 	}
 
-	return rest[:idx]
+	return before
 }

--- a/test/simulation/internal/coordinator/coordinator.go
+++ b/test/simulation/internal/coordinator/coordinator.go
@@ -2210,11 +2210,8 @@ func (c *Coordinator) RegisterLongDisconnectExpectation(workerID string, deadlin
 	owned := make(map[int]struct{})
 	if snap != nil {
 		for pid, owners := range snap.perPartition {
-			for _, o := range owners {
-				if o == workerID {
-					owned[pid] = struct{}{}
-					break
-				}
+			if slices.Contains(owners, workerID) {
+				owned[pid] = struct{}{}
 			}
 		}
 	}
@@ -2242,11 +2239,8 @@ func (c *Coordinator) PartitionsOwnedBy(workerID string) []int {
 	}
 	var out []int
 	for pid, owners := range snap.perPartition {
-		for _, o := range owners {
-			if o == workerID {
-				out = append(out, pid)
-				break
-			}
+		if slices.Contains(owners, workerID) {
+			out = append(out, pid)
 		}
 	}
 

--- a/test/simulation/internal/coordinator/process_stableid_env_test.go
+++ b/test/simulation/internal/coordinator/process_stableid_env_test.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"slices"
 	"testing"
 	"time"
 )
@@ -82,12 +83,7 @@ func TestBuildWorkerEnv_PartialOverrides(t *testing.T) {
 }
 
 func containsExact(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 func startsWith(s, prefix string) bool {


### PR DESCRIPTION
## Problem

When a NATS KV bucket lost RAFT quorum but the client stayed `CONNECTED`, reads to that bucket failed (`context deadline exceeded` / `nats.ErrNoResponders`) while `Keys()` still listed the claim. The resolver's `reconcileOnce` treated a listed-but-unreadable claim identically to a deleted one: it skipped adding the pid to `seen`, so the tombstone pass staged a synthetic delete at revision **R+1**. The cache's monotonic-revision guard then made R+1 permanently beat the live claim at R — a **transient read failure became an irreversible tombstone** that suppressed the consumer (`resolve_error`) until a process restart.

This PR **reproduces and attributes** the bug (earlier commits) and **fixes** it.

## The fix

- **`reconcileOnce` no longer tombstones a listed-but-unreadable claim.** A `Get` error records the pid in an `unreadable` set that the tombstone pass skips; the key still exists, we just couldn't read it this pass, and a later pass re-reads it. Genuine deletions — a key absent from `Keys()`, or `Get()` returning a delete/purge op — still tombstone.
- **Observability:** one aggregated `Warn` per reconcile pass surfaces the previously-swallowed read failures (count + sample error) for alerting. A metric was deferred because `durable.ResolverMetrics` is structurally coupled to the public `consumer.ResolverMetrics` interface (a metric method would break external implementers).
- **Regression guard:** a new live-NATS integration test drives the full `NewManager` + `NewDynamic` stack through the Keys-ok/Get-fail window and asserts the consumer keeps consuming throughout and after recovery — no restart. It is a verified flip oracle (re-introducing the tombstone turns it red).

## What was considered and dropped

An in-process tombstone *self-heal* (`forceReplaceResolve`) was implemented and reviewed, then **removed as dead code**: its heal branch is unreachable once the prevention fix is in place. The only two cache-tombstone writers always sit below any live re-creation (KV revisions are monotonic), so the existing revision guard already heals them; the sole state needing the bypass was the synthetic R+1-over-R poison, which this fix eliminates. See the decision log in `docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md`.

## Testing

- Tier 0 unit oracle flipped to assert the fixed behaviour + a boundary table (delete-op / purge-op / absent-from-Keys still tombstone; out-of-prefix key inert), each proven non-vacuous by mutation.
- New `test/integration/failure/resolver_readfault_test.go` (live NATS, `-race`).
- `make pre-pr` green (lint + unit `-race` + integration `-race`).

## Scope note

This is the **data-plane operational fix**. Two further, independent improvements from the plan remain unstarted: a manager-side classifier so the operator sees `Degraded` instead of a silent stall (F-D1), and a startup empty-diff retry fix (F-D3).