### PR TITLE
feat(manager): degrade on connected-but-KV-unavailable timeouts

### DIFF
--- a/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
@@ -20,7 +20,7 @@
 | **F-D2c** (observability) | ✅ **Shipped** (`bfacb44`) | Implemented as a **LOG, not a metric** — `durable.ResolverMetrics` is structurally coupled to the **public** `consumer.ResolverMetrics`, so a metric method would break external implementers (§0 invariant 1). One aggregated `Warn` per reconcile pass. (Non-breaking metric path if ever wanted: an optional interface the resolver type-asserts its metrics impl against.) |
 | **S2 regression guard** | ✅ **Shipped** (`70ed026`) | `test/integration/failure/resolver_readfault_test.go`; asserts the consumer keeps consuming through the Keys-ok/Get-fail window and after recovery — no restart. Verified a genuine flip oracle. |
 | **F-D2b** (tombstone self-heal) | ❌ **DROPPED — dead code** | Implemented + codex-reviewed to *merge*, then removed. **Its heal branch is unreachable once F-D2a is in place.** `forceReplaceResolve`'s revision-bypass only matters when a cached tombstone's revision ≥ a live KV claim's revision. The only two cache-tombstone writers (`claim_resolver.go` watcher real-delete at D; reconcile synthetic at `e.revision+1`, only for genuinely-gone pids) always sit **below** any live re-creation (KV revisions are monotonic ⇒ re-create at `C > D > tombstone`), so the existing `>=` guard + the reconciler already heal it. The **sole** state needing the bypass was the synthetic **R+1-over-live-R** poison — which **F-D2a eliminates**. **The §1 rollout note's rolling-upgrade rationale is WRONG:** that poison is per-process in-memory and dies with the restart the upgrade performs; the new binary `warm()`s clean — there is no cross-process poison to self-heal. Excised via `git rebase --onto`. |
-| **F-D1** (PR3, classifier) | ⏸ **Not started** | Still valid — it is observability whose open question is *desirability* (flapping) not reachability; the `Degraded(kv-read-unavailable)` state plainly arises (it is the incident). |
+| **F-D1** (PR3, classifier) | ✅ **Implemented** (branch `fix/quorum-loss-fd1-classifier`) | `markKVUnavailable` + `ErrKVUnavailable` + `recordKVOpError` helper; admitted in `recordKVError` with the distinct reason `kv-unavailable`. Wrap sites: heartbeat / leader &amp; follower election / assignment-watcher establish &amp; session / commit-watcher / stableid-renew. **Reachability re-verified** (the F-D2b lesson): the election loop bounds each KV op with `OperationTimeout` → `context.DeadlineExceeded` reaches `recordKVError` and was dropped at the old gate. Reason renamed `kv-read-unavailable`→`kv-unavailable` (the renewal/election triggers are KV *writes*). **Handoff apply path is NOT a wrap site** — see the correction in §2. Capstone `TestManager_KVUnavailable_EntersDegraded` proven RED on parent. `make pre-pr` green; 3 cross-feature contracts pass. |
 | **F-D3** (PR4, startup empty-diff) | ✅ **Implemented** (branch `fix/quorum-loss-fd3-startup-empty-diff`) | `initialClaimsCommitted` latch + an empty-prev bootstrap override in `applyAssignmentWithPrevCore`. **Correction (verified):** the spec's literal 3a (override only in `scheduleApplyRetry`) does NOT self-heal scenario_b — a `V1→V2` startup-window advance empty-diffs the new version AND stale-drops the old retry — so the override moved to the shared apply pipeline (covers retry + commit-/assignment-watcher). See §3 "Implementation correction". S3 promoted as `test/integration/failure/startup_writefault_test.go` (RED-on-parent). `make pre-pr` green; 3 cross-feature contracts pass. |
 
 **Lesson carried forward to F-D1/F-D3:** before building, re-verify the fix's branch *does something the existing code does not already handle* at HEAD — i.e. "can the state this fix targets actually arise post-fix / at HEAD?" That discriminating question is exactly what exposed F-D2b as dead. (It is a pre-flight check, not a presumption of deadness — F-D1/F-D3 are on firmer ground.)
