### PR TITLE
fix(manager): self-heal instead of reporting Stable with uncommitted claims

### DIFF
--- a/docs/plans/auto-healing-quorum-loss-fix/01-degraded-recovery-self-heal-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/01-degraded-recovery-self-heal-plan.md
@@ -1,0 +1,336 @@
+# Degraded-Recovery Self-Heal — Follow-Up Plan (F-D3 tail)
+
+- **Date:** 2026-05-30
+- **Status:** DRAFT (plan-review loop not yet run).
+- **Builds on:** `docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md` §3
+  "Deferred follow-up". This plan scopes the single deferred item from that fix
+  series: the sustained-write-fault Degraded-recovery path can report `Stable`
+  while claims are still uncommitted, and a version advance during the Degraded
+  window leaves a narrow non-heal (restart-only) tail.
+- **Origin:** PR4 (F-D3) post-implementation review v1, finding **P1-1**
+  (`tmp/00-fix-plan_PR4-F-D3_post_implementation_review_v1.md`). Deferred from
+  PR4 because the clean fix touches the **generic recovery path shared by all
+  degraded reasons** (cross-feature contracts 1 and 3) and warrants its own
+  contract-regression pass rather than being bundled into PR4.
+- **Relationship to the shipped series:** F-D2a/F-D2c/F-D1/F-D3 are all merged to
+  `main` (PRs #27/#28/#29). F-D2b was dropped as dead code. This is the last
+  open engineering item from the quorum-loss fix series; the remaining open
+  items in 00-fix-plan §7 are tuning/decision questions, not code.
+
+---
+
+## 1. The defect (precise statement)
+
+A worker that **(re)starts during a sustained claim-write fault** — assignment KV
+**reads** still succeed, claim **writes** fail — reaches a state where:
+
+- `waitForAssignment` pre-advances the in-memory snapshot to the full partition
+  set (`manager_election.go`), so `CurrentAssignment()` is **non-empty**;
+- every bootstrap apply fails its claim write → `scheduleApplyRetry` keeps
+  retrying → `initialClaimsCommitted` is **never latched** (it latches only on a
+  successful empty-prev → non-empty-next apply, `manager_assignment.go:1305`);
+- the startup-timeout watchdog correctly fires
+  `enterDegraded("startup-timeout")`.
+
+So far so good — the worker is Degraded with no claims written, which is correct.
+The bug is in **recovery**. On the connection-monitor goroutine, once the
+connection has been up past `ExitThreshold`, `checkConnectionHealth` calls
+`attemptRecoveryFromDegraded` (`manager_degraded.go:115`). That function:
+
+1. calls `refreshAssignmentFromNATS()` — a **read** via `monotonicStore`, NOT an
+   apply (`manager_assignment.go:1503`), which **succeeds** (reads are healthy);
+2. unconditionally calls `exitDegraded()` → `StateStable`
+   (`manager_degraded.go:323-331`).
+
+**Result:** the worker reports `StateStable` with **zero claims written**. Two
+residual edges (both named in 00-fix-plan §3, both pre-dating F-D3):
+
+- **Edge (a) — misleading `Stable`-while-uncommitted window.** The worker looks
+  healthy to operators/hooks while it owns no claims and processes nothing.
+- **Edge (b) — narrow non-heal tail (restart-only).** If a version advance lands
+  during the Degraded window, `refreshAssignmentFromNATS` monotonic-stores a
+  version (V2) strictly higher than the pending retry's coalesced version (V1).
+  The retry re-reads `prev := m.CurrentAssignment()` at apply time and
+  stale-gate-drops (`isApplyResultStale`, `manager_assignment.go:1161`), then the
+  retry loop self-exits. Claims are never written until a process restart.
+
+**Why this is still strictly better than pre-F-D3.** Before F-D3 the worker
+reached `Stable`-with-no-claims *immediately* via the empty-diff "success" and
+never self-healed. With F-D3 the retry stays alive (latch false) and self-heals
+once writes recover — except for edge (b). This plan closes both edges so the
+worker actively self-heals in all cases without a restart.
+
+---
+
+## 2. Invariants this fix MUST NOT regress (load-bearing)
+
+`attemptRecoveryFromDegraded → exitDegraded` is the **generic recovery path
+shared by every degraded reason** (`"NATS connection down"`,
+`"KV error threshold exceeded"`, `"kv-unavailable"`, `"startup-timeout"`,
+`"stream-missing-recovery-exhausted"`). The guard MUST NOT change recovery for
+any worker that has already committed its claims.
+
+**The guard keys on STATE, not on the degraded reason — and that is
+deliberate.** The condition `!initialClaimsCommitted && len(CurrentAssignment().
+Partitions) > 0` means precisely *"this worker holds an assignment but has never
+once committed claims for it."* `initialClaimsCommitted` is a one-way latch set
+only on a successful empty-prev → non-empty-next claim write
+(`manager_assignment.go:1305`), so any worker that ever reached Stable-with-claims
+has it permanently `true` and is immune. In the un-latched state, calling
+`exitDegraded → Stable` is the Stable-without-claims bug **regardless of which
+reason degraded the worker** — a NATS-down-during-startup or
+kv-unavailable-during-startup worker that recovers reads-first hits the exact same
+defect as the startup-timeout path. Therefore the guard *should* cover all of
+them. **A reviewer suggestion to narrow the guard to
+`degradedReason == "startup-timeout"` is explicitly rejected:** the degraded
+reason is not persisted today (`enterDegraded` only logs/hooks it,
+`manager_degraded.go:240-277`), and narrowing would *reintroduce* the bug for the
+NATS-down/kv-unavailable startup variants. This is approach C from §4, rejected
+for adding state and *less* coverage. The state guard is strictly the right
+predicate; §1's "startup-bootstrap case" is the dominant trigger, not the only
+in-scope one.
+
+1. **Cross-feature contract 1** (whole-bucket-missing → every worker
+   `StateDegraded`, recovers when the bucket returns). Unaffected by construction:
+   under whole-bucket loss `refreshAssignmentFromNATS` **fails** (the read
+   errors), so `attemptRecoveryFromDegraded` returns at the existing err-check
+   **before** reaching the new guard. The kv-error circuit is untouched.
+2. **Cross-feature contract 3** (OnDegraded fires exactly once per Degraded
+   entry per worker). Held **by construction**: the fix *stays* degraded
+   (returns without `exitDegraded`), so `degradedSince` stays non-zero and
+   `enterDegraded`'s CAS (`manager_degraded.go:249`) blocks any OnDegraded
+   re-fire across the held recovery ticks. This is a positive property of the
+   stay-degraded design vs any exit-then-re-enter alternative. **Asserted by a
+   test** (§5), not merely assumed.
+3. **Cross-feature contract 2** (peer-claim-takeover → only that worker enters
+   claim-lost shutdown). Untouched — this fix is in the degraded-recovery path,
+   not the claimer-error path.
+4. **Steady-state recovery must not change.** A worker that has committed claims
+   (`initialClaimsCommitted == true`) recovers exactly as today: the guard is
+   skipped. Pinned by a both-directions negative-space test (§5).
+5. **Monotonic snapshot semantics.** The re-armed apply uses the **current**
+   (post-refresh) assignment, so it passes the stale gate
+   (`isApplyResultStale(cur, cur) == false`) without weakening the gate for any
+   other path.
+6. **Mixed-version / rolling upgrade — safe.** During a rolling upgrade an
+   old-version worker (no guard) and a new-version worker (with guard) coexist.
+   The fix adds only an extra **trigger** for *one worker's own*
+   `scheduleApplyRetry`; it does NOT change which claim keys get written.
+   `handoffCoordinator.Apply(ctx, workerID, old, new)` writes claims **only for
+   the calling worker's own assignment** (`manager_assignment.go:1270`), and
+   `scheduleApplyRetry` already exists on the pre-fix apply path — so the *set* of
+   `(worker, partition)` claim-key writes the cluster performs is unchanged; the
+   fix only re-issues a worker's own already-possible retry. The per-claim CAS
+   (`UpdateClaim` Create/Update) arbitrates any concurrent writer **version-
+   agnostically** (the loser CAS-fails), so an old worker and a new worker racing
+   the same key is resolved identically with or without this fix. This fix
+   introduces no wire-format, schema, or claim-key-layout change, so version-
+   agnostic CAS arbitration is exactly the pre-fix behavior (the argument assumes
+   the upgrade does not itself restructure claim keys — a separate concern any
+   key-layout migration would own, orthogonal to this fix). The fix is therefore
+   safe in a mixed-version cluster and requires no same-version gating.
+
+---
+
+## 3. The fix (approach B — gate the exit + re-arm a bootstrap apply)
+
+Single site: `attemptRecoveryFromDegraded` in `manager_degraded.go`. After the
+existing `refreshAssignmentFromNATS()` success check, before `exitDegraded`:
+
+```go
+func (m *Manager) attemptRecoveryFromDegraded() {
+    if m.degradedSince.Load() == 0 {
+        return
+    }
+
+    if err := m.refreshAssignmentFromNATS(); err != nil {
+        m.logger.Warn("failed to refresh assignment during recovery", "error", err)
+        m.recordKVError(err)
+        return
+    }
+
+    // The refresh succeeded (assignment reads are healthy). Record that
+    // success regardless of which branch we take below — the read just
+    // proved the KV-error window is stale.
+    m.recordKVSuccess()
+
+    // F-D3 follow-up: a worker that started during a sustained claim-write
+    // fault has a non-empty assignment (waitForAssignment pre-advanced it) but
+    // never latched initialClaimsCommitted — no claims were ever written.
+    // Refresh-only recovery would exitDegraded → Stable with zero claims.
+    // Instead stay degraded and re-arm a bootstrap apply for the CURRENT
+    // (post-refresh) assignment so the worker actively self-heals once writes
+    // recover. cur is read AFTER the refresh so it captures any version advance
+    // that landed during the degraded window (fixes edge (b)).
+    cur := m.CurrentAssignment()
+    if !m.initialClaimsCommitted.Load() && len(cur.Partitions) > 0 {
+        m.scheduleApplyRetry(cur)
+        return // do NOT exitDegraded — wait until a real apply latches the flag
+    }
+
+    m.exitDegraded()
+}
+```
+
+### 3.1 Why each load-bearing detail is correct
+
+- **`cur` captured after the refresh.** The refresh is what advances the snapshot
+  to the higher version. Reading `cur` *before* the refresh would re-arm the stale
+  lower version, which is exactly the version edge (b) stale-drops — silently
+  leaving (b) unfixed. This ordering is the entire fix for edge (b).
+- **Re-arm with `cur`, not a pinned version.** `scheduleApplyRetry` coalesces to
+  the highest pending version and re-reads `prev := m.CurrentAssignment()` at
+  apply time. Because `cur` is the current snapshot, `isApplyResultStale(cur, cur)`
+  is `false` → the apply passes the stale gate. With `initialClaimsCommitted ==
+  false`, the bootstrap override in `applyAssignmentWithPrevCore`
+  (`manager_assignment.go:1264`) forces empty-prev → the prepare diff is the FULL
+  partition set → all claims written once the write fault clears.
+- **Level-triggered convergence.** `attemptRecoveryFromDegraded` runs every
+  recovery tick (~1s, bounded by `ExitThreshold`). Each tick re-reads the
+  then-current version and re-arms. If a burst of version advances (V2, V3, …)
+  lands during the outage, each tick targets the latest; the worker converges to
+  self-heal once advances quiesce and writes recover. A V_{n+1} advance landing
+  *between* a re-arm and its apply will stale-drop that one retry, but the **next**
+  tick re-arms with V_{n+1} — so the level-triggered loop is self-correcting. (The
+  edge-(b) test MUST advance the version *during* the degraded window, not just
+  once before, to exercise this.)
+- **Latch flips → exit on the next tick.** Once the re-armed apply succeeds it
+  latches `initialClaimsCommitted = true` (the existing latch at
+  `manager_assignment.go:1305`). The *next* recovery tick then skips the guard and
+  `exitDegraded`s normally → `StateStable` with claims actually present.
+
+### 3.2 Decisions pinned
+
+- **`recordKVSuccess()` is called on both branches** (moved above the guard). The
+  refresh succeeded, so the KV-error window the read just exercised is stale;
+  recording success is correct and not branch-dependent. Harmless on the held
+  path since the circuit short-circuits while degraded. *(Deliberate — surfaced in
+  review of the draft so it is not left accidental.)*
+- **Stay-degraded, not exit-then-re-enter.** Staying degraded is what gives the
+  free contract-3 guarantee (§2.2). No reason-tracking field is added.
+- **No new degraded-reason persistence.** The reviewer offered reason-tracking
+  (`startup-timeout`-only gating) as an alternative. Rejected (and see §2's
+  state-vs-reason rationale): the un-latched state — assignment held, claims never
+  committed — is the precise condition where `exitDegraded → Stable` is wrong, no
+  matter which reason degraded the worker. Gating on `startup-timeout` would add a
+  manager field *and* reintroduce the bug for the NATS-down/kv-unavailable startup
+  variants. The state guard is the correct predicate; the reason is irrelevant to
+  whether exiting is safe.
+
+---
+
+## 4. Why approach B over the alternatives (record)
+
+- **Approach A (gate the exit only, `return` without re-arming):** closes edge (a)
+  but leaves edge (b) restart-only — recovery would depend on the original
+  `scheduleApplyRetry` loop still being alive and not having been stale-dropped.
+  Rejected: it codifies a known non-heal tail.
+- **Approach C (persist degraded reason, gate only `startup-timeout`):** most
+  surgical in intent but most invasive in code (new manager field, every
+  `enterDegraded` call site writes it). Rejected: the §3 guard is provably
+  equivalent without the field.
+- **Approach B (gate + re-arm):** the "clean fix" 00-fix-plan §3 describes
+  ("self-heals once writes recover"). Self-scoping guard, contracts 1/3 untouched,
+  cost over A is a few lines + one concurrency test. **Chosen.**
+
+---
+
+## 5. Test & contract-regression plan (first-class deliverable)
+
+This is the reason the item was deferred from PR4. The test surface is the center
+of this work, not an appendix.
+
+### 5.1 RED-on-parent reproducers (both edges)
+
+Extend the existing write-axis fault seam in
+`test/integration/failure/startup_writefault_test.go` (the `wfFaultController` /
+`wfFaultKeyValue` harness already faults ONLY the per-claim write path and can be
+armed/disarmed mid-run).
+
+- **(a) sustained-fault, no version advance** — the PR4 v1 reviewer's exact
+  recipe:
+  1. Arm the write fault before the worker starts.
+  2. Hold it **past `StartupTimeout + DegradedBehavior.ExitThreshold`**.
+  3. Assert the worker reaches `StateDegraded` (watchdog).
+  4. Assert it does **NOT** transition to `StateStable` while
+     `initialClaimsCommitted == false` and claims are absent in KV. *(RED on
+     parent: parent reaches `Stable` via refresh-only recovery.)*
+  5. Disarm writes; assert a bootstrap apply writes the **full** claim set and the
+     worker reaches `StateStable` — **no restart**.
+- **(b) version advance during the degraded window** — exercises the
+  after-refresh `cur` capture:
+  1. Arm the write fault; start the worker; let it reach `StateDegraded`.
+  2. While degraded, publish a **version advance** (V1→V2) via the watchable
+     source (cold-start/rejoin rebalance shape).
+  3. Disarm writes; assert the worker self-heals by writing the **full claim set
+     at V2** with **no restart**. *(RED on parent: the V1 retry stale-drops on the
+     V2 advance and self-exits → restart-only.)*
+  - Non-vacuity: confirm the V2 advance genuinely landed (snapshot version moved)
+    before disarming, so the test proves the re-arm targets V2 and not a vacuous
+    pass.
+
+### 5.2 Concurrency `-race` stress test (AGENTS.md monitor-goroutine requirement)
+
+`attemptRecoveryFromDegraded` runs on the **connection-monitor goroutine**, and
+this fix adds an **apply-issuing side effect** (`scheduleApplyRetry`) to it. Per
+AGENTS.md "Concurrency stress tests for monitor goroutines", add a focused
+`-race` stress test in `test/integration/manager/` (template:
+`manager_epoch_monitor_concurrency_test.go`) that drives the recovery goroutine ↔
+`scheduleApplyRetry` ↔ commit-watcher interplay concurrently against the same
+handoff bucket for ~5s and asserts no race-detector trips. The per-claim CAS
+(`UpdateClaim` Create/Update) already makes a racing double-write safe (loser
+CAS-fails); this test pins that the **re-arm side effect** introduces no new race
+on the shared snapshot / `applyStoreMu` / `stashedApplyRetry` state.
+
+### 5.3 Contract-3 assertion (held by construction → pinned)
+
+Assert `OnDegraded` fires **exactly once** across the whole held recovery window
+(multiple recovery ticks while the guard holds the worker degraded), reusing the
+hook-count style of `TestManager_LiveNATSBucketLoss_OnDegradedHook`.
+
+### 5.4 Negative-space (both-directions-of-boundary discipline)
+
+A **steady-state** worker (`initialClaimsCommitted == true`) that enters Degraded
+for an *unrelated* reason and whose refresh succeeds must `exitDegraded` →
+`Stable` **exactly as today** — the guard must not hold it. (Per
+`feedback_test_both_directions_of_boundary`: the positive test alone is consistent
+with both a correct guard and an always-hold bug; this negative test discriminates.)
+
+### 5.5 Mandatory gate (per AGENTS.md pre-PR + cross-feature contracts)
+
+- The **3 cross-feature contract regression tests**:
+  `TestManager_LiveNATSBucketLoss`, `TestManager_LiveNATSBucketLoss_OnDegradedHook`,
+  `TestStableID_StaleKeyTakeover_Reclaim`.
+- `make test-integration -race` (this is a recovery-path change on a shared
+  monitor goroutine — the unit suite cannot reproduce the goroutine race).
+- `make pre-pr` (touches `manager/`).
+- Unit coverage for `attemptRecoveryFromDegraded` branch selection with fakes:
+  {latch false + non-empty → re-arm + stays degraded}, {latch true → exits},
+  {empty assignment → exits}, {refresh fails → returns before guard, records
+  KV error}.
+
+---
+
+## 6. Phasing
+
+Single PR (one localized site + its test surface). Per the repo's standard loop:
+implement (verify-first: both RED-on-parent reproducers compile and fail on the
+parent before the fix) → `/simplify` → review gate (`/codex:review`, fall back to
+`/post-impl-review` for spec-compliance) → fix-loop to merge-clean → squash on
+merge. `make pre-pr` + the 3 contract tests + `make test-integration -race` on the
+final tree.
+
+**Model/effort:** Opus, high. The change is small and the spec is airtight, but it
+sits on the contract-pinned shared recovery path; rigor goes on the
+contract-regression gate and the `-race` stress test, not on the 9-line diff.
+
+---
+
+## 7. Out of scope
+
+- F-D3 option 3b (don't pre-advance the snapshot in `waitForAssignment`) — a
+  larger startup-ordering change; 3a + this follow-up close the defect without it.
+  Remains deferred (00-fix-plan §3).
+- The F-D1 flapping-tuning decision and the pull-gating fail-open decision
+  (00-fix-plan §7) — tuning/policy questions, not this code path.
+- F2 (read-only-filesystem) incident variant (00-fix-plan §6).

--- a/docs/plans/auto-healing-quorum-loss-fix/02-degraded-recovery-self-heal-implementation.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/02-degraded-recovery-self-heal-implementation.md
@@ -1,0 +1,807 @@
+# Degraded-Recovery Self-Heal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a worker that started during a sustained claim-write fault from reporting `StateStable` with zero claims written, and make it actively self-heal (no restart) once writes recover — including when a version advance lands during the Degraded window.
+
+**Architecture:** A single guard in `Manager.attemptRecoveryFromDegraded` (`manager_degraded.go`). After the existing assignment refresh, if the worker holds an assignment it never committed claims for (`!initialClaimsCommitted && len(CurrentAssignment().Partitions) > 0`), stay degraded and re-arm a bootstrap apply for the **current** (post-refresh) assignment instead of exiting. The bootstrap override already in `applyAssignmentWithPrevCore` then writes the full claim set once the write fault clears; the next recovery tick latches the flag and exits to Stable normally.
+
+**Tech Stack:** Go, NATS JetStream KV, `github.com/stretchr/testify/require`, embedded NATS via `partitest` / `internal/testutil`, the existing write-axis fault seam in `test/integration/failure/startup_writefault_test.go`.
+
+**Spec:** `docs/plans/auto-healing-quorum-loss-fix/01-degraded-recovery-self-heal-plan.md` (approach B, review-clean). Read it before starting.
+
+---
+
+## Background the engineer must know (read once)
+
+- **The latch.** `m.initialClaimsCommitted` is an `atomic.Bool` one-way latch (`manager.go`), set `true` only on a successful empty-prev → non-empty-next apply (`manager_assignment.go:1305`). A worker that ever committed claims has it `true` forever.
+- **The bootstrap override** (`manager_assignment.go:1264`): while the latch is `false`, `applyAssignmentWithPrevCore` forces `oldAssignment = Assignment{}` so the prepare diff is the FULL partition set (writes every claim). This is the mechanism a re-armed apply rides.
+- **`scheduleApplyRetry(a)`** (`manager_assignment.go:1440`): coalesces `a` into `m.stashedApplyRetry` (keeps the highest `.Version`) **synchronously** before returning, then a single goroutine applies it after a ≥0.8s backoff, re-reading `prev := m.CurrentAssignment()` at apply time.
+- **The stale gate** (`isApplyResultStale`, `manager_assignment.go:1161`): `isApplyResultStale(cur, cur) == false` — re-arming with the *current* assignment passes the gate.
+- **The defect site** (`manager_degraded.go:316-332`): `attemptRecoveryFromDegraded` refreshes (a READ via `refreshAssignmentFromNATS` → `monotonicStore`) then unconditionally `exitDegraded()`. Under a sustained claim-write fault with healthy reads, this reports Stable with no claims.
+- **Why `cur` after the refresh:** the refresh is what advances the snapshot to a version published during the outage. Reading `cur` before the refresh re-arms the stale version that the stale gate would drop — that is the entire fix for edge (b).
+- **`newTestManager(t)`** (`manager_commit_state_machine_test.go:152`) returns `(*Manager, *recordingHandoff, *recordingHeartbeat, *recordingMetrics)`; the `recordingHandoff` (`:89`) records each `Apply(ctx, workerID, prev, next)` call. Worker ID is `"worker-test"`, snapshot starts `Assignment{}`.
+
+### Rebase note — base is `main @ 2b6bc16` ("fix manager startup stable readiness gate")
+
+This plan was authored against `2e24875` and rebased onto `2b6bc16`. That commit reworked the **startup → Stable** readiness path. It does **not** touch `manager_degraded.go` (the fix site), but the engineer must keep two things straight:
+
+- **Two distinct startup latches now exist** (`manager.go:154` / `:161`):
+  - `initialClaimsCommitted` — set only on a successful **claims-committed** apply (`manager_assignment.go:1306`). **This is the latch the guard keys on.** It is false exactly when the worker holds an uncommitted non-empty assignment — the defect state.
+  - `startupAssignmentApplied` — NEW; set once the startup assignment is **applied + acked** (true even for empty-source startup, which has no claims). **Do NOT key the guard on this one** — it would be true for a worker that acked an assignment but never wrote claims, defeating the fix.
+- **Apply-pipeline success now marks startup readiness via `markStartupAssignmentApplied()`** (`manager_startup_async.go:114`, called from `applyAssignmentWithPrevCore` ~`:1360`). (The startup runner `runStartupBackground` still keeps its own idempotent direct `casToStableFromWaitingAssignment()` after the initial apply, `manager_startup_async.go:66` — so the readiness path is "pipeline marks via the helper; runner also CASes directly".) For this fix the helper is a **no-op on the heal path**: when the re-armed bootstrap apply succeeds, the worker is in `StateDegraded` (not `WaitingAssignment`), so `markStartupAssignmentApplied`'s inner WaitingAssignment-only CAS no-ops and the calculator branch (calculator-owned active states only) is skipped. The exit to Stable still happens via `exitDegraded()` on the **next recovery tick** (latch now true → guard skipped), exactly as Task 2 describes. No plan step changes.
+- **Line drift is minor** (the claims latch moved `1305→1306`); every other cited line (`:1264` override, `:1440` `scheduleApplyRetry`, `:1503` `refreshAssignmentFromNATS`, `:316` `attemptRecoveryFromDegraded`) is unchanged. Treat cited line numbers as ±2 and confirm by symbol, not by number.
+
+---
+
+## File Structure
+
+- **Modify:** `manager_degraded.go` — the 1 guard in `attemptRecoveryFromDegraded` (Task 2). ~10 lines.
+- **Create:** `manager_degraded_recovery_selfheal_test.go` — unit tests for branch selection + edge (b) determinism + negative space (Tasks 1, 3).
+- **Modify:** `test/integration/failure/resolver_readfault_test.go` — add a config-accepting variant of `rfBuildWorkerStack` so the existing builder is unchanged but a short-timeout worker can be built (Task 4).
+- **Modify:** `test/integration/failure/startup_writefault_test.go` — add the edge-(a) sustained-fault integration test + the contract-3 OnDegraded-once assertion (Task 5).
+- **Create:** `test/integration/failure/degraded_recovery_rearm_concurrency_test.go` — `-race` monitor-goroutine stress test, reusing the `wf` write-fault harness (Task 6).
+
+---
+
+## Task 1: Unit test — recovery branch selection (RED)
+
+**Files:**
+- Create: `manager_degraded_recovery_selfheal_test.go`
+
+This test pins all four branches of the new guard. It is RED on the parent because the parent has no guard: the latch-false + non-empty case will `exitDegraded` to Stable instead of staying degraded.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package parti
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/stretchr/testify/require"
+)
+
+// plantAssignment writes an assignment to the worker's KV key so a subsequent
+// refreshAssignmentFromNATS succeeds and advances the snapshot to it.
+func plantAssignment(t *testing.T, m *Manager, a Assignment) {
+	t.Helper()
+	key := fmt.Sprintf("assignment.%s", m.WorkerID())
+	b, err := json.Marshal(a)
+	require.NoError(t, err)
+	// Create-or-update: the key may already exist from a prior plant.
+	if _, err := m.assignmentKV.Create(t.Context(), key, b); err != nil {
+		_, err = m.assignmentKV.Put(t.Context(), key, b)
+		require.NoError(t, err)
+	}
+}
+
+// armDegraded puts the manager into Degraded with the given latch state and
+// in-memory snapshot, then returns it ready for attemptRecoveryFromDegraded.
+func armDegraded(t *testing.T, latched bool, snapshot Assignment) (*Manager, *recordingHandoff) {
+	t.Helper()
+	m, rh, _, _ := newTestManager(t)
+	_, nc := partitest.StartEmbeddedNATS(t)
+	m.assignmentKV = partitest.CreateJetStreamKV(t, nc, "selfheal-asgn")
+	m.assignment.Store(snapshot)
+	m.initialClaimsCommitted.Store(latched)
+	m.state.Store(int32(StateDegraded))
+	m.degradedSince.Store(time.Now().UnixNano())
+
+	return m, rh
+}
+
+func TestAttemptRecovery_UnlatchedNonEmpty_StaysDegradedAndRearms(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, false, snap)
+	// KV holds the SAME assignment, so refresh succeeds and snapshot stays V1.
+	plantAssignment(t, m, snap)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(),
+		"unlatched worker holding an uncommitted assignment must STAY degraded, not exit")
+	require.Equal(t, StateDegraded, m.State())
+	stash := m.stashedApplyRetry.Load()
+	require.NotNil(t, stash, "recovery must re-arm a bootstrap apply")
+	require.Equal(t, int64(1), stash.Version, "re-arm targets the current assignment version")
+}
+
+func TestAttemptRecovery_Latched_ExitsToStable(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, true, snap) // claims already committed
+	plantAssignment(t, m, snap)
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Zero(t, m.degradedSince.Load(), "a committed worker recovers normally")
+	require.Equal(t, StateStable, m.State())
+	require.Nil(t, m.stashedApplyRetry.Load(), "no bootstrap re-arm for a committed worker")
+}
+
+func TestAttemptRecovery_UnlatchedEmptyAssignment_ExitsToStable(t *testing.T) {
+	t.Parallel()
+	m, _ := armDegraded(t, false, Assignment{})
+	// KV holds an empty-partition assignment at V1; refresh advances to it.
+	plantAssignment(t, m, Assignment{Version: 1, LeaderRevision: 5})
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Zero(t, m.degradedSince.Load(),
+		"a worker that owns no partitions has no claims to write — exit is correct")
+	require.Equal(t, StateStable, m.State())
+	require.Nil(t, m.stashedApplyRetry.Load())
+}
+
+func TestAttemptRecovery_RefreshFails_ReturnsBeforeGuard(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, false, snap)
+	// Do NOT plant the key: refreshAssignmentFromNATS's Get fails → return
+	// before the guard, no re-arm, stays degraded (whole-bucket-loss shape).
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(), "stays degraded when the refresh read fails")
+	require.Nil(t, m.stashedApplyRetry.Load(),
+		"a failed refresh must not re-arm a bootstrap apply (guard not reached)")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail on the parent**
+
+Run: `go test ./ -run 'TestAttemptRecovery_' -count=1 -v`
+Expected: `TestAttemptRecovery_UnlatchedNonEmpty_StaysDegradedAndRearms` FAILS (parent exits to Stable → `degradedSince` is 0 and stash is nil). The other three may pass on the parent (they don't depend on the new guard) — that is fine; the discriminating RED is the unlatched-non-empty case. Confirm it fails for the right reason (Stable instead of Degraded).
+
+- [ ] **Step 3: Commit the RED test**
+
+```bash
+git add manager_degraded_recovery_selfheal_test.go
+git commit -m "test(manager): pin degraded-recovery branch selection (RED)"
+```
+
+---
+
+## Task 2: Implement the guard (GREEN)
+
+**Files:**
+- Modify: `manager_degraded.go:316-332` (`attemptRecoveryFromDegraded`)
+
+- [ ] **Step 1: Replace the body of `attemptRecoveryFromDegraded`**
+
+Replace the existing function (currently lines 316-332) with:
+
+```go
+// attemptRecoveryFromDegraded checks if recovery conditions are met and exits degraded mode.
+func (m *Manager) attemptRecoveryFromDegraded() {
+	// Check if in degraded mode
+	if m.degradedSince.Load() == 0 {
+		return
+	}
+
+	// Try to refresh assignment from NATS
+	if err := m.refreshAssignmentFromNATS(); err != nil {
+		m.logger.Warn("failed to refresh assignment during recovery", "error", err)
+		m.recordKVError(err)
+		return
+	}
+
+	// The refresh succeeded (assignment reads are healthy), so the KV-error
+	// window the read just exercised is stale. Record success on BOTH branches
+	// below — it is not branch-dependent (harmless on the stay-degraded path
+	// since recordKVError short-circuits while degraded).
+	m.recordKVSuccess()
+
+	// Startup self-heal guard (F-D3 follow-up): a worker that started during a
+	// sustained claim-write fault holds a non-empty assignment (waitForAssignment
+	// pre-advanced it) but never latched initialClaimsCommitted — no claims were
+	// ever written. exitDegraded here would report StateStable with zero claims.
+	// Instead stay degraded and re-arm a bootstrap apply for the CURRENT
+	// (post-refresh) assignment so the worker actively self-heals once writes
+	// recover. cur is read AFTER the refresh so it captures any version advance
+	// that landed during the degraded window; re-arming with the current version
+	// passes the stale gate (isApplyResultStale(cur, cur) == false) and, with the
+	// latch false, the bootstrap override writes the FULL claim set. The next
+	// recovery tick (after a successful apply latches the flag) exits normally.
+	// This guard keys on STATE, not the degraded reason — exiting with an
+	// uncommitted non-empty assignment is wrong regardless of why we degraded.
+	cur := m.CurrentAssignment()
+	if !m.initialClaimsCommitted.Load() && len(cur.Partitions) > 0 {
+		m.scheduleApplyRetry(cur)
+		return
+	}
+
+	// Success - exit degraded mode
+	m.exitDegraded()
+}
+```
+
+- [ ] **Step 2: Run the unit tests to verify GREEN**
+
+Run: `go test ./ -run 'TestAttemptRecovery_' -count=1 -v`
+Expected: all four PASS.
+
+- [ ] **Step 3: Run the existing degraded-mode unit tests for no regression**
+
+Run: `go test ./ -run 'TestManager_recordKVError|TestManager_exitDegraded|TestEnterDegraded' -count=1 -v`
+Expected: all PASS (the `recordKVSuccess()` move is behavior-preserving on the exit path).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add manager_degraded.go
+git commit -m "fix(manager): self-heal instead of reporting Stable with uncommitted claims
+
+attemptRecoveryFromDegraded refreshed the assignment (a read) and then
+unconditionally exited degraded. A worker that started during a sustained
+claim-write fault thus reached Stable owning partitions for which no claims
+were ever written. Gate the exit on the bootstrap latch: while the worker
+holds an uncommitted non-empty assignment, stay degraded and re-arm a
+bootstrap apply for the current (post-refresh) assignment so it self-heals
+once writes recover, including across a version advance during the window."
+```
+
+---
+
+## Task 3: Unit test — edge (b) version advance during the window (RED-on-parent by determinism)
+
+**Files:**
+- Modify: `manager_degraded_recovery_selfheal_test.go`
+
+This deterministically proves the `cur`-after-refresh capture: the snapshot is at V1, KV holds V2 (a version advance that landed during the Degraded window), and the re-arm must target **V2**, not the stale V1. Mirrors the codebase's existing choice to pin the version-advance path with a unit test rather than a timing-sensitive integration case (see the note at `startup_writefault_test.go:284`).
+
+- [ ] **Step 1: Add the test**
+
+```go
+func TestAttemptRecovery_VersionAdvanceDuringWindow_RearmsAtNewVersion(t *testing.T) {
+	t.Parallel()
+	// Snapshot pinned at V1 (what the worker had when it degraded).
+	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, false, v1)
+	// A version advance landed in KV during the Degraded window: V2.
+	v2 := Assignment{Version: 2, LeaderRevision: 8, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+	plantAssignment(t, m, v2)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(), "must stay degraded")
+	require.Equal(t, int64(2), m.CurrentAssignment().Version,
+		"refresh must advance the snapshot to V2 before the re-arm reads cur")
+	stash := m.stashedApplyRetry.Load()
+	require.NotNil(t, stash, "must re-arm a bootstrap apply")
+	require.Equal(t, int64(2), stash.Version,
+		"re-arm MUST target V2 (cur read AFTER refresh) — not the stale V1 the gate would drop")
+}
+```
+
+- [ ] **Step 2: Verify it passes with the fix and fails under a mutation**
+
+Run: `go test ./ -run 'TestAttemptRecovery_VersionAdvanceDuringWindow' -count=1 -v`
+Expected: PASS.
+
+Mutation check (proves non-vacuity — do NOT commit the mutation): temporarily move `cur := m.CurrentAssignment()` to *before* `m.refreshAssignmentFromNATS()` in `attemptRecoveryFromDegraded`. Re-run; expected FAIL (`stash.Version == 1`, the stale version). Revert the mutation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add manager_degraded_recovery_selfheal_test.go
+git commit -m "test(manager): pin re-arm targets the post-refresh version (edge b)"
+```
+
+---
+
+## Task 4: Add a config-accepting integration worker-stack builder
+
+**Files:**
+- Modify: `test/integration/failure/resolver_readfault_test.go:182-245` (`rfBuildWorkerStack`)
+
+The edge-(a) integration test needs a SHORT `StartupTimeout` + `ExitThreshold` (so the watchdog and degraded-recovery fire within the test) and an `OnDegraded` hook. The current builder hard-codes `StartupTimeout = 60s` and wires no hooks. Refactor so the existing builder is unchanged but a customizable variant exists.
+
+- [ ] **Step 1: Extract a config/option-accepting variant and delegate**
+
+Replace the `rfBuildWorkerStack` definition (keep everything inside identical except the two new params and where they are applied):
+
+```go
+// rfBuildWorkerStack builds a worker with the default (60s startup) config.
+func rfBuildWorkerStack(
+	t *testing.T,
+	ctx context.Context,
+	faultJS jetstream.JetStream,
+	src parti.PartitionSource,
+	index int,
+) *rfWorkerStack {
+	t.Helper()
+
+	return rfBuildWorkerStackCfg(t, ctx, faultJS, src, index, nil, nil)
+}
+
+// rfBuildWorkerStackCfg is rfBuildWorkerStack with hooks for customizing the
+// manager Config (cfgFn) and the manager Hooks (hooksFn). Either may be nil.
+func rfBuildWorkerStackCfg(
+	t *testing.T,
+	ctx context.Context,
+	faultJS jetstream.JetStream,
+	src parti.PartitionSource,
+	index int,
+	cfgFn func(*parti.Config),
+	hooksFn func(*parti.Hooks),
+) *rfWorkerStack {
+	t.Helper()
+
+	s := &rfWorkerStack{}
+
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
+		const prefix = "events."
+		if subj := msg.Subject(); len(subj) > len(prefix) {
+			s.consumed.Add(1)
+		}
+
+		return msg.Ack()
+	})
+
+	dyn, err := consumer.NewDynamic(
+		faultJS,
+		rfStreamName,
+		fmt.Sprintf("w%d", index),
+		rfSubjectTmpl,
+		handler,
+		consumer.WithPullGating(true),
+		consumer.WithProcessingGate(&consumer.ProcessingGateConfig{
+			Enabled:  true,
+			NakDelay: 50 * time.Millisecond,
+			AllowedStates: []types.HandoffState{
+				types.HandoffStateStable,
+				types.HandoffStateCommit,
+			},
+		}),
+		consumer.WithResolver(consumer.ResolverConfig{
+			HandoffBucketName:   rfHandoffBucket,
+			HandoffClaimsPrefix: rfClaimsPrefix,
+			ReconcileInterval:   1 * time.Second,
+		}),
+	)
+	require.NoError(t, err)
+	s.dyn = dyn
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cfg := parti.TestConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.KVBuckets.HandoffBucket = rfHandoffBucket
+	cfg.WorkerIDMax = 8
+	cfg.StartupTimeout = 60 * time.Second
+	if cfgFn != nil {
+		cfgFn(&cfg)
+	}
+
+	opts := []parti.Option{parti.WithWorkerConsumerUpdater(dyn)}
+	if hooksFn != nil {
+		var h parti.Hooks
+		hooksFn(&h)
+		opts = append(opts, parti.WithHooks(&h)) // WithHooks takes *Hooks
+	}
+
+	mgr, err := parti.NewManager(&cfg, faultJS, src, strategy.NewConsistentHash(), opts...)
+	require.NoError(t, err)
+	s.mgr = mgr
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	require.NoError(t, mgr.Start(ctx))
+
+	return s
+}
+```
+
+- [ ] **Step 2: Verify the option API names (confirmed against source `2b6bc16`)**
+
+Run: `grep -n "type Option\|func WithHooks\|func NewManager" /home/arlo/projects/parti/options.go /home/arlo/projects/parti/manager.go`
+Expected: `type Option func(*managerOptions)` (`options.go:6`), `func WithHooks(hooks *Hooks) Option` (`options.go:57`), `func NewManager(..., opts ...Option)` (`manager.go:333`). The block above already uses `[]parti.Option` and `WithHooks(&h)` (pointer). If any name differs from this, match what grep returns — do NOT invent an API.
+
+- [ ] **Step 3: Verify the refactor compiles and existing tests still pass**
+
+Run: `go test ./test/integration/failure/ -run 'TestResolverReadFault_ConsumerSurvivesQuorumLossWindow|TestStartupWriteFault_SelfHealsWithoutRestart' -count=1`
+Expected: PASS (behavior unchanged — the default builder delegates with nil hooks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/integration/failure/resolver_readfault_test.go
+git commit -m "test(failure): add config/hooks-accepting worker-stack builder"
+```
+
+---
+
+## Task 5: Integration test — edge (a) sustained fault → Degraded → no false-Stable + contract 3
+
+**Files:**
+- Modify: `test/integration/failure/startup_writefault_test.go`
+
+Drives the worker into the unlatched-Degraded state under a sustained claim-write fault, holds it past several `ExitThreshold`-spaced recovery ticks, and asserts it does NOT report Stable while the latch is false. RED on parent: the parent exits to Stable via refresh-only recovery. Also asserts contract 3 (OnDegraded fires exactly once across the held window).
+
+> **⚠️ IMPLEMENTATION CORRECTION (verified empirically during impl, commit `80020a8`).**
+> The original premise below — "hold the claim-write fault past `StartupTimeout`, the
+> **startup-timeout watchdog** enters Degraded" — is FALSE for the single-worker leader
+> this test builds. `startStartupTimeoutWatchdog` only fires while state is still
+> `WaitingAssignment` (`manager_startup_async.go:180`, `if m.State() != StateWaitingAssignment { return }`),
+> but a single-worker leader's calculator drives state out of `WaitingAssignment` to
+> Scaling/Rebalancing within ~1s (`ColdStartWindow`), so the watchdog always misses.
+> The shipped test instead drives Degraded via a **dual write fault**: claims/* on the
+> handoff bucket (keeps `initialClaimsCommitted` false) PLUS all writes on the heartbeat
+> bucket, armed *after* `Start()` so the initial publish succeeds. Heartbeat-write errors
+> route through the heartbeat publisher's `recordKVOpError` → KV-error-threshold circuit →
+> `enterDegraded("kv-unavailable")`, which fires from any state. Config knobs:
+> `KVErrorThreshold = 3`, `ExitThreshold = 1s`. The harness gained `ArmHeartbeat()`,
+> `newWFFaultJetStreamDual`, and a `heartbeatMode` flag on `wfFaultKeyValue` (backward
+> compatible — the existing `TestStartupWriteFault_SelfHealsWithoutRestart` still passes).
+> **This change STRENGTHENS the design evidence:** it proves the guard fires for the
+> `kv-unavailable` Degraded reason, not just startup-timeout — exactly the
+> state-not-reason scoping argued in spec `01-...-plan.md` §2/§3.2. The RED-on-parent /
+> GREEN-with-fix / contract-3 assertions are unchanged in intent; only the Degraded-entry
+> seam changed. The code block below is the ORIGINAL (watchdog-premise) draft, retained as
+> the historical record — the committed test is the source of truth.
+
+- [ ] **Step 1: Add the test**
+
+```go
+// TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted pins the
+// F-D3 follow-up: under a sustained claim-write fault held PAST
+// StartupTimeout+ExitThreshold, the startup-timeout watchdog enters Degraded and
+// degraded-recovery runs. On the parent, recovery refreshes (a read) and exits to
+// Stable with zero claims written (RED). With the fix the worker STAYS degraded
+// (latch false, non-empty assignment) and self-heals once writes recover — no
+// restart. Also asserts OnDegraded fires exactly once across the held window
+// (cross-feature contract 3).
+func TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+	faultJS := newWFFaultJetStream(realJS, rfHandoffBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	pids := []string{"p0", "p1"}
+	src := newWFMutableSource([]types.Partition{{Keys: []string{pids[0]}}, {Keys: []string{pids[1]}}})
+
+	allStable := func() bool {
+		for _, pid := range pids {
+			if _, _, stable := rfReadClaimRevision(t, ctx, realJS, pid); !stable {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	var degradedCalls atomic.Int64
+
+	// Arm the write fault BEFORE start so the initial apply faults; short
+	// StartupTimeout + ExitThreshold so the watchdog fires and recovery runs
+	// well within the fault window.
+	fc.ArmWrites()
+	stack := rfBuildWorkerStackCfg(t, ctx, faultJS, src, 0,
+		func(cfg *parti.Config) {
+			cfg.StartupTimeout = 3 * time.Second
+			cfg.DegradedBehavior.ExitThreshold = 1 * time.Second
+		},
+		func(h *parti.Hooks) {
+			h.OnDegraded = func(_ context.Context, _ string) error {
+				degradedCalls.Add(1)
+				return nil
+			}
+		},
+	)
+
+	// The watchdog must drive the worker to Degraded under the held fault.
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 30*time.Second),
+		"startup-timeout watchdog must enter Degraded under a sustained claim-write fault")
+
+	// Hold the fault well past several ExitThreshold-spaced recovery ticks. On
+	// the parent, recovery exits to Stable here (RED). With the fix the worker
+	// stays Degraded because the latch is false and the assignment is non-empty.
+	require.Never(t, func() bool { return stack.mgr.State() == parti.StateStable },
+		8*time.Second, 250*time.Millisecond,
+		"a worker with an uncommitted non-empty assignment must NOT report Stable")
+	require.False(t, allStable(), "no claim may be Stable while writes are faulted")
+
+	// --- Disarm: KV writes recover. NO restart. ---
+	fc.DisarmWrites()
+
+	require.Eventually(t, allStable, 40*time.Second, 100*time.Millisecond,
+		"after write recovery the re-armed bootstrap apply must write the FULL claim set")
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 20*time.Second),
+		"worker must reach Stable once claims are actually committed")
+
+	// Contract 3: OnDegraded fired exactly once across the whole held window,
+	// despite many recovery ticks (stay-degraded never re-enters).
+	require.Equal(t, int64(1), degradedCalls.Load(),
+		"OnDegraded must fire exactly once per Degraded entry (contract 3)")
+
+	t.Logf("[%s] held Degraded under fault, self-healed to Stable after write recovery (no restart)", t.Name())
+}
+```
+
+- [ ] **Step 2: Confirm the imports include `sync/atomic`**
+
+Run: `grep -n '"sync/atomic"' /home/arlo/projects/parti/test/integration/failure/startup_writefault_test.go`
+Expected: present. If absent, add it to the import block.
+
+- [ ] **Step 3: Verify RED on the parent**
+
+Stash the Task-2 fix and run the new test against the parent:
+
+```bash
+git stash push -- manager_degraded.go
+go test ./test/integration/failure/ -run 'TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted' -count=1 -v
+git stash pop
+```
+Expected on parent: FAIL at the `require.Never(... StateStable ...)` assertion (parent exits to Stable via refresh-only recovery). After `git stash pop`, the fix is restored.
+
+- [ ] **Step 4: Verify GREEN with the fix**
+
+Run: `go test ./test/integration/failure/ -run 'TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted' -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/integration/failure/startup_writefault_test.go
+git commit -m "test(failure): degraded-recovery must not report Stable with uncommitted claims"
+```
+
+---
+
+## Task 6: Concurrency `-race` stress test for the recovery re-arm
+
+**Files:**
+- Create: `test/integration/failure/degraded_recovery_rearm_concurrency_test.go`
+
+`attemptRecoveryFromDegraded` runs on the connection-monitor goroutine; this fix adds an apply-issuing side effect (`scheduleApplyRetry`) to it. Per AGENTS.md "Concurrency stress tests for monitor goroutines", exercise the **real** recovery goroutine (driven by an armed write fault, NOT a test hook) concurrently with assignment-version churn on the same handoff bucket, and assert no race-detector trips. This reuses the `wf` write-fault harness in the same `failure_test` package (Tasks 4-5) rather than the `manager_test` `WorkerCluster` template — the `wf` harness gives a real worker stuck in unlatched-Degraded under a held fault, which is exactly the state whose recovery re-arm we must stress, and stays in one package so no cross-package exported test hooks are needed.
+
+Design rationale (why NOT the `manager_test` template): driving the state via exported `…ForTest` accessors would require them to live in `package parti`, which is invisible to an external `manager_test` test binary. Using the real fault path keeps the test honest (the actual connection-monitor goroutine calls recovery) and needs zero production-surface test hooks.
+
+- [ ] **Step 1: Write the stress test**
+
+```go
+package failure_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDegradedRecovery_Rearm_NoRace stresses the degraded-recovery re-arm side
+// effect (scheduleApplyRetry issued from the connection-monitor goroutine) added
+// by the F-D3 follow-up, concurrently with assignment-version churn on the same
+// handoff bucket. The worker is held in the real unlatched-Degraded state by a
+// sustained claim-write fault (short StartupTimeout/ExitThreshold so the watchdog
+// fires and recovery ticks run hot), while the source drives version advances
+// that the recovery path re-arms against. Only a live worker under -race can find
+// races between the real monitor goroutine and the production apply paths that
+// share nats.go cached *stream state.
+func TestDegradedRecovery_Rearm_NoRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+	faultJS := newWFFaultJetStream(realJS, rfHandoffBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	src := newWFMutableSource([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}})
+
+	// Hold the write fault for the whole run: the worker can never latch, so
+	// every recovery tick takes the re-arm path under the race detector.
+	fc.ArmWrites()
+	stack := rfBuildWorkerStackCfg(t, ctx, faultJS, src, 0,
+		func(cfg *parti.Config) {
+			cfg.StartupTimeout = 2 * time.Second
+			cfg.DegradedBehavior.ExitThreshold = 200 * time.Millisecond
+		},
+		nil,
+	)
+
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 30*time.Second),
+		"watchdog must drive the worker to Degraded so recovery ticks run")
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Driver: churn the source's partition set so the assignment version
+	// advances repeatedly during the held fault. Each advance is what the
+	// recovery re-arm reads as `cur` after the refresh — this races the
+	// monitor goroutine's scheduleApplyRetry against the watcher/apply paths.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		toggle := true
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if toggle {
+					src.set([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}, {Keys: []string{"p2"}}})
+				} else {
+					src.set([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}})
+				}
+				toggle = !toggle
+				time.Sleep(20 * time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+	close(stop)
+	wg.Wait()
+	fc.DisarmWrites()
+
+	// Pass condition: the run completes with no `WARNING: DATA RACE`. The race
+	// detector marks the test failed at detection time; t.Failed() is the
+	// in-body signal. No functional assertion is needed — the per-claim CAS
+	// already arbitrates concurrent writers; this test only guards the new
+	// monitor-goroutine side effect against data races.
+	require.False(t, t.Failed(), "race detector tripped during the recovery re-arm stress run")
+}
+```
+
+- [ ] **Step 2: Add a `set` mutator to `wfMutableSource`**
+
+The stress test churns the source's partition set. `wfMutableSource` (defined in `startup_writefault_test.go:24`) currently has no mutator. Add one next to its constructor:
+
+```go
+// set replaces the source's partition set and signals the watcher so the
+// manager re-lists and advances the assignment version.
+func (s *wfMutableSource) set(parts []types.Partition) {
+	s.mu.Lock()
+	s.parts = append([]types.Partition(nil), parts...)
+	s.mu.Unlock()
+	select {
+	case s.ch <- struct{}{}:
+	default:
+	}
+}
+```
+
+- [ ] **Step 3: Run under the race detector**
+
+Run: `go test ./test/integration/failure/ -run 'TestDegradedRecovery_Rearm_NoRace' -race -count=1 -v`
+Expected: PASS, no `WARNING: DATA RACE`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/integration/failure/degraded_recovery_rearm_concurrency_test.go test/integration/failure/startup_writefault_test.go
+git commit -m "test(failure): -race stress the degraded-recovery re-arm side effect"
+```
+
+---
+
+## Task 7: Full gate — cross-feature contracts + pre-pr
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Run the 3 cross-feature contract regression tests**
+
+Run:
+```bash
+go test ./test/integration/manager/ -run 'TestManager_LiveNATSBucketLoss|TestManager_LiveNATSBucketLoss_OnDegradedHook' -race -count=1 -v
+go test ./test/integration/stableid/ -run 'TestStableID_StaleKeyTakeover_Reclaim' -race -count=1 -v
+```
+Expected: all PASS. These pin contracts 1, 3, and 2 respectively. If any fails, STOP — the guard regressed a shared-recovery contract; do not proceed.
+
+- [ ] **Step 2: Run the full pre-PR gate**
+
+Run: `make pre-pr`
+Expected: lint clean, `make test` (`-race`) green, `make test-integration` (`-race`) green.
+
+Known load-flakes (NOT regressions — see project memory): `TestLeaderElection_ColdStart` and `TestHandoffConflictStress` may flake under full-suite CPU load; re-run in isolation to confirm (`go test ./test/integration/manager/ -run 'TestLeaderElection_ColdStart' -count=3 -race`). If `make test` globs the gitignored `tmp/` scratch modules, move them aside for the run.
+
+- [ ] **Step 3: Commit any lint fixes**
+
+If lint required changes:
+```bash
+git add -A
+git commit -m "chore: lint fixes for degraded-recovery self-heal"
+```
+
+---
+
+## Task 8: Review loop → merge
+
+- [ ] **Step 1: Simplify pass**
+
+Invoke `/simplify` on the diff (quality-only cleanup; the change is small, expect little).
+
+- [ ] **Step 2: External review gate**
+
+Invoke `/codex:review` (fall back to `/post-impl-review` against the spec `01-degraded-recovery-self-heal-plan.md` for spec-compliance). Per `feedback_external_reviewer_no_revalidation`: the reviewer must NOT re-run `make test-integration`; pass it the tails of the gate output from Task 7.
+
+- [ ] **Step 3: Fix-loop to merge-clean**
+
+Address findings; re-review until the verdict is merge / no P0-P1. Apply the `feedback_global_grep_stale_text_in_review_loops` discipline if a finding is about stale text.
+
+- [ ] **Step 4: Squash and open the PR**
+
+```bash
+git rebase -i main   # squash the task commits into one
+```
+PR title: `fix(manager): self-heal instead of reporting Stable with uncommitted claims`. Body summarizes the defect (degraded-recovery reported Stable with zero claims; version-advance left a restart-only tail), the guard, and the contract-safety argument. No plan/PR-jargon in the commit message (per `feedback_no_plan_jargon_in_commits`). Update the parent plan `00-fix-plan.md` §3 deferred-follow-up note and `01-...-plan.md` status to "implemented" in the same PR or a docs follow-up.
+
+---
+
+## Deferred follow-up surfaced by the final review (NOT fixed here — out of scope)
+
+The final post-implementation code review (codex, xhigh) surfaced a **pre-existing,
+out-of-scope P1** that this PR does not fix and does not regress:
+
+**The same Stable-with-uncommitted-claims defect also exists for an *already-latched*
+worker on a failed version-advance apply.** Scenario: a worker has committed V1 claims
+(`initialClaimsCommitted == true`), then a V2 apply fails before its Store. During Degraded
+recovery, `refreshAssignmentFromNATS` monotonic-stores V2 into the snapshot; because the
+latch is already true, this PR's guard is skipped and recovery `exitDegraded`s to Stable —
+while V2's newly-assigned claim is unwritten. The pending retry reads
+`prev = CurrentAssignment() == V2 == next`, so the two-phase prepare diff
+(`internal/assignment/handoff/twophase.go:216–230`) is empty and writes no claim.
+
+**Why it's out of scope here and not a regression:**
+- This PR's stated scope (spec `01-...-plan.md` §1/§2, invariant 4) is the **unlatched
+  bootstrap** worker only; it explicitly commits to leaving committed-worker recovery
+  "exactly as today." The latched path in `attemptRecoveryFromDegraded` is **byte-for-byte
+  equivalent to `main`** (the guard adds only a side-effect-free read + boolean test before
+  the same `exitDegraded`), so this PR cannot have regressed it.
+- The edge-(b) repair (post-refresh `cur` + re-arm) only engages because the bootstrap
+  override forces empty-prev *when `!latched`*. Once latched, that override never fires, so
+  the retry genuinely empty-diffs — this is a **new sibling** of the §3 deferred item, framed
+  around the latched worker, NOT something the existing §3 text covers ("immune" there meant
+  "the guard won't touch them," not "they can't exhibit the defect for a new version").
+- **This PR slightly increases the latched bug's reachability** (it makes unlatched workers
+  self-heal and *reach* the latched state more often), so the follow-up deserves higher
+  priority than "latent edge" — but it creates no new code path to the bug.
+
+**Clean fix (its own PR):** track claim commitment **per assignment version** (not a one-way
+"ever committed" latch); the recovery guard stays Degraded + re-arms whenever the current
+assignment is non-empty AND its claims are not confirmed committed, regardless of prior
+commits. This touches the shared recovery path + the latch/override semantics (contracts 1/3)
+and warrants its own contract-regression pass — exactly why it is deferred, not bundled.
+Do NOT add a latched-case regression test to THIS PR (it would be red or need a skip).
+
+## Notes for the engineer
+
+- **Verify-first is mandatory** (`feedback_verify_first_with_reproducer`): Task 1's unlatched-non-empty case and Task 5 must be confirmed RED on the parent before the fix (Tasks 1 Step 2, Task 5 Step 3). Task 3's edge-(b) determinism is proven by the mutation check (Task 3 Step 2).
+- **Do not narrow the guard to a degraded-reason check.** The spec §2/§3.2 explains why the state guard (`!latch && non-empty`) is the correct predicate and reason-gating reintroduces the bug for NATS-down/kv-unavailable startup variants. A reviewer may suggest it; push back with the spec rationale.
+- **API-name caution (Task 4 Step 2):** the option API is `parti.Option` + `parti.WithHooks(&h)` (pointer), confirmed against `options.go:6`/`:57` on base `2b6bc16`. If a future rebase changes these, match what grep returns — never invent an API.
+- **Integration timing:** Task 5 uses `StartupTimeout=3s`, `ExitThreshold=1s` so the watchdog + several recovery ticks land inside the held window; `require.Never(... 8s ...)` spans many ticks. If the embedded-NATS box is slow, the disarm-then-heal `Eventually` bounds (40s) have ample headroom.

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -326,8 +326,29 @@ func (m *Manager) attemptRecoveryFromDegraded() {
 		return
 	}
 
