### PR TITLE
fix(manager): write the full claim set on startup apply retries

### DIFF
--- a/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
@@ -4,10 +4,13 @@
 - **Status:** PARTIALLY IMPLEMENTED. The operational fix (**F-D2a + F-D2c + the S2 regression
   guard**) is implemented, `make pre-pr`-green, and codex-reviewed to *merge* on branch
   `fix/quorum-loss-fd2a-resolver-tombstone`. **F-D2b was implemented, reviewed, then DROPPED as
-  dead code** (see the decision log below). **F-D1 (PR3) and F-D3 (PR4) are not started.** The
-  plan originally cleared the review loop (1 `plan-review` xhigh + 4 `final-plan-review` high
-  passes; reports `tmp/00-fix-plan_*_review*.md`) — but that review missed the F-D2b
-  reachability gap, which only surfaced during implementation.
+  dead code** (see the decision log below). **F-D1 (PR3) is implemented** (branch
+  `fix/quorum-loss-fd1-classifier`, PR #28). **F-D3 (PR4) is implemented** (branch
+  `fix/quorum-loss-fd3-startup-empty-diff`) — with a verified correction to the spec's 3a
+  (the override moved to the shared apply pipeline; see §3). The plan originally cleared the
+  review loop (1 `plan-review` xhigh + 4 `final-plan-review` high passes; reports
+  `tmp/00-fix-plan_*_review*.md`) — but that review missed both the F-D2b reachability gap and
+  the F-D3 version-advance gap, which only surfaced during implementation.
 
 ### Implementation status & decision log (2026-05-30)
 
@@ -18,7 +21,7 @@
 | **S2 regression guard** | ✅ **Shipped** (`70ed026`) | `test/integration/failure/resolver_readfault_test.go`; asserts the consumer keeps consuming through the Keys-ok/Get-fail window and after recovery — no restart. Verified a genuine flip oracle. |
 | **F-D2b** (tombstone self-heal) | ❌ **DROPPED — dead code** | Implemented + codex-reviewed to *merge*, then removed. **Its heal branch is unreachable once F-D2a is in place.** `forceReplaceResolve`'s revision-bypass only matters when a cached tombstone's revision ≥ a live KV claim's revision. The only two cache-tombstone writers (`claim_resolver.go` watcher real-delete at D; reconcile synthetic at `e.revision+1`, only for genuinely-gone pids) always sit **below** any live re-creation (KV revisions are monotonic ⇒ re-create at `C > D > tombstone`), so the existing `>=` guard + the reconciler already heal it. The **sole** state needing the bypass was the synthetic **R+1-over-live-R** poison — which **F-D2a eliminates**. **The §1 rollout note's rolling-upgrade rationale is WRONG:** that poison is per-process in-memory and dies with the restart the upgrade performs; the new binary `warm()`s clean — there is no cross-process poison to self-heal. Excised via `git rebase --onto`. |
 | **F-D1** (PR3, classifier) | ⏸ **Not started** | Still valid — it is observability whose open question is *desirability* (flapping) not reachability; the `Degraded(kv-read-unavailable)` state plainly arises (it is the incident). |
