### PR TITLE
Fix manager startup stable readiness gate

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -153,6 +153,13 @@ type Manager struct {
 	// written — the startup empty-diff self-exit (F-D3). One-way latch.
 	initialClaimsCommitted atomic.Bool
 
+	// startupAssignmentApplied latches true once the startup assignment path
+	// has made this manager's local assignment visible and acked it. It is
+	// separate from initialClaimsCommitted: empty-source startup has no claims
+	// to commit but still must be allowed to reach StateStable after its
+	// applied-empty ack.
+	startupAssignmentApplied atomic.Bool
+
 	// Degraded mode tracking
 	degradedSince          atomic.Int64  // UnixNano when degraded mode entered; 0 = not degraded
 	lastAssignmentAt       atomic.Int64  // UnixNano of last successful assignment fetch; 0 = never
@@ -682,7 +689,7 @@ func (m *Manager) applyInitialAssignment(ctx context.Context, assignmentKV jetst
 		// stay in WaitingAssignment until a later non-empty assignment
 		// triggers applyAssignmentWithPrev's CAS — which may never
 		// happen if the source is genuinely empty.
-		m.casToStableFromWaitingAssignment()
+		m.markStartupAssignmentApplied()
 
 		return nil
 	}

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -1365,7 +1365,7 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 	// later succeeded would stay in WaitingAssignment forever even though
 	// the assignment was applied and acked. See manager_startup_async.go
 	// runStartupBackground Godoc.
-	m.casToStableFromWaitingAssignment()
+	m.markStartupAssignmentApplied()
 
 	return nil
 }

--- a/manager_calculator_state_monitor_test.go
+++ b/manager_calculator_state_monitor_test.go
@@ -62,6 +62,7 @@ func TestMonitorCalculatorState_ReconcileRecoversDroppedState(t *testing.T) {
 		heartbeat:       heartbeat.NewNop(),
 	}
 	m.state.Store(int32(StateStable))
+	m.startupAssignmentApplied.Store(true)
 	m.workerID.Store("worker-test")
 	m.assignment.Store(Assignment{})
 	m.ctx, m.cancel = context.WithCancel(context.Background())
@@ -164,6 +165,7 @@ func TestPartitionLifecycle_DrivesManagerStateRebalancing(t *testing.T) {
 		heartbeat:       heartbeat.NewNop(),
 	}
 	m.state.Store(int32(StateStable))
+	m.startupAssignmentApplied.Store(true)
 	m.workerID.Store("worker-test")
 	m.assignment.Store(Assignment{})
 	m.ctx, m.cancel = context.WithCancel(context.Background())

--- a/manager_startup_async.go
+++ b/manager_startup_async.go
@@ -3,6 +3,7 @@ package parti
 import (
 	"time"
 
+	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -24,13 +25,14 @@ import (
 // decoupled from the runner so the watchdog fires even if the runner is
 // blocked inside applyInitialAssignment).
 //
-// On a clean success the runner CAS-transitions WaitingAssignment → Stable
-// via casToStableFromWaitingAssignment. If the calculator-state monitor
-// (started in startCalculator at manager_assignment.go:157-168) has
-// already moved state to Scaling/Rebalancing/Emergency, the CAS fails and
-// the runner leaves state alone — calculator ownership wins. The
-// post-Stable monitor set always starts, regardless of apply success or
-// state path; the monitors handle whatever state they find.
+// On a clean success the runner marks startup assignment readiness. If state
+// is still WaitingAssignment, the readiness helper CAS-transitions
+// WaitingAssignment → Stable. If the calculator-state monitor (started in
+// startCalculator) has already moved state to Scaling/Rebalancing/Emergency,
+// the helper only completes the deferred calculator Idle → Stable transition
+// after the local assignment is applied and acked. The post-Stable monitor set
+// always starts, regardless of apply success or state path; the monitors handle
+// whatever state they find.
 //
 // Apply boundedness: applyInitialAssignment internally calls
 // handoffCoordinator.Apply(m.ctx, ...) which is unbounded per attempt.
@@ -103,6 +105,27 @@ func (m *Manager) casToStableFromWaitingAssignment() {
 		})
 	}
 	m.metrics.RecordStateTransition(StateWaitingAssignment, StateStable, 0)