-	// Success - exit degraded mode
+	// The refresh succeeded (assignment reads are healthy), so the KV-error
+	// window the read just exercised is stale. Record success on BOTH branches
+	// below — it is not branch-dependent (harmless on the stay-degraded path
+	// since recordKVError short-circuits while degraded).
 	m.recordKVSuccess()
+
+	// Startup self-heal guard (F-D3 follow-up): a worker that started during a
+	// sustained claim-write fault holds a non-empty assignment but never latched
+	// initialClaimsCommitted — no claims were ever written. exitDegraded here
+	// would report StateStable with zero claims. Instead stay degraded and re-arm
+	// a bootstrap apply so the worker actively self-heals once writes recover. cur
+	// is read AFTER the refresh so the re-arm targets the current version (the
+	// refresh may have advanced it during the degraded window). The guard keys on
+	// STATE, not the degraded reason — exiting with an uncommitted non-empty
+	// assignment is wrong regardless of why we degraded. See
+	// docs/plans/auto-healing-quorum-loss-fix/01-degraded-recovery-self-heal-plan.md.
+	cur := m.CurrentAssignment()
+	if !m.initialClaimsCommitted.Load() && len(cur.Partitions) > 0 {
+		m.scheduleApplyRetry(cur)
+		return
+	}
+
+	// Success - exit degraded mode
 	m.exitDegraded()
 }
 