-| **F-D3** (PR4, startup empty-diff) | ⏸ **Not started** | Still valid — its trigger was *traced* on v2.5.0 in the repro phase (not an untraced assertion like F-D2b's). |
+| **F-D3** (PR4, startup empty-diff) | ✅ **Implemented** (branch `fix/quorum-loss-fd3-startup-empty-diff`) | `initialClaimsCommitted` latch + an empty-prev bootstrap override in `applyAssignmentWithPrevCore`. **Correction (verified):** the spec's literal 3a (override only in `scheduleApplyRetry`) does NOT self-heal scenario_b — a `V1→V2` startup-window advance empty-diffs the new version AND stale-drops the old retry — so the override moved to the shared apply pipeline (covers retry + commit-/assignment-watcher). See §3 "Implementation correction". S3 promoted as `test/integration/failure/startup_writefault_test.go` (RED-on-parent). `make pre-pr` green; 3 cross-feature contracts pass. |
 
 **Lesson carried forward to F-D1/F-D3:** before building, re-verify the fix's branch *does something the existing code does not already handle* at HEAD — i.e. "can the state this fix targets actually arise post-fix / at HEAD?" That discriminating question is exactly what exposed F-D2b as dead. (It is a pre-flight check, not a presumption of deadness — F-D1/F-D3 are on firmer ground.)
 
@@ -251,8 +254,53 @@ Spec:
 - **(3b deferred, out of scope here):** coupling snapshot-advance to claim-commit is a
   larger startup-ordering change; 3a achieves the fix without it.
 
-**Tests:** the S3 harness `long_outage_restart_only` case must flip to self-heal; add a unit
-assertion that a retry after a failed initial apply re-attempts the full claim set.
+**Implementation correction (verified) — the override must live in the shared apply
+pipeline, not only in `scheduleApplyRetry`.** Localizing the empty-prev choice to
+`scheduleApplyRetry` (the literal 3a above) was empirically shown insufficient: running the
+S3 `long_outage_restart_only` repro against the retry-only fix still leaves claims absent
+(`KV-claim-reappears=false`). Cause: during the startup fault window the assignment advances
+`V1→V2` (a normal cold-start/rejoin rebalance). The `V2` apply (commit-/assignment-watcher)
+reads `prev = CurrentAssignment()` = the pre-advanced `V1` set → an **empty prepare diff** →
+it writes no claims **and** advances the snapshot to `V2`, which then **stale-gate-drops** the
+`V1` retry before it can write. So the one path 3a fixes is dropped, and the path that runs
+writes nothing. The shipped fix therefore puts the `if !initialClaimsCommitted { oldAssignment
+= Assignment{} }` override (and the latch) in **`applyAssignmentWithPrevCore`** — the single
+apply pipeline every path funnels through — under `applyStoreMu`. This makes *every* bootstrap
+apply (retry, commit-watcher, assignment-watcher) write the full claim set until the first
+successful full-set write latches `initialClaimsCommitted`; the per-claim CAS keeps any racing
+double-write safe, and `applyStoreMu` serializes the flag read/latch so exactly one apply takes
+the empty-prev path. Side benefit: a failed bootstrap write no longer falsely advances the
+snapshot to `V2` (the apply fails before the Store), so the version stays pinned during the
+outage. Decided with the user (PR-by-PR cadence); 3b (don't pre-advance) remains deferred.
+
+**Tests:** the S3 harness `long_outage_restart_only` case flips to self-heal — promoted as
+`test/integration/failure/startup_writefault_test.go` (write-axis fault seam; proven
+RED-on-parent / GREEN-with-fix, no restart). Unit coverage in
+`manager_initial_claims_bootstrap_test.go`: the retry path receives an empty prev before the
+first commit (verify-first, compiles+fails on parent), core overrides+latches on a bootstrap
+apply, keeps the real prev after the latch (both-directions boundary), the version-advance
+path (`applyAssignmentWithPrevCore(V1, V2)` with the latch false) gets an empty prev — the
+discriminator proven RED under retry-only placement by mutation, and a concurrent-apply
+`-race` test pins exactly-one empty-prev bootstrap path.
+
+**Deferred follow-up (not a regression; not in this PR) — sustained-write-fault Degraded
+recovery can report `Stable` while claims are still uncommitted.** If the claim-write fault
+persists past `StartupTimeout + DegradedBehavior.ExitThreshold` *with assignment reads still
+succeeding*, the worker can: startup-timeout watchdog → `Degraded` → `attemptRecoveryFromDegraded`
+(`manager_degraded.go`) refreshes the assignment snapshot via `monotonicStore` (a read, not an
+apply) → `exitDegraded` → `Stable`, all while no claims have been written. This is a pre-existing
+property of the connectivity-keyed Degraded-recovery path (untouched by this PR), and it is
+**strictly better than the pre-F-D3 behavior**: before F-D3 the worker reached `Stable`-with-no-
+claims *immediately* via the empty-diff "success" and never self-healed; with F-D3 the retry
+stays alive (latch false) and self-heals once writes recover. Two residual edges remain, both
+predating this PR: (a) a misleading `Stable`-while-uncommitted observability window, and (b) a
+narrow non-heal tail — if a version advance lands during the Degraded window and
+`refreshAssignmentFromNATS` monotonic-stores a version *strictly higher* than the retry's
+coalesced pending, the retry stale-drops and exits → restart-only. The clean fix (gate the
+Degraded-recovery exit on `initialClaimsCommitted` when `CurrentAssignment()` is non-empty)
+touches the generic recovery path shared by all degraded reasons (contracts 1/3) and warrants
+its own contract-regression pass — deferred rather than bundled here. (Surfaced by the PR4
+post-impl review v1, P1-1.)
 
 ---
 

--- a/manager.go
+++ b/manager.go
@@ -145,6 +145,14 @@ type Manager struct {
 	stashedApplyRetry atomic.Pointer[Assignment]
 	applyRetryActive  atomic.Bool
 
+	// initialClaimsCommitted latches true the first time an apply genuinely
+	// commits the full claim set to the handoff bucket. Until then,
+	// applyAssignmentWithPrevCore forces an empty prev on every apply so the
+	// prepare diff is the full partition set, instead of computing an empty
+	// diff against the snapshot waitForAssignment pre-advanced with no claims
+	// written — the startup empty-diff self-exit (F-D3). One-way latch.
+	initialClaimsCommitted atomic.Bool
+
 	// Degraded mode tracking
 	degradedSince          atomic.Int64  // UnixNano when degraded mode entered; 0 = not degraded
 	lastAssignmentAt       atomic.Int64  // UnixNano of last successful assignment fetch; 0 = never

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -1246,6 +1246,19 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 		return nil
 	}
 
+	// Startup bootstrap override (F-D3): until the worker has committed its
+	// claims at least once, force an empty prev so the prepare diff is the FULL
+	// partition set. waitForAssignment pre-advances the snapshot to the full set
+	// with no claims written, so any apply that reads CurrentAssignment() for
+	// prev would otherwise compute an empty diff and write zero claims. This must
+	// live here (not only in scheduleApplyRetry): a startup-window version
+	// advance (cold-start/rejoin rebalance to V+1) applies V+1 against the
+	// pre-advanced snapshot AND stale-gate-drops the V retry, so fixing the retry
+	// alone does not self-heal. One-way: once committed, prev is CurrentAssignment().
+	if !m.initialClaimsCommitted.Load() {
+		oldAssignment = Assignment{}
+	}
+
 	// 1) Apply via handoff coordinator. Must succeed before we touch the
 	//    in-memory snapshot or publish the ack.
 	applyErr := m.handoffCoordinator.Apply(m.ctx, workerID, oldAssignment, newAssignment)
@@ -1263,6 +1276,14 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 		m.logError("handoff apply failed", "error", applyErr)
 		m.scheduleApplyRetry(newAssignment)
 		return applyErr
+	}
+
+	// Latch initialClaimsCommitted on the first successful full-set write. During
+	// bootstrap the override forced oldAssignment empty, so an empty-prev →
+	// non-empty-next success genuinely wrote every claim — never a claim-less
+	// empty diff. One-way latch.
+	if len(oldAssignment.Partitions) == 0 && len(newAssignment.Partitions) > 0 {
+		m.initialClaimsCommitted.Store(true)
 	}
 
 	// 2) Advance lastSeenLeaderRevision (stale-leader fence) — single

--- a/manager_commit_state_machine_test.go
+++ b/manager_commit_state_machine_test.go
@@ -65,6 +65,7 @@ func (r *recordingMetrics) RecordAssignmentChange(_, _ int, _ int64) {
 type recordingHandoff struct {
 	mu         sync.Mutex
 	callOrder  []int64
+	applyPrevs []types.Assignment // the prev (previous) arg captured per Apply call
 	applyCount atomic.Int64
 
 	blockFirstApply atomic.Bool
@@ -85,7 +86,7 @@ func newRecordingHandoff() *recordingHandoff {
 
 func (h *recordingHandoff) Start(_ context.Context) {}
 
-func (h *recordingHandoff) Apply(_ context.Context, _ string, _ /* prev */, next types.Assignment) error {
+func (h *recordingHandoff) Apply(_ context.Context, _ string, prev, next types.Assignment) error {
 	// If blockFirstApply is set, the FIRST Apply call signals readiness then
 	// waits for the test to release it. Subsequent applies fall through.
 	if h.blockFirstApply.CompareAndSwap(true, false) {
@@ -95,6 +96,7 @@ func (h *recordingHandoff) Apply(_ context.Context, _ string, _ /* prev */, next
 	h.applyCount.Add(1)
 	h.mu.Lock()
 	h.callOrder = append(h.callOrder, next.Version)
+	h.applyPrevs = append(h.applyPrevs, prev)
 	h.mu.Unlock()
 	if box := h.errOnce.Swap(nil); box != nil {
 		return box.err

--- a/manager_initial_claims_bootstrap_test.go
+++ b/manager_initial_claims_bootstrap_test.go
@@ -1,0 +1,191 @@
+package parti
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fullBootstrapAssignment is the pre-advanced full set a worker's
+// waitForAssignment stores into the snapshot before any claim is written.
+func fullBootstrapAssignment() Assignment {
+	return Assignment{
+		Version:        1,
+		LeaderRevision: 5,
+		Partitions:     []Partition{{Keys: []string{"p1"}}, {Keys: []string{"p2"}}},
+	}
+}
+
+// TestScheduleApplyRetry_BeforeBootstrap_UsesEmptyPrev is the verify-first
+// reproducer for the startup empty-diff retry self-exit (root cause RC3 / F-D3).
+//
+// Sequence reproduced: waitForAssignment pre-advances the in-memory snapshot to
+// the full partition set BEFORE any claim is written (manager_election.go's
+// m.assignment.Store with no apply hook); the initial apply fails under a
+// KV-write fault and schedules a retry. On the parent the retry — and every
+// other apply path — reads prev = m.CurrentAssignment() = the pre-advanced full
+// set, so the handoff coordinator's prepare diff is EMPTY (preparePhase only
+// writes partitions in next absent from prev): the apply "succeeds" writing ZERO
+// claims and the retry self-exits. Claims never land until a process restart.
+//
+// The fix: while no claims have ever been committed, applyAssignmentWithPrevCore
+// overrides prev to empty so the FULL claim set is (re)written. This test pins
+// that the retry path benefits from the override by capturing the prev the
+// coordinator receives. It references only the pre-existing API, so it compiles
+// and FAILS on the parent base (the coordinator gets the full pre-advanced prev).
+func TestScheduleApplyRetry_BeforeBootstrap_UsesEmptyPrev(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	// Simulate waitForAssignment: pre-advance the snapshot to the full set with
+	// NO claims written (no apply hook ran — a direct, non-apply store).
+	full := fullBootstrapAssignment()
+	m.assignment.Store(full)
+
+	// Schedule a retry for the same full set, exactly as the failed initial
+	// apply does on its apply-failure arm.
+	m.scheduleApplyRetry(full)
+
+	// Wait past the ~1s+jitter retry backoff for the retry's Apply to fire.
+	require.Eventually(t, func() bool { return rh.applyCount.Load() >= 1 },
+		5*time.Second, 50*time.Millisecond, "retry's Apply must fire within 5s")
+
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	require.NotEmpty(t, rh.applyPrevs, "retry must have called Apply at least once")
+	prev := rh.applyPrevs[len(rh.applyPrevs)-1]
+	require.Empty(t, prev.Partitions,
+		"before the first claim commit the coordinator MUST receive an empty prev so the "+
+			"prepare diff is the FULL partition set; the pre-advanced snapshot yields an "+
+			"empty diff and a zero-claim self-exit (the startup empty-diff bug)")
+}
+
+// TestApplyCore_BootstrapOverridesPrevAndLatches pins both halves of the fix on
+// the shared apply pipeline: while no claims have been committed, core overrides
+// the caller's (pre-advanced) prev to empty so the coordinator writes the full
+// claim set, and a successful such write latches initialClaimsCommitted.
+func TestApplyCore_BootstrapOverridesPrevAndLatches(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	full := fullBootstrapAssignment()
+	m.assignment.Store(full) // waitForAssignment pre-advance
+	require.False(t, m.initialClaimsCommitted.Load(), "precondition: flag starts false")
+
+	// A same-version apply with the pre-advanced full prev (what the
+	// commit/assignment watcher computes after the pre-advance). Core must
+	// override prev to empty so claims are actually written.
+	require.NoError(t, m.applyAssignmentWithPrevCore(full, full))
+
+	require.True(t, m.initialClaimsCommitted.Load(),
+		"a full-set bootstrap write must latch initialClaimsCommitted")
+
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	require.Len(t, rh.applyPrevs, 1)
+	require.Empty(t, rh.applyPrevs[0].Partitions,
+		"during bootstrap core MUST hand the coordinator an empty prev so the full claim "+
+			"set is written, not an empty diff against the pre-advanced snapshot")
+}
+
+// TestApplyCore_BootstrapVersionAdvanceOverridesPrev pins the exact scenario
+// that REQUIRES the override to live in the shared apply pipeline rather than
+// only in scheduleApplyRetry: a higher-version apply (V2) arriving over the
+// pre-advanced V1 snapshot while no claims are committed (a startup-window
+// rebalance). Without the core override, that V2 apply reads prev =
+// CurrentAssignment() = V1, computes an empty prepare diff, and writes zero
+// claims — and it stale-gate-drops the V1 retry. The core override forces an
+// empty prev so the full set is written. A retry-only fix leaves THIS path
+// (commit-/assignment-watcher applies) empty-diffing, so this test goes RED
+// under retry-only placement (verified by mutation).
+func TestApplyCore_BootstrapVersionAdvanceOverridesPrev(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	v1 := fullBootstrapAssignment()
+	v2 := Assignment{Version: 2, LeaderRevision: 6, Partitions: v1.Partitions}
+	m.assignment.Store(v1) // waitForAssignment pre-advanced to V1, no claims written
+	require.False(t, m.initialClaimsCommitted.Load())
+
+	// Apply the NEWER version against the pre-advanced V1 snapshot.
+	require.NoError(t, m.applyAssignmentWithPrevCore(v1, v2))
+
+	require.True(t, m.initialClaimsCommitted.Load(), "the V2 bootstrap write must latch the flag")
+
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	require.Len(t, rh.applyPrevs, 1)
+	require.Empty(t, rh.applyPrevs[0].Partitions,
+		"a higher-version apply over the pre-advanced snapshot during bootstrap MUST receive an "+
+			"empty prev (full claim write); retry-only placement leaves this watcher path empty-diffing")
+}
+
+// TestApplyCore_AfterBootstrapKeepsPrev is the other direction of the boundary
+// (feedback_test_both_directions_of_boundary): once claims ARE committed, core
+// must NOT override prev, so steady-state applies stay incremental and do not
+// re-issue a full-set write over already-committed claims.
+func TestApplyCore_AfterBootstrapKeepsPrev(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	full := fullBootstrapAssignment()
+	next := Assignment{
+		Version:        2,
+		LeaderRevision: 6,
+		Partitions:     append(append([]Partition(nil), full.Partitions...), Partition{Keys: []string{"p3"}}),
+	}
+	m.assignment.Store(full)
+	m.initialClaimsCommitted.Store(true) // claims already committed at least once
+
+	require.NoError(t, m.applyAssignmentWithPrevCore(full, next))
+
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	require.Len(t, rh.applyPrevs, 1)
+	require.Equal(t, full.Partitions, rh.applyPrevs[0].Partitions,
+		"after the first claim commit core MUST use the real prev (incremental semantics), "+
+			"not a forced empty prev")
+}
+
+// TestApplyCore_ConcurrentBootstrapApplies_LatchOnceNoRace pins the
+// concurrent-apply safety the override relies on (AGENTS.md concurrency
+// discipline). The retry goroutine and the commit/assignment watchers can all
+// issue an apply for the same bootstrap version at once. applyStoreMu serializes
+// them and the latch is read+written under that lock, so EXACTLY ONE apply takes
+// the empty-prev bootstrap path; the rest observe the latched flag and use the
+// real prev. Run under -race by the suite.
+func TestApplyCore_ConcurrentBootstrapApplies_LatchOnceNoRace(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	full := fullBootstrapAssignment()
+	m.assignment.Store(full) // pre-advance
+
+	const racers = 8
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for range racers {
+		go func() {
+			defer wg.Done()
+			_ = m.applyAssignmentWithPrevCore(full, full)
+		}()
+	}
+	wg.Wait()
+
+	require.True(t, m.initialClaimsCommitted.Load(), "the bootstrap write must latch the flag")
+
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	require.Len(t, rh.applyPrevs, racers, "all serialized applies ran")
+	empties := 0
+	for _, p := range rh.applyPrevs {
+		if len(p.Partitions) == 0 {
+			empties++
+		}
+	}
+	require.Equal(t, 1, empties,
+		"exactly one apply may take the empty-prev bootstrap path; once it latches the flag "+
+			"the rest must use the real prev (no redundant full-set re-write)")
+}

--- a/test/integration/failure/startup_writefault_test.go
+++ b/test/integration/failure/startup_writefault_test.go
@@ -1,0 +1,293 @@
+package failure_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// wfMutableSource is a minimal types.WatchablePartitionSource. source.Static is
+// NOT watchable, which drives the calculator down a cold-start path that
+// re-publishes a fresh assignment version (V1→V2) — a cold-cluster-bootstrap
+// artifact that is NOT part of the F-D3 "restart into an existing fleet"
+// scenario. A watchable source whose partition set never changes after
+// construction keeps the assignment pinned at V1, matching the traced
+// long-outage repro. Ported from tmp/parti-repro/source.go.
+type wfMutableSource struct {
+	mu    sync.Mutex
+	parts []types.Partition
+	ch    chan struct{}
+}
+
+func newWFMutableSource(parts []types.Partition) *wfMutableSource {
+	return &wfMutableSource{
+		parts: append([]types.Partition(nil), parts...),
+		ch:    make(chan struct{}, 1),
+	}
+}
+
+func (s *wfMutableSource) Start(_ context.Context) error { return nil }
+func (s *wfMutableSource) Stop(_ context.Context) error  { return nil }
+
+func (s *wfMutableSource) List(_ context.Context) ([]types.Partition, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]types.Partition(nil), s.parts...), nil
+}
+
+func (s *wfMutableSource) Watch(_ context.Context) <-chan struct{} { return s.ch }
+
+// --- WRITE-axis fault seam ---------------------------------------------------
+//
+// The write-axis companion to resolver_readfault_test.go's READ seam. It wraps
+// the handoff bucket's KeyValue and faults ONLY the per-claim WRITE path
+// (Create / Update / Put of a claims-prefix key) when armed; Get / Keys / Watch
+// all pass through. This reproduces a startup KV-write outage: the two-phase
+// coordinator's preparePhase write (kv_store.go's Create/Update via PutIfEpoch)
+// fails, so the initial startup apply fails and schedules a retry.
+//
+// This file reuses the worker-stack / stream / read-back helpers and constants
+// (rfBuildStream, rfBuildWorkerStack, rfReadClaimRevision, rfPublish,
+// rfHandoffBucket, rfClaimsPrefix) defined in resolver_readfault_test.go — both
+// files are in package failure_test.
+
+// wfFaultController is the write-axis toggle+counter.
+type wfFaultController struct {
+	// writeArmed is the WRITE-axis toggle. When true, a Create/Update/Put
+	// against a claim key faults with context.DeadlineExceeded.
+	writeArmed atomic.Bool
+
+	// writeFaultsInjected counts how many claim-key writes actually returned
+	// the injected error. Lets the test assert the fault genuinely fired
+	// (non-vacuous) before disarming.
+	writeFaultsInjected atomic.Int64
+}
+
+// ArmWrites enables the claim-write fault and resets the counter.
+func (fc *wfFaultController) ArmWrites() {
+	fc.writeFaultsInjected.Store(0)
+	fc.writeArmed.Store(true)
+}
+
+// DisarmWrites disables the write fault (simulates KV write recovery).
+func (fc *wfFaultController) DisarmWrites() { fc.writeArmed.Store(false) }
+
+// shouldFaultWrite reports whether a claim-key write should fault and counts it.
+func (fc *wfFaultController) shouldFaultWrite() bool {
+	if !fc.writeArmed.Load() {
+		return false
+	}
+	fc.writeFaultsInjected.Add(1)
+
+	return true
+}
+
+// wfFaultJetStream wraps a real jetstream.JetStream. Only the handoff-bucket KV
+// handle is wrapped; every other bucket and method passes through.
+type wfFaultJetStream struct {
+	jetstream.JetStream // embedded: all non-overridden methods pass through
+
+	handoffBucket string
+	fc            *wfFaultController
+}
+
+func newWFFaultJetStream(inner jetstream.JetStream, handoffBucket string, fc *wfFaultController) *wfFaultJetStream {
+	return &wfFaultJetStream{JetStream: inner, handoffBucket: handoffBucket, fc: fc}
+}
+
+func (f *wfFaultJetStream) wrap(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
+	if bucket == f.handoffBucket {
+		return &wfFaultKeyValue{KeyValue: kv, fc: f.fc, claimsPrefix: rfClaimsPrefix}
+	}
+
+	return kv
+}
+
+func (f *wfFaultJetStream) KeyValue(ctx context.Context, bucket string) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.KeyValue(ctx, bucket)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, bucket), nil
+}
+
+func (f *wfFaultJetStream) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+func (f *wfFaultJetStream) CreateOrUpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateOrUpdateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+// wfFaultKeyValue wraps the real handoff KeyValue and faults ONLY claim-key
+// writes (Create / Update / Put of a claimsPrefix key) when the WRITE axis is
+// armed. Reads pass through so the resolver can still list/get.
+type wfFaultKeyValue struct {
+	jetstream.KeyValue // embedded: Get/Keys/Watch/Status/... pass through
+	fc                 *wfFaultController
+	claimsPrefix       string
+}
+
+func (k *wfFaultKeyValue) isClaimKey(key string) bool {
+	return k.claimsPrefix != "" && len(key) >= len(k.claimsPrefix) && key[:len(k.claimsPrefix)] == k.claimsPrefix
+}
+
+func (k *wfFaultKeyValue) Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error) {
+	if k.isClaimKey(key) && k.fc.shouldFaultWrite() {
+		return 0, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Create(ctx, key, value, opts...)
+}
+
+func (k *wfFaultKeyValue) Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	if k.isClaimKey(key) && k.fc.shouldFaultWrite() {
+		return 0, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Update(ctx, key, value, revision)
+}
+
+func (k *wfFaultKeyValue) Put(ctx context.Context, key string, value []byte) (uint64, error) {
+	if k.isClaimKey(key) && k.fc.shouldFaultWrite() {
+		return 0, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Put(ctx, key, value)
+}
+
+// TestStartupWriteFault_SelfHealsWithoutRestart pins the startup empty-diff
+// retry fix (RC3 / F-D3) end-to-end through the public NewManager + NewDynamic
+// stack.
+//
+// The bug (on the parent base): a KV-write fault during the one-shot initial
+// startup apply fails the claim write. waitForAssignment has already
+// pre-advanced the in-memory snapshot to the full partition set, so
+// scheduleApplyRetry re-applies with prev = CurrentAssignment() = that full set
+// → an EMPTY prepare diff → the retry "succeeds" writing ZERO claims and
+// self-exits. The claim never lands in KV and the consumer is suppressed until a
+// process restart — even after the KV write fault clears.
+//
+// This test FLIPS the original scratch scenario's "restart-only" assertion to
+// the FIXED behaviour: once the write fault clears, the retry (which now uses an
+// explicit empty prev until the first claim commit) re-writes the FULL claim set
+// and the consumer resumes — with NO restart.
+//
+// On the parent base this test FAILS at the healedA step: the claim never
+// reappears because the retry self-exited on the first empty-diff success.
+func TestStartupWriteFault_SelfHealsWithoutRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+	faultJS := newWFFaultJetStream(realJS, rfHandoffBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	// Single (leader) worker over a WATCHABLE source whose partition set never
+	// changes — the assignment pins at V1 so the only claim-writing path during
+	// the fault window is the initial apply and its scheduleApplyRetry. This is
+	// the traced long-outage repro (tmp/parti-repro scenario_b), NOT a fresh
+	// cold cluster that would re-publish V2.
+	pids := []string{"p0", "p1"}
+	src := newWFMutableSource([]types.Partition{{Keys: []string{pids[0]}}, {Keys: []string{pids[1]}}})
+
+	allStable := func() bool {
+		for _, pid := range pids {
+			if _, _, stable := rfReadClaimRevision(t, ctx, realJS, pid); !stable {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	// Arm the write fault BEFORE the worker starts so the INITIAL startup apply's
+	// claim write faults. waitForAssignment then pre-advances the snapshot to the
+	// full set with no claims written — the precondition for the empty-diff retry.
+	fc.ArmWrites()
+
+	stack := rfBuildWorkerStack(t, ctx, faultJS, src, 0)
+
+	// The initial startup apply must attempt a faulted claim write.
+	require.Eventually(t, func() bool { return fc.writeFaultsInjected.Load() >= 1 },
+		30*time.Second, 25*time.Millisecond,
+		"the initial startup apply never attempted a faulted claim write")
+
+	// Non-vacuous precondition: no Stable claim while claim writes are faulted.
+	require.False(t, allStable(), "no claim must be Stable in KV while claim writes are faulted")
+
+	// Hold the fault briefly so the parent's retry demonstrably self-exits on its
+	// empty-diff trivial success during the window (claims stay absent), pushing
+	// the scenario into the regime that is restart-only on the parent.
+	time.Sleep(2 * time.Second)
+	require.False(t, allStable(), "claims must still be absent/non-Stable after the retry window under fault")
+
+	t.Logf("[%s] DURING write-fault: writeFaults=%d asg(V=%d parts=%d) state=%s",
+		t.Name(), fc.writeFaultsInjected.Load(),
+		stack.mgr.CurrentAssignment().Version, len(stack.mgr.CurrentAssignment().Partitions), stack.mgr.State())
+
+	// --- Disarm: simulate KV write recovery. NO restart anywhere. ---
+	fc.DisarmWrites()
+
+	// (a) KV layer: every claim must now appear Stable WITHOUT a restart. On the
+	// parent the retry already self-exited, so this never happens (RED).
+	require.Eventually(t, allStable, 40*time.Second, 100*time.Millisecond,
+		"with the fix the retry re-writes the FULL claim set after write recovery — "+
+			"every claim must appear Stable in KV WITHOUT any restart")
+
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 20*time.Second),
+		"manager did not reach Stable after write recovery")
+
+	// (b) Consumer layer: a post-recovery publish is consumed end-to-end.
+	base := stack.consumed.Load()
+	for _, pid := range pids {
+		rfPublish(t, ctx, realJS, pid, "post-"+pid)
+	}
+	require.Eventually(t, func() bool { return stack.consumed.Load() > base },
+		40*time.Second, 100*time.Millisecond,
+		"after write recovery the consumer must resume pulling without any restart")
+
+	t.Logf("[%s] AFTER write-recovery (no restart): all claims Stable, consumer resumed total=%d",
+		t.Name(), stack.consumed.Load())
+}
+
+// Note on the version-advance scenario: the path that specifically REQUIRES the
+// override to live in the shared apply pipeline (rather than only in
+// scheduleApplyRetry) — a higher-version apply over the pre-advanced snapshot —
+// is pinned deterministically by the unit test
+// TestApplyCore_BootstrapVersionAdvanceOverridesPrev (proven RED under
+// retry-only placement by mutation). It is not duplicated as an integration
+// case here: with the fix in place the override makes that V2 apply FAIL under
+// the write fault (a real write attempt), so the worker snapshot never falsely
+// advances to V2 during the fault — there is no longer a worker-observable
+// version advance to assert against, which is precisely the corrected behavior.


### PR DESCRIPTION
## Problem

When a worker's startup KV write fails, `waitForAssignment` has already pre-advanced the in-memory snapshot to the full partition set **with no claims written**. Every apply path that derives its previous-assignment from the snapshot (`scheduleApplyRetry`, the commit-watcher, the assignment-watcher) then computes an **empty prepare diff** (`preparePhase` only writes partitions in `next` absent from `prev`), "succeeds" writing zero claims, and the retry self-exits. The consumer is suppressed until a process restart — the startup arm of the auto-healing quorum-loss incident.

## The fix

Track whether the worker has committed its claims at least once (`initialClaimsCommitted atomic.Bool`) and, until it has, force an empty previous assignment in `applyAssignmentWithPrevCore` (under `applyStoreMu`) so every bootstrap apply writes the **full** claim set. The first successful full-set write latches the flag; applies then revert to incremental semantics.

**Why the shared apply pipeline, not just `scheduleApplyRetry`:** the original plan (option 3a) localized the fix to the retry loop. That was empirically verified **insufficient** — running the S3 repro (`scenario_b/long_outage_restart_only`) against it still leaves claims absent. During the fault window the assignment advances `V1→V2` (a normal cold-start/rejoin rebalance); the `V2` apply reads `prev = CurrentAssignment()` = the pre-advanced `V1` set → an empty diff → it writes no claims **and** advances the snapshot to `V2`, which then stale-gate-drops the `V1` retry before it can write. So the override moved to the single pipeline every apply path funnels through. Side benefit: a failed bootstrap write no longer falsely advances the snapshot to `V2` — the version stays pinned during the outage. (Approved with the maintainer; option 3b — not pre-advancing the snapshot — remains deferred as the larger startup-ordering change.)

## Testing

- **Integration** (`test/integration/failure/startup_writefault_test.go`): a write-axis fault seam over the handoff bucket; the worker self-heals (claims become Stable, consumer resumes) once writes recover, **without any restart**. Proven RED on the parent base (`V→2`, claims never reappear) / GREEN with the fix (`V` stays 1, self-heals in ~4s).
- **Unit** (`manager_initial_claims_bootstrap_test.go`): the retry path receives an empty prev before the first commit (verify-first, compiles+fails on parent); core overrides+latches on a bootstrap apply; keeps the real prev after the latch (both-directions boundary); a **version-advance discriminator** (`applyAssignmentWithPrevCore(V1, V2)` with the latch false → empty prev) proven RED under retry-only placement by mutation; and a concurrent-apply `-race` test pins exactly-one empty-prev bootstrap path.
- `make pre-pr` green (the only failure is the known `TestLeaderElection_ColdStart` CPU-load flake, which passes 3/3 in isolation); the 3 cross-feature contract tests pass.
- Codex post-impl review v1 → fix-then-merge; P1-2 (version-advance test gap) fixed via the unit discriminator above.

## Deferred follow-up (not a regression; separate PR)

Codex P1-1: if a claim-write fault persists past `StartupTimeout + ExitThreshold` **with assignment reads still succeeding**, the connectivity-keyed Degraded recovery (`attemptRecoveryFromDegraded` → `refreshAssignmentFromNATS` monotonic-store → `exitDegraded`) can report `Stable` while claims are still uncommitted. This is a **pre-existing** property of the recovery path (untouched here) and is **strictly better than pre-F-D3** (which reached `Stable`-with-no-claims immediately and never self-healed; now the retry stays alive and heals when writes return). The clean fix — gating the Degraded-recovery exit on `initialClaimsCommitted` when the assignment is non-empty — touches the recovery path shared by all degraded reasons (cross-feature contracts 1/3) and warrants its own contract-regression pass, so it is deferred rather than bundled here. Documented in the fix plan §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)