@@ -199,30 +199,47 @@ and (b) a hook to drive the consumer re-resolve.
   and break contract 1. Do **NOT** widen `IsConnectivityError`/`IsDegradingJetStreamError`
   (contract 2's `onClaimerError` keys off exactly those).
 - **Call-site scoped, not global — concrete API [Review P1].** Define a sentinel
-  `ErrKVReadUnavailable` and a call-site wrapper `markKVReadUnavailable(err)` that wraps
-  `context.DeadlineExceeded`/`nats.ErrNoResponders` (and ONLY those, after excluding
-  stream-missing/bucket-missing) **applied only at the manager's handoff/assignment claim
-  read+list sites** — i.e. the sites that already feed `recordKVError` (heartbeat / election /
-  assignment-watcher / stableid-renew + the handoff claim get/list in the apply path). In
-  `recordKVError`, admit the new path via `errors.Is(err, ErrKVReadUnavailable)` → degrade
-  with a **distinct reason** `kv-read-unavailable` (NOT `"KV error threshold exceeded"`,
-  preserving that docstring contract). Because the wrapper is applied ONLY at those sites,
-  an unwrapped `DeadlineExceeded`/`ErrNoResponders` from anywhere else (or a peer-takeover
-  claim-get timeout, which flows through `onClaimerError`, not these sites) never enters the
-  new path. Do not add the raw errors to any global predicate.
+  `ErrKVUnavailable` and a call-site wrapper `markKVUnavailable(err)` that wraps
+  `context.DeadlineExceeded`/`nats.ErrNoResponders` (and ONLY those — existing classifiers
+  win first, so a connectivity/degrading-JetStream error is returned unchanged and keeps its
+  route) **applied only at the manager's periodic KV-op sites via the helper
+  `recordKVOpError`** — i.e. the sites that already feed `recordKVError`: heartbeat / leader
+  &amp; follower election / assignment-watcher establish &amp; session / commit-watcher /
+  stableid-renew (`onClaimerError`'s non-`ErrClaimLost` branch). In `recordKVError`, admit the
+  new path via `errors.Is(err, ErrKVUnavailable)` → degrade with a **distinct reason**
+  `kv-unavailable` (NOT `"KV error threshold exceeded"`, preserving that docstring contract).
+  Because the wrapper is applied ONLY at those sites, an unwrapped
+  `DeadlineExceeded`/`ErrNoResponders` from anywhere else (or a peer-takeover claim-get
+  timeout, which flows through `onClaimerError`'s `ErrClaimLost` branch, not these sites)
+  never enters the new path. Do not add the raw errors to any global predicate.
+  - **The handoff apply path is intentionally NOT a wrap site (implementation correction).**
+    An earlier draft of this section listed "the handoff claim get/list in the apply path"
+    among "the sites that already feed `recordKVError`". That premise is wrong:
+    `applyAssignmentWithPrevCore`'s `handoffCoordinator.Apply` error routes to
+    `scheduleApplyRetry` (`manager_assignment.go`), never to `recordKVError`. Routing it would
+    be new degrade-on-apply behavior, and apply fires during `WaitingAssignment` so it would
+    pre-empt the startup-timeout watchdog's reason. It is also already covered: in steady
+    state no apply fires (RC2 — only renewal/heartbeat/election sites are active, and those are
+    marked); a startup apply that never reaches Stable is covered by
+    `enterDegraded("startup-timeout")`. Only a rebalance coinciding with a handoff-bucket-only
+    quorum loss (every other bucket healthy) is uncovered — there the existing assignment keeps
+    working and the retry is the correct response, not a worker-wide degrade. Documented at the
+    `applyErr` site.
 - **No manager→consumer bridge.** [Review P1] The earlier "bridge" is dropped — there is no
   wireable surface for it (`UpdateWorkerConsumer` only takes `(workerID, partitions)`; the
   resolver is private to `WorkerConsumer`). The data-plane self-heal lives entirely in
   **F-D2b (consumer-local)**. F-D1 is therefore **purely manager-side observability**:
-  the operator sees `Degraded(kv-read-unavailable)` instead of a silent stall. It does NOT
+  the operator sees `Degraded(kv-unavailable)` instead of a silent stall. It does NOT
   itself fix the data plane (F-D2 does).
 
 **RISK CALLOUT for the reviewer:** this is the change AGENTS.md warns about. Mandatory:
 the 3 contract regression tests (`TestManager_LiveNATSBucketLoss*`, `TestStableID_StaleKeyTakeover_Reclaim`,
 `OnDegradedHook`) + `make test-integration -race` + a classifier/routing table test (below)
 proving stableID bucket-deletion still reaches whole-bucket-degraded, peer-takeover still
-reaches claim-lost shutdown, and handoff `Get`/`Keys` deadline/`ErrNoResponders` reach the
-new reason ONLY from the intended call-sites.
+reaches claim-lost shutdown, and a deadline/`ErrNoResponders` reaches the new reason ONLY
+from the intended periodic KV-op call-sites (heartbeat / election / assignment-watcher /
+commit-watcher / stableid-renew) — NOT from the handoff apply path (see the apply-path
+boundary correction above).
 **Open decision:** is entering Degraded on transient read timeouts desirable, or does it
 cause Degraded flapping on brief blips? Tunable via `KVErrorThreshold`/`KVErrorWindow`.
 
@@ -378,7 +395,7 @@ not big-bang before or defer after).
   restart from an already-poisoned cache.
 - **F-D1 classifier/routing table**: `context.DeadlineExceeded`, `nats.ErrNoResponders`,
   `jetstream.ErrNoStreamResponse`, `ErrBucketNotFound`, `ErrStreamNotFound`, wrapped
-  `ErrClaimLost` — each asserted to route to the correct path (new `kv-read-unavailable` vs
+  `ErrClaimLost` — each asserted to route to the correct path (new `kv-unavailable` vs
   whole-bucket-degraded vs claim-lost-shutdown), from the intended call-sites only.
 - **F-D3 retry** (must match the chosen 3a flag semantics): initial apply fails after partial
   claim writes with `initialClaimsCommitted == false` → the retry uses explicit empty `prev`

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -391,8 +391,10 @@ func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.Key
 					// envelope's exhaustion is the orthogonal
 					// escalation for non-recordable error classes
 					// and for sustained establish failure rates that
-					// outrun the threshold window.
-					m.recordKVError(err)
+					// outrun the threshold window. A connected-but-KV-
+					// unavailable timeout (quorum loss) is marked so it
+					// also degrades.
+					m.recordKVOpError(err)
 					m.logError("assignment watcher establish failed, will retry", "error", err)
 
 					return fmt.Errorf("failed to watch assignments: %w", err)
@@ -428,8 +430,10 @@ func (m *Manager) monitorAssignmentChanges(ctx context.Context, kv jetstream.Key
 		}
 		// Session ended on channel close. Feed the threshold circuit
 		// (preserves whole-bucket-loss → Degraded contract when the
-		// loss manifests mid-session) and loop with a fresh envelope.
-		m.recordKVError(sessionErr)
+		// loss manifests mid-session) and loop with a fresh envelope. A
+		// connected-but-KV-unavailable timeout (quorum loss) is marked so
+		// it also degrades.
+		m.recordKVOpError(sessionErr)
 		m.logError("assignment watcher session ended, will reconnect", "error", sessionErr)
 	}
 }
@@ -626,7 +630,9 @@ func (m *Manager) monitorCommitChanges(ctx context.Context, kv jetstream.KeyValu
 			return
 		}
 		m.logError("commit watcher failed, retrying", "error", err, "backoff", backoff)
-		m.recordKVError(err)
+		// A connected-but-KV-unavailable timeout (quorum loss, connection
+		// still up) is marked so the commit reconcile-fetch path degrades too.
+		m.recordKVOpError(err)
 
 		//nolint:gosec // jitter does not require crypto-secure random
 		f := rand.Float64()
@@ -1274,7 +1280,21 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 	if applyErr != nil {
 		m.applyStoreMu.Unlock()
 		m.logError("handoff apply failed", "error", applyErr)
+		// Apply errors deliberately do NOT route through recordKVOpError /
+		// the degraded circuit. The apply path has its own recovery
+		// (scheduleApplyRetry), and a connected-but-KV-unavailable timeout
+		// here is already observable as Degraded by other means: in steady
+		// state no apply fires (the quorum-loss incident shape — only the
+		// renewal/heartbeat/election sites are active, and those ARE marked),
+		// and a startup-time apply that never reaches Stable is covered by the
+		// startup-timeout watchdog (enterDegraded("startup-timeout")). Routing
+		// here would also fire enterDegraded during WaitingAssignment and
+		// pre-empt that watchdog reason. Only a rebalance coinciding with a
+		// handoff-bucket-only quorum loss (every other bucket healthy) is
+		// uncovered, where the existing assignment keeps working and the retry
+		// is the correct response, not a worker-wide degrade.
 		m.scheduleApplyRetry(newAssignment)
+
 		return applyErr
 	}
 

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -1,6 +1,7 @@
 package parti
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -8,6 +9,51 @@ import (
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go"
 )
+
+// degradedReasonKVUnavailable is the distinct enterDegraded reason for the
+// connected-but-KV-unavailable condition (a bucket reachable on the connection
+// but unable to serve ops because its RAFT quorum is lost). It is kept separate
+// from "KV error threshold exceeded" so the operator-facing Degraded surface
+// distinguishes a quorum-loss op stall from a whole-bucket wipe, and so the
+// docstring contract that whole-bucket loss is the ONLY path to the threshold
+// reason is preserved.
+const degradedReasonKVUnavailable = "kv-unavailable"
+
+// ErrKVUnavailable marks a KV operation that failed because its backing
+// bucket is reachable on the live NATS connection but cannot serve the op
+// (deadline / no-responders) — the quorum-loss condition the connection-status
+// monitor and the connectivity/degrading-JetStream classifiers all miss.
+//
+// It is applied ONLY at the manager's own periodic KV-op call sites via
+// [markKVUnavailable], never added to any global predicate. That keeps an
+// unwrapped deadline / no-responders from anywhere else (notably the
+// peer-takeover claim path through onClaimerError) out of the degraded circuit,
+// preserving the cross-feature classification contracts.
+var ErrKVUnavailable = errors.New("kv unavailable")
+
+// markKVUnavailable wraps err with [ErrKVUnavailable] iff err is an
+// otherwise-unclassified deadline / no-responders timeout. Existing classifiers
+// win first: if err already classifies as connectivity (e.g.
+// jetstream.ErrNoStreamResponse, the whole-bucket-loss surface) or as degrading
+// JetStream (bucket / stream / consumer missing), it is returned unchanged so
+// the established routes keep ownership. nil and unrelated errors pass through
+// unchanged. Applied at the manager's heartbeat / election / assignment-watcher
+// / stableid-renew / commit KV-op sites.
+func markKVUnavailable(err error) error {
+	if err == nil {
+		return nil
+	}
+	// Existing classifiers win first — this is what makes it impossible to
+	// steal the whole-bucket (ErrNoStreamResponse) or bucket-missing route.
+	if natsutil.IsConnectivityError(err) || natsutil.IsDegradingJetStreamError(err) {
+		return err
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, nats.ErrNoResponders) {
+		return errors.Join(ErrKVUnavailable, err)
+	}
+
+	return err
+}
 
 // monitorNATSConnection starts a goroutine that monitors NATS connectivity.
 // Uses connMonitorOnce to ensure only one monitor runs per Manager instance.
@@ -95,7 +141,12 @@ func (m *Manager) recordKVError(err error) {
 	if errors.Is(err, types.ErrStreamMissing) {
 		return
 	}
-	if !natsutil.IsConnectivityError(err) && !natsutil.IsDegradingJetStreamError(err) {
+	// kvUnavailable is the F-D1 path: a marked connected-but-KV-unavailable
+	// timeout from one of the manager's periodic KV-op sites. It is admitted
+	// here (the connection-status monitor and the connectivity/degrading
+	// classifiers all miss it) and degrades with a distinct reason below.
+	kvUnavailable := errors.Is(err, ErrKVUnavailable)
+	if !natsutil.IsConnectivityError(err) && !natsutil.IsDegradingJetStreamError(err) && !kvUnavailable {
 		return
 	}
 	// Short-circuit once already Degraded. Every subsystem (heartbeat 500ms,
@@ -136,13 +187,35 @@ func (m *Manager) recordKVError(err error) {
 
 	// Check threshold
 	if int(count) >= m.cfg.DegradedBehavior.KVErrorThreshold {
-		m.logger.Warn("KV error threshold exceeded",
+		// Whole-bucket loss (connectivity / degrading JetStream) keeps the
+		// canonical threshold reason — the AGENTS.md contract that whole-bucket
+		// loss is the ONLY path to "KV error threshold exceeded". A marked
+		// connected-but-KV-unavailable timeout degrades with the distinct
+		// reason. Errors that classify both ways (a bucket-missing error never
+		// reaches markKVUnavailable's wrap branch) keep the threshold
+		// reason, so the contract holds.
+		reason := "KV error threshold exceeded"
+		if kvUnavailable {
+			reason = degradedReasonKVUnavailable
+		}
+		m.logger.Warn(reason,
 			"count", count,
 			"threshold", m.cfg.DegradedBehavior.KVErrorThreshold,
 			"window", m.cfg.DegradedBehavior.KVErrorWindow,
 		)
-		m.enterDegraded("KV error threshold exceeded")
+		m.enterDegraded(reason)
 	}
+}
+
+// recordKVOpError marks err as a possible connected-but-KV-unavailable
+// timeout (via [markKVUnavailable]) and feeds it to [Manager.recordKVError].
+// It is the single entry point for the manager's periodic KV-op call sites
+// (heartbeat / election / assignment-watcher / stableid-renew / commit) so a
+// future site only has to call this — not remember to wrap. The
+// peer-takeover claim path (onClaimerError's ErrClaimLost branch) intentionally
+// does NOT route through here, keeping its claim-lost shutdown semantics.
+func (m *Manager) recordKVOpError(err error) {
+	m.recordKVError(markKVUnavailable(err))
 }
 
 // recordKVSuccess records a successful KV operation and resets error count.

--- a/manager_election.go
+++ b/manager_election.go
@@ -118,7 +118,12 @@ func (m *Manager) onClaimerError(err error) {
 		claimLostShutdown(m)
 		return
 	}
-	m.recordKVError(err)
+	// Non-ErrClaimLost renewal failures reach here, including a renewal read
+	// timeout (renew's default branch — neither ErrClaimLost nor a
+	// bucket-missing sentinel). recordKVOpError marks a connected-but-KV-
+	// unavailable timeout so it drives the degraded circuit; the ErrClaimLost
+	// peer-takeover branch above is intentionally NOT routed through here.
+	m.recordKVOpError(err)
 }
 
 // claimWorkerID claims a stable worker ID.
@@ -249,8 +254,12 @@ func (m *Manager) monitorLeadership() {
 					m.logError("failed to renew leadership", "error", err)
 					// Feed into degraded circuit: ErrBucketNotFound or
 					// ErrStreamNotFound from the election bucket is the
-					// canonical live-wipe signal on the leader side.
-					m.recordKVError(err)
+					// canonical live-wipe signal on the leader side. A
+					// bounded-ctx deadline / no-responders (quorum loss,
+					// connection still up) is marked so it also degrades —
+					// RenewLeadership surfaces the renewCtx deadline as
+					// ErrLeadershipLost: context.DeadlineExceeded.
+					m.recordKVOpError(err)
 					// Leadership lost
 					m.isLeader.Store(false)
 					m.logger.Info("lost leadership", "worker_id", m.WorkerID())
@@ -288,8 +297,10 @@ func (m *Manager) monitorLeadership() {
 					m.logError("failed to request leadership", "error", err)
 					// Feed into degraded circuit for the follower path:
 					// if the election bucket is gone, every follower will
-					// surface NotFound here each tick.
-					m.recordKVError(err)
+					// surface NotFound here each tick. A bounded-ctx deadline
+					// / no-responders (quorum loss, connection still up) is
+					// marked so it also degrades.
+					m.recordKVOpError(err)
 
 					continue
 				}
@@ -408,7 +419,9 @@ func (m *Manager) startHeartbeat(kv jetstream.KeyValue) error {
 	publisher := heartbeat.New(kv, "heartbeat", workerID, m.cfg.HeartbeatInterval, m.metrics, m.logger)
 	// Feed publish failures into the degraded-mode circuit so sustained KV
 	// errors (connection loss or bucket wipe) drive the manager into Degraded.
-	publisher.SetOnError(m.recordKVError)
+	// A connected-but-KV-unavailable timeout (quorum loss) is marked so the
+	// heartbeat-publish path degrades too — the connection monitor misses it.
+	publisher.SetOnError(m.recordKVOpError)
 	// Wire the capability function so the publisher reads the live bitmask on
 	// every heartbeat composition, reflecting runtime wire-up state.
 	publisher.SetCapabilitiesFn(m.Capabilities)

--- a/manager_kv_read_unavailable_test.go
+++ b/manager_kv_read_unavailable_test.go
@@ -1,0 +1,218 @@
+package parti
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// kvUnavailManager builds a minimal Manager parked in StateStable with a
+// degrade-reason capture hook. The returned pointer receives the reason string
+// passed to enterDegraded (via the OnDegraded hook, the only surface that
+// observes it).
+//
+// The threshold is fixed at 3: low enough that the degrade tests trip it with a
+// short loop, high enough that the isolated-below-threshold negative-space test
+// (which clears the window after each error) never reaches it.
+func kvUnavailManager(t *testing.T) (*Manager, *string, context.CancelFunc) {
+	t.Helper()
+	const threshold = 3
+	cfg := Config{
+		DegradedBehavior: DegradedBehaviorConfig{
+			KVErrorThreshold: threshold,
+			KVErrorWindow:    10 * time.Second,
+		},
+		DegradedAlert: DegradedAlertConfig{
+			AlertInterval: 1 * time.Minute,
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	reason := new(string)
+	m := &Manager{
+		logger:  logging.NewNop(),
+		cfg:     cfg,
+		hooks:   &Hooks{},
+		metrics: metrics.NewNop(),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	m.hooks.OnDegraded = func(_ context.Context, r string) error {
+		*reason = r
+		return nil
+	}
+	m.state.Store(int32(StateStable))
+
+	return m, reason, cancel
+}
+
+// TestMarkKVUnavailable is the F-D1 classifier/routing table. It pins the
+// "existing classifiers win first" construction that makes it impossible for
+// the new path to steal the whole-bucket-loss route (ErrNoStreamResponse stays
+// connectivity) or the bucket-missing route (ErrBucketNotFound stays degrading
+// JetStream). Only an otherwise-unclassified deadline / no-responders timeout
+// is marked.
+func TestMarkKVUnavailable(t *testing.T) {
+	t.Run("nil passes through", func(t *testing.T) {
+		require.NoError(t, markKVUnavailable(nil))
+	})
+
+	t.Run("bare deadline is marked", func(t *testing.T) {
+		got := markKVUnavailable(context.DeadlineExceeded)
+		require.ErrorIs(t, got, ErrKVUnavailable)
+		require.ErrorIs(t, got, context.DeadlineExceeded,
+			"the original cause must remain inspectable")
+	})
+
+	t.Run("no-responders is marked", func(t *testing.T) {
+		got := markKVUnavailable(nats.ErrNoResponders)
+		require.ErrorIs(t, got, ErrKVUnavailable)
+		require.ErrorIs(t, got, nats.ErrNoResponders)
+	})
+
+	t.Run("wrapped deadline is marked", func(t *testing.T) {
+		// The election renew path wraps the ctx deadline as
+		// "leadership was lost: context deadline exceeded"; the wrapper must
+		// still see the deadline through the wrap.
+		got := markKVUnavailable(
+			fmt.Errorf("leadership was lost: %w", context.DeadlineExceeded))
+		require.ErrorIs(t, got, ErrKVUnavailable)
+	})
+
+	t.Run("ErrNoStreamResponse is NOT marked (stays whole-bucket route)", func(t *testing.T) {
+		got := markKVUnavailable(jetstream.ErrNoStreamResponse)
+		require.NotErrorIs(t, got, ErrKVUnavailable,
+			"ErrNoStreamResponse must remain on the connectivity / whole-bucket route")
+		require.True(t, natsutil.IsConnectivityError(got),
+			"must still classify as connectivity after the wrapper")
+	})
+
+	t.Run("ErrBucketNotFound is NOT marked (stays degrading route)", func(t *testing.T) {
+		got := markKVUnavailable(jetstream.ErrBucketNotFound)
+		require.NotErrorIs(t, got, ErrKVUnavailable)
+		require.True(t, natsutil.IsDegradingJetStreamError(got),
+			"must still classify as degrading JetStream after the wrapper")
+	})
+
+	t.Run("unrelated error is NOT marked", func(t *testing.T) {
+		got := markKVUnavailable(nats.ErrInvalidArg)
+		require.NotErrorIs(t, got, ErrKVUnavailable)
+		require.ErrorIs(t, got, nats.ErrInvalidArg, "passes through unchanged")
+	})
+}
+
+// TestRecordKVError_ReadUnavailable_Degrades pins that a marked
+// KV-unavailable error, sustained past the threshold, drives the manager into
+// Degraded with the distinct reason kv-unavailable — the F-D1 observability
+// value (the operator sees Degraded instead of a silent stall).
+func TestRecordKVError_ReadUnavailable_Degrades(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		base error
+	}{
+		{"deadline", context.DeadlineExceeded},
+		{"no-responders", nats.ErrNoResponders},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, reason, cancel := kvUnavailManager(t)
+			defer cancel()
+
+			for range 3 {
+				m.recordKVError(markKVUnavailable(tc.base))
+			}
+			cancel()
+			m.wg.Wait()
+
+			require.Equal(t, StateDegraded, m.State())
+			require.Equal(t, degradedReasonKVUnavailable, *reason,
+				"a sustained KV-unavailable condition must use the distinct reason")
+		})
+	}
+}
+
+// TestRecordKVError_RawDeadline_StillDropped is the scoping guarantee: an
+// UNWRAPPED deadline (one that did not pass through a manager KV-op call site)
+// must still be dropped, exactly as before F-D1. Only call-site-marked errors
+// enter the new path.
+func TestRecordKVError_RawDeadline_StillDropped(t *testing.T) {
+	m, _, cancel := kvUnavailManager(t)
+	defer cancel()
+
+	for range 5 {
+		m.recordKVError(context.DeadlineExceeded) // raw, never marked
+	}
+
+	require.Equal(t, int32(0), m.kvErrorCount.Load(),
+		"a raw deadline from outside the wrapped call sites must not count")
+	require.NotEqual(t, StateDegraded, m.State())
+}
+
+// TestRecordKVError_WholeBucketLoss_KeepsThresholdReason pins cross-feature
+// contract 1: whole-bucket loss must still reach
+// enterDegraded("KV error threshold exceeded"), NOT the new reason — even when
+// the bucket-missing error flows through a marked call site. The wrapper returns
+// bucket-missing unchanged (classifiers win first), so the reason is unaffected.
+func TestRecordKVError_WholeBucketLoss_KeepsThresholdReason(t *testing.T) {
+	m, reason, cancel := kvUnavailManager(t)
+	defer cancel()
+
+	for range 3 {
+		m.recordKVError(markKVUnavailable(jetstream.ErrBucketNotFound))
+	}
+	cancel()
+	m.wg.Wait()
+
+	require.Equal(t, StateDegraded, m.State())
+	require.Equal(t, "KV error threshold exceeded", *reason,
+		"whole-bucket loss must keep the threshold reason, not the KV-unavailable reason")
+}
+
+// TestRecordKVError_ReadUnavailable_IsolatedBelowThreshold_NoDegrade is the
+// negative-space test for the threshold circuit (see the both-directions-of-a-
+// boundary discipline): isolated marked failures, each fully recovered, must
+// NEVER accumulate to a degrade. Positive-space "N consecutive failures degrade"
+// is consistent with both correct and broken counter semantics; this proves the
+// window resets on success.
+func TestRecordKVError_ReadUnavailable_IsolatedBelowThreshold_NoDegrade(t *testing.T) {
+	m, _, cancel := kvUnavailManager(t)
+	defer cancel()
+
+	// Ten isolated failures, each cleared by a success before the next.
+	for range 10 {
+		m.recordKVError(markKVUnavailable(context.DeadlineExceeded))
+		m.recordKVSuccess()
+	}
+
+	require.NotEqual(t, StateDegraded, m.State(),
+		"isolated KV-unavailable blips that each recover must not degrade")
+	require.Zero(t, m.degradedSince.Load())
+}
+
+// TestOnClaimerError_ReadTimeout_Degrades pins the stableid-renew wrap site
+// (onClaimerError's non-ErrClaimLost branch): a renewal read timeout — which
+// arrives as a plain (non-ErrClaimLost) error — must be marked and drive the
+// degraded circuit, NOT be silently dropped.
+func TestOnClaimerError_ReadTimeout_Degrades(t *testing.T) {
+	m, reason, cancel := kvUnavailManager(t)
+	defer cancel()
+
+	origShutdown := claimLostShutdown
+	claimLostShutdown = func(*Manager) { t.Error("a read timeout must not stop the worker") }
+	defer func() { claimLostShutdown = origShutdown }()
+
+	for range 3 {
+		m.onClaimerError(context.DeadlineExceeded) // renewal default branch: plain deadline
+	}
+	cancel()
+	m.wg.Wait()
+
+	require.Equal(t, StateDegraded, m.State())
+	require.Equal(t, degradedReasonKVUnavailable, *reason)
+}

--- a/test/integration/manager/manager_kv_read_unavailable_test.go
+++ b/test/integration/manager/manager_kv_read_unavailable_test.go
@@ -1,0 +1,208 @@
+package manager_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// --- connected-but-KV-unavailable fault seam ---------------------------------
+//
+// This seam reproduces the quorum-loss condition F-D1 targets: the NATS
+// connection stays CONNECTED, but ops against specific buckets time out with
+// context.DeadlineExceeded (their RAFT quorum is lost). It wraps the JetStream
+// handle and, for an armed set of buckets, faults every KV op. Setup runs
+// BEFORE arming, so bucket creation / warm succeed; arming after Stable mimics
+// quorum loss striking a healthy cluster — exactly the bucket-wipe test's shape
+// but with a read/op timeout instead of a delete, and the connection still up.
+
+type kuFaultController struct {
+	armed    atomic.Bool
+	injected atomic.Int64
+}
+
+func (fc *kuFaultController) arm() { fc.injected.Store(0); fc.armed.Store(true) }
+func (fc *kuFaultController) fault() bool {
+	if !fc.armed.Load() {
+		return false
+	}
+	fc.injected.Add(1)
+
+	return true
+}
+
+type kuFaultJetStream struct {
+	jetstream.JetStream
+	buckets map[string]struct{}
+	fc      *kuFaultController
+}
+
+func (f *kuFaultJetStream) wrap(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
+	if _, ok := f.buckets[bucket]; ok {
+		return &kuFaultKeyValue{KeyValue: kv, fc: f.fc}
+	}
+
+	return kv
+}
+
+func (f *kuFaultJetStream) KeyValue(ctx context.Context, bucket string) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.KeyValue(ctx, bucket)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, bucket), nil
+}
+
+func (f *kuFaultJetStream) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+func (f *kuFaultJetStream) CreateOrUpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateOrUpdateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+// kuFaultKeyValue faults the active write/read ops the manager's periodic loops
+// use (heartbeat Put, election renew Update, follower request Create, stableid
+// renew Update) with context.DeadlineExceeded when armed. Watch/WatchAll/Keys
+// pass through (embedded) — the assignment watcher is intentionally NOT in the
+// fault set, so its envelope's OnPermanent cannot race a competing degraded
+// reason against the one under test.
+type kuFaultKeyValue struct {
+	jetstream.KeyValue
+	fc *kuFaultController
+}
+
+func (k *kuFaultKeyValue) Put(ctx context.Context, key string, value []byte) (uint64, error) {
+	if k.fc.fault() {
+		return 0, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Put(ctx, key, value)
+}
+
+func (k *kuFaultKeyValue) Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	if k.fc.fault() {
+		return 0, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Update(ctx, key, value, revision)
+}
+
+func (k *kuFaultKeyValue) Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error) {
+	if k.fc.fault() {
+		return 0, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Create(ctx, key, value, opts...)
+}
+
+func (k *kuFaultKeyValue) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	if k.fc.fault() {
+		return nil, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Get(ctx, key)
+}
+
+// TestManager_KVUnavailable_EntersDegraded is the F-D1 capstone: it drives
+// the REAL production trigger end-to-end. With the connection up and the
+// election / heartbeat / stableid buckets timing out (context.DeadlineExceeded),
+// the manager must enter Degraded with the distinct reason "kv-unavailable"
+// — the observability the operator relies on instead of a silent stall.
+//
+// Before F-D1 those timeouts were dropped by recordKVError (neither connectivity
+// nor degrading-JetStream), so the manager never degraded.
+func TestManager_KVUnavailable_EntersDegraded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	cfg := testutil.IntegrationTestConfig()
+	// Degrade quickly and deterministically under the fault.
+	cfg.DegradedBehavior.KVErrorThreshold = 3
+	cfg.DegradedBehavior.KVErrorWindow = 15 * time.Second
+
+	fc := &kuFaultController{}
+	faultJS := &kuFaultJetStream{
+		JetStream: realJS,
+		fc:        fc,
+		buckets: map[string]struct{}{
+			cfg.KVBuckets.ElectionBucket:  {},
+			cfg.KVBuckets.HeartbeatBucket: {},
+			cfg.KVBuckets.StableIDBucket:  {},
+		},
+	}
+
+	src := source.NewStatic(testutil.CreateTestPartitions(4))
+
+	degradedReasons := make(chan string, 8)
+	hooks := &parti.Hooks{
+		OnDegraded: func(_ context.Context, reason string) error {
+			select {
+			case degradedReasons <- reason:
+			default:
+			}
+
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	mgr, err := parti.NewManager(&cfg, faultJS, src, strategy.NewConsistentHash(), parti.WithHooks(hooks))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	require.NoError(t, mgr.Start(ctx))
+	require.NoError(t, <-mgr.WaitState(types.StateStable, 30*time.Second),
+		"manager must stabilize before the fault is armed")
+
+	// Arm the connected-but-KV-unavailable fault: every op against the election
+	// / heartbeat / stableid buckets now times out, but the connection stays up.
+	fc.arm()
+
+	// The manager must enter Degraded with the distinct KV-unavailable reason.
+	select {
+	case reason := <-degradedReasons:
+		require.Equal(t, "kv-unavailable", reason,
+			"connected-but-KV-unavailable timeouts must degrade with the distinct reason")
+	case <-time.After(30 * time.Second):
+		t.Fatalf("manager did not enter Degraded within 30s of the KV-unavailable fault; state=%s", mgr.State())
+	}
+
+	require.Equal(t, types.StateDegraded, mgr.State())
+	// Non-vacuous: the fault genuinely fired (the manager actually hit the
+	// timing-out buckets, it did not degrade for some unrelated reason).
+	require.Positive(t, fc.injected.Load(), "the KV-unavailable fault must have actually injected")
+	require.True(t, nc.IsConnected(),
+		"the NATS connection must remain CONNECTED throughout (this is the whole point)")
+}


### PR DESCRIPTION
## Problem

When a KV bucket loses RAFT quorum while the NATS connection stays `CONNECTED`, ops against that bucket time out with `context.DeadlineExceeded` / `nats.ErrNoResponders`. `recordKVError` classified neither (only connectivity and missing bucket/stream/consumer errors counted), so the manager **never entered Degraded** — operators saw a silent stall instead of a readiness signal. This is the manager-side enabler ("Defect 1") of the quorum-loss non-recovery incident; the data-plane root cause ("Defect 2") was already fixed in #27.

## The fix

- `markKVUnavailable(err)` — a call-site wrapper that tags an otherwise-unclassified deadline / no-responders timeout with the new `ErrKVUnavailable` sentinel. **Existing classifiers win first**, so a whole-bucket-loss error (`ErrNoStreamResponse` / bucket-missing) is returned unchanged and keeps its established route and its `"KV error threshold exceeded"` reason — the cross-feature contract that whole-bucket loss is the only path to that reason is preserved.
- `recordKVError` admits the tagged error into the same windowed threshold circuit and degrades with a **distinct reason `kv-unavailable`**.
- Applied via the `recordKVOpError` helper at the manager's periodic KV-op sites only: heartbeat, leader/follower election, assignment + commit watchers, stable-ID renewal. The **peer-takeover claim path** (`onClaimerError`'s `ErrClaimLost` branch) is intentionally left unwrapped, so a lost claim still self-stops the worker rather than degrading.

## What is *not* changed (documented boundary)

The handoff apply path is **not** a wrap site. Its errors route to `scheduleApplyRetry`, never `recordKVError`; steady-state fires no apply (the renewal/heartbeat/election sites carry the incident), a startup apply that never reaches Stable is already covered by the startup-timeout watchdog, and routing there would pre-empt that watchdog's reason during `WaitingAssignment`. Documented at the `applyErr` site and in the plan §2.

## Testing

- Unit classifier/routing table + threshold positive/negative-space (isolated blips that each recover never degrade) + whole-bucket-loss reason-preservation + the stableid-renew site. Verify-first: RED on parent, non-vacuity proven by mutation.
- Live-NATS capstone `TestManager_KVUnavailable_EntersDegraded`: faults the election / heartbeat / stable-ID buckets with the connection **up** and asserts the manager enters `Degraded(kv-unavailable)`. **Proven RED on parent** (stays Stable through a 30s fault) → GREEN with the fix (degrades in ~4s).
- `make pre-pr` green (lint + `make test` -race + `make test-integration` -race). The 3 AGENTS.md cross-feature contracts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)