--- a/manager_degraded_recovery_selfheal_test.go
+++ b/manager_degraded_recovery_selfheal_test.go
@@ -1,0 +1,120 @@
+package parti
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/stretchr/testify/require"
+)
+
+// plantAssignment writes an assignment to the worker's KV key so a subsequent
+// refreshAssignmentFromNATS succeeds and advances the snapshot to it.
+func plantAssignment(t *testing.T, m *Manager, a Assignment) {
+	t.Helper()
+	key := fmt.Sprintf("assignment.%s", m.WorkerID())
+	b, err := json.Marshal(a)
+	require.NoError(t, err)
+	// Create-or-update: the key may already exist from a prior plant.
+	if _, err := m.assignmentKV.Create(t.Context(), key, b); err != nil {
+		_, err = m.assignmentKV.Put(t.Context(), key, b)
+		require.NoError(t, err)
+	}
+}
+
+// armDegraded puts the manager into Degraded with the given latch state and
+// in-memory snapshot, then returns it ready for attemptRecoveryFromDegraded.
+func armDegraded(t *testing.T, latched bool, snapshot Assignment) (*Manager, *recordingHandoff) {
+	t.Helper()
+	m, rh, _, _ := newTestManager(t)
+	_, nc := partitest.StartEmbeddedNATS(t)
+	m.assignmentKV = partitest.CreateJetStreamKV(t, nc, "selfheal-asgn")
+	m.assignment.Store(snapshot)
+	m.initialClaimsCommitted.Store(latched)
+	m.state.Store(int32(StateDegraded))
+	m.degradedSince.Store(time.Now().UnixNano())
+
+	return m, rh
+}
+
+func TestAttemptRecovery_UnlatchedNonEmpty_StaysDegradedAndRearms(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, false, snap)
+	// KV holds the SAME assignment, so refresh succeeds and snapshot stays V1.
+	plantAssignment(t, m, snap)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(),
+		"unlatched worker holding an uncommitted assignment must STAY degraded, not exit")
+	require.Equal(t, StateDegraded, m.State())
+	stash := m.stashedApplyRetry.Load()
+	require.NotNil(t, stash, "recovery must re-arm a bootstrap apply")
+	require.Equal(t, int64(1), stash.Version, "re-arm targets the current assignment version")
+}
+
+func TestAttemptRecovery_Latched_ExitsToStable(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, true, snap) // claims already committed
+	plantAssignment(t, m, snap)
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Zero(t, m.degradedSince.Load(), "a committed worker recovers normally")
+	require.Equal(t, StateStable, m.State())
+	require.Nil(t, m.stashedApplyRetry.Load(), "no bootstrap re-arm for a committed worker")
+}
+
+func TestAttemptRecovery_UnlatchedEmptyAssignment_ExitsToStable(t *testing.T) {
+	t.Parallel()
+	m, _ := armDegraded(t, false, Assignment{})
+	// KV holds an empty-partition assignment at V1; refresh advances to it.
+	plantAssignment(t, m, Assignment{Version: 1, LeaderRevision: 5})
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Zero(t, m.degradedSince.Load(),
+		"a worker that owns no partitions has no claims to write — exit is correct")
+	require.Equal(t, StateStable, m.State())
+	require.Nil(t, m.stashedApplyRetry.Load())
+}
+
+func TestAttemptRecovery_RefreshFails_ReturnsBeforeGuard(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, false, snap)
+	// Do NOT plant the key: refreshAssignmentFromNATS's Get fails → return
+	// before the guard, no re-arm, stays degraded (whole-bucket-loss shape).
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(), "stays degraded when the refresh read fails")
+	require.Nil(t, m.stashedApplyRetry.Load(),
+		"a failed refresh must not re-arm a bootstrap apply (guard not reached)")
+}
+
+func TestAttemptRecovery_VersionAdvanceDuringWindow_RearmsAtNewVersion(t *testing.T) {
+	t.Parallel()
+	// Snapshot pinned at V1 (what the worker had when it degraded).
+	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, false, v1)
+	// A version advance landed in KV during the Degraded window: V2.
+	v2 := Assignment{Version: 2, LeaderRevision: 8, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+	plantAssignment(t, m, v2)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(), "must stay degraded")
+	require.Equal(t, int64(2), m.CurrentAssignment().Version,
+		"refresh must advance the snapshot to V2 before the re-arm reads cur")
+	stash := m.stashedApplyRetry.Load()
+	require.NotNil(t, stash, "must re-arm a bootstrap apply")
+	require.Equal(t, int64(2), stash.Version,
+		"re-arm MUST target V2 (cur read AFTER refresh) — not the stale V1 the gate would drop")
+}

