### PR TITLE
fix(manager): self-heal a failed version-advance via per-version commitment

### DIFF
--- a/docs/plans/auto-healing-quorum-loss-fix/03-latched-worker-version-commitment-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/03-latched-worker-version-commitment-plan.md
@@ -1,0 +1,576 @@
+# Latched-Worker Version-Commitment Self-Heal — Follow-Up Plan
+
+- **Date:** 2026-05-31
+- **Status:** REVIEW-CLEAN, ready to implement (plan-review v4 = "ready to implement,
+  no design gate remains"; reports `tmp/03-latched-worker-version-commitment-plan_review{,_v2,_v3,_v4}.md`).
+  v1-v3 each found a real correctness hole, all closed. The recovery guard keys on the
+  **applied-ack identity** `(Version, LeaderRevision, PartitionSetDigest,
+  source-rev-when-known)`, ungated on non-empty, with an **audit-asymmetric** source
+  comparison (cur-unknown always matches; cur-known requires committed known+equal).
+  Closes same-version divergence (v1 P0), empty/revoke-all bypass (v2 P0), stale-LR
+  ack (v2 P1), source-downgrade-on-alias-refresh (v3 P0). Next: reachability spike (§5.0).
+- **Builds on:** the degraded-recovery self-heal work merged via PR #32
+  (`docs/plans/auto-healing-quorum-loss-fix/01-degraded-recovery-self-heal-plan.md`
+  and `02-degraded-recovery-self-heal-implementation.md`). This plan scopes the
+  **single remaining open item** from that series: the
+  "Deferred follow-up surfaced by the final review"
+  (`02-degraded-recovery-self-heal-implementation.md:766-800`).
+- **Origin:** PR4 (F-D3) post-implementation review v1, finding **P1-1**, whose
+  *latched* sibling was then surfaced by the PR #32 final review and explicitly
+  deferred. Deferred because the clean fix replaces the F-D3 one-way latch with
+  per-version commitment tracking, which changes the **prev source for the entire
+  apply pipeline** (cross-feature contracts) and warrants its own
+  contract-regression pass rather than being bundled into PR #32.
+- **Design consensus:** Approach A below was agreed by three independent passes —
+  the maintainer, the advisor model, and Codex (`codex exec`, read-only, full
+  run). Codex verdict: *"A per-assignment committed source of truth is the right
+  invariant; B is another patch on the latch, C weakens the intentionally
+  monotonic refresh path. Contract risk: Low."* The four Codex corrections that
+  shaped this plan are folded in below (§3.1 callouts).
+- **Relationship to the shipped series:** F-D2a/F-D2c/F-D1/F-D3 and the
+  degraded-recovery self-heal are all merged to `main`. This is the **last open
+  engineering item** from the quorum-loss fix series.
+
+---
+
+## 1. The defect (precise statement)
+
+The same Stable-with-uncommitted-claims defect that PR #32 fixed for the
+*un-latched bootstrap* worker also exists for an **already-latched** worker on a
+failed version-advance apply. PR #32 is byte-for-byte equivalent to `main` on the
+latched path, so it did not regress this — but it *slightly increases its
+reachability* (more workers now self-heal and reach the latched state).
+
+Precise sequence:
+
+1. A worker has committed V1 claims, so `initialClaimsCommitted` is latched `true`
+   (`manager.go:148-154`).
+2. A V2 assignment is published. Apply V2 runs through
+   `applyAssignmentWithPrevCore` (`manager_assignment.go:1227+`). Because the
+   worker is latched, the F-D3 bootstrap override
+   (`manager_assignment.go:1264-1266`) does **not** fire, so `prev =
+   CurrentAssignment() = V1` — correct at this instant. But
+   `handoffCoordinator.Apply` **fails before Store** (claim-write fault);
+   `scheduleApplyRetry(V2)` stashes V2; the snapshot stays V1.
+3. The worker enters Degraded (the KV-error circuit, via the renewal/heartbeat/
+   election write sites — not the apply path).
+4. Recovery `attemptRecoveryFromDegraded` (`manager_degraded.go:315-353`) calls
+   `refreshAssignmentFromNATS`, which `monotonicStore`s V2 into the snapshot
+   (`manager_assignment.go:1385-1399`, `1502-1524`). Now `CurrentAssignment() ==
+   V2`.
+5. The recovery guard (`manager_degraded.go:345-349`) tests
+   `!initialClaimsCommitted && len(cur.Partitions) > 0`. The latch is **already
+   `true`**, so the guard is skipped → `exitDegraded` → **`StateStable` reported
+   while V2's newly-assigned claims are unwritten.**
+6. The pending retry fires: `prev := m.CurrentAssignment() == V2 == next`, so the
+   prepare diff (`internal/assignment/handoff/twophase.go:208-232`) is **empty**
+   (it writes only partitions in `next` not in `prev`) → zero claims written → the
+   newly-assigned partition is never claimed → **restart-only tail.**
+
+Two symptoms, both must be fixed and **asserted independently**:
+
+- **Symptom (a) — false `Stable`.** The worker reports `StateStable` at V2 while
+  owning no claim for V2's newly-assigned partition.
+- **Symptom (b) — empty-diff non-heal.** Even after writes recover, the pending
+  retry self-terminates with an empty diff; the partition is never claimed until a
+  process restart.
+
+> **Framing correction (Codex):** `preparePhase` does **not** release dropped
+> claims — it *writes the newly-acquired set* (`next` minus `prev`) and updates the
+> consumer to `next.Partitions` (`internal/assignment/handoff/twophase.go:57-93`,
+> `208-232`). The bug is precisely that the newly-acquired set goes empty. Release/
+> cleanup of dropped claims is a separate phase and is **out of scope** here.
+
+---
+
+## 2. Invariants this fix MUST NOT regress (load-bearing)
+
+The fix changes the **prev source for every apply** (from `CurrentAssignment()` to
+the new committed-assignment state). The contract-safety argument rests on a single
+invariant — prove it once, and the per-contract review is mechanical:
+
+> **Invariant I0:** in **healthy post-apply steady state**, `committedAssignment ==
+> snapshot` on the full **applied-ack identity** `(Version, LeaderRevision,
+> PartitionSetDigest, source-rev-when-known)`. The snapshot can be advanced past
+> `committedAssignment` by exactly three paths, two of them startup-only and all
+> three handled by the guard: (1) **startup pre-advance** — `waitForAssignment`
+> stores the initial assignment before `applyInitialAssignment`
+> (`manager_election.go:461-474`); (2) **cold-empty startup** — directly stores+acks
+> `Assignment{}` without `handoffCoordinator.Apply` (`manager.go:657-681`), which
+> matches the zero committed value so the guard exits; (3) **recovery refresh** —
+> `monotonicStore` (the only POST-START non-apply snapshot writer,
+> `manager_assignment.go:1524`). Every healthy *steady-state* apply
+> (`applyAssignmentWithPrevCore`) advances both together. So in steady state they
+> diverge **only** on the bug/recovery path — when a refresh stored an assignment
+> whose apply had not succeeded; the startup divergences are exactly the
+> bootstrap/cold cases the guard re-arms or exits correctly. Divergence is detected by full identity, NOT version alone: the
+> publisher can expose two different partition sets at the same version (§3.4), and
+> empty/revoke-all assignments all share digest 0 so only Version/LR distinguish
+> them — a version-only or non-empty-gated test would mistake an unapplied
+> assignment for applied. With the identity guard, changing `prev` from
+> `CurrentAssignment()` to `committedAssignment` is a **no-op on every path a
+> contract test exercises**; it is observable *only* where it heals.
+
+Because `committedAssignment` advances **only after a successful `Apply`** (never
+by `monotonicStore`/refresh), and a successful `Apply` also Stores the same
+snapshot under `applyStoreMu`, the snapshot is always `>=` committed. There is no
+visible state where committed has advanced past the snapshot.
+
+1. **Cross-feature contract 1** (whole-bucket-missing → every worker
+   `StateDegraded`, recovers when the bucket returns). Unaffected: the routing
+   lives in `recordKVError` (`manager_degraded.go:128-160`), not the apply path;
+   `prev=committedAssignment` is inside `applyAssignmentWithPrevCore`. Under
+   whole-bucket loss `refreshAssignmentFromNATS` fails → recovery returns at the
+   existing err-check before the guard.
+2. **Cross-feature contract 2** (peer-claim-takeover → only that worker enters
+   claim-lost shutdown). Untouched — this fix is in the apply/recovery path, not
+   the claimer-error path (`manager_election.go:106-127`). `committedAssignment` is
+   process-local and is *not* read or reset by claim-loss handling.
+3. **Cross-feature contract 3** (OnDegraded fires exactly once per Degraded entry).
+   Held by construction: the generalized guard *stays* degraded (returns without
+   `exitDegraded`), so `degradedSince` stays non-zero and `enterDegraded`'s CAS
+   blocks any re-fire across the held recovery ticks. `recordKVError`
+   short-circuits while degraded (`manager_degraded.go:152-159`). **Asserted by a
+   test** (§5.3).
+4. **Contract 4 (startup readiness CAS).** **`startupAssignmentApplied` is NOT
+   touched** (`manager.go:156-161`, `manager_startup_async.go:114-129`). It is the
+   readiness/WaitingAssignment→Stable latch, *not* claim commitment. Only the
+   `initialClaimsCommitted` latch is generalized. Conflating the two would regress
+   contract 4 on a transition this fix does not target. *(Codex constraint.)*
+5. **The `(V,LR)` stale gate stays against `CurrentAssignment()`, NOT committed
+   state** (`manager_assignment.go:1240-1253`, `1161-1169`). Only the *prev source*
+   changes; the gate's comparand is unchanged. *(Codex constraint.)*
+6. **Ordering and atomicity.** Under `applyStoreMu`, the success path stays:
+   `Apply` success → LSR advance → snapshot Store → **`committedAssignment` Store**
+   → heartbeat `SetAppliedAssignment` (`manager_assignment.go:1309-1339`). The
+   heartbeat publisher is version-only monotone and accepts equal versions, so
+   keeping `SetAppliedAssignment` inside the lock remains load-bearing
+   (`internal/heartbeat/publisher.go:176-202`). **Recovery read — decided, not a
+   fork:** the guard reads `committedAssignment` (an `atomic.Pointer`) and
+   `CurrentAssignment()` (a lock-free atomic, `manager.go:846-860`) **lock-free**,
+   NOT under `applyStoreMu` — taking the apply lock on the connection-monitor
+   goroutine would serialize the monitor against every apply (and apply holds the
+   lock across a possibly-slow `handoffCoordinator.Apply`). The guard reads `cur`
+   then `committed` as two independent atomics, so a torn read can observe either
+   *new snapshot + old committed* OR *old snapshot + new committed* (committed
+   "ahead" of the stale `cur`). **The safety property is NOT "committed never ahead
+   of snapshot" — it is "no missed heal, at most a redundant re-arm":** a torn read
+   that re-arms a stale `cur` schedules a retry the `(V,LR)` stale gate then drops,
+   and because the guard re-evaluates with fresh reads every recovery tick, a
+   genuinely-unapplied current assignment is always eventually re-armed — a transient
+   torn read costs at most one extra tick, never a permanent false exit. Pinned by a
+   hook-based unit test (§5.2) asserting exactly that: an unapplied current
+   assignment is always eventually re-armed, and the only torn-read effect is a
+   redundant/stale-dropped retry.
+7. **Steady-state recovery must not change.** A healthy worker (committed
+   applied-ack identity == current's) that degrades for an unrelated reason recovers
+   exactly as today: the guard predicate is false → `exitDegraded`. Pinned by the existing negative-space test
+   (`manager_degraded_recovery_selfheal_test.go`) plus a new latched-version one
+   (§5.4).
+8. **Mixed-version / rolling upgrade — safe.** `committedAssignment` is
+   process-local in-memory state; it does not change wire format, schema, or
+   claim-key layout. A restart begins with committed empty → the first apply writes
+   the full set; existing-owner stable claims no-op in prepare/commit
+   (`internal/assignment/handoff/twophase.go:289-318`, `351-357`). No cross-process
+   inheritance, no same-version gating needed.
+
+---
+
+## 3. The fix (Approach A — universal committed-prev)
+
+Replace the one-way `initialClaimsCommitted atomic.Bool` with a tracked
+**last-committed assignment** held separately from the snapshot, updated on **every
+successful apply** (not one-way). The apply pipeline diffs `prev` against the
+committed assignment instead of `CurrentAssignment()`.
+
+### 3.0 State
+
+```go
+// manager.go — replaces initialClaimsCommitted.
+//
+// committedAssignment holds the last assignment this worker successfully
+// applied+acked (a successful handoffCoordinator.Apply through
+// applyAssignmentWithPrevCore). Two roles: (1) the prev source for every apply's
+// prepare diff; (2) the source of truth for "is the current snapshot assignment
+// applied?" — compared on the full applied-ack identity (Version, LeaderRevision,
+// PartitionSetDigest, source-rev-when-known), §3.2. Starts as the zero Assignment
+// (empty@0) — a never-applied worker diffs against empty → writes the full set
+// (subsumes the old F-D3 bootstrap override) and its identity matches a cold
+// empty snapshot so a never-assigned worker still exits recovery. Distinct from
+// the snapshot (m.assignment): the snapshot can be advanced by the recovery
+// refresh's monotonicStore (sole non-test caller, manager_assignment.go:1524)
+// past an apply that failed before Store; committedAssignment cannot. Distinct
+// from startupAssignmentApplied (readiness CAS). Full Assignment, not just an
+// identity tuple: preparePhase needs the previous partitions to drive the diff.
+committedAssignment atomic.Pointer[Assignment]
+```
+
+`committedAssignment` is a **full `Assignment`** — Codex: a digest can *compare*
+but cannot *drive* the `next`-minus-`prev` diff in `preparePhase`
+(`internal/assignment/handoff/twophase.go:216-232`).
+
+### 3.1 Apply pipeline (`applyAssignmentWithPrevCore`, `manager_assignment.go`)
+
+Two edits, both inside the existing `applyStoreMu` critical section:
+
+```go
+// (unchanged) stale gate compares newAssignment vs CurrentAssignment().
+curAssignment := m.CurrentAssignment()
+if isApplyResultStale(newAssignment, curAssignment) { ... return nil }
+
+// CHANGED: prev source is the committed assignment, not the passed-in
+// oldAssignment / CurrentAssignment(). Generalizes the F-D3 bootstrap override:
+//   - never committed  → committed == empty → full set (old override case)
+//   - steady V1→V2     → committed == V1 == snapshot → identical diff to today
+//   - failed-V2+refresh → committed == V1, snapshot == V2 → diff acquires V2's
+//                          new partitions correctly (the heal)
+oldAssignment = m.committedAssignmentOrEmpty()
+
+applyErr := m.handoffCoordinator.Apply(m.ctx, workerID, oldAssignment, newAssignment)
+if applyErr != nil { ... scheduleApplyRetry(newAssignment); return applyErr }
+
+// ... LSR advance → snapshot Store ...
+
+// CHANGED: record commitment for this version AFTER a successful Apply, on the
+// snapshot Store ordering, still under applyStoreMu. Replaces the one-way
+// initialClaimsCommitted latch. Updated on EVERY successful apply (so the guard
+// reduces to "exit" in steady state); never updated by monotonicStore/refresh.
+m.committedAssignment.Store(&newAssignment)
+
+// ... heartbeat SetAppliedAssignment (unchanged ordering) ...
+```
+
+> **Why prev = committed, not the passed-in `oldAssignment`.** Today every call
+> site (retry, commit-watcher, assignment-watcher) passes some `prev`; with this
+> change the passed-in value becomes dead for the diff. Confirm during
+> implementation that **no caller legitimately needs a non-current prev** before
+> retiring that plumbing; if any does, keep its argument but override here. *(This
+> is the advisor's "nice retirement, confirm first" note — a simplification to
+> verify, not assume.)*
+
+### 3.2 Recovery guard (`attemptRecoveryFromDegraded`, `manager_degraded.go:345-349`)
+
+The exit-safe condition is **"the current snapshot assignment has been successfully
+applied and acked"** — NOT "version is greater" and NOT gated on non-empty. The
+identity is the **applied-ack identity**: `(Version, LeaderRevision,
+PartitionSetDigest, SourceRevision when known)` — exactly the fields a successful
+apply commits to the heartbeat (`manager_assignment.go:1329-1337`) and the leader
+audit compares (`internal/assignment/calculator_audit.go:93-99,125-146`).
+
+```go
+// currentAssignmentApplied reports whether the current snapshot assignment has
+// been successfully applied+acked by this worker, i.e. committedAssignment (set
+// only on a successful Apply) matches it on the full applied-ack identity. NOT
+// version alone (the publisher can expose two DIFFERENT partition sets at the
+// SAME version: a legacy alias is written at proposedVersion before the commit
+// CAS, and a batch can abort post-alias or lose the CAS without advancing
+// currentVersion — assignment_publisher.go:345,380-398,437-456, metered as
+// IncrementAliasVisibleUncommitted; the (V,LR) gate admits same-version higher-LR
+// — manager_assignment.go:1161-1169). LeaderRevision/source ARE included: the
+// applied-ack heartbeat carries them and the audit flags a mismatch as behind, so
+// a same-version/same-digest/higher-LR assignment that only entered the snapshot
+// via refresh is NOT applied until re-acked. Empty/revoke-all (case (d),
+// buildAssignmentFromCommit) is a real versioned apply path too — empty sets all
+// have digest 0, so Version+LR are what distinguish them; hence no len()>0 gate.
+func (m *Manager) currentAssignmentApplied(cur Assignment) bool {
+    c := m.committedAssignmentOrEmpty()
+    // Source comparison is AUDIT-SHAPED (asymmetric), mirroring
+    // calculator_audit.go:121-126 — NOT strict flag equality. cur is the
+    // authoritative target (the audit's commit), c is what we acked (the
+    // audit's heartbeat): cur-unknown always matches; cur-known requires c
+    // known AND equal. The degraded refresh reads the legacy alias
+    // (assignment.<workerID>), and buildLegacyAlias DROPS source revision
+    // (assignment_publisher.go:1316-1341 — SourceRevision intentionally unused),
+    // so a refreshed snapshot is source-unknown at a V/LR/digest the worker may
+    // have already acked with source KNOWN. Strict flag equality would re-arm and
+    // re-ack a DOWNGRADE to AppliedSourceRevKnown=false, which the audit then
+    // classifies as behind. The asymmetric form never downgrades a stronger ack.
+    srcOK := !cur.SourceRevisionKnown ||
+        (c.SourceRevisionKnown && c.SourceRevision == cur.SourceRevision)
+    return c.Version == cur.Version &&
+        c.LeaderRevision == cur.LeaderRevision &&
+        srcOK &&
+        types.PartitionSetDigest(c.Partitions) == types.PartitionSetDigest(cur.Partitions)
+}
+
+// Stay degraded + re-arm whenever the current assignment is not yet applied+acked:
+// never committed (old F-D3 bootstrap), an earlier version (latched advance), a
+// DIFFERENT set at the same version (alias/split-brain divergence), a versioned
+// empty revoke whose apply failed, or a same-version higher-LR re-issue picked up
+// by refresh. cur is read AFTER the refresh so it captures any advance during the
+// degraded window. The cold zero-state (Assignment{}) is applied-by-identity
+// against the zero committed value, so a never-assigned worker still exits.
+cur := m.CurrentAssignment()
+if !m.currentAssignmentApplied(cur) {
+    m.scheduleApplyRetry(cur)
+    return // do NOT exitDegraded until a real apply+ack commits THIS assignment
+}
+m.exitDegraded()
+```
+
+`types.PartitionSetDigest` already exists and is the apply path's own digest
+(`manager_assignment.go:1329`). The implementer must confirm the field set against
+`heartbeat.AppliedAssignment` (`manager_assignment.go:1329-1337`) and the audit
+(`calculator_audit.go`) — match those exactly; do not invent fields. I0 holds
+because in **post-start steady state** the snapshot is advanced past
+`committedAssignment` only by the recovery refresh's `monotonicStore` (the sole
+post-start non-apply snapshot writer, `manager_assignment.go:1524`); the two
+startup pre-advance paths (§2 I0) match the zero/bootstrap committed value, and
+every steady-state apply advances both together — so including LR/source causes no
+healthy-state spurious re-arm.
+
+In steady state `committed == cur` on the full identity → predicate false → exits
+exactly as today. The re-armed retry runs through the §3.1 pipeline, so its prev is
+`committedAssignment` → the prepare diff acquires the uncommitted partitions (or, for
+an empty revoke, the apply re-runs the consumer teardown + re-ack) → self-heal once
+writes recover, then the next tick sees the assignment applied and exits to `Stable`
+with claims/ack actually current.
+
+### 3.3 The four Codex corrections folded in (record)
+
+1. `preparePhase` writes newly-acquired only; "release dropped" reframed (§1 note).
+2. `committedAssignment` is a full `Assignment`, not `(version, digest)` (§3.0).
+3. The `(V,LR)` stale gate keeps comparing against `CurrentAssignment()` (§2.5).
+4. `startupAssignmentApplied` is untouched (§2.4).
+
+Plus: committed updates **only on successful Apply**, never by refresh (§3.1); the
+recovery read is lock-free with a documented benign interleaving (§2.6); the
+recovery guard keys on the **applied-ack identity** `(Version, LeaderRevision,
+PartitionSetDigest, source-rev-when-known)` and is **not** gated on non-empty, so
+neither a same-version partition-set divergence (review v1 P0), an empty/revoke-all
+implicit-revoke (review v2 P0), nor a same-version higher-LR refresh (review v2 P1)
+can be mistaken for applied (§3.2).
+
+### 3.4 Same-version divergence is IN scope (was the plan-review P0)
+
+The publisher can expose two different partition sets at the **same version** for
+one worker: a legacy alias is written at `proposedVersion` before the commit CAS,
+and a batch can abort post-alias (`assignment_publisher.go:387-398`) or lose the
+commit CAS (`:437-452`) without advancing `currentVersion` (`:456`) — the code
+meters this as `IncrementAliasVisibleUncommitted`. Such a same-version, higher-LR
+assignment is admitted by the `(V,LR)` gate (`manager_assignment.go:1161-1169`),
+observed by the alias watcher (`manager_assignment.go:574-614`) /
+`manager_select_authority.go:33-63`, and can land in the snapshot via the degraded
+refresh. The §3.2 identity guard (digest, not version) detects this: committed
+`N/A` vs current `N/B` → digests differ → stay degraded + re-arm. The reproducer
+(§5.1) covers the V1→V2 advance; a unit/protocol discriminator (§5.2) covers the
+same-version `N/A`→`N/B` divergence so the digest term is proven non-vacuous.
+
+### 3.5 Residual stale-retry interaction (level-triggered convergence)
+
+If the refresh `monotonicStore`d the current assignment at a **higher
+LeaderRevision** than a *stashed* retry, that retry's candidate is stale
+(`candidate.LR < cur.LR` → `isApplyResultStale == true`,
+`manager_assignment.go:1161-1169`) and is dropped. The **next** recovery tick
+re-arms with the current assignment (which the identity guard still flags as
+uncommitted), so the level-triggered loop converges; and a higher-LR assignment
+normally also arrives as a fresh watcher apply (prev = committed) that heals
+directly. Not a new tail — this is the existing stale-gate behavior, now backstopped
+by the identity guard re-arming every tick until the current assignment commits.
+
+---
+
+## 4. Why Approach A over the alternatives (consensus record)
+
+- **Approach B (keep the bootstrap latch; add a recovery-only `lastCommittedVersion`
+  guard + store the last-committed assignment only to feed the re-armed retry's
+  prev).** Narrower blast radius but more special-casing — and it still has to store
+  the committed assignment to give the retry a correct prev, so it converges toward
+  A while keeping a second, redundant latch. Codex: *"another patch on the latch."*
+  Rejected.
+- **Approach C (make `refreshAssignmentFromNATS` not advance the snapshot past the
+  committed version, so prev stays V1 and the existing retry heals).** Narrowest,
+  but it special-cases — and weakens — the intentionally monotonic refresh path,
+  which other recovery logic relies on. Codex: *"weakens the intentionally monotonic
+  refresh path."* Rejected.
+- **Approach A (universal committed-prev).** One source of truth for "claims
+  committed for this version," subsuming the F-D3 bootstrap override as its empty
+  case. Contract-safe by invariant I0 (no-op except on the bug path). **Chosen** —
+  unanimous (maintainer + advisor + Codex).
+
+---
+
+## 5. Test & contract-regression plan (first-class deliverable)
+
+This is why the item was deferred from PR #32. The reachability spike is a **hard
+gate**, and both symptoms are asserted **independently**.
+
+### 5.0 Reachability spike FIRST — RED-on-parent or STOP
+
+Before any fix code, build the §5.1 reproducer and confirm it fails on the current
+`main`. **If it cannot be driven RED on parent, STOP and reassess** — the merged
+fixes may already foreclose the state (per the F-D2b/F-D3 lessons:
+`project_quorum_loss_repro_status`, `feedback_verify_first_with_reproducer`). Do not
+write the fix for an unreachable state.
+
+### 5.1 RED-on-parent reproducer (both symptoms) — `test/integration/failure/`
+
+Reuse the existing `wfMutableSource` watchable source and the **dual** write-fault
+JetStream (`newWFFaultJetStreamDual` + `wfFaultController.{ArmWrites,ArmHeartbeat,
+DisarmWrites}`) already in `test/integration/failure/startup_writefault_test.go`.
+The dual (claim + heartbeat) fault is required because a single-worker leader's
+startup-timeout watchdog does **not** fire (the calculator leaves
+WaitingAssignment within ~1s); Degraded is driven via the heartbeat-write KV-error
+circuit — the same technique the PR #32 integration test used (its KEY IMPL
+FINDING).
+
+Choreography:
+1. Start one worker with source `[p0]`, **no faults**. Wait `StateStable`; assert
+   p0's claim is Stable. *(This commits V1 — the worker is latched on parent.)*
+2. `ArmWrites()` (claim) + `ArmHeartbeat()`, then `src.set([p0, p1])` to publish
+   V2. Assert a claim-write fault fired for V2 (counter > 0).
+3. Wait `StateDegraded` (heartbeat circuit); hold the fault past several
+   recovery/`ExitThreshold` ticks. Recovery reads V2, `monotonicStore`s it, skips
+   the latched guard, exits.
+4. **Assert symptom (a) — false Stable:** `StateStable` **and**
+   `CurrentAssignment().Version == 2` **and** p1's claim is absent / not Stable in
+   KV. *(RED on parent: parent reports Stable here.)*
+5. `DisarmWrites()`; wait beyond the retry cadence. **Assert symptom (b) —
+   non-heal:** p1's claim is still never Stable **and** a publish to p1 is not
+   consumed. *(RED on parent: the pending retry self-terminated with prev ==
+   CurrentAssignment() == V2 → empty `preparePhase` diff.)*
+6. GREEN with the fix: after disarm the worker writes p1's claim at V2 and consumes
+   p1 — **no restart**.
+
+Non-vacuity: confirm V2 genuinely landed (snapshot version moved to 2) before the
+assertions, so the test proves the heal targets V2 and is not a vacuous pass.
+
+### 5.2 Unit discriminators (with fakes / `recordingHandoff`)
+
+- **`TestApplyCore_PrevIsCommittedNotSnapshot`:** commit V1; advance the snapshot to
+  V2 via `monotonicStore` (no apply); apply V2 through core; assert the coordinator
+  received `prev == V1` (committed), **not** V2 (snapshot), and that
+  `committedAssignment` moves to V2 only after the apply succeeds.
+- **`TestApplyCore_CommittedUpdatesEveryApply`:** apply V1 then V2 (both succeed);
+  assert `committedAssignment` tracks each (proves not one-way) and that a failed
+  apply does **not** advance it.
+- **Recovery branch selection (applied-ack identity guard).** Each row sets
+  `committedAssignment` and the snapshot, then asserts re-arm-stays-degraded vs exit:
+  - `{committed N/A, cur N+1/B, non-empty}` → re-arm (version advance).
+  - **`{committed N/A, cur N/B (same V, different digest)}` → re-arm.** *(review v1
+    P0 — a version-only guard would WRONGLY exit; proves the digest term.)*
+  - **`{committed N/A (non-empty), cur N+1/empty (versioned revoke)}` → re-arm.**
+    *(review v2 P0 — a `len(cur)>0` gate would WRONGLY exit; proves the no-len-gate.)*
+  - **`{committed empty@N, cur empty@N+1 (both digest 0)}` → re-arm.** *(empty-vs-
+    empty across versions; proves Version distinguishes digest-0 sets.)*
+  - **`{committed N/A/LR1, cur N/A (same V, same digest, higher LR2 via refresh)}` →
+    re-arm.** *(review v2 P1 — proves LR is in the identity so a stale applied-ack
+    is re-acked before exit.)*
+  - `{committed N/A/LR1, cur N/A/LR1 (full identity match)}` → exits.
+  - **`{committed N/A/LR/source-KNOWN=S, cur N/A/LR/source-UNKNOWN (legacy-alias
+    refresh)}` → EXITS without re-arm, keeps the known-source ack.** *(review v3 P0 —
+    strict flag equality would re-arm and downgrade the ack to source-unknown, which
+    the audit flags as behind; the audit-asymmetric predicate must not.)*
+  - `{committed source-unknown, cur N/A/LR/source-KNOWN=S}` → re-arm *(weaker acked
+    than the known-source target the worker should apply).*
+  - `{cold zero: committed Assignment{}, cur Assignment{} (empty@0)}` → exits
+    *(never-assigned worker; proves the zero value is "applied-by-identity").*
+  - `{refresh fails}` → returns before guard, records KV error.
+- **`TestRecoveryGuard_TornRead_NoMissedHeal`:** force both torn-read windows
+  (new-snapshot/old-committed AND old-snapshot/new-committed) via a test hook;
+  assert a genuinely-unapplied current assignment is **always eventually re-armed**
+  and the only torn-read effect is a redundant/stale-dropped retry — NOT a claim
+  that committed is never ahead of snapshot (pins §2.6 as reworded).
+- **Heartbeat / audit boundary:** assert an equal-version re-apply with a different
+  digest OR a higher LR is not treated as applied merely because the version
+  matches (guards against the heartbeat publisher's version-only monotonicity,
+  `internal/heartbeat/publisher.go:176-202`, and aligns with the audit's
+  LR/source/digest comparison, `internal/assignment/calculator_audit.go:93-99`).
+
+### 5.3 Contract-3 assertion (held by construction → pinned)
+
+Assert `OnDegraded` fires **exactly once** across the whole held recovery window
+(multiple ticks while the guard holds the worker degraded), reusing the hook-count
+style of `TestManager_LiveNATSBucketLoss_OnDegradedHook`.
+
+### 5.4 Negative-space (both-directions-of-boundary discipline)
+
+A worker whose committed applied-ack identity equals its current assignment's, that
+degrades for an unrelated reason and whose refresh succeeds, must `exitDegraded` →
+`Stable` **exactly as today**. (Per `feedback_test_both_directions_of_boundary`: the
+positive heal test alone is consistent with both a correct guard and an always-hold
+bug; this negative test discriminates.) The existing
+`manager_degraded_recovery_selfheal_test.go` negative case stays GREEN; extend it
+for the latched (committed-V1, cur-V1 full-identity-match healthy) path.
+
+### 5.4a Same-version divergence protocol test (review v1 P0 surface)
+
+The §5.2 same-version unit discriminator mutates the struct directly; add one test
+that drives the **real** alias-visible-uncommitted shape so the digest guard is
+proven against the protocol, not a synthetic mutation: expose a legacy alias for a
+worker at version `N` for set A (or commit `N/A`), then expose a *different*
+same-version assignment `N/B` (higher LR) for that worker — via the alias watcher /
+`monotonicStore` refresh path — without a successful `Apply` of B, and assert the
+worker stays degraded + re-arms and ultimately commits B's claims, never reporting
+`Stable` at `N/B` with B's claims absent. If a full protocol setup is too heavy,
+encode it at the `handleAssignmentEntry` + recovery-guard seam with a faulted apply
+for B.
+
+### 5.4b Empty/revoke-all failed-apply test (review v2 P0 surface)
+
+The implicit-revoke case (d) — a worker absent from `commit.Workers` applies a
+**versioned empty** assignment that still calls `UpdateWorkerConsumer(empty)` and
+publishes `AppliedVersion=N`/digest 0 (`manager_assignment.go:916-925`,
+`buildAssignmentFromCommit` 1038-1053, pinned by
+`manager_commit_state_machine_test.go:239-248`). Drive it on the `wf` harness or at
+the commit-state-machine seam: worker committed `V1` (non-empty); publish a commit
+that drops the worker (→ empty@`V2`); fault the empty apply (updater error) before
+Store; let recovery refresh `monotonicStore` empty@`V2` into the snapshot. Assert
+the worker stays degraded + re-arms (NOT exits as `Stable` with the revoke
+un-applied / consumer not torn down / ack stale at `V1`), and on disarm completes
+the revoke apply, publishes `AppliedVersion=V2`, and exits. RED on the version-only
+or `len>0`-gated guard; GREEN on the applied-ack-identity guard.
+
+### 5.5 Concurrency `-race` stress test (AGENTS.md monitor-goroutine requirement)
+
+`attemptRecoveryFromDegraded` runs on the **connection-monitor goroutine** and this
+fix keeps its apply-issuing side effect (`scheduleApplyRetry`) **and** adds a new
+shared field (`committedAssignment`) read on that goroutine and written on the apply
+goroutine. Add / extend a focused `-race` stress test in
+`test/integration/failure/` (template: the existing
+`degraded_recovery_rearm_concurrency_test.go`, and AGENTS.md's
+`epoch_monitor_concurrency_test.go` pattern): drive the real recovery goroutine
+(armed write fault) ↔ apply pipeline ↔ commit-watcher against the same handoff
+bucket for ~5s; assert no race-detector trips on `committedAssignment` / snapshot /
+`applyStoreMu` / `stashedApplyRetry`.
+
+### 5.6 Mandatory gate (AGENTS.md pre-PR + cross-feature contracts)
+
+- The **3 cross-feature contract regression tests**:
+  `TestManager_LiveNATSBucketLoss`, `TestManager_LiveNATSBucketLoss_OnDegradedHook`,
+  `TestStableID_StaleKeyTakeover_Reclaim`.
+- `make test-integration -race` (recovery-path change on a shared monitor
+  goroutine — the unit suite cannot reproduce the goroutine race).
+- `make pre-pr` (touches `manager/`).
+
+---
+
+## 6. Phasing
+
+Single PR (one model change across the apply core + recovery guard + its test
+surface). Per the repo's standard loop: **reachability spike first** (§5.0:
+RED-on-parent or STOP) → implement → `/simplify` → review gate (`/codex:review`,
+fall back to `/post-impl-review` for spec-compliance) → fix-loop to merge-clean →
+squash on merge. `make pre-pr` + the 3 contract tests + `make test-integration
+-race` on the final tree.
+
+**Model/effort:** Opus, high. Small diff but it sits on the contract-pinned shared
+apply/recovery path; rigor goes on invariant I0, the contract-regression gate, and
+the `-race` stress test.
+
+**Commit-message discipline:** no plan/PR jargon (`feedback_no_plan_jargon_in_commits`),
+no attribution trailers (`feedback_no_commit_attribution`). PR title shape:
+`fix(manager): track claim commitment per version so a failed version-advance self-heals`.
+
+---
+
+## 7. Out of scope
+
+- F-D3 option 3b (don't pre-advance the snapshot in `waitForAssignment`) — a larger
+  startup-ordering change; A closes the defect without it. Remains deferred.
+- Same-V/higher-LR stale-gate residual (§3.4) — pre-existing, converges via the
+  level-triggered loop; not introduced or worsened here.
+- Release/cleanup of *dropped* claims on a version advance (a separate phase from
+  `preparePhase`) — unrelated to this defect.
+- The F-D1 flapping-tuning and pull-gating fail-open decisions (00-fix-plan §7) —
+  tuning/policy questions.

--- a/manager.go
+++ b/manager.go
@@ -145,17 +145,25 @@ type Manager struct {
 	stashedApplyRetry atomic.Pointer[Assignment]
 	applyRetryActive  atomic.Bool
 
-	// initialClaimsCommitted latches true the first time an apply genuinely
-	// commits the full claim set to the handoff bucket. Until then,
-	// applyAssignmentWithPrevCore forces an empty prev on every apply so the
-	// prepare diff is the full partition set, instead of computing an empty
-	// diff against the snapshot waitForAssignment pre-advanced with no claims
-	// written — the startup empty-diff self-exit (F-D3). One-way latch.
-	initialClaimsCommitted atomic.Bool
+	// committedAssignment holds the last assignment this worker successfully
+	// applied+acked (a successful handoffCoordinator.Apply through
+	// applyAssignmentWithPrevCore). Two roles: (1) the prev source for every
+	// apply's prepare diff; (2) the source of truth for "is the current snapshot
+	// assignment applied?" — compared on the full applied-ack identity (Version,
+	// LeaderRevision, PartitionSetDigest, source-rev-when-known) by
+	// currentAssignmentApplied, used by the degraded-recovery guard. Starts as
+	// the zero Assignment (empty@0): a never-applied worker diffs against empty →
+	// writes the full set (subsuming the old F-D3 one-way bootstrap override),
+	// and its identity matches a cold empty snapshot so a never-assigned worker
+	// still exits recovery. Distinct from the snapshot (m.assignment): the
+	// snapshot can be advanced past a failed apply by the recovery refresh's
+	// monotonicStore; committedAssignment advances only on a successful apply.
+	// Distinct from startupAssignmentApplied (readiness CAS).
+	committedAssignment atomic.Pointer[Assignment]
 
 	// startupAssignmentApplied latches true once the startup assignment path
 	// has made this manager's local assignment visible and acked it. It is
-	// separate from initialClaimsCommitted: empty-source startup has no claims
+	// separate from committedAssignment: empty-source startup has no claims
 	// to commit but still must be allowed to reach StateStable after its
 	// applied-empty ack.
 	startupAssignmentApplied atomic.Bool
@@ -671,6 +679,12 @@ func (m *Manager) applyInitialAssignment(ctx context.Context, assignmentKV jetst
 		// PublishNow is faithful to the cold-empty intent.
 		empty := Assignment{}
 		m.assignment.Store(empty)
+		// Record the applied-empty assignment as committed too, so the
+		// "committedAssignment = last applied+acked" invariant holds by
+		// construction at this ack site (not by zero-value coincidence). The
+		// degraded-recovery guard then exits for a cold-empty worker because the
+		// snapshot and committed identities match.
+		m.committedAssignment.Store(&empty)
 		m.heartbeat.SetAppliedAssignment(heartbeat.AppliedAssignment{
 			LeaderRevision:        0,
 			AppliedVersion:        0,

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -1168,6 +1168,53 @@ func isApplyResultStale(candidate, cur Assignment) bool {
 	return candidate.LeaderRevision < cur.LeaderRevision
 }
 
+// committedAssignmentOrEmpty returns the last successfully applied+acked
+// assignment, or the zero Assignment if none has been committed yet (the
+// never-applied bootstrap state). It is the prev source for the apply prepare
+// diff and the comparand for currentAssignmentApplied.
+func (m *Manager) committedAssignmentOrEmpty() Assignment {
+	if c := m.committedAssignment.Load(); c != nil {
+		return *c
+	}
+
+	return Assignment{}
+}
+
+// currentAssignmentApplied reports whether the given (current snapshot)
+// assignment has been successfully applied+acked by this worker — i.e. whether
+// committedAssignment matches it on the full APPLIED-ACK identity. This is the
+// safe-to-exit-degraded predicate.
+//
+// Identity = (Version, LeaderRevision, PartitionSetDigest, source-rev-when-known),
+// NOT version alone and NOT gated on a non-empty partition set:
+//   - The publisher can expose two DIFFERENT partition sets at the SAME version
+//     for one worker (a legacy alias is written at the proposed version before
+//     the commit CAS, and an aborted/CAS-lost batch does not advance the version),
+//     so version alone can mistake an uncommitted set for committed.
+//   - Empty/revoke-all assignments (commit case (d)) are real versioned apply
+//     paths and all share digest 0, so Version/LR are what distinguish them —
+//     hence no len()>0 gate.
+//   - The applied-ack heartbeat carries LeaderRevision/source and the leader
+//     audit flags a mismatch as behind, so a same-version/same-digest/higher-LR
+//     assignment that only entered the snapshot via refresh is not "applied"
+//     until re-acked.
+//
+// The source comparison is AUDIT-SHAPED (asymmetric), mirroring the leader
+// audit: a source-unknown current target always matches (the degraded refresh
+// reads the legacy alias, which drops source revision, so re-arming to "fix" it
+// would only downgrade a stronger known-source ack); a source-known current
+// target requires the committed assignment known and equal.
+func (m *Manager) currentAssignmentApplied(cur Assignment) bool {
+	c := m.committedAssignmentOrEmpty()
+	srcOK := !cur.SourceRevisionKnown ||
+		(c.SourceRevisionKnown && c.SourceRevision == cur.SourceRevision)
+
+	return c.Version == cur.Version &&
+		c.LeaderRevision == cur.LeaderRevision &&
+		srcOK &&
+		types.PartitionSetDigest(c.Partitions) == types.PartitionSetDigest(cur.Partitions)
+}
+
 // applyAssignmentWithPrev is the fresh-version apply entry (watcher,
 // commit, alias, initial-bootstrap). It jitters once before calling core,
 // so a fleet of workers observing the same fresh version spreads its
@@ -1252,18 +1299,18 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 		return nil
 	}
 
-	// Startup bootstrap override (F-D3): until the worker has committed its
-	// claims at least once, force an empty prev so the prepare diff is the FULL
-	// partition set. waitForAssignment pre-advances the snapshot to the full set
-	// with no claims written, so any apply that reads CurrentAssignment() for
-	// prev would otherwise compute an empty diff and write zero claims. This must
-	// live here (not only in scheduleApplyRetry): a startup-window version
-	// advance (cold-start/rejoin rebalance to V+1) applies V+1 against the
-	// pre-advanced snapshot AND stale-gate-drops the V retry, so fixing the retry
-	// alone does not self-heal. One-way: once committed, prev is CurrentAssignment().
-	if !m.initialClaimsCommitted.Load() {
-		oldAssignment = Assignment{}
-	}
+	// Prev source = the last assignment this worker successfully applied+acked
+	// (committedAssignment), NOT the passed-in oldAssignment / CurrentAssignment().
+	// The snapshot can be advanced past a failed apply by the recovery refresh's
+	// monotonicStore, so reading CurrentAssignment() for prev would compute an
+	// empty diff and write zero claims. Generalizes the old F-D3 bootstrap
+	// override (never-committed → committed empty → full set) to cover a latched
+	// worker whose version-advance apply failed before Store: committed stays the
+	// prior version, so the diff still acquires the new partitions. This must live
+	// here (not only in scheduleApplyRetry): a startup-window or post-commit
+	// version advance applies V+1 against a snapshot the refresh may have advanced
+	// AND stale-gate-drops the V retry, so fixing the retry alone does not heal.
+	oldAssignment = m.committedAssignmentOrEmpty()
 
 	// 1) Apply via handoff coordinator. Must succeed before we touch the
 	//    in-memory snapshot or publish the ack.
@@ -1298,14 +1345,6 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 		return applyErr
 	}
 
-	// Latch initialClaimsCommitted on the first successful full-set write. During
-	// bootstrap the override forced oldAssignment empty, so an empty-prev →
-	// non-empty-next success genuinely wrote every claim — never a claim-less
-	// empty diff. One-way latch.
-	if len(oldAssignment.Partitions) == 0 && len(newAssignment.Partitions) > 0 {
-		m.initialClaimsCommitted.Store(true)
-	}
-
 	// 2) Advance lastSeenLeaderRevision (stale-leader fence) — single
 	//    source of truth for LSR. LSR MUST advance BEFORE the snapshot
 	//    Store, otherwise a concurrent handleCommitValueOnce reader could
@@ -1319,7 +1358,17 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 		hook(newAssignment)
 	}
 
-	// 4) Update heartbeat in-memory snapshot INSIDE the lock (W15+W16
+	// 4) Record this assignment as the last one successfully applied+acked, on
+	//    EVERY successful apply (not one-way). Stored AFTER the snapshot Store so
+	//    a lock-free recovery-guard read can at worst see new-snapshot/old-
+	//    committed (a redundant re-arm), never a missed heal. This is the prev
+	//    source for the next apply AND the source of truth for "is the current
+	//    snapshot assignment applied?" (currentAssignmentApplied, used by the
+	//    degraded-recovery guard). newAssignment is a by-value parameter, so its
+	//    address is a distinct per-call pointer nothing mutates after this point.
+	m.committedAssignment.Store(&newAssignment)
+
+	// 5) Update heartbeat in-memory snapshot INSIDE the lock (W15+W16
 	//    plan-review v2 P0-B fix). The heartbeat publisher's monotonicity
 	//    is V-only (internal/heartbeat/publisher.go:170-195); equal-V Acks
 	//    overwrite LeaderRevision unconditionally. If we released the lock

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -332,18 +332,21 @@ func (m *Manager) attemptRecoveryFromDegraded() {
 	// since recordKVError short-circuits while degraded).
 	m.recordKVSuccess()
 
-	// Startup self-heal guard (F-D3 follow-up): a worker that started during a
-	// sustained claim-write fault holds a non-empty assignment but never latched
-	// initialClaimsCommitted — no claims were ever written. exitDegraded here
-	// would report StateStable with zero claims. Instead stay degraded and re-arm
-	// a bootstrap apply so the worker actively self-heals once writes recover. cur
-	// is read AFTER the refresh so the re-arm targets the current version (the
-	// refresh may have advanced it during the degraded window). The guard keys on
-	// STATE, not the degraded reason — exiting with an uncommitted non-empty
-	// assignment is wrong regardless of why we degraded. See
-	// docs/plans/auto-healing-quorum-loss-fix/01-degraded-recovery-self-heal-plan.md.
+	// Self-heal guard: stay degraded + re-arm an apply whenever the current
+	// snapshot assignment has NOT been successfully applied+acked
+	// (currentAssignmentApplied compares the full applied-ack identity). This
+	// covers a worker that never committed (startup bootstrap, F-D3), one that
+	// committed an earlier version but whose version-advance apply failed (the
+	// latched case), an empty/revoke-all apply that failed, and a same-version
+	// higher-LR re-issue that only entered the snapshot via the refresh above.
+	// exitDegraded here would otherwise report StateStable with the current
+	// assignment's claims/ack uncommitted. cur is read AFTER the refresh so the
+	// re-arm targets the post-refresh assignment. The guard keys on commitment
+	// STATE, not the degraded reason — exiting with an unapplied assignment is
+	// wrong regardless of why we degraded. See
+	// docs/plans/auto-healing-quorum-loss-fix/03-latched-worker-version-commitment-plan.md.
 	cur := m.CurrentAssignment()
-	if !m.initialClaimsCommitted.Load() && len(cur.Partitions) > 0 {
+	if !m.currentAssignmentApplied(cur) {
 		m.scheduleApplyRetry(cur)
 		return
 	}

--- a/manager_degraded_recovery_selfheal_test.go
+++ b/manager_degraded_recovery_selfheal_test.go
@@ -24,71 +24,259 @@ func plantAssignment(t *testing.T, m *Manager, a Assignment) {
 	}
 }
 
-// armDegraded puts the manager into Degraded with the given latch state and
-// in-memory snapshot, then returns it ready for attemptRecoveryFromDegraded.
-func armDegraded(t *testing.T, latched bool, snapshot Assignment) (*Manager, *recordingHandoff) {
+// armDegraded puts the manager into Degraded with the given committed assignment
+// (nil = never applied) and in-memory snapshot, then returns it ready for
+// attemptRecoveryFromDegraded. The committed assignment is the new source of
+// truth for "has the current assignment been applied+acked" (replaces the old
+// one-way initialClaimsCommitted latch).
+func armDegraded(t *testing.T, committed *Assignment, snapshot Assignment) (*Manager, *recordingHandoff) {
 	t.Helper()
 	m, rh, _, _ := newTestManager(t)
 	_, nc := partitest.StartEmbeddedNATS(t)
 	m.assignmentKV = partitest.CreateJetStreamKV(t, nc, "selfheal-asgn")
 	m.assignment.Store(snapshot)
-	m.initialClaimsCommitted.Store(latched)
+	if committed != nil {
+		m.committedAssignment.Store(committed)
+	}
 	m.state.Store(int32(StateDegraded))
 	m.degradedSince.Store(time.Now().UnixNano())
 
 	return m, rh
 }
 
-func TestAttemptRecovery_UnlatchedNonEmpty_StaysDegradedAndRearms(t *testing.T) {
+func TestAttemptRecovery_NeverApplied_NonEmpty_StaysDegradedAndRearms(t *testing.T) {
 	t.Parallel()
 	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
-	m, _ := armDegraded(t, false, snap)
+	m, _ := armDegraded(t, nil, snap) // nothing committed
 	// KV holds the SAME assignment, so refresh succeeds and snapshot stays V1.
 	plantAssignment(t, m, snap)
 
 	m.attemptRecoveryFromDegraded()
 
 	require.NotZero(t, m.degradedSince.Load(),
-		"unlatched worker holding an uncommitted assignment must STAY degraded, not exit")
+		"a worker holding an unapplied assignment must STAY degraded, not exit")
 	require.Equal(t, StateDegraded, m.State())
 	stash := m.stashedApplyRetry.Load()
 	require.NotNil(t, stash, "recovery must re-arm a bootstrap apply")
 	require.Equal(t, int64(1), stash.Version, "re-arm targets the current assignment version")
 }
 
-func TestAttemptRecovery_Latched_ExitsToStable(t *testing.T) {
+func TestAttemptRecovery_Applied_ExitsToStable(t *testing.T) {
 	t.Parallel()
 	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
-	m, _ := armDegraded(t, true, snap) // claims already committed
+	committed := snap
+	m, _ := armDegraded(t, &committed, snap) // current assignment already applied+acked
 	plantAssignment(t, m, snap)
 
 	m.attemptRecoveryFromDegraded()
 	m.wg.Wait()
 
-	require.Zero(t, m.degradedSince.Load(), "a committed worker recovers normally")
+	require.Zero(t, m.degradedSince.Load(), "an applied worker recovers normally")
 	require.Equal(t, StateStable, m.State())
-	require.Nil(t, m.stashedApplyRetry.Load(), "no bootstrap re-arm for a committed worker")
+	require.Nil(t, m.stashedApplyRetry.Load(), "no bootstrap re-arm for an applied worker")
 }
 
-func TestAttemptRecovery_UnlatchedEmptyAssignment_ExitsToStable(t *testing.T) {
+// TestAttemptRecovery_LatchedVersionAdvance_RearmsAtNewVersion is the core
+// reproducer for THIS PR's defect: a worker that committed V1 then has the
+// snapshot advanced to a failed V2 via the recovery refresh must NOT exit — the
+// version-only/latch-based guard wrongly did, reporting Stable with V2 unwritten.
+func TestAttemptRecovery_LatchedVersionAdvance_RearmsAtNewVersion(t *testing.T) {
 	t.Parallel()
-	m, _ := armDegraded(t, false, Assignment{})
-	// KV holds an empty-partition assignment at V1; refresh advances to it.
-	plantAssignment(t, m, Assignment{Version: 1, LeaderRevision: 5})
+	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	committed := v1
+	m, _ := armDegraded(t, &committed, v1) // committed at V1
+	// A failed version advance: KV now holds V2; refresh stores it into the snapshot.
+	v2 := Assignment{Version: 2, LeaderRevision: 8, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+	plantAssignment(t, m, v2)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(),
+		"a worker committed at V1 but holding an unapplied V2 must STAY degraded")
+	require.Equal(t, int64(2), m.CurrentAssignment().Version, "refresh advances the snapshot to V2")
+	stash := m.stashedApplyRetry.Load()
+	require.NotNil(t, stash, "must re-arm a V2 apply")
+	require.Equal(t, int64(2), stash.Version, "re-arm targets V2 (cur read AFTER refresh)")
+}
+
+// TestAttemptRecovery_SameVersionDifferentDigest_Rearms pins the digest term of
+// the identity (review v1 P0): the publisher can expose two different partition
+// sets at the same version/LR (legacy alias before commit CAS), so version alone
+// must not be treated as applied.
+func TestAttemptRecovery_SameVersionDifferentDigest_Rearms(t *testing.T) {
+	t.Parallel()
+	setA := Assignment{Version: 3, LeaderRevision: 7, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	committed := setA
+	m, _ := armDegraded(t, &committed, setA)
+	// Same version AND same LR, DIFFERENT partition set lands in KV.
+	setB := Assignment{Version: 3, LeaderRevision: 7, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+	plantAssignment(t, m, setB)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(),
+		"same version but a different partition-set digest is NOT applied — must re-arm")
+	require.NotNil(t, m.stashedApplyRetry.Load())
+}
+
+// TestAttemptRecovery_SameVersionHigherLR_Rearms pins the LeaderRevision term
+// (review v2 P1): a same-version/same-digest higher-LR re-issue that entered the
+// snapshot via refresh has a stale applied-ack until re-applied; the leader audit
+// flags an LR mismatch as behind.
+func TestAttemptRecovery_SameVersionHigherLR_Rearms(t *testing.T) {
+	t.Parallel()
+	parts := []Partition{{Keys: []string{"p0"}}}
+	committed := Assignment{Version: 4, LeaderRevision: 9, Partitions: parts}
+	m, _ := armDegraded(t, &committed, committed)
+	// Same version, same partitions, HIGHER leader revision lands in KV.
+	higher := Assignment{Version: 4, LeaderRevision: 11, Partitions: parts}
+	plantAssignment(t, m, higher)
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(),
+		"same version/digest but a higher leader revision is NOT applied — must re-arm")
+	require.NotNil(t, m.stashedApplyRetry.Load())
+}
+
+// TestAttemptRecovery_SourceKnownVsUnknownAlias_ExitsNoDowngrade pins the
+// audit-asymmetric source comparison (review v3 P0): the degraded refresh reads
+// the legacy alias, which DROPS source revision. A worker that applied a
+// known-source assignment must NOT re-arm against the source-unknown alias (which
+// would downgrade its known-source ack to unknown — the audit then flags it as
+// behind). cur-source-unknown always matches a known-source committed.
+func TestAttemptRecovery_SourceKnownVsUnknownAlias_ExitsNoDowngrade(t *testing.T) {
+	t.Parallel()
+	parts := []Partition{{Keys: []string{"p0"}}}
+	committed := Assignment{Version: 5, LeaderRevision: 5, Partitions: parts, SourceRevision: 42, SourceRevisionKnown: true}
+	m, _ := armDegraded(t, &committed, committed)
+	// Legacy alias: same version/LR/partitions but source revision DROPPED.
+	alias := Assignment{Version: 5, LeaderRevision: 5, Partitions: parts}
+	plantAssignment(t, m, alias)
 
 	m.attemptRecoveryFromDegraded()
 	m.wg.Wait()
 
 	require.Zero(t, m.degradedSince.Load(),
-		"a worker that owns no partitions has no claims to write — exit is correct")
+		"a source-unknown alias must NOT trigger a re-arm that downgrades a known-source ack")
 	require.Equal(t, StateStable, m.State())
 	require.Nil(t, m.stashedApplyRetry.Load())
+	c := m.committedAssignment.Load()
+	require.NotNil(t, c)
+	require.True(t, c.SourceRevisionKnown, "the known-source ack must NOT be downgraded")
+}
+
+// TestAttemptRecovery_ColdZero_ExitsToStable: a never-assigned worker (committed
+// nil → empty@0) whose snapshot is also empty@0 is applied-by-identity and exits.
+func TestAttemptRecovery_ColdZero_ExitsToStable(t *testing.T) {
+	t.Parallel()
+	m, _ := armDegraded(t, nil, Assignment{})
+	plantAssignment(t, m, Assignment{}) // KV holds empty@0; refresh keeps empty@0
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Zero(t, m.degradedSince.Load(),
+		"a never-assigned worker (empty@0 == committed empty@0) exits normally")
+	require.Equal(t, StateStable, m.State())
+	require.Nil(t, m.stashedApplyRetry.Load())
+}
+
+// TestAttemptRecovery_VersionedEmptyRevoke_Rearms: an implicit-revoke (commit
+// case (d)) empty assignment carrying a real version that was never applied must
+// re-arm (the apply still tears down the consumer and re-acks the version) — NOT
+// exit as Stable with a stale ack. This is the empty-set arm of review v2 P0.
+func TestAttemptRecovery_VersionedEmptyRevoke_Rearms(t *testing.T) {
+	t.Parallel()
+	// Committed a non-empty V1; a revoke-all empty@V2 lands in KV.
+	committed := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, &committed, committed)
+	plantAssignment(t, m, Assignment{Version: 2, LeaderRevision: 8}) // empty@V2
+
+	m.attemptRecoveryFromDegraded()
+
+	require.NotZero(t, m.degradedSince.Load(),
+		"a versioned empty revoke that was never applied must re-arm, not exit")
+	require.Equal(t, int64(2), m.CurrentAssignment().Version)
+	stash := m.stashedApplyRetry.Load()
+	require.NotNil(t, stash, "must re-arm the empty-revoke apply")
+	require.Equal(t, int64(2), stash.Version)
+}
+
+// TestRecoveryGuard_TornRead_NoMissedHeal pins the §2.6 lock-free safety property
+// deterministically (the -race stress in test/integration/failure only proves "no
+// data race"). The guard reads CurrentAssignment() and committedAssignment as two
+// independent atomics, so a torn read can present either skew. The invariant: the
+// guard exits ONLY when the cur it observed has actually been committed
+// (currentAssignmentApplied is true IFF committed identity == cur identity), so no
+// torn read can cause a missed heal — at worst a redundant, stale-dropped re-arm
+// that the next tick corrects.
+func TestRecoveryGuard_TornRead_NoMissedHeal(t *testing.T) {
+	t.Parallel()
+	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	v2 := Assignment{Version: 2, LeaderRevision: 8, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+
+	// Predicate invariant: a torn read presents some (cur, committed) pair; the
+	// guard exits only when they match identity. Prove the predicate never
+	// reports "applied" for an unapplied cur, in BOTH skews.
+	t.Run("predicate exits only on a genuine identity match", func(t *testing.T) {
+		t.Parallel()
+		m, _, _, _ := newTestManager(t)
+
+		// new-snapshot/old-committed skew: cur=V2, committed=V1 → not applied.
+		committedV1 := v1
+		m.committedAssignment.Store(&committedV1)
+		require.False(t, m.currentAssignmentApplied(v2),
+			"new-cur/old-committed must NOT be treated as applied (would miss the V2 heal)")
+
+		// old-snapshot/new-committed skew: cur=V1, committed=V2 → not applied.
+		committedV2 := v2
+		m.committedAssignment.Store(&committedV2)
+		require.False(t, m.currentAssignmentApplied(v1),
+			"old-cur/new-committed must NOT be treated as applied (no false exit)")
+
+		// The only exit: committed identity actually matches the observed cur.
+		require.True(t, m.currentAssignmentApplied(v2), "a genuine identity match exits")
+	})
+
+	// Guard level, new-snapshot/old-committed: re-arms the real new version.
+	t.Run("new-snapshot/old-committed re-arms the current version", func(t *testing.T) {
+		t.Parallel()
+		committed := v1
+		m, _ := armDegraded(t, &committed, v1)
+		plantAssignment(t, m, v2) // refresh advances snapshot to V2
+
+		m.attemptRecoveryFromDegraded()
+
+		require.NotZero(t, m.degradedSince.Load(), "must stay degraded, not falsely exit")
+		stash := m.stashedApplyRetry.Load()
+		require.NotNil(t, stash)
+		require.Equal(t, int64(2), stash.Version, "re-arms the real current version V2")
+	})
+
+	// Guard level, old-snapshot/new-committed: must not falsely exit; any re-arm
+	// of the stale lower version is dropped by the (V,LR) gate on the next apply.
+	t.Run("old-snapshot/new-committed does not falsely exit; stale re-arm is gate-dropped", func(t *testing.T) {
+		t.Parallel()
+		committed := v2
+		m, _ := armDegraded(t, &committed, v1) // committed ahead of snapshot (torn-read shape)
+		plantAssignment(t, m, v1)              // refresh keeps snapshot at V1
+
+		m.attemptRecoveryFromDegraded()
+
+		require.NotZero(t, m.degradedSince.Load(),
+			"committed-ahead-of-snapshot must NOT be treated as applied — no missed heal")
+		// Whatever was re-armed at the stale V1 is dropped once the real V2 is the
+		// current snapshot, so it cannot corrupt the heal.
+		require.True(t, isApplyResultStale(v1, v2),
+			"a stale V1 re-arm is dropped by the (V,LR) gate against the eventual V2 snapshot")
+	})
 }
 
 func TestAttemptRecovery_RefreshFails_ReturnsBeforeGuard(t *testing.T) {
 	t.Parallel()
 	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
-	m, _ := armDegraded(t, false, snap)
+	m, _ := armDegraded(t, nil, snap)
 	// Do NOT plant the key: refreshAssignmentFromNATS's Get fails → return
 	// before the guard, no re-arm, stays degraded (whole-bucket-loss shape).
 
@@ -97,24 +285,4 @@ func TestAttemptRecovery_RefreshFails_ReturnsBeforeGuard(t *testing.T) {
 	require.NotZero(t, m.degradedSince.Load(), "stays degraded when the refresh read fails")
 	require.Nil(t, m.stashedApplyRetry.Load(),
 		"a failed refresh must not re-arm a bootstrap apply (guard not reached)")
-}
-
-func TestAttemptRecovery_VersionAdvanceDuringWindow_RearmsAtNewVersion(t *testing.T) {
-	t.Parallel()
-	// Snapshot pinned at V1 (what the worker had when it degraded).
-	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
-	m, _ := armDegraded(t, false, v1)
-	// A version advance landed in KV during the Degraded window: V2.
-	v2 := Assignment{Version: 2, LeaderRevision: 8, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
-	plantAssignment(t, m, v2)
-
-	m.attemptRecoveryFromDegraded()
-
-	require.NotZero(t, m.degradedSince.Load(), "must stay degraded")
-	require.Equal(t, int64(2), m.CurrentAssignment().Version,
-		"refresh must advance the snapshot to V2 before the re-arm reads cur")
-	stash := m.stashedApplyRetry.Load()
-	require.NotNil(t, stash, "must re-arm a bootstrap apply")
-	require.Equal(t, int64(2), stash.Version,
-		"re-arm MUST target V2 (cur read AFTER refresh) — not the stale V1 the gate would drop")
 }

--- a/manager_initial_claims_bootstrap_test.go
+++ b/manager_initial_claims_bootstrap_test.go
@@ -1,12 +1,15 @@
 package parti
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+var errTestApplyFailed = errors.New("test: apply failed")
 
 // fullBootstrapAssignment is the pre-advanced full set a worker's
 // waitForAssignment stores into the snapshot before any claim is written.
@@ -62,25 +65,25 @@ func TestScheduleApplyRetry_BeforeBootstrap_UsesEmptyPrev(t *testing.T) {
 			"empty diff and a zero-claim self-exit (the startup empty-diff bug)")
 }
 
-// TestApplyCore_BootstrapOverridesPrevAndLatches pins both halves of the fix on
-// the shared apply pipeline: while no claims have been committed, core overrides
-// the caller's (pre-advanced) prev to empty so the coordinator writes the full
-// claim set, and a successful such write latches initialClaimsCommitted.
-func TestApplyCore_BootstrapOverridesPrevAndLatches(t *testing.T) {
+// TestApplyCore_BootstrapOverridesPrevAndRecordsCommitted pins both halves of the
+// fix on the shared apply pipeline: while nothing has been committed, core uses an
+// empty prev (committedAssignmentOrEmpty) so the coordinator writes the full claim
+// set, and a successful write records the applied assignment as committed.
+func TestApplyCore_BootstrapOverridesPrevAndRecordsCommitted(t *testing.T) {
 	t.Parallel()
 	m, rh, _, _ := newTestManager(t)
 
 	full := fullBootstrapAssignment()
 	m.assignment.Store(full) // waitForAssignment pre-advance
-	require.False(t, m.initialClaimsCommitted.Load(), "precondition: flag starts false")
+	require.Nil(t, m.committedAssignment.Load(), "precondition: nothing committed yet")
 
 	// A same-version apply with the pre-advanced full prev (what the
-	// commit/assignment watcher computes after the pre-advance). Core must
-	// override prev to empty so claims are actually written.
+	// commit/assignment watcher computes after the pre-advance). Core must use the
+	// empty committed prev so claims are actually written.
 	require.NoError(t, m.applyAssignmentWithPrevCore(full, full))
 
-	require.True(t, m.initialClaimsCommitted.Load(),
-		"a full-set bootstrap write must latch initialClaimsCommitted")
+	require.True(t, m.currentAssignmentApplied(full),
+		"a full-set bootstrap write must record full as the committed assignment")
 
 	rh.mu.Lock()
 	defer rh.mu.Unlock()
@@ -107,12 +110,12 @@ func TestApplyCore_BootstrapVersionAdvanceOverridesPrev(t *testing.T) {
 	v1 := fullBootstrapAssignment()
 	v2 := Assignment{Version: 2, LeaderRevision: 6, Partitions: v1.Partitions}
 	m.assignment.Store(v1) // waitForAssignment pre-advanced to V1, no claims written
-	require.False(t, m.initialClaimsCommitted.Load())
+	require.Nil(t, m.committedAssignment.Load())
 
 	// Apply the NEWER version against the pre-advanced V1 snapshot.
 	require.NoError(t, m.applyAssignmentWithPrevCore(v1, v2))
 
-	require.True(t, m.initialClaimsCommitted.Load(), "the V2 bootstrap write must latch the flag")
+	require.True(t, m.currentAssignmentApplied(v2), "the V2 bootstrap write must record V2 as committed")
 
 	rh.mu.Lock()
 	defer rh.mu.Unlock()
@@ -137,7 +140,8 @@ func TestApplyCore_AfterBootstrapKeepsPrev(t *testing.T) {
 		Partitions:     append(append([]Partition(nil), full.Partitions...), Partition{Keys: []string{"p3"}}),
 	}
 	m.assignment.Store(full)
-	m.initialClaimsCommitted.Store(true) // claims already committed at least once
+	committed := full
+	m.committedAssignment.Store(&committed) // full already applied+acked
 
 	require.NoError(t, m.applyAssignmentWithPrevCore(full, next))
 
@@ -145,17 +149,77 @@ func TestApplyCore_AfterBootstrapKeepsPrev(t *testing.T) {
 	defer rh.mu.Unlock()
 	require.Len(t, rh.applyPrevs, 1)
 	require.Equal(t, full.Partitions, rh.applyPrevs[0].Partitions,
-		"after the first claim commit core MUST use the real prev (incremental semantics), "+
-			"not a forced empty prev")
+		"once an assignment is committed core MUST diff against the committed prev "+
+			"(incremental semantics), not a forced empty prev")
+}
+
+// TestApplyCore_PrevIsCommittedNotSnapshot pins the heart of the fix: the apply
+// prev is the last COMMITTED assignment, not the current snapshot. After V1 is
+// committed, a refresh advances the snapshot to V2 (no apply); a subsequent V2
+// apply must still diff against committed V1 — otherwise prev==snapshot==V2
+// yields an empty diff and writes zero claims (the latched-worker defect).
+func TestApplyCore_PrevIsCommittedNotSnapshot(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	v2 := Assignment{Version: 2, LeaderRevision: 8, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+
+	// Commit V1 (bootstrap: empty prev → full set → committed = V1).
+	m.assignment.Store(v1)
+	require.NoError(t, m.applyAssignmentWithPrevCore(v1, v1))
+
+	// Refresh advances the snapshot to V2 WITHOUT an apply (the monotonicStore
+	// the recovery refresh performs). committed stays V1.
+	m.assignment.Store(v2)
+
+	// Apply V2: prev MUST be committed V1, NOT the V2 snapshot.
+	require.NoError(t, m.applyAssignmentWithPrevCore(v2, v2))
+
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	require.Len(t, rh.applyPrevs, 2)
+	require.Empty(t, rh.applyPrevs[0].Partitions, "bootstrap V1 apply uses empty prev")
+	require.Equal(t, v1.Partitions, rh.applyPrevs[1].Partitions,
+		"the V2 apply MUST diff against committed V1, not the pre-advanced V2 snapshot "+
+			"(otherwise an empty diff writes zero claims)")
+}
+
+// TestApplyCore_CommittedUpdatesEveryApply pins that committedAssignment tracks
+// EVERY successful apply (not a one-way latch) and that a FAILED apply does not
+// advance it.
+func TestApplyCore_CommittedUpdatesEveryApply(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+
+	v1 := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	v2 := Assignment{Version: 2, LeaderRevision: 6, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}}
+	v3 := Assignment{Version: 3, LeaderRevision: 7, Partitions: []Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}, {Keys: []string{"p2"}}}}
+
+	m.assignment.Store(v1)
+	require.NoError(t, m.applyAssignmentWithPrevCore(v1, v1))
+	require.True(t, m.currentAssignmentApplied(v1), "committed tracks V1")
+
+	m.assignment.Store(v2)
+	require.NoError(t, m.applyAssignmentWithPrevCore(v2, v2))
+	require.True(t, m.currentAssignmentApplied(v2), "committed advances to V2 (not one-way)")
+	require.False(t, m.currentAssignmentApplied(v1), "committed no longer matches V1")
+
+	// A FAILED apply must not advance committed.
+	rh.errOnce.Store(&errBox{err: errTestApplyFailed})
+	m.assignment.Store(v3)
+	require.Error(t, m.applyAssignmentWithPrevCore(v3, v3))
+	require.True(t, m.currentAssignmentApplied(v2), "a failed apply must NOT advance committed past V2")
+	require.False(t, m.currentAssignmentApplied(v3), "committed must not record the failed V3")
 }
 
 // TestApplyCore_ConcurrentBootstrapApplies_LatchOnceNoRace pins the
 // concurrent-apply safety the override relies on (AGENTS.md concurrency
 // discipline). The retry goroutine and the commit/assignment watchers can all
 // issue an apply for the same bootstrap version at once. applyStoreMu serializes
-// them and the latch is read+written under that lock, so EXACTLY ONE apply takes
-// the empty-prev bootstrap path; the rest observe the latched flag and use the
-// real prev. Run under -race by the suite.
+// them and committedAssignment is read+written under that lock, so EXACTLY ONE
+// apply takes the empty-prev bootstrap path; the rest observe the recorded
+// committed assignment and use it as prev. Run under -race by the suite.
 func TestApplyCore_ConcurrentBootstrapApplies_LatchOnceNoRace(t *testing.T) {
 	t.Parallel()
 	m, rh, _, _ := newTestManager(t)
@@ -174,7 +238,7 @@ func TestApplyCore_ConcurrentBootstrapApplies_LatchOnceNoRace(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.True(t, m.initialClaimsCommitted.Load(), "the bootstrap write must latch the flag")
+	require.True(t, m.currentAssignmentApplied(full), "the bootstrap write must record full as committed")
 
 	rh.mu.Lock()
 	defer rh.mu.Unlock()
@@ -186,6 +250,6 @@ func TestApplyCore_ConcurrentBootstrapApplies_LatchOnceNoRace(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, empties,
-		"exactly one apply may take the empty-prev bootstrap path; once it latches the flag "+
-			"the rest must use the real prev (no redundant full-set re-write)")
+		"exactly one apply may take the empty-prev bootstrap path; once it records committed "+
+			"the rest must use the committed prev (no redundant full-set re-write)")
 }

--- a/test/integration/failure/degraded_recovery_rearm_concurrency_test.go
+++ b/test/integration/failure/degraded_recovery_rearm_concurrency_test.go
@@ -16,8 +16,8 @@ import (
 // TestDegradedRecovery_Rearm_NoRace stresses the degraded-recovery re-arm side
 // effect (scheduleApplyRetry issued from the connection-monitor goroutine) added
 // by the F-D3 follow-up, concurrently with assignment-version churn. The worker
-// is held in the real unlatched-Degraded state by a DUAL write fault: claims/*
-// on the handoff bucket (keeps initialClaimsCommitted false) plus all writes on
+// is held in the real uncommitted-Degraded state by a DUAL write fault: claims/*
+// on the handoff bucket (keeps the assignment uncommitted) plus all writes on
 // the heartbeat bucket (drives Degraded via the KV-error threshold circuit, which
 // fires from any state — the startup-timeout watchdog does not, because a
 // single-worker leader's calculator leaves WaitingAssignment within ~1s). While

--- a/test/integration/failure/latched_version_advance_test.go
+++ b/test/integration/failure/latched_version_advance_test.go
@@ -1,0 +1,192 @@
+package failure_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLatchedWorkerVersionAdvance_DoesNotReportStableUncommitted is the
+// reachability spike + verify-first reproducer for the latched-worker
+// version-advance defect (docs/plans/auto-healing-quorum-loss-fix/
+// 03-latched-worker-version-commitment-plan.md §5.1).
+//
+// Distinct from TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted
+// (which covers the UN-latched bootstrap worker, fixed on main): here the worker
+// FIRST commits V1 cleanly (recording V1 as committed), THEN a
+// version advance V1→V2 fails its claim write and the worker degrades.
+//
+// The bug (on the current base, where the per-version fix is NOT yet present):
+//  1. Worker commits V1={p0} cleanly → committed=V1, Stable.
+//  2. Claim-write fault armed; source advances to [p0,p1] → V2 published. The V2
+//     apply fails the p1 claim write → scheduleApplyRetry(V2), snapshot stays V1.
+//  3. Heartbeat-write fault drives the KV-error circuit → Degraded.
+//  4. Recovery refresh monotonic-stores V2 into the snapshot. Because committed
+//     still equals V1, the old version-only/latch guard is skipped →
+//     exitDegraded → Stable, while p1's claim is unwritten (symptom a: false Stable).
+//  5. The pending retry reads prev = CurrentAssignment() == V2 == next → empty
+//     prepare diff → p1 is never claimed, even after the write fault clears
+//     (symptom b: empty-diff non-heal, restart-only).
+//
+// This test asserts the FIXED behavior, so it is RED on the parent base (verified
+// by reverting the three source files to the pre-fix state and re-running — BOTH
+// assertions below fail). Both symptoms are recorded over a bounded poll window and
+// asserted NON-fatally (assert, not require) so a single run reports both even when
+// the first is violated on the parent:
+//   - (a) the worker must NOT report Stable while the advanced version's claims are
+//     uncommitted. RED on base: the latched worker exits to Stable@advanced version.
+//   - (b) once writes recover it must self-heal p1 without a restart. RED on base:
+//     the retry self-exited on the empty diff (prev == advanced snapshot == next).
+func TestLatchedWorkerVersionAdvance_DoesNotReportStableUncommitted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+
+	// Dual-fault JS: handoff bucket faults claims/* writes; heartbeat bucket
+	// faults all writes (drives the KV-error circuit from any active state).
+	faultJS := newWFFaultJetStreamDual(realJS, rfHandoffBucket, rfHeartbeatBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	// Start with ONLY p0 so V1={p0}. The advance to [p0,p1] is what makes p1 the
+	// newly-acquired partition whose claim write fails at V2.
+	src := newWFMutableSource([]types.Partition{{Keys: []string{"p0"}}})
+
+	claimStable := func(pid string) bool {
+		_, _, stable := rfReadClaimRevision(t, ctx, realJS, pid)
+		return stable
+	}
+
+	var degradedCalls atomic.Int64
+
+	// NO faults armed at start: the worker must commit V1 cleanly and latch.
+	stack := rfBuildWorkerStackCfg(t, ctx, faultJS, src, 0,
+		func(cfg *parti.Config) {
+			cfg.DegradedBehavior.KVErrorThreshold = 3
+			cfg.DegradedBehavior.ExitThreshold = 1 * time.Second
+		},
+		func(h *parti.Hooks) {
+			h.OnDegraded = func(_ context.Context, _ string) error {
+				degradedCalls.Add(1)
+				return nil
+			}
+		},
+	)
+
+	// (1) Clean commit of the initial {p0} assignment: record it as committed.
+	// The exact starting version is leader/cold-start dependent (not necessarily
+	// 1), so capture it rather than asserting a literal.
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 30*time.Second),
+		"worker must reach Stable on the clean initial commit")
+	require.Eventually(t, func() bool { return claimStable("p0") },
+		20*time.Second, 100*time.Millisecond, "p0's claim must be Stable after the clean initial commit")
+	vBefore := stack.mgr.CurrentAssignment().Version
+	require.Positive(t, vBefore, "expected a committed initial version")
+
+	// (2) Arm the claim-write fault, then advance the source to [p0,p1] → next
+	// version. The advance's p1 claim write faults; the worker stays committed on
+	// the prior claim set.
+	fc.ArmWrites()
+	src.set([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}})
+
+	// The fault firing proves the version-advance apply attempted p1's claim
+	// write. (The snapshot itself only advances to the new version via the
+	// recovery refresh AFTER Degraded — that monotonic-store is part of the bug
+	// mechanism — so we do NOT assert the version moved here.)
+	require.Eventually(t, func() bool { return fc.writeFaultsInjected.Load() >= 1 },
+		30*time.Second, 25*time.Millisecond,
+		"the version-advance apply never attempted a faulted p1 claim write")
+
+	// (3) Arm the heartbeat fault → KV-error circuit → Degraded.
+	fc.ArmHeartbeat()
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 30*time.Second),
+		"the KV-error circuit must enter Degraded under the sustained write fault")
+
+	// Non-vacuous pin: the recovery refresh monotonic-stores the new (still
+	// uncommitted) version into the snapshot. This happens on BOTH the parent and
+	// the fix — it is the bug precondition — so the "stays degraded" observation
+	// below proves the latched recovery GUARD held it, not merely that no Stable
+	// transition happened to occur.
+	require.Eventually(t, func() bool { return stack.mgr.CurrentAssignment().Version > vBefore },
+		30*time.Second, 50*time.Millisecond,
+		"the recovery refresh must advance the snapshot past the committed version")
+	require.False(t, claimStable("p1"), "precondition: p1's claim is uncommitted while writes are faulted")
+
+	// (a) SYMPTOM A — false Stable. OBSERVED (not require.Never) so the test still
+	// reaches symptom (b) on the parent and asserts BOTH RED symptoms
+	// independently. On the parent the latched worker skips the version-only guard
+	// and exits to Stable@advanced-version with p1 unwritten; with the fix it stays
+	// Degraded. Held past several ExitThreshold-spaced recovery ticks.
+	sawStableUncommitted := false
+	for deadline := time.Now().Add(8 * time.Second); time.Now().Before(deadline); {
+		if stack.mgr.State() == parti.StateStable &&
+			stack.mgr.CurrentAssignment().Version > vBefore && !claimStable("p1") {
+			sawStableUncommitted = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	assert.False(t, sawStableUncommitted,
+		"SYMPTOM A: a latched worker with an uncommitted version-advance must NOT report Stable")
+
+	t.Logf("[%s] DURING fault: writeFaults=%d asg(V=%d parts=%d) state=%s sawStableUncommitted=%v",
+		t.Name(), fc.writeFaultsInjected.Load(),
+		stack.mgr.CurrentAssignment().Version, len(stack.mgr.CurrentAssignment().Partitions),
+		stack.mgr.State(), sawStableUncommitted)
+
+	// --- Disarm: KV writes recover. NO restart. ---
+	fc.DisarmWrites()
+
+	// (b) SYMPTOM B — self-heal, asserted INDEPENDENTLY of (a). On the parent the
+	// retry self-exited on prev==next==advanced-version (empty diff), so p1 never
+	// appears even after the fault clears; with the fix the re-armed apply writes
+	// it. Observed (not require.Eventually) so both symptoms are reported.
+	healed := false
+	for deadline := time.Now().Add(40 * time.Second); time.Now().Before(deadline); {
+		if claimStable("p0") && claimStable("p1") {
+			healed = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.True(t, healed,
+		"SYMPTOM B: after write recovery the re-armed apply must write the FULL claim set (incl. p1), no restart")
+
+	if healed {
+		require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 20*time.Second),
+			"worker must reach Stable once the advanced version's claims are committed")
+		require.Greater(t, stack.mgr.CurrentAssignment().Version, vBefore,
+			"worker must be applied at the advanced version")
+
+		// Consumer layer: a post-recovery publish to p1 is consumed end-to-end.
+		base := stack.consumed.Load()
+		rfPublish(t, ctx, realJS, "p1", "post-p1")
+		require.Eventually(t, func() bool { return stack.consumed.Load() > base },
+			40*time.Second, 100*time.Millisecond,
+			"after recovery the consumer must pull p1 without any restart")
+	}
+
+	// Contract 3: OnDegraded fired exactly once across the held window.
+	require.Equal(t, int64(1), degradedCalls.Load(),
+		"OnDegraded must fire exactly once per Degraded entry (contract 3)")
+
+	t.Logf("[%s] held Degraded under fault, self-healed V2 to Stable after recovery (no restart)", t.Name())
+}

--- a/test/integration/failure/startup_writefault_test.go
+++ b/test/integration/failure/startup_writefault_test.go
@@ -361,16 +361,14 @@ func TestStartupWriteFault_SelfHealsWithoutRestart(t *testing.T) {
 // the leader's calculator drives the manager out of WaitingAssignment long
 // before the watchdog triggers. The heartbeat fault is the correct seam for an
 // integration test that must produce Degraded while the leader's claim-write
-// fault keeps initialClaimsCommitted latched false.
+// fault keeps the assignment uncommitted.
 const rfHeartbeatBucket = "parti-heartbeat"
 
 // TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted pins the
 // F-D3 follow-up: under a dual write fault (claims/* on the handoff bucket AND
 // all writes on the heartbeat bucket), the KV-error threshold circuit enters
-// Degraded while initialClaimsCommitted is still false and the assignment is
-// non-empty. On the parent, recovery refreshes (a read) and exits to Stable with
-// zero claims written (RED). With the fix the worker STAYS degraded (latch false,
-// non-empty assignment) and self-heals once writes recover — no restart. Also
+// Degraded while the assignment is non-empty and uncommitted. On the parent, recovery refreshes (a read) and exits to Stable with
+// zero claims written (RED). With the fix the worker STAYS degraded (uncommitted, non-empty assignment) and self-heals once writes recover — no restart. Also
 // asserts OnDegraded fires exactly once across the held window (cross-feature
 // contract 3).
 //
@@ -379,7 +377,7 @@ const rfHeartbeatBucket = "parti-heartbeat"
 // Rebalancing before the watchdog triggers. Faulting heartbeat bucket writes
 // (all-key mode) routes errors through the heartbeat publisher's
 // recordKVOpError → KV-error threshold → enterDegraded, which fires from any
-// active state. Claim-write faults keep initialClaimsCommitted false so the
+// active state. Claim-write faults keep the assignment uncommitted so the
 // guard in attemptRecoveryFromDegraded has something to act on.
 func TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Summary

Closes the last open code item of the quorum-loss fix series. A worker that committed one assignment then **failed to apply a later version** (its claim write faulted before the store) could report `Stable` with the new version's claims unwritten and never self-heal until a restart:

1. Degraded recovery refreshes the new version into the snapshot.
2. The old commitment guard keyed on a one-way "ever committed" latch, so it was skipped → recovery exits to `Stable`.
3. The pending retry diffs the new version against the now-equal snapshot → empty diff → zero claims written, until a process restart.

## The fix

Replace the one-way `initialClaimsCommitted` latch with **`committedAssignment`** — the last assignment actually applied + acked, updated on every successful apply and never by the recovery refresh. The apply pipeline diffs `prev` against it (subsuming the prior F-D3 bootstrap override as the empty case), and degraded recovery stays degraded + re-arms whenever the current snapshot is **not applied by full applied-ack identity**: version, leader revision, partition-set digest, and source revision when known.

- **Audit-asymmetric source comparison** — the degraded refresh reads the legacy alias (which drops source revision), so a source-unknown current target always matches a known-source commitment; a healthy known-source ack is never downgraded into an audit-behind state.
- **Not gated on a non-empty partition set** — a versioned empty revoke (commit case (d)) that failed to apply also self-heals.
- **Cold-empty bootstrap** records committed at its ack site, so the invariant holds by construction, not by zero-value coincidence.

## Verification

- **Verify-first reproducer** (`test/integration/failure/latched_version_advance_test.go`): asserts, **independently and RED on the pre-fix tree**, that the worker does not report Stable while the advance is uncommitted (symptom A) and self-heals the new claim once writes recover with no restart (symptom B). Confirmed RED-on-parent on both symptoms by reverting the source; GREEN with the fix.
- **Unit discriminators**: prev-is-committed-not-snapshot, every-apply update, lock-free torn-read / no-missed-heal, and the recovery guard across version advance, same-version different digest, same-version higher leader revision, source known-vs-unknown alias, cold zero, and versioned empty revoke.
- **`make pre-pr` green**: lint (0 issues) · all unit `-race` · all 11 integration `-race`, including the 3 cross-feature contract tests.

## Process

Design plan cleared 4 rounds of external plan-review; implementation cleared `/simplify` and a `/post-impl-review` loop (v1 fix-then-merge on 2 test-coverage gaps → v2 **merge**, zero P0/P1). Plan + review reports referenced in `docs/plans/auto-healing-quorum-loss-fix/` and `tmp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)