+}
+
+func isCalculatorOwnedActiveState(state State) bool {
+	return state == StateScaling || state == StateRebalancing || state == StateEmergency
+}
+
+func (m *Manager) markStartupAssignmentApplied() {
+	if !m.startupAssignmentApplied.CompareAndSwap(false, true) {
+		return
+	}
+
+	m.casToStableFromWaitingAssignment()
+
+	if !isCalculatorOwnedActiveState(m.State()) {
+		return
+	}
+	if m.calculator == nil || m.calculator.GetState() != types.CalcStateIdle {
+		return
+	}
+
+	m.transitionState(StateStable)
 }
 
 // startPostStableMonitors launches the four monitor goroutines that drive

--- a/manager_state.go
+++ b/manager_state.go
@@ -217,8 +217,15 @@ func (m *Manager) syncStateFromCalculator(calcState types.CalculatorState) error
 		// This prevents flapping back to Stable when we're already stable,
 		// which can happen when subscribing to calculator state changes
 		// (the calculator sends its current state immediately on subscription).
-		if currentState != StateScaling && currentState != StateRebalancing && currentState != StateEmergency {
+		if !isCalculatorOwnedActiveState(currentState) {
 			// Already stable or in a non-active state, no transition needed.
+			return nil
+		}
+		if !m.startupAssignmentApplied.Load() {
+			// Startup readiness is owned by the local apply/store/ack path.
+			// Calculator Idle can arrive before the leader has applied its own
+			// startup assignment; do not advertise StateStable until that path
+			// completes.
 			return nil
 		}
 

--- a/manager_state_test.go
+++ b/manager_state_test.go
@@ -8,8 +8,17 @@ import (
 
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/types"
 	"github.com/stretchr/testify/require"
 )
+
+func newStateProjectionTestManager() *Manager {
+	return &Manager{
+		hooks:   &types.Hooks{},
+		logger:  logging.NewNop(),
+		metrics: metrics.NewNop(),
+	}
+}
 
 func TestManager_WaitState_AlreadyInState(t *testing.T) {
 	m := &Manager{}
@@ -41,6 +50,33 @@ func TestManager_WaitState_StateTransition(t *testing.T) {
 	// Should receive nil when state is reached
 	err := <-errCh
 	require.NoError(t, err)
+}
+
+func TestSyncStateFromCalculator_DefersStableUntilStartupAssignmentApplied(t *testing.T) {
+	m := newStateProjectionTestManager()
+	m.state.Store(int32(StateRebalancing))
+
+	require.NoError(t, m.syncStateFromCalculator(types.CalcStateIdle))
+	require.Equal(t, StateRebalancing, m.State(),
+		"calculator Idle must not report StateStable before startup assignment apply/store completes")
+
+	m.startupAssignmentApplied.Store(true)
+
+	require.NoError(t, m.syncStateFromCalculator(types.CalcStateIdle))
+	require.Equal(t, StateStable, m.State(),
+		"calculator Idle may report StateStable after startup assignment apply/store completes")
+}
+
+func TestMarkStartupAssignmentApplied_CompletesDeferredCalculatorIdle(t *testing.T) {
+	m := newStateProjectionTestManager()
+	m.calculator = &stubCalculator{}
+	m.state.Store(int32(StateRebalancing))
+
+	m.markStartupAssignmentApplied()
+
+	require.True(t, m.startupAssignmentApplied.Load())
+	require.Equal(t, StateStable, m.State(),
+		"apply success must complete a previously deferred calculator Idle -> Stable transition")
 }
 
 func TestManager_WaitState_Timeout(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a startup assignment readiness latch so `StateStable` means the local startup assignment has been applied and acked.
- Defer calculator `Idle -> StateStable` projection until that startup apply/store/ack path completes.
- Add focused regression coverage for the deferred stable transition and update post-startup calculator-state monitor fixtures.

## Test Plan

- `make lint`
- `go test . -run 'TestSyncStateFromCalculator_DefersStableUntilStartupAssignmentApplied|TestMarkStartupAssignmentApplied_CompletesDeferredCalculatorIdle|TestPartitionLifecycle_DrivesManagerStateRebalancing' -count=1`
- `go test ./test/integration/manager -run '^TestIntegration_K8sRollingUpdate_PreservesAssignments$' -count=10 -v`
- `go test ./test/integration/manager -count=1`
- `go test ./... -count=1`
- `make pre-pr`