--- a/test/integration/failure/degraded_recovery_rearm_concurrency_test.go
+++ b/test/integration/failure/degraded_recovery_rearm_concurrency_test.go
@@ -1,0 +1,100 @@
+package failure_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDegradedRecovery_Rearm_NoRace stresses the degraded-recovery re-arm side
+// effect (scheduleApplyRetry issued from the connection-monitor goroutine) added
+// by the F-D3 follow-up, concurrently with assignment-version churn. The worker
+// is held in the real unlatched-Degraded state by a DUAL write fault: claims/*
+// on the handoff bucket (keeps initialClaimsCommitted false) plus all writes on
+// the heartbeat bucket (drives Degraded via the KV-error threshold circuit, which
+// fires from any state — the startup-timeout watchdog does not, because a
+// single-worker leader's calculator leaves WaitingAssignment within ~1s). While
+// degraded, the source churns its partition set so the assignment version
+// advances repeatedly; each recovery tick re-arms scheduleApplyRetry against the
+// then-current version, racing the monitor goroutine against the watcher/apply
+// paths that share nats.go cached *stream state. Only a live worker under -race
+// can find such races. Pass condition: the run completes with no DATA RACE.
+func TestDegradedRecovery_Rearm_NoRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+	faultJS := newWFFaultJetStreamDual(realJS, rfHandoffBucket, rfHeartbeatBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	src := newWFMutableSource([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}})
+
+	// Claim-write fault armed before Start so the worker can never latch; the
+	// heartbeat fault is armed after Start so the initial heartbeat succeeds and
+	// the background publisher's periodic puts then drive the KV-error circuit.
+	fc.ArmWrites()
+	stack := rfBuildWorkerStackCfg(t, ctx, faultJS, src, 0,
+		func(cfg *parti.Config) {
+			cfg.DegradedBehavior.KVErrorThreshold = 3
+			cfg.DegradedBehavior.ExitThreshold = 200 * time.Millisecond
+		},
+		nil,
+	)
+	fc.ArmHeartbeat()
+
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 30*time.Second),
+		"KV-error circuit must drive the worker to Degraded so recovery ticks run")
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Driver: churn the source's partition set so the assignment version advances
+	// repeatedly during the held fault. Each advance is what the recovery re-arm
+	// reads as cur after the refresh — racing scheduleApplyRetry (monitor
+	// goroutine) against the watcher/apply paths.
+	wg.Go(func() {
+		toggle := true
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if toggle {
+					src.set([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}, {Keys: []string{"p2"}}})
+				} else {
+					src.set([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}})
+				}
+				toggle = !toggle
+				time.Sleep(20 * time.Millisecond)
+			}
+		}
+	})
+
+	time.Sleep(5 * time.Second)
+	close(stop)
+	wg.Wait()
+	fc.DisarmWrites()
+
+	// Pass condition: the run completes with no DATA RACE. The race detector marks
+	// the test failed at detection time; t.Failed() is the in-body signal. No
+	// functional assertion is needed — the per-claim CAS arbitrates concurrent
+	// writers; this test only guards the new monitor-goroutine side effect.
+	require.False(t, t.Failed(), "race detector tripped during the recovery re-arm stress run")
+}

--- a/test/integration/failure/resolver_readfault_test.go
+++ b/test/integration/failure/resolver_readfault_test.go
@@ -175,16 +175,34 @@ func rfBuildStream(t *testing.T, ctx context.Context, realJS jetstream.JetStream
 	require.NoError(t, err)
 }
 
-// rfBuildWorkerStack constructs one worker: a consumer.Dynamic (pull-gating +
-// processing gate + auto-created claim resolver reading the WRAPPED handoff KV)
-// wired into a Manager via WithWorkerConsumerUpdater. The manager runs two-phase
-// handoff. faultJS is handed to BOTH NewDynamic and NewManager.
+// rfBuildWorkerStack builds a worker with the default (60s startup) config and
+// no manager hooks. See rfBuildWorkerStackCfg for the construction details.
 func rfBuildWorkerStack(
 	t *testing.T,
 	ctx context.Context,
 	faultJS jetstream.JetStream,
 	src parti.PartitionSource,
 	index int,
+) *rfWorkerStack {
+	t.Helper()
+
+	return rfBuildWorkerStackCfg(t, ctx, faultJS, src, index, nil, nil)
+}
+
+// rfBuildWorkerStackCfg constructs one worker: a consumer.Dynamic (pull-gating +
+// processing gate + auto-created claim resolver reading the WRAPPED handoff KV)
+// wired into a Manager via WithWorkerConsumerUpdater. The manager runs two-phase
+// handoff. faultJS is handed to BOTH NewDynamic and NewManager. cfgFn customizes
+// the manager Config (applied after the defaults) and hooksFn customizes the
+// manager Hooks; either may be nil.
+func rfBuildWorkerStackCfg(
+	t *testing.T,
+	ctx context.Context,
+	faultJS jetstream.JetStream,
+	src parti.PartitionSource,
+	index int,
+	cfgFn func(*parti.Config),
+	hooksFn func(*parti.Hooks),
 ) *rfWorkerStack {
 	t.Helper()
 
@@ -231,10 +249,18 @@ func rfBuildWorkerStack(
 	cfg.KVBuckets.HandoffBucket = rfHandoffBucket
 	cfg.WorkerIDMax = 8
 	cfg.StartupTimeout = 60 * time.Second
+	if cfgFn != nil {
+		cfgFn(&cfg)
+	}
 
-	mgr, err := parti.NewManager(&cfg, faultJS, src, strategy.NewConsistentHash(),
-		parti.WithWorkerConsumerUpdater(dyn),
-	)
+	opts := []parti.Option{parti.WithWorkerConsumerUpdater(dyn)}
+	if hooksFn != nil {
+		var h parti.Hooks
+		hooksFn(&h)
+		opts = append(opts, parti.WithHooks(&h)) // WithHooks takes *Hooks
+	}
+
+	mgr, err := parti.NewManager(&cfg, faultJS, src, strategy.NewConsistentHash(), opts...)
 	require.NoError(t, err)
 	s.mgr = mgr
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })

--- a/test/integration/failure/startup_writefault_test.go
+++ b/test/integration/failure/startup_writefault_test.go
@@ -34,6 +34,18 @@ func newWFMutableSource(parts []types.Partition) *wfMutableSource {
 	}
 }
 
+// set replaces the source's partition set and signals the watcher so the
+// manager re-lists and advances the assignment version.
+func (s *wfMutableSource) set(parts []types.Partition) {
+	s.mu.Lock()
+	s.parts = append([]types.Partition(nil), parts...)
+	s.mu.Unlock()
+	select {
+	case s.ch <- struct{}{}:
+	default:
+	}
+}
+
 func (s *wfMutableSource) Start(_ context.Context) error { return nil }
 func (s *wfMutableSource) Stop(_ context.Context) error  { return nil }
 
@@ -66,6 +78,12 @@ type wfFaultController struct {
 	// against a claim key faults with context.DeadlineExceeded.
 	writeArmed atomic.Bool
 
+	// heartbeatArmed is a separate WRITE-axis toggle for the heartbeat bucket's
+	// all-key fault (used in the dual-fault harness). Armed independently so
+	// the heartbeat initial publish at manager Start() can succeed before the
+	// KV-error circuit fault begins.
+	heartbeatArmed atomic.Bool
+
 	// writeFaultsInjected counts how many claim-key writes actually returned
 	// the injected error. Lets the test assert the fault genuinely fired
 	// (non-vacuous) before disarming.
@@ -78,8 +96,15 @@ func (fc *wfFaultController) ArmWrites() {
 	fc.writeArmed.Store(true)
 }
 
-// DisarmWrites disables the write fault (simulates KV write recovery).
-func (fc *wfFaultController) DisarmWrites() { fc.writeArmed.Store(false) }
+// ArmHeartbeat enables the heartbeat-bucket all-writes fault.
+// Called AFTER manager.Start() so the initial heartbeat publish succeeds.
+func (fc *wfFaultController) ArmHeartbeat() { fc.heartbeatArmed.Store(true) }
+
+// DisarmWrites disables both the claim-write and heartbeat-write faults.
+func (fc *wfFaultController) DisarmWrites() {
+	fc.writeArmed.Store(false)
+	fc.heartbeatArmed.Store(false)
+}
 
 // shouldFaultWrite reports whether a claim-key write should fault and counts it.
 func (fc *wfFaultController) shouldFaultWrite() bool {
@@ -91,22 +116,43 @@ func (fc *wfFaultController) shouldFaultWrite() bool {
 	return true
 }
 
+// shouldFaultHeartbeat reports whether a heartbeat-bucket write should fault.
+func (fc *wfFaultController) shouldFaultHeartbeat() bool {
+	return fc.heartbeatArmed.Load()
+}
+
 // wfFaultJetStream wraps a real jetstream.JetStream. Only the handoff-bucket KV
 // handle is wrapped; every other bucket and method passes through.
 type wfFaultJetStream struct {
 	jetstream.JetStream // embedded: all non-overridden methods pass through
 
-	handoffBucket string
-	fc            *wfFaultController
+	handoffBucket   string
+	heartbeatBucket string // optional: if non-empty, all writes on this bucket are faulted
+	fc              *wfFaultController
 }
 
 func newWFFaultJetStream(inner jetstream.JetStream, handoffBucket string, fc *wfFaultController) *wfFaultJetStream {
 	return &wfFaultJetStream{JetStream: inner, handoffBucket: handoffBucket, fc: fc}
 }
 
+// newWFFaultJetStreamDual wraps BOTH the handoff bucket (claims-key writes only)
+// AND the heartbeat bucket (all writes). The dual fault drives the KV-error
+// threshold circuit even when the worker's calculator has moved state out of
+// WaitingAssignment, enabling reliable Degraded entry without the startup watchdog.
+func newWFFaultJetStreamDual(inner jetstream.JetStream, handoffBucket, heartbeatBucket string, fc *wfFaultController) *wfFaultJetStream {
+	return &wfFaultJetStream{JetStream: inner, handoffBucket: handoffBucket, heartbeatBucket: heartbeatBucket, fc: fc}
+}
+
 func (f *wfFaultJetStream) wrap(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
 	if bucket == f.handoffBucket {
 		return &wfFaultKeyValue{KeyValue: kv, fc: f.fc, claimsPrefix: rfClaimsPrefix}
+	}
+	if f.heartbeatBucket != "" && bucket == f.heartbeatBucket {
+		// Fault ALL writes on the heartbeat bucket using the separate heartbeatArmed
+		// toggle so the initial heartbeat publish at Start() can succeed before
+		// ArmHeartbeat() is called. Every faulted error routes through the
+		// heartbeat publisher's recordKVOpError → KV-error threshold circuit.
+		return &wfFaultKeyValue{KeyValue: kv, fc: f.fc, heartbeatMode: true}
 	}
 
 	return kv
@@ -142,18 +188,32 @@ func (f *wfFaultJetStream) CreateOrUpdateKeyValue(ctx context.Context, cfg jetst
 // wfFaultKeyValue wraps the real handoff KeyValue and faults ONLY claim-key
 // writes (Create / Update / Put of a claimsPrefix key) when the WRITE axis is
 // armed. Reads pass through so the resolver can still list/get.
+// When heartbeatMode is true, ALL key writes are faulted using the separate
+// heartbeatArmed toggle (so the initial heartbeat publish at Start() can succeed
+// before ArmHeartbeat() is called).
 type wfFaultKeyValue struct {
 	jetstream.KeyValue // embedded: Get/Keys/Watch/Status/... pass through
 	fc                 *wfFaultController
 	claimsPrefix       string
+	heartbeatMode      bool // when true, fault ALL writes via fc.shouldFaultHeartbeat
 }
 
+// isClaimKey reports whether a key should be faulted in claim-write mode.
+// Only keys with a non-empty claimsPrefix are faulted (an empty prefix would
+// otherwise match every key — a footgun for any future claim-mode caller).
 func (k *wfFaultKeyValue) isClaimKey(key string) bool {
 	return k.claimsPrefix != "" && len(key) >= len(k.claimsPrefix) && key[:len(k.claimsPrefix)] == k.claimsPrefix
 }
 
+func (k *wfFaultKeyValue) shouldFault(key string) bool {
+	if k.heartbeatMode {
+		return k.fc.shouldFaultHeartbeat()
+	}
+	return k.isClaimKey(key) && k.fc.shouldFaultWrite()
+}
+
 func (k *wfFaultKeyValue) Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error) {
-	if k.isClaimKey(key) && k.fc.shouldFaultWrite() {
+	if k.shouldFault(key) {
 		return 0, context.DeadlineExceeded
 	}
 
@@ -161,7 +221,7 @@ func (k *wfFaultKeyValue) Create(ctx context.Context, key string, value []byte, 
 }
 
 func (k *wfFaultKeyValue) Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error) {
-	if k.isClaimKey(key) && k.fc.shouldFaultWrite() {
+	if k.shouldFault(key) {
 		return 0, context.DeadlineExceeded
 	}
 
@@ -169,7 +229,7 @@ func (k *wfFaultKeyValue) Update(ctx context.Context, key string, value []byte, 
 }
 
 func (k *wfFaultKeyValue) Put(ctx context.Context, key string, value []byte) (uint64, error) {
-	if k.isClaimKey(key) && k.fc.shouldFaultWrite() {
+	if k.shouldFault(key) {
 		return 0, context.DeadlineExceeded
 	}
 
@@ -291,3 +351,121 @@ func TestStartupWriteFault_SelfHealsWithoutRestart(t *testing.T) {
 // the write fault (a real write attempt), so the worker snapshot never falsely
 // advances to V2 during the fault — there is no longer a worker-observable
 // version advance to assert against, which is precisely the corrected behavior.
+
+// rfHeartbeatBucket is the default heartbeat KV bucket name, mirroring the
+// parti default ("parti-heartbeat"). Used by the dual-fault harness to inject
+// write errors on the heartbeat publisher's Put path, which routes through
+// recordKVOpError → the KV-error threshold circuit → enterDegraded. This gives
+// a reliable Degraded entry from any state (Scaling, Rebalancing, Stable), not
+// only from WaitingAssignment where the startup-timeout watchdog fires — because
+// the leader's calculator drives the manager out of WaitingAssignment long
+// before the watchdog triggers. The heartbeat fault is the correct seam for an
+// integration test that must produce Degraded while the leader's claim-write
+// fault keeps initialClaimsCommitted latched false.
+const rfHeartbeatBucket = "parti-heartbeat"
+
+// TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted pins the
+// F-D3 follow-up: under a dual write fault (claims/* on the handoff bucket AND
+// all writes on the heartbeat bucket), the KV-error threshold circuit enters
+// Degraded while initialClaimsCommitted is still false and the assignment is
+// non-empty. On the parent, recovery refreshes (a read) and exits to Stable with
+// zero claims written (RED). With the fix the worker STAYS degraded (latch false,
+// non-empty assignment) and self-heals once writes recover — no restart. Also
+// asserts OnDegraded fires exactly once across the held window (cross-feature
+// contract 3).
+//
+// Why dual fault: the startup-timeout watchdog fires only when state is
+// WaitingAssignment; but the leader's calculator drives state to Scaling/
+// Rebalancing before the watchdog triggers. Faulting heartbeat bucket writes
+// (all-key mode) routes errors through the heartbeat publisher's
+// recordKVOpError → KV-error threshold → enterDegraded, which fires from any
+// active state. Claim-write faults keep initialClaimsCommitted false so the
+// guard in attemptRecoveryFromDegraded has something to act on.
+func TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+
+	// Dual-fault JS: handoff bucket faults claims/* writes; heartbeat bucket
+	// faults all writes. This drives the KV-error threshold circuit even when
+	// the calculator has moved state out of WaitingAssignment.
+	faultJS := newWFFaultJetStreamDual(realJS, rfHandoffBucket, rfHeartbeatBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	pids := []string{"p0", "p1"}
+	src := newWFMutableSource([]types.Partition{{Keys: []string{pids[0]}}, {Keys: []string{pids[1]}}})
+
+	allStable := func() bool {
+		for _, pid := range pids {
+			if _, _, stable := rfReadClaimRevision(t, ctx, realJS, pid); !stable {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	var degradedCalls atomic.Int64
+
+	// Arm ONLY the claim-write fault before start so the initial heartbeat
+	// publish (which happens synchronously in Start()) succeeds. The heartbeat
+	// fault is armed AFTER Start() returns, at which point the background
+	// heartbeat publisher's periodic puts will begin faulting.
+	fc.ArmWrites()
+	stack := rfBuildWorkerStackCfg(t, ctx, faultJS, src, 0,
+		func(cfg *parti.Config) {
+			cfg.DegradedBehavior.KVErrorThreshold = 3
+			cfg.DegradedBehavior.ExitThreshold = 1 * time.Second
+		},
+		func(h *parti.Hooks) {
+			h.OnDegraded = func(_ context.Context, _ string) error {
+				degradedCalls.Add(1)
+				return nil
+			}
+		},
+	)
+
+	// Arm the heartbeat-bucket write fault AFTER Start() so the initial
+	// heartbeat publish succeeds. The background publisher fires every 500ms;
+	// with KVErrorThreshold=3 that is ~1.5s to Degraded entry.
+	fc.ArmHeartbeat()
+
+	// The KV-error circuit must drive the worker to Degraded. With HeartbeatInterval
+	// 500ms and KVErrorThreshold 3, Degraded fires within ~3s of start.
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 30*time.Second),
+		"KV-error threshold must enter Degraded under a sustained heartbeat+claim write fault")
+
+	// Hold the fault well past several ExitThreshold-spaced recovery ticks. On
+	// the parent, recovery calls exitDegraded here (RED). With the fix the worker
+	// stays Degraded because the latch is false and the assignment is non-empty.
+	require.Never(t, func() bool { return stack.mgr.State() == parti.StateStable },
+		8*time.Second, 250*time.Millisecond,
+		"a worker with an uncommitted non-empty assignment must NOT report Stable")
+	require.False(t, allStable(), "no claim may be Stable while writes are faulted")
+
+	// --- Disarm: KV writes recover. NO restart. ---
+	fc.DisarmWrites()
+
+	require.Eventually(t, allStable, 40*time.Second, 100*time.Millisecond,
+		"after write recovery the re-armed bootstrap apply must write the FULL claim set")
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 20*time.Second),
+		"worker must reach Stable once claims are actually committed")
+
+	// Contract 3: OnDegraded fired exactly once across the whole held window,
+	// despite many recovery ticks (stay-degraded never re-enters).
+	require.Equal(t, int64(1), degradedCalls.Load(),
+		"OnDegraded must fire exactly once per Degraded entry (contract 3)")
+
+	t.Logf("[%s] held Degraded under fault, self-healed to Stable after write recovery (no restart)", t.Name())
+}


### PR DESCRIPTION
## Summary

A worker that started during a sustained claim-write fault could reach `StateStable` while owning partitions whose claims were never written, and a version advance during the degraded window left a restart-only tail. `attemptRecoveryFromDegraded` refreshed the assignment (a read) and then unconditionally exited degraded mode.

This gates the exit on the bootstrap latch: while a worker holds an **uncommitted, non-empty** assignment, it stays degraded and re-arms a bootstrap apply for the current (post-refresh) assignment, self-healing once writes recover — no restart. The guard keys on worker **state**, not the degraded reason, so it is correct for every reason that can leave claims uncommitted (startup-timeout, kv-unavailable, connection-down).

- `manager_degraded.go` — the ~10-line guard (the only production change).
- Closes the last open engineering item from the auto-healing quorum-loss fix series (parent: `docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md` §3 deferred follow-up).

## Invariant safety
- **Contract 1** (whole-bucket loss → all workers Degraded): untouched — under whole-bucket loss the refresh *fails* and recovery returns before the guard.
- **Contract 2** (peer takeover): untouched — this change is in the degraded-recovery path only.
- **Contract 3** (OnDegraded fires once): held by construction — staying degraded keeps `degradedSince` set, so `enterDegraded`'s CAS blocks any re-fire.
- **Steady-state recovery**: a latched worker skips the guard and reaches the same `exitDegraded` — byte-equivalent to before.
- **Rolling upgrade**: the only new side effect is re-triggering a worker's own retry; the claim-key write set and per-claim CAS are unchanged.

## Test Plan
- [x] `make lint` — 0 issues
- [x] `make test` (unit, `-race`) — pass; new unit tests pin all four recovery branches + the post-refresh version-advance re-arm (mutation-proven discriminating)
- [x] `make test-integration` (`-race`) — all 11 packages pass; new sustained-fault test asserts a worker never reports Stable while claims are uncommitted (RED-on-parent verified) + OnDegraded-once; new `-race` stress test for the recovery re-arm on the connection-monitor goroutine
- [x] 3 cross-feature contract regression tests pass under `-race`

## Deferred follow-up (out of scope, recorded)
A sibling defect exists for an **already-latched** worker on a failed version-advance apply (same Stable-with-uncommitted-claims shape). It is **pre-existing — not a regression** (the latched recovery path is byte-identical to `main`). The clean fix is per-assignment-version commitment tracking, which touches the shared recovery path (contracts 1/3) and warrants its own contract-regression pass. Documented in `docs/plans/auto-healing-quorum-loss-fix/02-degraded-recovery-self-heal-implementation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)