### PR TITLE
feat(auto-healing): close fault-model gaps with handoff removal guard

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -883,6 +883,19 @@ Called once when the manager transitions into degraded mode.
 - `ctx`: Lifecycle context (cancelled during shutdown)
 - `reason`: Description of the cause (e.g., "NATS connection down", "KV error threshold exceeded")
 
+Known reasons and operator intent:
+
+| Reason | Class | Operator action |
+|---|---|---|
+| `NATS connection down` | ride-through if reconnecting | Keep readiness degraded until NATS is stable; rotate only if the connection is closed or the outage exceeds policy. |
+| `kv-unavailable` | connected but KV quorum unavailable | Keep readiness degraded; rotation is acceptable if the outage exceeds SLO. |
+| `KV error threshold exceeded` | Parti-owned coordination data missing/lost | Restart or rotate workers after confirming bucket loss. |
+| `bucket-recreated:<bucket>` | ambiguous Parti-owned data loss | Restart or rotate workers; inspect JetStream storage before trusting the recreated bucket. |
+| `startup-timeout` | startup apply/wait did not reach Stable in budget | Readiness rotation unless the runner recovers before the pod is replaced. |
+| `assignment-watcher-exhausted` | assignment watcher retry envelope exhausted | Restart or rotate the worker; inspect the assignment bucket and NATS logs. |
+| `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | Recover the stream or rotate workers according to application ownership. |
+| `source-unavailable:<bucket>` | caller-owned source bucket unavailable | Caller/operator recovers the source bucket; Parti does not recreate it. |
+
 **Returns**:
 - `error`: Error for logging (doesn't fail manager operation)
 
@@ -1177,7 +1190,7 @@ const (
     StateScaling
     StateRebalancing
     StateEmergency
-    StateDegraded         // NEW: Degraded mode (stale cache, NATS disconnected)
+    StateDegraded         // Degraded mode (fault-specific readiness signal)
     StateShutdown
 )
 ```
@@ -1191,7 +1204,7 @@ const (
 - `StateScaling`: New workers joining, preparing to rebalance
 - `StateRebalancing`: Actively redistributing partitions
 - `StateEmergency`: Critical worker failure, emergency rebalancing
-- `StateDegraded`: **Degraded mode** - Using stale cache due to NATS connectivity loss
+- `StateDegraded`: **Degraded mode** - Fresh coordination, source, or consumer state is unreliable; use `OnDegraded` reason to choose ride-through, recovery, rotation, or operator-owned response
 - `StateShutdown`: Graceful shutdown in progress
 
 **Start return point:** `Manager.Start(ctx)` returns once the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -112,6 +112,23 @@ negative; the warning is informational only, not blocking.
 `nats.RootCAs(...)`, etc. are orthogonal to the recovery posture —
 configure as your environment requires.
 
+### Degraded Reason Taxonomy
+
+`StateDegraded` is a readiness signal. The `OnDegraded` reason tells
+operators whether the expected response is ride-through, in-process
+recovery, rotation, or caller-owned recovery.
+
+| Reason | Class | Operator action |
+|---|---|---|
+| `NATS connection down` | ride-through if reconnecting | Keep readiness degraded until NATS is stable; rotate only if the connection is closed or the outage exceeds policy. |
+| `kv-unavailable` | connected but KV quorum unavailable | Keep readiness degraded; rotation is acceptable if the outage exceeds SLO. |
+| `KV error threshold exceeded` | Parti-owned coordination data missing/lost | Restart or rotate workers after confirming bucket loss. |
+| `bucket-recreated:<bucket>` | ambiguous Parti-owned data loss | Restart or rotate workers; inspect JetStream storage before trusting the recreated bucket. |
+| `startup-timeout` | startup apply/wait did not reach Stable in budget | Readiness rotation unless the runner recovers before the pod is replaced. |
+| `assignment-watcher-exhausted` | assignment watcher retry envelope exhausted | Restart or rotate the worker; inspect the assignment bucket and NATS logs. |
+| `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | Recover the stream or rotate workers according to application ownership. |
+| `source-unavailable:<bucket>` | caller-owned source bucket unavailable | Caller/operator recovers the source bucket; Parti does not recreate it. |
+
 ### KV Bucket Pre-Creation (Optional)
 
 Parti auto-creates KV buckets, but you can pre-create them for custom settings:

--- a/docs/plans/auto-healing-gap-closure/00-fix-plan.md
+++ b/docs/plans/auto-healing-gap-closure/00-fix-plan.md
@@ -1,0 +1,524 @@
+# Auto-Healing Gap Closure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the confirmed auto-healing fault-model gaps from `tmp/auto_healing_gap_analysis.md` with source-grounded policy, focused tests, and operator-facing documentation.
+
+**Architecture:** Add policy first, then executable proof. The matrix is the source of truth for expected degraded/self-heal/operator behavior; synthetic seams close cheap deterministic gaps before gated real-cluster and environment probes cover failures that cannot be represented safely in normal CI.
+
+**Tech Stack:** Go, NATS JetStream, existing `partitest` embedded NATS helpers, `test/integration/failure`, `test/integration/manager`, `source`, `consumer`, and `docs/`.
+
+---
+
+## Execution Status
+
+- Task 1 fault matrix and reason taxonomy: implemented.
+- Task 2 source timeout signaling: implemented and verified.
+- Task 3 G4 handoff-only rebalance proof: implemented as an opt-in known
+  failing proof; the proof fails against current production behavior. See
+  `02-g4-handoff-rebalance-fix-plan.md`.
+- Task 4 full NATS outage proof: implemented and verified.
+- Task 5 N-node helper and gated Tier 2 selective-peer probe: implemented and opt-in verified.
+- Task 6 wedged/read-only storage probe: implemented and opt-in verified; chmod StoreDir produced API error 10049 for new file-backed stream/bucket creation, while existing runtime surfaces stayed OK, so stronger runtime storage-fault injection remains an investigation finding.
+- Task 7 dynamic generic permanent-failure policy: resolved as local durable-layer WARN/metric policy.
+- Findings index: `03-findings-index.md` records evidence, status, and the implementation-fix boundary.
+
+## File Map
+
+- Create: `docs/plans/auto-healing-gap-closure/01-fault-matrix.md`
+- Create: `docs/plans/auto-healing-gap-closure/03-findings-index.md`
+- Modify: `docs/OPERATIONS.md`
+- Modify: `docs/API_REFERENCE.md`
+- Modify: `types/state.go`
+- Modify: `partitest/nats.go`
+- Modify: `partitest/doc.go`
+- Modify: `partitest/nats_test.go`
+- Create: `test/integration/failure/handoff_rebalance_writefault_test.go`
+- Create: `test/integration/failure/full_nats_outage_test.go`
+- Create: `test/integration/failure/quorum_loss_tier2_test.go`
+- Create: `test/integration/failure/wedged_storage_probe_test.go`
+- Modify: `source/nats_kv.go`
+- Modify: `source/nats_kv_unavailable_hook_test.go`
+- Modify: `consumer/dynamic.go`
+- Modify: `consumer/dynamic_on_permanent_failure_test.go`
+
+## Invariant
+
+For every fault row, Parti must make one explicit choice: keep serving from committed cached state, self-heal in process, enter Degraded for restart/rotation, call an operator-owned hook, or intentionally stay local with a durable-layer log/metric. No fault row may rely on an implicit fall-through that is not named in source, tests, or docs.
+
+## Task 1: Write The Fault Matrix And Reason Taxonomy
+
+**Files:**
+- Create: `docs/plans/auto-healing-gap-closure/01-fault-matrix.md`
+- Modify: `docs/OPERATIONS.md`
+- Modify: `docs/API_REFERENCE.md`
+- Modify: `types/state.go`
+
+- [ ] **Step 1: Create the matrix document**
+
+Create `docs/plans/auto-healing-gap-closure/01-fault-matrix.md` with these rows at minimum:
+
+```markdown
+# Auto-Healing Fault Matrix
+
+| ID | Connection | JetStream state | Operation surface | Subsystem | Timing | Expected policy | Reason / signal | Proof |
+|---|---|---|---|---|---|---|---|---|
+| M1 | connected | RF3 bucket quorum lost | `Get` after `Keys` | handoff claims | stable | in-process self-heal / retry | none | `TestResolverReadFault_ConsumerSurvivesQuorumLossWindow` |
+| M2 | connected | manager KV quorum lost | heartbeat/election/stableid KV op | manager | stable | Degraded / rotate if sustained | `kv-unavailable` | `TestManager_KVUnavailable_EntersDegraded` |
+| M3 | connected | Parti-owned bucket deleted | KV op | manager | stable | Degraded + restart/rotation | `KV error threshold exceeded` | `TestManager_LiveNATSBucketLoss` |
+| M4 | connected | Parti-owned bucket recreated | bucket epoch monitor | manager | stable | Degraded + restart/rotation | `bucket-recreated:<bucket>` | `TestManager_BucketRecreated...` |
+| M5 | reconnecting | NATS nodes stopped, reconnect budget unlimited | connection monitor | manager + dynamic consumer | stable | Degraded, keep cached assignment, recover to Stable | `NATS connection down` | planned `TestFullNATSOutage_UnlimitedReconnects_RecoversFleet` |
+| M6 | closed | NATS nodes stopped, finite reconnect budget exhausted | connection monitor | manager | stable | Degraded/readiness rotation | `NATS connection down` or explicit closed-connection reason | planned `TestFullNATSOutage_FiniteReconnects_DegradesClosedConnection` |
+| M7 | connected | handoff bucket write timeout only | `Create`/`Update` claim | handoff apply | rebalance | keep old data-plane assignment, retry, no false Stable for new assignment | retry log/metric only | opt-in known failing `TestHandoffOnlyWriteFault_RebalancePreservesOldOwners` |
+| M8 | connected | source bucket missing/deleted | `Get`/`Watch` | `source.NatsKV` | reconcile | operator-owned recovery | source unavailable hook + gauge | `TestNatsKV_F6A_BucketMissing_FiresHookAndSetsMetric` |
+| M9 | connected | source bucket quorum lost | `Get` deadline/no responders | `source.NatsKV` | reconcile | sustained source-unavailable signal, no bucket recreation | source unavailable hook + gauge | planned `TestNatsKV_SourceUnavailable_DeadlineExceededThreshold` |
+| M10 | connected | stream missing | consumer info / pull | dynamic consumer | stable | manager Degraded if no user callback overrides | `stream-missing-recovery-exhausted` | `TestStreamMissingNoHook_RoutesPermanentFailureToManager` |
+| M11 | connected | generic durable permanent failure | durable retry envelope | dynamic consumer | stable | TBD policy: local log/metric or manager Degraded | TBD typed reason if promoted | planned policy test |
+| M12 | connected | read-only/wedged disk | write/read/watch/stream-info/consumer-info | all | any | fail loud according to observed surface | matrix-specific | planned gated probe |
+```
+
+- [ ] **Step 2: Update public reason taxonomy**
+
+In `docs/OPERATIONS.md` and `docs/API_REFERENCE.md`, add a compact table with these reason meanings:
+
+```markdown
+| Reason | Class | Operator action |
+|---|---|---|
+| `NATS connection down` | ride-through if reconnecting | keep readiness degraded until NATS is stable; rotate only if closed/expired by policy |
+| `kv-unavailable` | connected but KV quorum unavailable | readiness degraded; rotation is acceptable if outage exceeds SLO |
+| `KV error threshold exceeded` | Parti-owned coordination data missing/lost | restart/rotate workers after confirming bucket loss |
+| `bucket-recreated:<bucket>` | ambiguous Parti-owned data loss | restart/rotate workers; inspect JetStream storage |
+| `startup-timeout` | startup apply/wait did not reach Stable in budget | readiness rotation unless recovery completes first |
+| `assignment-watcher-exhausted` | assignment watcher retry envelope exhausted | restart/rotate worker; inspect assignment bucket and NATS logs |
+| `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | operator-owned stream recovery or worker rotation |
+| `source-unavailable:<bucket>` | caller-owned source bucket unavailable | caller/operator recovers the source bucket; Parti does not recreate it |
+```
+
+- [ ] **Step 3: Clarify `StateDegraded` Godoc**
+
+Change `types/state.go` from a connectivity-only description to a policy description:
+
+```go
+// StateDegraded indicates Parti has detected a fault that makes fresh
+// coordination, source, or consumer state unreliable. Workers continue with
+// last known safe local state where possible; the OnDegraded reason determines
+// whether the intended response is ride-through, in-process recovery,
+// readiness rotation, or operator-owned recovery.
+StateDegraded
+```
+
+- [ ] **Step 4: Verify docs**
+
+Run:
+
+```bash
+go test ./types -run TestNonExistent -count=0
+git diff --check
+```
+
+Expected: both commands exit 0.
+
+## Task 2: Close G5 Source-Bucket Sustained Timeout Signaling
+
+**Files:**
+- Modify: `source/nats_kv.go`
+- Modify: `source/nats_kv_unavailable_hook_test.go`
+
+- [ ] **Step 1: Write failing source timeout tests**
+
+Add tests that inject `context.DeadlineExceeded` and assert no missing-bucket semantics are used until a threshold is crossed:
+
+```go
+func TestNatsKV_SourceUnavailable_DeadlineExceededThreshold(t *testing.T) {
+	t.Parallel()
+
+	src := NewNatsKV(&deadlineKV{}, "config", nil,
+		WithReconcileInterval(10*time.Millisecond),
+		WithUnavailableHook(rec.fn()),
+		WithMetrics(gauge),
+	)
+	src.unavailableCooldown = 10 * time.Millisecond
+
+	require.NoError(t, src.Start(t.Context()))
+	t.Cleanup(func() { _ = src.Stop(t.Context()) })
+
+	require.Eventually(t, func() bool {
+		return rec.calls.Load() >= 1
+	}, time.Second, 10*time.Millisecond)
+	require.True(t, gauge.missing.Load())
+	require.ErrorIs(t, rec.last(), context.DeadlineExceeded)
+}
+```
+
+Run:
+
+```bash
+go test ./source -run TestNatsKV_SourceUnavailable_DeadlineExceededThreshold -count=1
+```
+
+Expected before implementation: FAIL because `context.DeadlineExceeded` falls through to the generic reconcile error and does not fire the hook.
+
+- [ ] **Step 2: Implement the minimal classifier**
+
+Add a separate helper so source timeout policy stays distinct from bucket deletion:
+
+```go
+func isSourceUnavailableErr(err error) bool {
+	return isBucketUnavailableErr(err) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+```
+
+Then update `noteBucketUnavailable` call sites so source timeout drives the hook/gauge but log text does not say "bucket missing" unless `isBucketUnavailableErr(err)` is true.
+
+- [ ] **Step 3: Verify source package**
+
+Run:
+
+```bash
+go test ./source -run 'TestNatsKV_(F6A|SourceUnavailable)' -count=1
+```
+
+Expected: PASS.
+
+## Task 3: Close G4 Handoff-Only Rebalance Proof
+
+**Files:**
+- Create: `test/integration/failure/handoff_rebalance_writefault_test.go`
+
+- [ ] **Step 1: Write the failing proof test**
+
+Build from the existing startup write-fault wrapper, but arm only the handoff claim bucket after a two-worker dynamic consumer is Stable. Force a rebalance by adding a worker.
+
+Test oracle:
+
+```go
+func TestHandoffOnlyWriteFault_RebalancePreservesOldOwners(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	// Arrange two Stable workers and record owner per partition.
+	// Arm handoff claim write faults only.
+	// Add a third worker to force rebalance.
+	// Assert the pre-fault owners continue consuming their old partitions.
+	// Assert the new worker does not expose ownership until claims commit.
+	// Disarm faults.
+	// Assert retry converges, claims are Stable, and all partitions consume.
+}
+```
+
+Run:
+
+```bash
+go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1
+```
+
+Expected before implementation: the test must at least prove the current behavior. If it fails because new ownership is exposed before claim commit, stop and create a code fix plan before changing production code.
+
+After the finding is recorded, keep the proof opt-in until the production fix
+lands so the default PR gate does not fail on an intentionally open gap:
+
+```bash
+PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1
+```
+
+- [ ] **Step 2: Implement the production fix per the G4 fix plan**
+
+The proof exposed the bug, so the fix is scoped and reviewed separately in
+`02-g4-handoff-rebalance-fix-plan.md` (see its "Implementation Outcome" header).
+The delivered fix is the **worker-side removal guard**: a `RemovalGuard` hook in
+the handoff coordinator plus a fail-closed `guardHandoffRemoval` in the manager
+(positive allow-predicate, version/`_commit`-revision-keyed commit-set cache,
+`parti_handoff_removal_pending` metric). Do not route handoff apply errors
+through `recordKVOpError` by default; that would contradict the policy in the
+`applyErr` branch of `applyAssignmentWithPrevCore`
+(`manager_assignment.go:1327-1346`). A leader-side calculator capability gate
+was tried and removed (bootstrap deadlock — see `02`); mixed-version safety is a
+rollout contract, not an in-process gate.
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1
+go test . -run 'TestApply|TestAttemptRecovery' -count=1
+```
+
+Expected: PASS.
+
+## Task 4: Close G3 Full NATS Outage Proof
+
+**Files:**
+- Create: `test/integration/failure/full_nats_outage_test.go`
+
+- [ ] **Step 1: Add unlimited reconnect fleet test**
+
+Use embedded NATS with file storage intact. Start manager + dynamic consumer, stop all NATS servers, wait for Degraded, restart the same server(s), and assert Stable plus consumption resumes.
+
+```go
+func TestFullNATSOutage_UnlimitedReconnects_RecoversFleet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	// Connect with nats.MaxReconnects(-1).
+	// Start a manager and Dynamic consumer.
+	// Stop NATS long enough for enterDegraded("NATS connection down").
+	// Restart NATS with the same StoreDir.
+	// Assert manager reaches Stable and post-restart messages are consumed.
+}
+```
+
+- [ ] **Step 2: Add finite reconnect closed-connection test**
+
+```go
+func TestFullNATSOutage_FiniteReconnects_DegradesClosedConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	// Connect with nats.MaxReconnects(0) or a small positive value.
+	// Stop NATS until the connection status is CLOSED.
+	// Assert OnDegraded fires and readiness state does not claim self-healed Stable.
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+go test ./test/integration/failure -run 'TestFullNATSOutage_' -count=1
+```
+
+Expected: PASS.
+
+## Task 5: Close G2 Real 5-Node RF3 Selective Peer Fault
+
+**Files:**
+- Modify: `partitest/nats.go`
+- Modify: `partitest/doc.go`
+- Modify: `partitest/nats_test.go`
+- Create: `test/integration/failure/quorum_loss_tier2_test.go`
+
+- [ ] **Step 1: Add an N-node cluster helper**
+
+Add:
+
+```go
+func StartEmbeddedNATSClusterN(t *testing.T, clusterSize int) ([]*server.Server, *nats.Conn) {
+	t.Helper()
+	if clusterSize < 1 {
+		t.Fatalf("clusterSize must be >= 1, got %d", clusterSize)
+	}
+	return startEmbeddedNATSClusterSized(t, clusterSize)
+}
+```
+
+Refactor existing `StartEmbeddedNATSCluster` to call the shared helper with `3`, preserving its public behavior.
+
+- [ ] **Step 2: Test helper sizes**
+
+Add:
+
+```go
+func TestStartEmbeddedNATSClusterN_FiveNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	servers, nc := StartEmbeddedNATSClusterN(t, 5)
+	require.Len(t, servers, 5)
+	require.True(t, nc.IsConnected())
+	for _, s := range servers {
+		require.GreaterOrEqual(t, s.NumRoutes(), 4)
+	}
+}
+```
+
+Run:
+
+```bash
+go test ./partitest -run 'TestStartEmbeddedNATSCluster' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Add gated Tier 2 test**
+
+Create `TestRF3SelectivePeerFault_HandoffQuorumLoss` guarded by:
+
+```go
+if os.Getenv("PARTI_RUN_QUORUM_LOSS_TIER2") != "1" {
+	t.Skip("set PARTI_RUN_QUORUM_LOSS_TIER2=1 to run")
+}
+```
+
+Test oracle:
+
+```go
+// Start 5-node cluster.
+// Create RF3 Parti KV buckets.
+// Read handoff stream cluster info and identify the leader plus replicas.
+// Stop two nodes that host handoff replicas while keeping JetStream meta quorum alive.
+// Assert manager state and dynamic consumer data-plane behavior match the matrix.
+// Restart nodes and assert recovery/convergence without process restart when policy says self-heal.
+```
+
+- [ ] **Step 4: Verify gated default and opt-in paths**
+
+Run:
+
+```bash
+go test ./test/integration/failure -run TestRF3SelectivePeerFault_HandoffQuorumLoss -count=1
+PARTI_RUN_QUORUM_LOSS_TIER2=1 go test ./test/integration/failure -run TestRF3SelectivePeerFault_HandoffQuorumLoss -count=1
+```
+
+Expected: first command skips cleanly; second command passes on machines that can run a 5-node embedded cluster.
+
+## Task 6: Close G1 Wedged / Read-Only Storage Probe
+
+**Files:**
+- Create: `test/integration/failure/wedged_storage_probe_test.go`
+
+- [ ] **Step 1: Add gated read-only file-store probe**
+
+Guard the test:
+
+```go
+if os.Getenv("PARTI_RUN_WEDGED_STORAGE_PROBE") != "1" {
+	t.Skip("set PARTI_RUN_WEDGED_STORAGE_PROBE=1 to run")
+}
+```
+
+Probe:
+
+```go
+func TestWedgedStorage_ReadOnlyFileStore_RecordsOperationSurfaces(t *testing.T) {
+	// Start file-backed embedded NATS with known StoreDir.
+	// Create RF1 and RF3 streams/buckets as available.
+	// chmod the relevant store subtree read-only.
+	// Attempt Keys, Get, Watch, Create, Update, Put, StreamInfo, ConsumerInfo.
+	// Record exact error classes in t.Logf and assert each maps to a matrix row.
+}
+```
+
+- [ ] **Step 2: Keep the probe observational**
+
+The first version must not change production classifiers. If a new error surface appears, update the matrix and create a follow-up production fix plan with the exact error chain and operation surface.
+
+- [ ] **Step 3: Verify gated behavior**
+
+Run:
+
+```bash
+go test ./test/integration/failure -run TestWedgedStorage_ReadOnlyFileStore_RecordsOperationSurfaces -count=1
+PARTI_RUN_WEDGED_STORAGE_PROBE=1 go test ./test/integration/failure -run TestWedgedStorage_ReadOnlyFileStore_RecordsOperationSurfaces -count=1
+```
+
+Expected: first command skips cleanly; second command passes or produces a failing observation that names the unmapped operation surface.
+
+## Task 7: Resolve G6 Dynamic Generic Permanent Failure Policy
+
+**Files:**
+- Modify: `consumer/dynamic.go`
+- Modify: `consumer/dynamic_on_permanent_failure_test.go`
+- Modify: `docs/plans/auto-healing-gap-closure/01-fault-matrix.md`
+
+- [ ] **Step 1: Decide the policy in the matrix before code**
+
+Choose one:
+
+```markdown
+| M11 | connected | generic durable permanent failure | durable retry envelope | dynamic consumer | stable | local WARN/metric only | durable permanent metric | `TestDynamic_onPermanentFailure_ManagerObserverOnlyOnStreamMissing` |
+```
+
+or:
+
+```markdown
+| M11 | connected | generic durable permanent failure | durable retry envelope | dynamic consumer | stable | manager Degraded | `dynamic-permanent-failure-exhausted` | planned test |
+```
+
+- [ ] **Step 2A: If local-only stays policy, document it**
+
+Keep `consumer/dynamic.go` behavior unchanged and strengthen docs so this is explicit operator policy, not an accidental gap.
+
+Run:
+
+```bash
+go test ./consumer -run TestDynamic_onPermanentFailure_ManagerObserverOnlyOnStreamMissing -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2B: If manager Degraded becomes policy, write failing test first**
+
+Add:
+
+```go
+func TestDynamic_onPermanentFailure_ManagerObserverOnConfiguredGenericExhaustion(t *testing.T) {
+	// Install manager observer.
+	// Trigger generic permanent failure.
+	// Assert observer receives typed reason dynamic-permanent-failure-exhausted.
+}
+```
+
+Run:
+
+```bash
+go test ./consumer -run TestDynamic_onPermanentFailure_ManagerObserverOnConfiguredGenericExhaustion -count=1
+```
+
+Expected before implementation: FAIL.
+
+- [ ] **Step 3: Verify chosen policy**
+
+Run:
+
+```bash
+go test ./consumer -run TestDynamic_onPermanentFailure -count=1
+go test ./test/integration/failure -run TestStreamMissingNoHook_RoutesPermanentFailureToManager -count=1
+```
+
+Expected: PASS.
+
+## Final Verification
+
+- [ ] **Step 1: Format and go fix affected Go packages**
+
+Run only after Go edits:
+
+```bash
+go fix ./partitest ./source ./consumer ./test/integration/failure
+make fmt
+```
+
+- [ ] **Step 2: Run required focused checks**
+
+```bash
+go test . -run 'Test(MarkKVUnavailable|RecordKVError_ReadUnavailable_Degrades|Manager_MaxReconnects|Manager_warnOnFiniteMaxReconnects)' -count=1
+go test ./partitest -run 'TestStartEmbeddedNATSCluster' -count=1
+go test ./source -run 'TestNatsKV_(F6A|SourceUnavailable)' -count=1
+go test ./consumer -run TestDynamic_onPermanentFailure -count=1
+go test ./internal/durable -run TestQuorumLoss -count=1
+go test ./test/integration/failure -run 'Test(ResolverReadFault_ConsumerSurvivesQuorumLossWindow|StartupWriteFault_SelfHealsWithoutRestart|StartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted|ClaimResolver_RecoversAfterNATSRestart|StreamMissingNoHook_RoutesPermanentFailureToManager|FullNATSOutage)' -count=1
+PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1
+go test ./test/integration/manager -run 'TestManager_(KVUnavailable_EntersDegraded|LiveNATSBucketLoss|LiveNATSBucketLoss_OnDegradedHook|Restart_AfterNATSBucketLoss)' -count=1
+```
+
+- [ ] **Step 3: Run lint before any commit**
+
+```bash
+make lint
+git diff --check
+```
+
+- [ ] **Step 4: Run pre-PR gate before opening a PR**
+
+This plan touches `manager`-adjacent behavior, `source`, `consumer`, and `internal` test coverage. Before PR:
+
+```bash
+make pre-pr
+```

--- a/docs/plans/auto-healing-gap-closure/01-fault-matrix.md
+++ b/docs/plans/auto-healing-gap-closure/01-fault-matrix.md
@@ -1,0 +1,46 @@
+# Auto-Healing Fault Matrix
+
+This matrix is the policy source of truth for the remaining auto-healing gap
+closure work. Each row names the expected response before tests or production
+classifiers are added.
+
+| ID | Connection | JetStream state | Operation surface | Subsystem | Timing | Expected policy | Reason / signal | Proof |
+|---|---|---|---|---|---|---|---|---|
+| M1 | connected | RF3 bucket quorum lost | `Get` after `Keys`; real RF3 peer loss | handoff claims | stable | In-process self-heal / retry; do not tombstone listed-but-unreadable claims. | none | `TestResolverReadFault_ConsumerSurvivesQuorumLossWindow`; gated `TestRF3SelectivePeerFault_HandoffQuorumLoss` |
+| M2 | connected | manager KV quorum lost | heartbeat / election / stableid KV op | manager | stable | Enter Degraded; rotate if sustained past operator SLO. | `kv-unavailable` | `TestManager_KVUnavailable_EntersDegraded` |
+| M3 | connected | Parti-owned bucket deleted | KV op | manager | stable | Enter Degraded; live workers must not recreate coordination buckets. | `KV error threshold exceeded` | `TestManager_LiveNATSBucketLoss` |
+| M4 | connected | Parti-owned bucket recreated | bucket epoch monitor | manager | stable | Enter Degraded because revision reset is ambiguous data loss. | `bucket-recreated:<bucket>` | `TestManager_BucketRecreated_EntersDegraded` |
+| M5 | reconnecting | all NATS nodes stopped, reconnect budget unlimited | connection monitor | manager + dynamic consumer | stable | Enter Degraded, keep committed cached assignment where possible, recover to Stable when NATS returns. | `NATS connection down` | `TestFullNATSOutage_UnlimitedReconnects_RecoversFleet` |
+| M6 | closed | all NATS nodes stopped, finite reconnect budget exhausted | connection monitor | manager | stable | Enter Degraded/readiness rotation; do not claim in-process self-heal after the client is closed. | `NATS connection down` or a future explicit closed-connection reason | `TestFullNATSOutage_FiniteReconnects_DegradesClosedConnection` |
+| M7 | connected | handoff bucket write timeout only | `Create` / `Update` claim | handoff apply | rebalance | Keep old data-plane ownership, retry, and do not expose new ownership until claims commit. **Holds for a fully-upgraded fleet that wires `CapProcessingGate` (fences the gaining worker before commit). Mixed-version safety is a rollout contract — finish the upgrade before relying on M7; during the upgrade window an un-upgraded worker is no worse than current `main`.** | retry log + `parti_handoff_removal_pending` metric | `TestHandoffOnlyWriteFault_RebalancePreservesOldOwners` (passes; opt-in via `PARTI_RUN_HANDOFF_REBALANCE_PROOF=1` pending promotion); see `02-g4-handoff-rebalance-fix-plan.md` |
+| M8 | connected | source bucket missing/deleted | `Get` / `Watch` | `source.NatsKV` | reconcile | Caller/operator-owned recovery; Parti must not recreate caller-owned source buckets. | `source-unavailable:<bucket>` hook + gauge | `TestNatsKV_F6A_BucketMissing_FiresHookAndSetsMetric` |
+| M9 | connected | source bucket quorum lost | `Get` deadline/no responders | `source.NatsKV` | reconcile | Sustained source-unavailable signal without treating the bucket as deleted or recreating it. | `source-unavailable:<bucket>` hook + gauge | `TestNatsKV_SourceUnavailable_DeadlineExceededThreshold` |
+| M10 | connected | stream missing | consumer info / pull | dynamic consumer | stable | Manager Degraded if no application callback recovers or overrides. | `stream-missing-recovery-exhausted` | `TestStreamMissingNoHook_RoutesPermanentFailureToManager` |
+| M11 | connected | generic durable permanent failure | durable retry envelope | dynamic consumer | stable | Local durable-layer WARN/metric only. Applications that need readiness impact must install their own permanent-failure callback. | durable permanent-failure log/metric | `TestDynamic_onPermanentFailure_ManagerObserverOnlyOnStreamMissing` |
+| M12 | connected | read-only/wedged disk | write / read / watch / stream-info / consumer-info / file-backed create | all | any | Fail loud according to the observed operation surface; update this matrix before widening classifiers. | matrix-specific | gated `TestWedgedStorage_ReadOnlyFileStore_RecordsOperationSurfaces` (existing surfaces stayed OK; new file-backed stream/bucket create returned API error 10049) |
+
+## Reason Taxonomy
+
+| Reason | Class | Operator action |
+|---|---|---|
+| `NATS connection down` | ride-through if reconnecting | Keep readiness degraded until NATS is stable; rotate only if the connection is closed or the outage exceeds policy. |
+| `kv-unavailable` | connected but KV quorum unavailable | Keep readiness degraded; rotation is acceptable if the outage exceeds SLO. |
+| `KV error threshold exceeded` | Parti-owned coordination data missing/lost | Restart or rotate workers after confirming bucket loss. |
+| `bucket-recreated:<bucket>` | ambiguous Parti-owned data loss | Restart or rotate workers; inspect JetStream storage before trusting the recreated bucket. |
+| `startup-timeout` | startup apply/wait did not reach Stable in budget | Readiness rotation unless the runner recovers before the pod is replaced. |
+| `assignment-watcher-exhausted` | assignment watcher retry envelope exhausted | Restart or rotate the worker; inspect the assignment bucket and NATS logs. |
+| `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | Recover the stream or rotate workers according to application ownership. |
+| `source-unavailable:<bucket>` | caller-owned source bucket unavailable | Caller/operator recovers the source bucket; Parti does not recreate it. |
+
+## Open Proof Rows
+
+The remaining executable work is intentionally split by cost:
+
+1. M9 is deterministic and should be closed first with a synthetic source KV
+   timeout seam.
+2. M7 has an executable failing proof and a dedicated fix plan.
+3. M12 and the RF3 selective-peer proof are gated probes because they require
+   environment-specific storage or five-node cluster conditions. The read-only
+   StoreDir probe observed API error 10049 for new file-backed stream/bucket
+   creation, while existing stream/KV operations stayed OK; a stronger
+   wedged-storage mechanism is still needed for runtime write failure proof.

--- a/docs/plans/auto-healing-gap-closure/02-g4-handoff-rebalance-fix-plan.md
+++ b/docs/plans/auto-healing-gap-closure/02-g4-handoff-rebalance-fix-plan.md
@@ -1,0 +1,723 @@
+# G4 Handoff Rebalance Write-Fault Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Implementation Outcome (read first — supersedes Task 1 below)
+
+The **worker-side removal guard is the fix** and is implemented:
+- **Task 2** (handoff coordinator `RemovalGuard` hook) — done.
+- **Task 3** (manager `guardHandoffRemoval`, fail-closed positive allow-predicate,
+  version/`_commit`-revision-keyed commit-set cache, `parti_handoff_removal_pending`
+  metric, retry routing that never enters the degraded circuit) — done. The G4
+  proof `TestHandoffOnlyWriteFault_RebalancePreservesOldOwners` **passes** with
+  these two alone.
+
+**Task 1 (the leader-side calculator capability gate) was implemented and then
+removed.** A post-implementation review confirmed it had a fatal bootstrap
+deadlock: the target-side check refused to assign a transfer-gained partition to
+a worker until it reported `CapProcessingGate`, but that capability is only
+reported *after* a worker's first apply — so a freshly-joined worker (whose first
+partitions are always transfers in steady state) could never be assigned work.
+Capabilities are runtime wire-up state, not config intent, so a pre-assignment
+gate on a post-apply capability is inherently circular. The whole gate (source +
+target), the `CapHandoffRemovalGuard` bit, and the `RecordRebalanceDeferred`
+metric were dropped.
+
+**Mixed-version safety is now a rollout contract, not an in-process gate:** M7
+safety holds for a fully-upgraded fleet running two-phase handoff with the
+processing gate wired; complete the rolling upgrade before relying on M7. During
+the upgrade window an un-upgraded worker carries the same M7 exposure it has on
+current `main` — no regression, just no new in-process protection. A future
+mixed-version defense (e.g. a startup-reported config-intent capability) is a
+separate plan-review item and must not reuse the post-apply `CapProcessingGate`
+as a pre-transfer predicate.
+
+Task 1 below is retained for historical context only; **do not implement it.**
+
+**Tasks 4 and 5 are done.**
+- **Task 4 (gaining-worker-death liveness)** — `TestGuardHandoffRemoval_GainingWorkerDeath_Liveness`
+  in `manager_handoff_liveness_test.go` wires the REAL sweep to the REAL guard:
+  a real `twoPhaseCoordinator` sweep resets an expired
+  `{owner: OLD, pending: NEW, prepare}` claim to `{owner: OLD, stable}`, and the
+  manager guard then blocks OLD's removal. **Convergence dependency (rollout
+  note):** when the gaining worker dies, the data plane stays *safe* (OLD keeps
+  serving) but does NOT self-converge — `scheduleApplyRetry` replays the same
+  failed commit and the guard keeps blocking. Convergence requires a *new*
+  signal: a later assignment that returns the partition to OLD, or one that
+  reassigns it to a live worker whose claim commits. The test asserts both the
+  safety block (including no spurious self-convergence on retry) and both
+  convergence paths.
+- **Task 5 (proof + matrix + contract/concurrency sweep)** — the G4 proof
+  `TestHandoffOnlyWriteFault_RebalancePreservesOldOwners` passes with the
+  processing gate wired (via the shared `rfBuildWorkerStack`); it stays opt-in
+  behind `PARTI_RUN_HANDOFF_REBALANCE_PROOF=1` (a 30–45s rebalance+write-fault
+  timing test kept out of the default suite to avoid load-flakes — run it in a
+  dedicated job, not unconditionally in CI). The matrix M7 row already names the
+  `parti_handoff_removal_pending` signal and the `CapProcessingGate`-only
+  prerequisite (the dropped `CapHandoffRemovalGuard` is intentionally absent).
+  `TestHandoffRemovalGuard_NoRaceUnderConcurrentApplies`
+  (`test/integration/failure/handoff_removal_guard_concurrency_test.go`) is the
+  AGENTS.md-required `-race` stress test: it churns the partition set on a live
+  3-worker two-phase cluster so the guard's commit/payload reads on
+  `m.assignmentKV` race the assignment/commit watcher goroutines.
+
+**Goal:** Keep pre-fault data-plane owners active during a handoff-bucket-only
+write outage in a rebalance, then converge after claim writes recover — and make
+that property hold under a rolling/mixed-version fleet, not only a homogeneous
+fully-upgraded one.
+
+**Architecture:** The failing proof shows the new (gaining) worker is gated
+correctly, but old owners drop some partitions before the receiving worker can
+commit ownership. The fix has three layers, in dependency order:
+
+1. **Capability gate (leader-side, two-sided).** **(SUPERSEDED — see the
+   Implementation Outcome header: this leader-side gate was implemented then
+   removed due to a bootstrap deadlock; `CapHandoffRemovalGuard` was dropped and
+   mixed-version source-side safety is a rollout contract, not an in-process
+   gate. Layer 1 is retained only to explain the original three-layer design.)**
+   The removal guard and the
+   processing gate are *local* defenses on the losing and gaining workers
+   respectively. A worker on an older binary reports `CapTwoPhaseHandoff` but may
+   lack either, so the leader must gate BOTH endpoints of a transfer: do not move
+   a partition away from a source that does not report `CapHandoffRemovalGuard`,
+   and do not assign a transfer-gained partition to a target that does not report
+   `CapProcessingGate` (Task 1 Step 3). This mirrors the existing safety-chain
+   gate the audit path already uses on both ends
+   (`internal/assignment/calculator_audit.go:15` — `requiredAuditCaps`; `:171`
+   filters source/behind workers, `:185-190` filters target workers; with
+   `cap_missing_behind` / `cap_missing_targets` metrics).
+2. **Removal guard (worker-side).** Add a two-phase removal guard that runs
+   before the consumer updater removes partitions: if a removed partition is
+   still present in the current assignment batch and its handoff claim is not
+   yet committed to a different owner, return a retryable apply error so Manager
+   keeps the old local assignment and `scheduleApplyRetry` drives convergence.
+   Partition-source deletion must still remove the local subject, so the guard
+   only blocks **transfer** removals (partition still in the current commit
+   batch), not globally removed partitions.
+3. **Processing-gate prerequisite (explicit).** "The new owner does not expose
+   uncommitted ownership" is only true when the consumer processing/pull gate is
+   wired. That gate is optional and **default-disabled**
+   (`internal/durable/processing_gate.go:15-17`;
+   `internal/durable/worker_consumer.go:386-387` wraps handlers only when
+   `ProcessingGate.Enabled` + a resolver are present). M7 safety therefore
+   requires `CapProcessingGate`; the plan and matrix must say so, and the
+   integration proof must run with the gate enabled.
+
+**Tech Stack:** Go, Parti manager assignment commit path, internal handoff
+coordinator, NATS JetStream KV handoff claims, leader calculator capability
+filtering, existing integration failure harness.
+
+---
+
+## Safety Contract (read before implementing)
+
+The G4 invariant — "during a handoff-bucket-only write outage in a rebalance,
+pre-fault owners keep consuming, the gaining worker does not expose uncommitted
+ownership, and the fleet converges after writes recover" — holds **only** under
+this contract:
+
+- **C1 (gate):** **(SUPERSEDED — the leader-side capability gate was removed; see
+  the Implementation Outcome header. `CapHandoffRemovalGuard` does not exist and
+  mixed-version source-side safety is a rollout contract, not an in-process gate.
+  The C2 fencing requirement below still holds.)** The leader gates both
+  endpoints of a two-phase transfer: a
+  transfer *source* must report `CapHandoffRemovalGuard` before the leader moves
+  a partition away from it, and a transfer *target* must report
+  `CapProcessingGate` (see C2) before the leader assigns it a transfer-gained
+  partition. During a rolling upgrade the leader itself must be upgraded for the
+  gate to take effect (an old-binary leader runs old behavior); this is the same
+  rollout limitation that already applies to `CapTwoPhaseHandoff` /
+  `requiredAuditCaps`. Document this in the rollout notes.
+- **C2 (fencing):** Workers report `CapProcessingGate`. Without it the consumer
+  updater can expose the gaining worker while its claim is still `prepare`
+  (`internal/assignment/handoff/twophase.go:80-91` runs the updater before
+  `commitPhase`). The manager already WARNs on this misconfiguration
+  (`manager.go` `maybeWarnMissingProcessingGate`, ~`:956`/`:985`).
+- **C3 (fail-closed):** A transfer removal whose claim cannot be proven
+  committed-to-another-owner is **retryable**, never silently allowed. This
+  covers `rev == 0` (missing claim) for a partition still in the current commit
+  batch.
+
+## Current Evidence
+
+Command:
+
+```bash
+PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1 -v
+```
+
+Observed failure:
+
+```text
+during handoff write fault: new worker state=WaitingAssignment assignment_parts=3 writeFaults=6
+old owners must keep consuming their pre-fault partitions while new ownership is uncommitted;
+want old deltas=(8,4) got=(5,3) new_delta=0
+```
+
+Source evidence:
+
+- `internal/assignment/handoff/twophase.go:64-67` returns on prepare write
+  failure before the consumer updater, so the receiving worker is protected.
+- `internal/assignment/handoff/twophase.go:80-91` applies the consumer updater
+  after prepare succeeds and before `commitPhase`. A losing worker with no
+  newly acquired partitions can reach this updater and remove subjects even
+  while the receiver is failing claim writes.
+- The `applyErr` branch of `applyAssignmentWithPrevCore`
+  (`manager_assignment.go:1327-1346`) already defines the intended policy:
+  handoff apply errors stay local, route through `scheduleApplyRetry`, and must
+  not flow through `recordKVOpError` / manager Degraded.
+- Claims are keyed by `Partition.SubjectKey()` (dot-joined), not `ID()`
+  (dash-joined) (`internal/assignment/handoff/twophase.go` prepare/commit;
+  `types/partition.go:60`). The guard and the diff helper must key the same way.
+- During a transfer the claim reads `{owner: OLD, pendingOwner: NEW,
+  state: prepare}` because `NextPrepare` keeps `Owner` unchanged
+  (`internal/assignment/handoff/claims.go:66-70`) and `NextCommit` only then
+  switches owner (`:76-80`). The guard's positive allow predicate (Task 3 Step 2)
+  permits removal only for a non-empty owner *different from* this worker in
+  `commit`/`stable` state, so while the claim still names OLD (any state) it
+  keeps the OLD owner blocking until the transfer commits to NEW.
+
+## File Map
+
+- Modify: `types/heartbeat.go` (add `CapHandoffRemovalGuard`)
+- Modify: `manager.go` (report the capability; add `handoffStore` field)
+- Modify: `manager_setup.go` (wire guard + capability)
+- Modify: `manager_assignment.go` (guard helper, diff helper, cached commit-set lookup)
+- Modify: `internal/assignment/calculator.go` (gate transfer-removals by capability)
+- Modify: `internal/assignment/calculator_audit.go` (extend or reuse the safety-chain constant)
+- Modify: `internal/assignment/handoff/coordinator.go` (RemovalGuard API)
+- Modify: `internal/assignment/handoff/twophase.go` (invoke guard before consumer update)
+- Modify: `internal/assignment/handoff/twophase_test.go`
+- Modify: `internal/assignment/calculator_test.go` (or a focused new test file)
+- Modify: `types/metrics_collector.go` + `internal/metrics/prometheus.go` (removal-pending metric)
+- Modify: `test/integration/failure/handoff_rebalance_writefault_test.go`
+- Modify: `docs/plans/auto-healing-gap-closure/01-fault-matrix.md`
+
+## Task 1: Add The Capability Gate (Mixed-Version Safety, P0)
+
+**Files:**
+- Modify: `types/heartbeat.go`
+- Modify: `manager.go`, `manager_setup.go`
+- Modify: `internal/assignment/calculator.go`, `internal/assignment/calculator_audit.go`
+- Modify: `internal/assignment/calculator_test.go`
+
+- [ ] **Step 1: Add the capability bit**
+
+In `types/heartbeat.go`, alongside the existing bits
+(`CapAckV1 = 1 << 0`, `CapTwoPhaseHandoff = 1 << 1`,
+`CapProcessingGate = 1 << 2` at `:42-46`), add:
+
+```go
+// CapHandoffRemovalGuard indicates the manager runs the handoff removal guard
+// that blocks transfer removals until the gaining worker commits its claim.
+CapHandoffRemovalGuard uint32 = 1 << 3
+```
+
+Do **not** add it to `reportableCapBits` (`manager.go:927`). That set is only
+sampled from the consumer updater's `CapabilityReporter` after apply
+(`manager.go:944-955`); `CapHandoffRemovalGuard` is manager/coordinator-owned,
+not consumer-updater state. It is reported solely via `SetCapability` in Step 2.
+The heartbeat publisher reads the live capability function when building each
+heartbeat (`internal/heartbeat/publisher.go:377-401`), so a `SetCapability` call
+is sufficient to surface the bit.
+
+- [ ] **Step 2: Report the capability after wiring the guard**
+
+In `manager.go`, where `SetCapability(types.CapTwoPhaseHandoff, true)` fires
+after `setupHandoff` (~`:563`), report `CapHandoffRemovalGuard` once the guard
+is wired into the live coordinator (Task 2/3). Only report it when the guard
+is actually installed, never on the constructor-time placeholder coordinator.
+
+- [ ] **Step 3: Gate transfer-removals in the calculator (source AND target)**
+
+A two-phase transfer is M7-safe only when BOTH endpoints carry their respective
+capability: the losing worker cannot run a guard it does not have, and the
+gaining worker cannot fence delivery before commit without a processing gate
+(C1 + C2). So the leader must not generate a transfer unless both hold. Reuse
+the existing capability-filter pattern — the audit path already filters BOTH the
+reassignment source (behind) and the target by capability
+(`internal/assignment/calculator_audit.go:15` defines `requiredAuditCaps`;
+`:171` filters behind/source workers, `:185-190` filters target workers).
+
+Add two sibling constants (do **not** silently widen `requiredAuditCaps`, which
+is the audit-escalation chain):
+
+```go
+// requiredRemovalSourceCaps is the chain a worker must report before the leader
+// will move a partition AWAY from it during a two-phase rebalance.
+const requiredRemovalSourceCaps = types.CapTwoPhaseHandoff | types.CapHandoffRemovalGuard
+
+// requiredTransferTargetCaps is the chain a worker must report before the
+// leader will assign it a partition GAINED via two-phase transfer (fencing).
+const requiredTransferTargetCaps = types.CapTwoPhaseHandoff | types.CapProcessingGate
+```
+
+Gate semantics, when `EnableTwoPhaseHandoff` is on (direct mode is unaffected,
+matching the audit gate's scope):
+- **Source check:** do not remove a partition from a *live, active* owner `W`
+  unless `hbs[W].Capabilities & requiredRemovalSourceCaps == requiredRemovalSourceCaps`.
+  Keep the partition on `W` (defer the transfer).
+- **Target check:** do not assign a transfer-gained partition to worker `T`
+  unless `hbs[T].Capabilities & requiredTransferTargetCaps == requiredTransferTargetCaps`.
+  Leave the partition on its current owner (defer) rather than handing it to an
+  unfenceable target.
+- Record a skip metric mirroring `cap_missing_behind` / `cap_missing_targets`,
+  e.g. `RecordRebalanceDeferred("cap_missing_removal_source", W)` and
+  `RecordRebalanceDeferred("cap_missing_transfer_target", T)`.
+
+**Heartbeat snapshot + absent-worker semantics (P1):** current rebalance has no
+heartbeat map at assignment time — `collectRebalanceWorkers` returns only
+`([]string, bool, error)` (`internal/assignment/calculator.go:1472`) and
+`rebalance` then calls `Strategy.Assign(workers, partitions)` (`:1541-1564`,
+`:1620-1625`). Add a heartbeat fetch via `WorkerMonitor.GetHeartbeats`
+(`internal/assignment/worker_monitor.go:197`) and thread the resulting
+`map[string]types.Heartbeat` into the gate. Failure / absence policy:
+  - **KV read failure** (GetHeartbeats returns error): treat as
+    inconclusive — defer the transfer (fail safe), do not move partitions.
+  - **Active worker with missing/undecodable heartbeat** (GetHeartbeats silently
+    omits decode failures per its Godoc): treat as *missing caps* → defer
+    transfers off and onto it.
+  - **Worker absent from the active set** (scale-down / removal): do NOT apply
+    the removal-source gate — an absent worker cannot run a local removal path,
+    and pinning its partitions would strand them. Reassignment of an absent
+    worker's partitions is governed by the existing worker-removal semantics
+    (workers not in `PublishInput.Workers` are implicitly revoked —
+    `internal/assignment/assignment_publisher.go:401-413`,
+    `types/assignment_commit.go:102-109`). The gate composes with — does not
+    replace — the F10-A worker-shrink floor that already gates shrunk-worker-set
+    rebalances on emergency-confirmed deaths (`internal/assignment/calculator.go:1579-1608`):
+    the floor decides *whether* a shrink is real; this gate only constrains
+    transfers among the live active set.
+
+- [ ] **Step 4: Rollout note**
+
+In the rollout notes for this plan, state C1 from the Safety Contract: the gate
+only takes effect once the **leader** is upgraded; until then an old-binary
+leader rebalances with pre-fix behavior, which is no worse than current `main`
+(the existing M7 gap), i.e. no regression — but full mixed-version safety is
+reached only after the whole fleet, including any worker that can win election,
+is upgraded.
+
+- [ ] **Step 5: Run the calculator unit checks**
+
+```bash
+go test ./internal/assignment -run 'TestCalculator.*Rebalance|TestCalculator.*Cap' -count=1
+```
+
+Expected: PASS. Add tests covering:
+- **Source-missing/target-full:** active owner lacks `CapHandoffRemovalGuard` →
+  transfer off it is deferred (partition stays).
+- **Source-full/target-missing:** target lacks `CapProcessingGate` → transfer to
+  it is deferred (partition stays on current owner).
+- **Both-full:** fully-capable source and target → transfer proceeds.
+- **Heartbeat read failure / undecodable active-worker heartbeat:** transfer
+  deferred (fail safe).
+- **Absent (confirmed-dead) source:** its partitions are reassignable under the
+  existing worker-removal path, not pinned by the source gate.
+- **Direct mode:** gate bypassed when `EnableTwoPhaseHandoff` is disabled.
+
+## Task 2: Pin The Coordinator Guard Contract
+
+**Files:**
+- Modify: `internal/assignment/handoff/coordinator.go`
+- Modify: `internal/assignment/handoff/twophase.go`
+- Modify: `internal/assignment/handoff/twophase_test.go`
+
+- [ ] **Step 1: Add the failing unit test**
+
+Add this test to `internal/assignment/handoff/twophase_test.go`:
+
+```go
+func TestTwoPhase_RemovalGuardBlocksConsumerRemoval(t *testing.T) {
+	t.Parallel()
+
+	up := &mockUpdater{}
+	guardCalls := atomic.Int64{}
+	coord := New(Config{
+		Store:           newMemStore(),
+		ConsumerUpdater: up,
+		RemovalGuard: func(ctx context.Context, workerID string, previous, next types.Assignment) error {
+			guardCalls.Add(1)
+			require.Equal(t, "w1", workerID)
+			require.Len(t, previous.Partitions, 1)
+			require.Empty(t, next.Partitions)
+			return ErrRemovalPending
+		},
+		TTL: time.Minute,
+	}, true)
+
+	prev := types.Assignment{Version: 1, Partitions: []types.Partition{{Keys: []string{"p0"}}}}
+	next := types.Assignment{Version: 2, Partitions: nil}
+
+	err := coord.Apply(context.Background(), "w1", prev, next)
+	require.ErrorIs(t, err, ErrRemovalPending)
+	require.Equal(t, int64(1), guardCalls.Load())
+	require.Equal(t, int64(0), up.calls.Load(), "consumer updater must not remove subjects while guard blocks")
+}
+```
+
+- [ ] **Step 2: Run the unit RED**
+
+```bash
+go test ./internal/assignment/handoff -run TestTwoPhase_RemovalGuardBlocksConsumerRemoval -count=1
+```
+
+Expected before implementation: compile failure for missing `RemovalGuard` and `ErrRemovalPending`.
+
+- [ ] **Step 3: Add the internal guard API**
+
+In `internal/assignment/handoff/coordinator.go`, add:
+
+```go
+var ErrRemovalPending = errors.New("handoff removal pending")
+
+type RemovalGuard func(ctx context.Context, workerID string, previous, next types.Assignment) error
+```
+
+Add this field to `Config`:
+
+```go
+// RemovalGuard optionally blocks consumer removal of partitions whose transfer
+// has not committed yet. It must return ErrRemovalPending for retryable
+// handoff-transfer waits.
+RemovalGuard RemovalGuard
+```
+
+Add the `errors` import.
+
+- [ ] **Step 4: Invoke the guard before consumer update**
+
+In `internal/assignment/handoff/twophase.go`, immediately before the
+`ConsumerUpdater.UpdateWorkerConsumer` phase (the `// Phase: apply` block at
+`:80-91`), insert:
+
+```go
+if t.cfg.RemovalGuard != nil {
+	if err := t.cfg.RemovalGuard(ctx, workerID, previous, next); err != nil {
+		inst.finish(err)
+		return err
+	}
+}
+```
+
+- [ ] **Step 5: Run the unit GREEN**
+
+```bash
+go test ./internal/assignment/handoff -run 'TestTwoPhase_(RemovalGuardBlocksConsumerRemoval|DelaysExposeIntermediateStates|MultiKeyPartition)' -count=1
+```
+
+Expected: PASS.
+
+## Task 3: Implement Manager Transfer-Removal Detection (Fail-Closed)
+
+**Files:**
+- Modify: `manager_setup.go`
+- Modify: `manager_assignment.go`
+- Modify: `manager.go`
+- Modify: `types/metrics_collector.go`, `internal/metrics/prometheus.go`
+
+- [ ] **Step 1: Wire the guard into the real two-phase coordinator**
+
+In `manager_setup.go`, add `RemovalGuard: m.guardHandoffRemoval,` to the
+`handoff.Config` used in `setupHandoff`. Do not add the guard to the
+constructor-time placeholder coordinator in `manager.go`; that coordinator has
+no claim store yet and is replaced during `Start`.
+
+- [ ] **Step 2: Add the manager guard helper (fail-closed on uncommitted transfer)**
+
+Add this helper near the apply helpers in `manager_assignment.go`:
+
+```go
+func (m *Manager) guardHandoffRemoval(ctx context.Context, workerID string, previous, next Assignment) error {
+	removed := removedPartitions(previous.Partitions, next.Partitions)
+	if len(removed) == 0 {
+		return nil
+	}
+
+	batch, err := m.currentCommitPartitionSet(ctx, next.Version)
+	if err != nil {
+		// Read failure is retryable, not fail-open: a guard read error
+		// returns through scheduleApplyRetry (apply errors do not enter the
+		// degraded circuit — manager_assignment.go:1327-1346).
+		return fmt.Errorf("handoff removal guard commit read: %w", err)
+	}
+	if len(batch) == 0 {
+		return nil
+	}
+
+	store, ok := m.handoffClaimStore()
+	if !ok {
+		return nil
+	}
+	for _, p := range removed {
+		pid := p.SubjectKey()
+		if _, transfer := batch[pid]; !transfer {
+			// Globally removed (partition-source deletion) — release locally.
+			continue
+		}
+		claim, rev, err := store.Get(ctx, pid)
+		if err != nil {
+			return fmt.Errorf("handoff removal guard claim read %s: %w", pid, err)
+		}
+		// FAIL CLOSED: a transfer removal is safe ONLY when the claim proves a
+		// DIFFERENT owner now holds the partition. Use a POSITIVE allow
+		// predicate; a negative block list lets unsafe shapes through —
+		// self-owned commit, different-owner prepare/abort/unknown, empty
+		// owner. NextCommit only sets Owner=PendingOwner
+		// (internal/assignment/handoff/claims.go:76-84), and resume treats
+		// owner==self && state==commit as still-owned-by-self
+		// (manager_handoff.go:124-130), so a self-commit is NOT proof of
+		// transfer. Allow removal only for a non-empty owner different from
+		// this worker in a post-switch ownership state (commit or stable).
+		committedElsewhere := rev != 0 &&
+			claim.Owner != "" &&
+			claim.Owner != workerID &&
+			(claim.State == handoff.ClaimStateCommit || claim.State == handoff.ClaimStateStable)
+		if !committedElsewhere {
+			m.metrics.RecordHandoffRemovalPending(workerID)
+			m.logger.Debug("handoff removal deferred: transfer not committed",
+				"worker_id", workerID, "partition_id", pid,
+				"claim_owner", claim.Owner, "claim_state", string(claim.State), "rev", rev)
+			return handoff.ErrRemovalPending
+		}
+	}
+
+	return nil
+}
+```
+
+> Rationale for fail-closed (P0): the claim store returns `rev == 0` for a
+> missing key (`internal/assignment/handoff/kv_store.go:77-82`). A swept,
+> aged-out (handoff bucket MaxAge — see `manager_setup.go` handoff TTL note), or
+> never-populated claim during a write-fault transfer would otherwise let the
+> OLD owner drop a still-assigned partition — the exact M7 dark-partition
+> outcome. The guard only fails open for partitions **absent from the current
+> commit batch**, which is the legitimate source-deletion release path.
+
+The implementation requires a manager-owned claim-store reference. Add this
+private field to `Manager` in `manager.go`:
+
+```go
+handoffStore handoff.ClaimStore
+```
+
+Set it in `setupHandoff` after `store := handoff.NewNATSClaimStore(...)`:
+
+```go
+m.handoffStore = store
+```
+
+Add:
+
+```go
+func (m *Manager) handoffClaimStore() (handoff.ClaimStore, bool) {
+	if m.handoffStore == nil {
+		return nil, false
+	}
+	return m.handoffStore, true
+}
+```
+
+- [ ] **Step 3: Add the partition diff helper**
+
+```go
+func removedPartitions(previous, next []types.Partition) []types.Partition {
+	nextSet := make(map[string]struct{}, len(next))
+	for _, p := range next {
+		nextSet[p.SubjectKey()] = struct{}{}
+	}
+	removed := make([]types.Partition, 0)
+	for _, p := range previous {
+		if _, ok := nextSet[p.SubjectKey()]; !ok {
+			removed = append(removed, p)
+		}
+	}
+	return removed
+}
+```
+
+- [ ] **Step 4: Add current commit batch lookup with a version-keyed cache (P1 cost)**
+
+Add `currentCommitPartitionSet(ctx, version)` in `manager_assignment.go`. It must
+read `assignment._commit`, verify the version matches `next.Version`, fetch each
+payload referenced by `commit.Payloads`, and return a `map[string]struct{}`
+keyed by `Partition.SubjectKey()`. Use the same payload reader as
+`buildAssignmentFromCommit` (`manager_assignment.go:1063`):
+
+```go
+payload, err := assignment.FetchAndVerifyCommitPayload(ctx, m.assignmentKV, ref)
+```
+
+Return an empty map when the current commit version does not match `version`
+(avoids blocking stale alias paths).
+
+**Cache requirement:** `FetchAndVerifyCommitPayload` does a KV `Get` + gzip
+decode + sha256 + JSON decode + digest check per payload
+(`internal/assignment/commit_payload_fetch.go:43-99`), and `scheduleApplyRetry`
+repeats the failed assignment on a 1s→30s backoff
+(`manager_assignment.go`), so a naive lookup re-fans-out N payload reads on every
+retry tick while holding `applyStoreMu`. Cache the partition set keyed by `(commit version, commit identity)`, where
+**commit identity is the `assignment._commit` KV entry revision** (the `uint64`
+returned by the KV `Get` of `_commit`) — not `AssignmentCommit.PrevCommitRev`,
+which is diagnostic-only and does not identify the entry itself
+(`types/assignment_commit.go:116-119`). Invalidate when a newer version or a
+different `_commit` revision for the same version is observed (guards against a
+commit replaced at the same version). The `len(removed) == 0` short-circuit in
+`guardHandoffRemoval` already avoids the fan-out when nothing is removed; the
+cache covers the repeated-retry case.
+
+- [ ] **Step 5: Add the removal-pending metric (P2 — closes matrix M7 signal)**
+
+Add a bounded metric to `types/metrics_collector.go` and
+`internal/metrics/prometheus.go` (mirror the existing apply/handoff metric
+surface, e.g. `types/metrics_collector.go:58`, `internal/metrics/prometheus.go:555`):
+
+```go
+// RecordHandoffRemovalPending counts guard blocks of a transfer removal while
+// the gaining worker has not committed its claim. Worker-scoped label only, to
+// keep cardinality bounded — matching RecordApplyAttempt which intentionally
+// discards version (types/metrics_collector.go:58, internal/metrics/prometheus.go:555).
+RecordHandoffRemovalPending(workerID string)
+```
+
+The metric carries no `partitionID` label (cardinality). Per-partition detail is
+emitted on the debug log line in `guardHandoffRemoval` (Step 2), not as a label.
+
+- [ ] **Step 6: Run the manager unit checks**
+
+```bash
+go test . -run 'TestApply|TestAttemptRecovery|TestCasToStableFromWaitingAssignment|TestGuardHandoffRemoval' -count=1
+```
+
+Expected: PASS. Add `guardHandoffRemoval` unit tests covering the full
+positive-predicate state matrix:
+- **Allows** (committed-elsewhere): different-owner `commit`; different-owner `stable`.
+- **Blocks** (`ErrRemovalPending`): self-owner `commit`; self-owner `stable`;
+  self-owner `prepare`; different-owner `prepare`; different-owner `abort`;
+  different-owner `unknown`; empty owner; **missing claim (`rev==0`) in current batch**.
+- **Allows** (not a transfer): source-deletion partition absent from the current
+  commit batch.
+- **Retryable, not Degraded:** claim-read error and commit-read error return a
+  wrapped error that routes through `scheduleApplyRetry`.
+- **No block:** commit version mismatch returns an empty batch.
+
+## Task 4: Document And Test Gaining-Worker-Death Liveness (P1)
+
+**Files:**
+- Modify: `docs/plans/auto-healing-gap-closure/02-g4-handoff-rebalance-fix-plan.md` (this section)
+- Modify: `internal/assignment/handoff/twophase_test.go` or `test/integration/failure/handoff_rebalance_writefault_test.go`
+
+The guard makes the data plane *safe* when the gaining worker dies mid-handoff,
+but it does **not** by itself make the fleet *converge against the same commit*:
+
+- `maybeSweepClaims` resets an expired non-stable claim back to `stable` and
+  clears `PendingOwner` (`internal/assignment/handoff/twophase.go:467-487`); it
+  does not delete a stable claim for a still-owned partition. So after sweep the
+  claim is `{owner: OLD, state: stable}`.
+- With the current commit still assigning that partition away from OLD, the
+  guard keeps blocking: a `{owner: OLD, state: stable}` claim is owned by *this*
+  worker, so it never satisfies the positive "committed to a different owner"
+  allow predicate (Task 3 Step 2). OLD keeps serving — safe — but does not
+  converge to the assignment that moved the partition away.
+- **Convergence dependency:** either the gaining worker returns and commits, or
+  the leader publishes a *later* assignment that assigns the partition to a live
+  worker. `scheduleApplyRetry` alone retries the same failed commit and will not
+  converge against a dead gaining worker. State this dependency in the rollout
+  notes.
+
+- [x] **Step 1: Add the liveness test** — done:
+`TestGuardHandoffRemoval_GainingWorkerDeath_Liveness` (`manager_handoff_liveness_test.go`).
+
+Simulate `{owner: OLD, pendingOwner: NEW, state: prepare}`, stop NEW, let the
+sweep run, assert OLD keeps serving and the guard still blocks the stale
+removal, then publish a later assignment returning the partition to OLD (or to a
+third live worker) and assert convergence.
+
+## Task 5: Verify The G4 Integration Proof (Gate Enabled)
+
+**Files:**
+- Modify: `test/integration/failure/handoff_rebalance_writefault_test.go`
+- Modify: `docs/plans/auto-healing-gap-closure/01-fault-matrix.md`
+
+- [x] **Step 1: Ensure the proof runs the full safety stack (C2)**
+
+The proof must enable the processing/pull gate (as the existing M7-adjacent
+proof does — `test/integration/failure/resolver_readfault_test.go:226-230`
+enables pull gating and allows only Stable/Commit states). M7 safety is only
+claimed for `CapProcessingGate` deployments; assert the gate is wired.
+
+- [x] **Step 2: Run the failing proof again**
+
+```bash
+PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1 -v
+```
+
+Expected after implementation: PASS. The log should still show `writeFaults>0`;
+old-owner deltas must meet the pre-fault owner counts and `new_delta=0` during
+the fault window.
+
+- [x] **Step 3: Update the matrix proof + prerequisite cells**
+
+In `docs/plans/auto-healing-gap-closure/01-fault-matrix.md`, the M7 proof now
+names `TestHandoffOnlyWriteFault_RebalancePreservesOldOwners`, the expected-policy
+cell carries the `CapProcessingGate` prerequisite (the `CapHandoffRemovalGuard`
+gate was dropped — see the Implementation Outcome header; do NOT add it), and the
+signal cell names the concrete metric (`parti_handoff_removal_pending` / the
+apply-retry log). Already reflected in the matrix; no further edit needed.
+
+- [x] **Step 4: Run focused regression + contract checks**
+
+```bash
+go test ./internal/assignment/handoff -run 'TestTwoPhase' -count=1
+go test ./internal/assignment -run 'TestCalculator' -count=1
+go test ./test/integration/failure -run TestStartupWriteFault -count=1
+PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault -count=1
+```
+
+Cross-feature contracts (AGENTS.md) — a classification/apply-path change must
+not regress these:
+
+```bash
+go test ./test/integration/manager -run 'TestManager_(LiveNATSBucketLoss|LiveNATSBucketLoss_OnDegradedHook)' -count=1 -race
+go test ./test/integration/stableid -run TestStableID_StaleKeyTakeover_Reclaim -count=1 -race
+go test . -run 'TestStart_ReturnsBeforeStable|TestCasToStableFromWaitingAssignment|TestStartupAsync_CalculatorStateNotClobbered' -count=1
+```
+
+Expected: PASS.
+
+## Final Verification
+
+- [ ] **Step 1: Format and go fix affected packages**
+
+```bash
+go fix ./internal/assignment/handoff ./internal/assignment ./test/integration/failure
+make fmt
+```
+
+- [ ] **Step 2: Run required gates**
+
+```bash
+make lint
+make test
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Run pre-PR gate before PR**
+
+This touches `manager`, `internal/assignment`, and `internal/assignment/handoff`,
+so run:
+
+```bash
+make pre-pr
+```
+
+The guard adds claim-store + assignment-commit KV reads inside the apply
+critical section (`applyStoreMu`), and this repo has a history of nats.go cached
+`*stream` concurrency races under live load. `make pre-pr` chains the
+race-enabled integration suite (`Makefile`), but additionally add a focused
+race check covering guarded applies while assignment/commit watchers are active
+(template: `test/integration/manager/epoch_monitor_concurrency_test.go`).
+
+Expected: PASS before opening a PR.

--- a/docs/plans/auto-healing-gap-closure/03-findings-index.md
+++ b/docs/plans/auto-healing-gap-closure/03-findings-index.md
@@ -1,0 +1,21 @@
+# Auto-Healing Gap Closure Findings Index
+
+This index records the current investigation output and the boundary for the
+next task. Implementation fixes are intentionally out of scope here; the next
+task starts from the fix plans and failing proofs named below.
+
+| Finding | Matrix rows | Status | Evidence | Follow-up |
+|---|---|---|---|---|
+| G1 wedged/read-only storage surface | M12 | Probe implemented and opt-in verified. Existing runtime KV/stream surfaces stayed OK after StoreDir chmod, while new file-backed stream and bucket creation returned JetStream API error 10049. Stronger runtime storage-fault injection remains open. | `PARTI_RUN_WEDGED_STORAGE_PROBE=1 go test ./test/integration/failure -run TestWedgedStorage_ReadOnlyFileStore_RecordsOperationSurfaces -count=1 -v` | Create a deeper storage-fault harness before widening classifiers. |
+| G2 RF3 selective-peer quorum loss | M1, M7 | Five-node gated probe implemented and opt-in verified. The probe avoids stopping the JetStream meta leader and records KV get/put/status error surfaces under handoff bucket quorum loss. | `PARTI_RUN_QUORUM_LOSS_TIER2=1 go test ./test/integration/failure -run TestRF3SelectivePeerFault_HandoffQuorumLoss -count=1 -v` | Keep gated; use probe output when changing handoff quorum-loss classifiers. |
+| G3 full NATS outage | M5, M6 | Unlimited reconnect and finite reconnect proofs implemented and verified. Unlimited reconnect recovers to Stable after restart; finite reconnect reaches Degraded after the client closes and must not claim Stable. | `go test ./test/integration/failure -run 'TestFullNATSOutage_' -count=1 -v` | No implementation fix planned from this investigation. |
+| G4 handoff-only rebalance write fault | M7 | Opt-in known failing proof implemented. Current behavior protects the new worker from exposing uncommitted ownership, but old owners stop consuming some pre-fault partitions while handoff writes are failing. | `PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners -count=1 -v` fails with old-owner deltas below the pre-fault owner counts. | Implement `02-g4-handoff-rebalance-fix-plan.md` in the next task. |
+| G5 source bucket sustained timeout signaling | M9 | Implemented and verified. `context.DeadlineExceeded` now fires the source-unavailable hook and gauge without classifying the source as bucket deletion. | `go test ./source -run 'TestNatsKV_(F6A|SourceUnavailable)' -count=1` | No additional fix planned. |
+| G6 dynamic generic permanent failure policy | M11 | Policy resolved as local durable-layer WARN/metric only. Manager Degraded remains reserved for stream-missing recovery exhaustion unless application callbacks choose a broader policy. | `go test ./consumer -run TestDynamic_onPermanentFailure -count=1` | No implementation fix planned. |
+| G7 public degraded reason taxonomy | M2-M6, M8-M11 | Operator-facing taxonomy documented in the fault matrix, operations guide, API reference, and `StateDegraded` Godoc. | `make lint`; `git diff --check` | Keep synchronized when adding new `OnDegraded` reasons. |
+
+## Commit Boundary
+
+This investigation branch should stop after recording evidence and committing
+the probes, taxonomy, and plans. The next task is implementation work, starting
+with G4 unless a higher-priority finding is selected.

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -2,10 +2,16 @@ package handoff
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/arloliu/parti/v2/types"
 )
+
+// ErrRemovalPending is returned by a RemovalGuard to signal that the handoff
+// removal is not yet safe to execute (i.e. the in-flight transfer has not
+// committed). Callers may treat this as a retryable condition.
+var ErrRemovalPending = errors.New("handoff removal pending")
 
 // Coordinator abstracts partition handoff application for a single worker.
 //
@@ -68,12 +74,25 @@ type ConsumerUpdater interface {
 	UpdateWorkerConsumer(ctx context.Context, workerID string, partitions []types.Partition) error
 }
 
+// RemovalGuard is an optional hook invoked immediately before the consumer-updater
+// phase of Apply. It allows the caller to block partition-subject removal while an
+// in-flight transfer to another worker has not yet committed. When the guard returns
+// a non-nil error (typically ErrRemovalPending for retryable waits), Apply returns
+// that error without calling the ConsumerUpdater. A nil RemovalGuard is a complete
+// no-op.
+type RemovalGuard func(ctx context.Context, workerID string, previous, next types.Assignment) error
+
 // Config configures a Coordinator.
 // All fields are optional; a nil ConsumerUpdater produces a no-op behavior.
 type Config struct {
 	ConsumerUpdater ConsumerUpdater
-	Metrics         MetricsRecorder
-	Now             Now
+	// RemovalGuard optionally blocks consumer removal of partitions whose transfer
+	// has not committed yet. Called immediately before the consumer-updater phase.
+	// Must return ErrRemovalPending for retryable handoff-transfer waits.
+	// A nil RemovalGuard is a complete no-op.
+	RemovalGuard RemovalGuard
+	Metrics      MetricsRecorder
+	Now          Now
 	// Logger is optional structured logger for transition logs.
 	// When nil, logging is disabled in the coordinator.
 	Logger types.Logger

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -77,6 +77,14 @@ func (t *twoPhaseCoordinator) Apply(ctx context.Context, workerID string, previo
 		}
 	}
 
+	// Phase: removal guard — block consumer removal until any in-flight transfer commits.
+	if t.cfg.RemovalGuard != nil {
+		if err := t.cfg.RemovalGuard(ctx, workerID, previous, next); err != nil {
+			inst.finish(err)
+			return err
+		}
+	}
+
 	// Phase: apply (delegate to updater for now)
 	if t.cfg.ConsumerUpdater != nil {
 		err := inst.phase("apply", func() error {

--- a/internal/assignment/handoff/twophase_test.go
+++ b/internal/assignment/handoff/twophase_test.go
@@ -183,6 +183,36 @@ func TestTwoPhaseRetryCAS_ExhaustsRetries(t *testing.T) {
 	require.GreaterOrEqual(t, store.calls, 3) // initial + 2 retries
 }
 
+// TestTwoPhase_RemovalGuardBlocksConsumerRemoval verifies that a non-nil RemovalGuard
+// is invoked before the consumer-updater phase and that a guard error prevents the
+// consumer updater from being called.
+func TestTwoPhase_RemovalGuardBlocksConsumerRemoval(t *testing.T) {
+	t.Parallel()
+
+	up := &mockUpdater{}
+	guardCalls := atomic.Int64{}
+	coord := New(Config{
+		Store:           newMemStore(),
+		ConsumerUpdater: up,
+		RemovalGuard: func(ctx context.Context, workerID string, previous, next types.Assignment) error {
+			guardCalls.Add(1)
+			require.Equal(t, "w1", workerID)
+			require.Len(t, previous.Partitions, 1)
+			require.Empty(t, next.Partitions)
+			return ErrRemovalPending
+		},
+		TTL: time.Minute,
+	}, true)
+
+	prev := types.Assignment{Version: 1, Partitions: []types.Partition{{Keys: []string{"p0"}}}}
+	next := types.Assignment{Version: 2, Partitions: nil}
+
+	err := coord.Apply(context.Background(), "w1", prev, next)
+	require.ErrorIs(t, err, ErrRemovalPending)
+	require.Equal(t, int64(1), guardCalls.Load())
+	require.Equal(t, int64(0), up.calls.Load(), "consumer updater must not remove subjects while guard blocks")
+}
+
 // TestTwoPhase_MultiKeyPartition_ClaimKeyedBySubjectKey verifies the coordinator
 // keys ownership claims by Partition.SubjectKey() (dot-joined) — the identity
 // the consumer's pull gating and processing gate resolve ownership by — and not

--- a/internal/metrics/nop.go
+++ b/internal/metrics/nop.go
@@ -68,6 +68,11 @@ func (n *NopMetrics) RecordApplyAttempt(_ /* workerID */ string, _ /* version */
 	// No-op
 }
 
+// RecordHandoffRemovalPending discards the handoff-removal-pending counter.
+func (n *NopMetrics) RecordHandoffRemovalPending(_ /* workerID */ string) {
+	// No-op
+}
+
 // CalculatorMetrics implementation
 
 // RecordRebalanceDuration discards the rebalance duration metric.

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -46,6 +46,7 @@ type PrometheusCollector struct {
 	mAlertLevel         prometheus.Gauge
 	mAlertEmitted       *prometheus.CounterVec
 	mApplyAttempts      *prometheus.CounterVec
+	mHandoffRemovalPend *prometheus.CounterVec
 
 	// Calculator metrics
 	cRebalanceDuration    *prometheus.HistogramVec
@@ -273,6 +274,12 @@ func (p *PrometheusCollector) ensureRegistered() {
 			Name:      "apply_attempts_total",
 			Help:      "Total invocations of applyAssignmentWithPrev counted before the (V, LR) stale gate. A higher rate after a NATS leader re-election indicates the watcher debounce did not collapse a burst.",
 		}, []string{"worker_id"})
+		p.mHandoffRemovalPend = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: p.namespace,
+			Subsystem: "manager",
+			Name:      "handoff_removal_pending_total",
+			Help:      "Total deferrals of a handoff transfer removal by the manager removal guard: a partition removal was blocked because the gaining worker had not yet committed its claim. A sustained rate indicates a transfer stuck before commit.",
+		}, []string{"worker_id"})
 
 		// Calculator metrics
 		p.cRebalanceDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -395,6 +402,7 @@ func (p *PrometheusCollector) ensureRegistered() {
 		p.reg.MustRegister(p.mAlertLevel)
 		p.reg.MustRegister(p.mAlertEmitted)
 		p.reg.MustRegister(p.mApplyAttempts)
+		p.reg.MustRegister(p.mHandoffRemovalPend)
 
 		p.reg.MustRegister(p.cRebalanceDuration)
 		p.reg.MustRegister(p.cRebalanceAttempts)
@@ -559,6 +567,14 @@ func (p *PrometheusCollector) IncrementAlertEmitted(level string) {
 func (p *PrometheusCollector) RecordApplyAttempt(workerID string, _ int64) {
 	p.ensureRegistered()
 	p.mApplyAttempts.WithLabelValues(workerID).Inc()
+}
+
+// RecordHandoffRemovalPending increments the handoff-removal-pending counter
+// for the given worker. Label cardinality is bounded to the fleet size (one
+// series per worker); no partition label.
+func (p *PrometheusCollector) RecordHandoffRemovalPending(workerID string) {
+	p.ensureRegistered()
+	p.mHandoffRemovalPend.WithLabelValues(workerID).Inc()
 }
 
 // CalculatorMetrics implementation

--- a/manager.go
+++ b/manager.go
@@ -70,6 +70,27 @@ type Manager struct {
 	// Handoff coordinator (feature-flagged); abstracts assignment application.
 	handoffCoordinator handoff.Coordinator
 	handoffMetrics     HandoffMetricsRecorder
+	// handoffStore is the claim store backing the two-phase coordinator. It is
+	// wired during Start (setupHandoff) when the handoff KV bucket is created;
+	// nil when two-phase handoff is disabled. The removal guard reads it to
+	// decide whether a transfer has committed elsewhere.
+	handoffStore handoff.ClaimStore
+
+	// commitBatchCache memoizes the partition set of the current "_commit"
+	// entry, keyed by (commit version, _commit KV revision), so the removal
+	// guard does not re-fan-out per-payload KV reads on every apply-retry tick.
+	// Guarded by commitBatchMu (independent of applyStoreMu; lock order is
+	// applyStoreMu -> commitBatchMu, never the reverse).
+	commitBatchMu    sync.Mutex
+	commitBatchCache *commitBatchEntry
+
+	// testHookCommitRead, when non-nil, replaces the live "_commit" KV read in
+	// currentCommitPartitionSet. Test-only seam; nil in production.
+	testHookCommitRead func(ctx context.Context) (*types.AssignmentCommit, uint64, error)
+	// testHookCommitBatch, when non-nil, replaces the per-payload fan-out in
+	// currentCommitPartitionSet (called only on a cache miss). Test-only seam
+	// for asserting fetch-once cache behavior; nil in production.
+	testHookCommitBatch func(ctx context.Context, commit *types.AssignmentCommit) (map[string]struct{}, error)
 
 	// Two-phase resume tracking
 	// Populated at startup if we detect in-flight claims that require resumption.
@@ -907,6 +928,17 @@ func (m *Manager) SetCapability(capBit uint32, active bool) {
 	} else {
 		m.capabilities.And(^capBit)
 	}
+}
+
+// handoffClaimStore returns the manager's handoff claim store and whether it is
+// wired. It is non-nil only when two-phase handoff is enabled and setupHandoff
+// has run. The removal guard treats a nil store as "no proof available" and
+// allows removals (no two-phase coordination in effect).
+func (m *Manager) handoffClaimStore() (handoff.ClaimStore, bool) {
+	if m.handoffStore == nil {
+		return nil, false
+	}
+	return m.handoffStore, true
 }
 
 // Capabilities returns the current capability bitmask as an atomic snapshot.

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/assignment"
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
 	"github.com/arloliu/parti/v2/internal/heartbeat"
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/retry"
@@ -1326,7 +1327,15 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 
 	if applyErr != nil {
 		m.applyStoreMu.Unlock()
-		m.logError("handoff apply failed", "error", applyErr)
+		if errors.Is(applyErr, handoff.ErrRemovalPending) {
+			// ErrRemovalPending is expected backpressure from the removal guard
+			// while the gaining worker has not yet committed. Log at DEBUG to
+			// avoid spamming OnError on every 1s→30s retry tick.
+			m.logger.Debug("handoff apply deferred: transfer removal pending",
+				"error", applyErr)
+		} else {
+			m.logError("handoff apply failed", "error", applyErr)
+		}
 		// Apply errors deliberately do NOT route through recordKVOpError /
 		// the degraded circuit. The apply path has its own recovery
 		// (scheduleApplyRetry), and a connected-but-KV-unavailable timeout
@@ -1649,4 +1658,189 @@ func diffPartitions(oldPartitions, newPartitions []Partition) (added, removed []
 	}
 
 	return added, removed
+}
+
+// commitBatchEntry is a cached snapshot of the current "_commit" entry's
+// partition set, keyed by (version, _commit KV revision).
+type commitBatchEntry struct {
+	version int64
+	rev     uint64
+	batch   map[string]struct{}
+}
+
+// guardHandoffRemoval is the manager-side RemovalGuard wired into the two-phase
+// coordinator. It blocks the consumer-updater phase from removing a partition
+// subject during a rebalance transfer until the gaining worker has durably
+// committed its ownership claim.
+//
+// Fail CLOSED: a transfer removal is permitted ONLY when the claim positively
+// proves a DIFFERENT owner now holds the partition in a post-switch ownership
+// state. Every ambiguous, missing, or error condition returns a retryable error
+// (ErrRemovalPending or a wrapped read error). Retryable errors ride the apply
+// path's existing scheduleApplyRetry branch — they do NOT enter the degraded
+// circuit and do NOT advance the snapshot — so the worker keeps its old
+// assignment (and its subjects) and retries on backoff.
+func (m *Manager) guardHandoffRemoval(ctx context.Context, workerID string, previous, next Assignment) error {
+	removed := removedPartitions(previous.Partitions, next.Partitions)
+	if len(removed) == 0 {
+		return nil
+	}
+
+	batch, err := m.currentCommitPartitionSet(ctx, next.Version)
+	if err != nil {
+		// Retryable, NOT fail-open: routes through scheduleApplyRetry, not Degraded.
+		return fmt.Errorf("handoff removal guard commit read: %w", err)
+	}
+	if len(batch) == 0 {
+		return nil
+	}
+
+	store, ok := m.handoffClaimStore()
+	if !ok {
+		return nil
+	}
+	for _, p := range removed {
+		pid := p.SubjectKey()
+		if _, transfer := batch[pid]; !transfer {
+			// Globally removed (partition-source deletion) — release locally.
+			continue
+		}
+		claim, rev, err := store.Get(ctx, pid)
+		if err != nil {
+			return fmt.Errorf("handoff removal guard claim read %s: %w", pid, err)
+		}
+		// FAIL CLOSED via a POSITIVE allow predicate: a transfer removal is safe
+		// ONLY when the claim proves a DIFFERENT owner now holds the partition —
+		// a non-empty owner != this worker, in a post-switch ownership state
+		// (commit or stable). Everything else (rev==0 missing, self-owned any
+		// state, different-owner prepare/abort/unknown, empty owner) is retryable.
+		committedElsewhere := rev != 0 &&
+			claim.Owner != "" &&
+			claim.Owner != workerID &&
+			(claim.State == handoff.ClaimStateCommit || claim.State == handoff.ClaimStateStable)
+		if !committedElsewhere {
+			m.metrics.RecordHandoffRemovalPending(workerID)
+			m.logger.Debug("handoff removal deferred: transfer not committed",
+				"worker_id", workerID, "partition_id", pid,
+				"claim_owner", claim.Owner, "claim_state", string(claim.State), "rev", rev)
+
+			return handoff.ErrRemovalPending
+		}
+	}
+
+	return nil
+}
+
+// removedPartitions returns the partitions present in previous but absent from
+// next, keyed by SubjectKey() (the identity under which handoff claims are
+// stored). It must key by SubjectKey() and NOT reuse diffPartitions, which keys
+// by ID() (a different separator); the claim store and the commit batch both
+// key by SubjectKey().
+func removedPartitions(previous, next []types.Partition) []types.Partition {
+	nextSet := make(map[string]struct{}, len(next))
+	for _, p := range next {
+		nextSet[p.SubjectKey()] = struct{}{}
+	}
+	var removed []types.Partition
+	for _, p := range previous {
+		if _, ok := nextSet[p.SubjectKey()]; !ok {
+			removed = append(removed, p)
+		}
+	}
+
+	return removed
+}
+
+// currentCommitPartitionSet reads the singleton "assignment._commit" entry and
+// returns the set of Partition.SubjectKey() across every payload in that
+// commit, but ONLY when the commit's Version matches version. On a version
+// mismatch (the live commit has moved past the candidate, or a stale alias is
+// driving this apply) it returns an empty map so the guard does not block.
+//
+// The expensive per-payload fan-out (KV get + gzip + sha256 + json + digest per
+// payload) is memoized in commitBatchCache keyed by (version, _commit KV
+// revision). The cheap "_commit" Get runs on every call so a same-version
+// revision change still invalidates the cache. The cache exists because
+// scheduleApplyRetry repeats the failed apply on a 1s..30s backoff; without it
+// the guard would re-fan-out N payload reads every retry tick while holding
+// applyStoreMu.
+func (m *Manager) currentCommitPartitionSet(ctx context.Context, version int64) (map[string]struct{}, error) {
+	commit, rev, err := m.readCommitEntry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if commit == nil || commit.Version != version {
+		// No commit, or the live commit is for a different version: do not block.
+		return map[string]struct{}{}, nil
+	}
+
+	// Cache hit: same version AND same _commit revision.
+	m.commitBatchMu.Lock()
+	if c := m.commitBatchCache; c != nil && c.version == version && c.rev == rev {
+		batch := c.batch
+		m.commitBatchMu.Unlock()
+
+		return batch, nil
+	}
+	m.commitBatchMu.Unlock()
+
+	batch, err := m.commitPartitionBatch(ctx, commit)
+	if err != nil {
+		return nil, err
+	}
+
+	m.commitBatchMu.Lock()
+	m.commitBatchCache = &commitBatchEntry{version: version, rev: rev, batch: batch}
+	m.commitBatchMu.Unlock()
+
+	return batch, nil
+}
+
+// readCommitEntry reads and decodes the singleton "_commit" entry, returning
+// the decoded commit and its KV revision. A missing commit returns (nil, 0,
+// nil). Replaced by testHookCommitRead when set (test-only seam).
+func (m *Manager) readCommitEntry(ctx context.Context) (*types.AssignmentCommit, uint64, error) {
+	if hook := m.testHookCommitRead; hook != nil {
+		return hook(ctx)
+	}
+
+	key := "assignment." + commitKeyName
+	entry, err := m.assignmentKV.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, 0, nil
+		}
+
+		return nil, 0, fmt.Errorf("get commit entry: %w", err)
+	}
+
+	var commit types.AssignmentCommit
+	if err := json.Unmarshal(entry.Value(), &commit); err != nil {
+		return nil, 0, fmt.Errorf("unmarshal commit entry: %w", err)
+	}
+
+	return &commit, entry.Revision(), nil
+}
+
+// commitPartitionBatch fans out over the commit's payload refs, fetches and
+// verifies each payload, and collects every partition's SubjectKey() into a
+// set. Replaced by testHookCommitBatch when set (test-only seam for asserting
+// fetch-once cache behavior).
+func (m *Manager) commitPartitionBatch(ctx context.Context, commit *types.AssignmentCommit) (map[string]struct{}, error) {
+	if hook := m.testHookCommitBatch; hook != nil {
+		return hook(ctx, commit)
+	}
+
+	batch := make(map[string]struct{})
+	for _, ref := range commit.Payloads {
+		payload, err := assignment.FetchAndVerifyCommitPayload(ctx, m.assignmentKV, ref)
+		if err != nil {
+			return nil, fmt.Errorf("fetch commit payload %s: %w", ref.Key, err)
+		}
+		for _, p := range payload.Partitions {
+			batch[p.SubjectKey()] = struct{}{}
+		}
+	}
+
+	return batch, nil
 }

--- a/manager_handoff_guard_test.go
+++ b/manager_handoff_guard_test.go
@@ -1,0 +1,468 @@
+package parti
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingRemovalMetrics embeds NopMetrics and counts RecordHandoffRemovalPending.
+type recordingRemovalMetrics struct {
+	*metrics.NopMetrics
+	mu      sync.Mutex
+	pending []string
+}
+
+func newRecordingRemovalMetrics() *recordingRemovalMetrics {
+	return &recordingRemovalMetrics{NopMetrics: metrics.NewNop()}
+}
+
+func (r *recordingRemovalMetrics) RecordHandoffRemovalPending(workerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pending = append(r.pending, workerID)
+}
+
+func (r *recordingRemovalMetrics) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.pending)
+}
+
+// fakeClaimStore is an in-memory ClaimStore for guard tests. Get returns a
+// seeded claim or, when getErr is set, that error.
+type fakeClaimStore struct {
+	claims map[string]struct {
+		claim handoff.Claim
+		rev   uint64
+	}
+	getErr error
+}
+
+func newFakeClaimStore() *fakeClaimStore {
+	return &fakeClaimStore{claims: map[string]struct {
+		claim handoff.Claim
+		rev   uint64
+	}{}}
+}
+
+func (f *fakeClaimStore) seed(pid string, claim handoff.Claim, rev uint64) {
+	f.claims[pid] = struct {
+		claim handoff.Claim
+		rev   uint64
+	}{claim, rev}
+}
+
+func (f *fakeClaimStore) Get(_ context.Context, partitionID string) (handoff.Claim, uint64, error) {
+	if f.getErr != nil {
+		return handoff.Claim{}, 0, f.getErr
+	}
+	if c, ok := f.claims[partitionID]; ok {
+		return c.claim, c.rev, nil
+	}
+	// Missing claim: rev==0.
+	return handoff.Claim{}, 0, nil
+}
+
+func (f *fakeClaimStore) PutIfEpoch(_ context.Context, _ string, _ int64, _ handoff.Claim) (uint64, error) {
+	return 0, nil
+}
+
+func (f *fakeClaimStore) ListKeys(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func part(key string) types.Partition {
+	return types.Partition{Keys: []string{key}}
+}
+
+// newGuardManager builds a Manager wired for guardHandoffRemoval testing: a
+// recording metrics double, a nop logger, the supplied claim store, and a
+// commit-batch test hook that returns batchKeys as the current commit's
+// partition set for version commitVersion.
+func newGuardManager(store handoff.ClaimStore, commitVersion int64, batchKeys ...string) (*Manager, *recordingRemovalMetrics) {
+	rm := newRecordingRemovalMetrics()
+	m := &Manager{
+		logger:  logging.NewNop(),
+		metrics: rm,
+	}
+	m.handoffStore = store
+
+	batch := make(map[string]struct{}, len(batchKeys))
+	for _, k := range batchKeys {
+		batch[k] = struct{}{}
+	}
+	// Commit read returns a commit at commitVersion (one synthetic payload ref
+	// per key is unnecessary because the batch hook supplies the set directly).
+	m.testHookCommitRead = func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+		return &types.AssignmentCommit{Version: commitVersion}, 1, nil
+	}
+	m.testHookCommitBatch = func(_ context.Context, _ *types.AssignmentCommit) (map[string]struct{}, error) {
+		return batch, nil
+	}
+
+	return m, rm
+}
+
+func TestGuardHandoffRemoval(t *testing.T) {
+	const (
+		me    = "worker-self"
+		other = "worker-other"
+		ver   = int64(7)
+	)
+	prev := Assignment{Version: ver, Partitions: []types.Partition{part("p1")}}
+	next := Assignment{Version: ver, Partitions: nil} // p1 removed
+
+	allowCases := []struct {
+		name  string
+		claim handoff.Claim
+		rev   uint64
+	}{
+		{"different-owner commit", handoff.Claim{Owner: other, State: handoff.ClaimStateCommit}, 5},
+		{"different-owner stable", handoff.Claim{Owner: other, State: handoff.ClaimStateStable}, 5},
+	}
+	for _, tc := range allowCases {
+		t.Run("ALLOW/"+tc.name, func(t *testing.T) {
+			store := newFakeClaimStore()
+			store.seed("p1", tc.claim, tc.rev)
+			m, rm := newGuardManager(store, ver, "p1")
+
+			err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+			require.NoError(t, err)
+			require.Equal(t, 0, rm.count())
+		})
+	}
+
+	blockCases := []struct {
+		name  string
+		seed  bool
+		claim handoff.Claim
+		rev   uint64
+	}{
+		{"self-owner commit", true, handoff.Claim{Owner: me, State: handoff.ClaimStateCommit}, 5},
+		{"self-owner stable", true, handoff.Claim{Owner: me, State: handoff.ClaimStateStable}, 5},
+		{"self-owner prepare", true, handoff.Claim{Owner: me, State: handoff.ClaimStatePrepare}, 5},
+		{"different-owner prepare", true, handoff.Claim{Owner: other, State: handoff.ClaimStatePrepare}, 5},
+		{"different-owner abort", true, handoff.Claim{Owner: other, State: handoff.ClaimStateAbort}, 5},
+		{"different-owner unknown", true, handoff.Claim{Owner: other, State: handoff.ClaimStateUnknown}, 5},
+		{"empty owner", true, handoff.Claim{Owner: "", State: handoff.ClaimStateCommit}, 5},
+		{"missing claim rev0", false, handoff.Claim{}, 0},
+	}
+	for _, tc := range blockCases {
+		t.Run("BLOCK/"+tc.name, func(t *testing.T) {
+			store := newFakeClaimStore()
+			if tc.seed {
+				store.seed("p1", tc.claim, tc.rev)
+			}
+			m, rm := newGuardManager(store, ver, "p1")
+
+			err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+			require.ErrorIs(t, err, handoff.ErrRemovalPending)
+			require.Equal(t, 1, rm.count())
+		})
+	}
+
+	t.Run("ALLOW/not-a-transfer (source deletion)", func(t *testing.T) {
+		// p1 removed but absent from current commit batch -> not a transfer.
+		store := newFakeClaimStore()
+		// The current commit batch is {p-other}; the removed p1 is NOT a
+		// transfer (it left the batch entirely -> source deletion). A claim on
+		// the in-batch partition exists but is never consulted for p1.
+		store.seed("p-other", handoff.Claim{Owner: me, State: handoff.ClaimStatePrepare}, 5)
+		m, rm := newGuardManager(store, ver, "p-other")
+
+		err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+		require.NoError(t, err)
+		require.Equal(t, 0, rm.count())
+	})
+
+	t.Run("ALLOW/no removed partitions", func(t *testing.T) {
+		store := newFakeClaimStore()
+		m, rm := newGuardManager(store, ver, "p1")
+		samePrev := Assignment{Version: ver, Partitions: []types.Partition{part("p1")}}
+		err := m.guardHandoffRemoval(context.Background(), me, samePrev, samePrev)
+		require.NoError(t, err)
+		require.Equal(t, 0, rm.count())
+	})
+
+	t.Run("RETRYABLE/claim read error", func(t *testing.T) {
+		store := newFakeClaimStore()
+		store.getErr = errors.New("kv unavailable")
+		m, rm := newGuardManager(store, ver, "p1")
+
+		err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, handoff.ErrRemovalPending)
+		require.Contains(t, err.Error(), "claim read")
+		// Read error is not a "pending" deferral.
+		require.Equal(t, 0, rm.count())
+	})
+
+	t.Run("RETRYABLE/commit read error", func(t *testing.T) {
+		store := newFakeClaimStore()
+		m, _ := newGuardManager(store, ver, "p1")
+		m.testHookCommitRead = func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+			return nil, 0, errors.New("commit kv unavailable")
+		}
+
+		err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, handoff.ErrRemovalPending)
+		require.Contains(t, err.Error(), "commit read")
+	})
+
+	t.Run("ALLOW/commit version mismatch -> empty batch", func(t *testing.T) {
+		store := newFakeClaimStore()
+		// Seed a self-owned prepare that WOULD block if it were a transfer.
+		store.seed("p1", handoff.Claim{Owner: me, State: handoff.ClaimStatePrepare}, 5)
+		m, rm := newGuardManager(store, ver+1, "p1") // commit at a different version
+		err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+		require.NoError(t, err)
+		require.Equal(t, 0, rm.count())
+	})
+
+	t.Run("ALLOW/nil store", func(t *testing.T) {
+		m, rm := newGuardManager(nil, ver, "p1")
+		m.handoffStore = nil
+		err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+		require.NoError(t, err)
+		require.Equal(t, 0, rm.count())
+	})
+
+	t.Run("ALLOW/no commit present", func(t *testing.T) {
+		// readCommitEntry maps a missing _commit (ErrKeyNotFound) to (nil,0,nil);
+		// currentCommitPartitionSet then returns an empty batch -> no block. This
+		// is the alias-only rebalance shape where no commit exists.
+		store := newFakeClaimStore()
+		store.seed("p1", handoff.Claim{Owner: me, State: handoff.ClaimStatePrepare}, 5)
+		m, rm := newGuardManager(store, ver, "p1")
+		m.testHookCommitRead = func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+			return nil, 0, nil
+		}
+		err := m.guardHandoffRemoval(context.Background(), me, prev, next)
+		require.NoError(t, err)
+		require.Equal(t, 0, rm.count())
+	})
+}
+
+// TestCurrentCommitPartitionSet_CacheFetchOnce asserts the per-payload fan-out
+// runs once per (version, _commit rev), not once per call.
+func TestCurrentCommitPartitionSet_CacheFetchOnce(t *testing.T) {
+	m := &Manager{logger: logging.NewNop(), metrics: metrics.NewNop()}
+
+	var commitRev uint64 = 1
+	m.testHookCommitRead = func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+		return &types.AssignmentCommit{Version: 9}, atomic.LoadUint64(&commitRev), nil
+	}
+	var fanouts int32
+	m.testHookCommitBatch = func(_ context.Context, _ *types.AssignmentCommit) (map[string]struct{}, error) {
+		atomic.AddInt32(&fanouts, 1)
+		return map[string]struct{}{"p1": {}}, nil
+	}
+
+	for range 5 {
+		batch, err := m.currentCommitPartitionSet(context.Background(), 9)
+		require.NoError(t, err)
+		require.Len(t, batch, 1)
+	}
+	require.Equal(t, int32(1), atomic.LoadInt32(&fanouts), "fan-out should run once for a stable (version, rev)")
+
+	// A new _commit revision for the same version invalidates the cache.
+	atomic.StoreUint64(&commitRev, 2)
+	_, err := m.currentCommitPartitionSet(context.Background(), 9)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), atomic.LoadInt32(&fanouts), "fan-out should re-run when _commit revision changes")
+
+	// Version mismatch returns an empty batch and does NOT fan out.
+	batch, err := m.currentCommitPartitionSet(context.Background(), 10)
+	require.NoError(t, err)
+	require.Empty(t, batch)
+	require.Equal(t, int32(2), atomic.LoadInt32(&fanouts), "version mismatch must not fan out")
+}
+
+// TestReadCommitEntry_RealKV exercises the REAL readCommitEntry / currentCommitPartitionSet
+// code paths (hooks nil) against a live in-process JetStream bucket. The test-hook
+// seam in the guard tests bypasses these paths entirely, so the SAFETY-critical
+// error mappings — especially ErrKeyNotFound → (nil,0,nil) (a misclassification
+// here = premature removal) — had zero coverage until this test.
+func TestReadCommitEntry_RealKV(t *testing.T) {
+	t.Parallel()
+
+	// Each sub-test gets its own NATS + KV so they can run in parallel without
+	// conflicting on the shared "assignment._commit" key.
+	newKV := func(t *testing.T, name string) (jetstream.KeyValue, context.Context) {
+		t.Helper()
+		_, nc := partitest.StartEmbeddedNATS(t)
+		kv := partitest.CreateJetStreamKV(t, nc, name)
+		return kv, t.Context()
+	}
+	newM := func(kv jetstream.KeyValue) *Manager {
+		m := &Manager{logger: logging.NewNop(), metrics: metrics.NewNop()}
+		m.assignmentKV = kv
+		// Leave hooks nil so the REAL path executes.
+		return m
+	}
+
+	t.Run("missing key maps to nil commit", func(t *testing.T) {
+		t.Parallel()
+		// ErrKeyNotFound from a live bucket with no entry must map to (nil,0,nil),
+		// not a wrapped error. A wrapped error would cause currentCommitPartitionSet
+		// to propagate an error and guardHandoffRemoval to fail closed — but with a
+		// generic "commit read" error rather than the expected empty-batch allow.
+		// Misclassifying ErrKeyNotFound as an error is the SAFETY bug: the guard
+		// would block ALL removals until the key exists.
+		kv, ctx := newKV(t, "rce-missing")
+		m := newM(kv)
+		commit, rev, err := m.readCommitEntry(ctx)
+		require.NoError(t, err, "ErrKeyNotFound must map to (nil,0,nil), not an error")
+		require.Nil(t, commit)
+		require.Zero(t, rev)
+	})
+
+	t.Run("missing key -> currentCommitPartitionSet returns empty batch", func(t *testing.T) {
+		t.Parallel()
+		// Exercises the nil-commit short-circuit in currentCommitPartitionSet.
+		kv, ctx := newKV(t, "rce-ccps-empty")
+		m := newM(kv)
+		batch, err := m.currentCommitPartitionSet(ctx, 5)
+		require.NoError(t, err)
+		require.Empty(t, batch)
+	})
+
+	t.Run("version mismatch returns empty batch", func(t *testing.T) {
+		t.Parallel()
+		// Seed a commit at version 3; query at version 4 must return empty.
+		kv, ctx := newKV(t, "rce-ver-mismatch")
+		m := newM(kv)
+		c := types.AssignmentCommit{Version: 3}
+		raw, marshalErr := json.Marshal(c)
+		require.NoError(t, marshalErr)
+		_, putErr := kv.Put(ctx, "assignment."+commitKeyName, raw)
+		require.NoError(t, putErr)
+
+		batch, err := m.currentCommitPartitionSet(ctx, 4) // wrong version
+		require.NoError(t, err)
+		require.Empty(t, batch, "version mismatch must yield empty batch (no block)")
+	})
+
+	t.Run("corrupt entry returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+		// An undecodable _commit entry must surface as an error (fail-closed).
+		kv, ctx := newKV(t, "rce-corrupt")
+		m := newM(kv)
+		_, putErr := kv.Put(ctx, "assignment."+commitKeyName, []byte("not-json{{"))
+		require.NoError(t, putErr)
+
+		commit, rev, err := m.readCommitEntry(ctx)
+		require.Error(t, err, "corrupt JSON must return a non-nil error")
+		require.Contains(t, err.Error(), "unmarshal commit entry")
+		require.Nil(t, commit)
+		require.Zero(t, rev)
+
+		// currentCommitPartitionSet must propagate the unmarshal error.
+		_, err2 := m.currentCommitPartitionSet(ctx, 1)
+		require.Error(t, err2)
+	})
+
+	t.Run("valid commit, no payload refs, version match -> empty batch, no error", func(t *testing.T) {
+		t.Parallel()
+		// A valid commit at the queried version with no payload refs yields an
+		// empty batch (nothing to block), not an error.
+		kv, ctx := newKV(t, "rce-valid")
+		m := newM(kv)
+		c := types.AssignmentCommit{Version: 7}
+		raw, marshalErr := json.Marshal(c)
+		require.NoError(t, marshalErr)
+		_, putErr := kv.Put(ctx, "assignment."+commitKeyName, raw)
+		require.NoError(t, putErr)
+
+		// Verify readCommitEntry round-trips the version correctly.
+		got, rev, err := m.readCommitEntry(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, int64(7), got.Version)
+		require.NotZero(t, rev)
+
+		// currentCommitPartitionSet: version matches, no payload refs -> empty batch, no error.
+		batch, err2 := m.currentCommitPartitionSet(ctx, 7)
+		require.NoError(t, err2)
+		require.Empty(t, batch, "commit with no payload refs yields empty batch, not an error")
+	})
+
+	t.Run("valid commit with real payload -> SubjectKey lands in batch", func(t *testing.T) {
+		t.Parallel()
+		// Case (b): exercises the real commitPartitionBatch fan-out loop.
+		// Seed a real gzip-compressed, sha256-hashed payload blob in the KV, plant
+		// a matching AssignmentCommit._commit entry, and confirm the partition's
+		// SubjectKey() appears in the returned batch. This is the safety-critical
+		// path the guard blocks on — it was dead code in tests before this case.
+		kv, ctx := newKV(t, "rce-real-payload")
+		m := newM(kv)
+
+		parts := []types.Partition{{Keys: []string{"alpha", "beta"}}}
+		payload := types.AssignmentPayload{
+			SchemaVersion: types.AssignmentSchemaVersion,
+			Partitions:    parts,
+		}
+		canonical, jerr := json.Marshal(payload)
+		require.NoError(t, jerr)
+		hash := sha256.Sum256(canonical)
+		hashHex := hex.EncodeToString(hash[:])
+		payloadKey := "assignment._payload." + hashHex
+
+		var buf bytes.Buffer
+		w, werr := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+		require.NoError(t, werr)
+		_, werr = w.Write(canonical)
+		require.NoError(t, werr)
+		require.NoError(t, w.Close())
+		_, perr := kv.Create(ctx, payloadKey, buf.Bytes())
+		require.NoError(t, perr)
+
+		ref := types.AssignmentPayloadRef{
+			Key:         payloadKey,
+			PayloadHash: hashHex,
+			SetDigest:   types.PartitionSetDigest(parts),
+		}
+		commit := types.AssignmentCommit{
+			Version:  11,
+			Payloads: map[string]types.AssignmentPayloadRef{"worker-x": ref},
+		}
+		commitRaw, cerr := json.Marshal(commit)
+		require.NoError(t, cerr)
+		_, putErr := kv.Put(ctx, "assignment."+commitKeyName, commitRaw)
+		require.NoError(t, putErr)
+
+		batch, err := m.currentCommitPartitionSet(ctx, 11)
+		require.NoError(t, err)
+		wantKey := parts[0].SubjectKey()
+		require.Contains(t, batch, wantKey,
+			"partition SubjectKey must appear in batch from real fan-out; batch=%v", batch)
+	})
+
+	// Confirm the jetstream.ErrKeyNotFound sentinel is what the live bucket actually
+	// returns for a missing key, not ErrNoResponders or ErrBucketNotFound (which would
+	// silently skip the errors.Is branch in readCommitEntry and treat it as a real error).
+	t.Run("live bucket missing key produces ErrKeyNotFound sentinel", func(t *testing.T) {
+		t.Parallel()
+		kv, ctx := newKV(t, "rce-sentinel")
+		_, err := kv.Get(ctx, "no-such-key")
+		require.True(t, errors.Is(err, jetstream.ErrKeyNotFound),
+			"live bucket Get on missing key must produce ErrKeyNotFound; got %v", err)
+	})
+}

--- a/manager_handoff_liveness_test.go
+++ b/manager_handoff_liveness_test.go
@@ -1,0 +1,217 @@
+package parti
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// casClaimStore is a real (non-no-op) in-memory handoff.ClaimStore. Unlike the
+// stub fakeClaimStore in manager_handoff_guard_test.go (whose PutIfEpoch is a
+// no-op), this one actually persists writes, so a REAL twoPhaseCoordinator sweep
+// mutates the stored claim instead of leaving the seeded value untouched — the
+// stub would make the sweep-reset assertions below vacuous. It mirrors the
+// handoff package's test memStore semantics
+// (internal/assignment/handoff/claim_test.go). The epoch-gated CAS branches
+// (create, epoch-mismatch) are implemented for fidelity but are NOT contended in
+// this single-writer test; production contention is covered by the handoff
+// package's own CAS tests.
+type casClaimStore struct {
+	mu   sync.Mutex
+	data map[string]handoff.Claim
+	rev  map[string]uint64
+}
+
+var _ handoff.ClaimStore = (*casClaimStore)(nil)
+
+func newCASClaimStore() *casClaimStore {
+	return &casClaimStore{data: make(map[string]handoff.Claim), rev: make(map[string]uint64)}
+}
+
+func (s *casClaimStore) seed(pid string, claim handoff.Claim, rev uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[pid] = claim
+	s.rev[pid] = rev
+}
+
+func (s *casClaimStore) Get(_ context.Context, partitionID string) (handoff.Claim, uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.data[partitionID]
+	if !ok {
+		return handoff.Claim{}, 0, nil
+	}
+
+	return c, s.rev[partitionID], nil
+}
+
+var errCASEpochMismatch = errors.New("cas claim store: epoch mismatch")
+
+func (s *casClaimStore) PutIfEpoch(_ context.Context, partitionID string, expectedEpoch int64, next handoff.Claim) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.data[partitionID]
+	if !ok {
+		if expectedEpoch != 0 {
+			return 0, errCASEpochMismatch
+		}
+		s.data[partitionID] = next
+		s.rev[partitionID] = 1
+
+		return s.rev[partitionID], nil
+	}
+	if cur.Epoch != expectedEpoch {
+		return 0, errCASEpochMismatch
+	}
+	s.data[partitionID] = next
+	s.rev[partitionID]++
+
+	return s.rev[partitionID], nil
+}
+
+func (s *casClaimStore) ListKeys(_ context.Context) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.data))
+	for k := range s.data {
+		out = append(out, k)
+	}
+
+	return out, nil
+}
+
+// TestGuardHandoffRemoval_GainingWorkerDeath_Liveness pins the safety/liveness
+// boundary documented in Task 4 of the G4 fix plan
+// (docs/plans/auto-healing-gap-closure/02-g4-handoff-rebalance-fix-plan.md).
+//
+// Unlike TestGuardHandoffRemoval — which seeds a hand-built claim shape into a
+// stub store and only proves the guard's per-state decision — this test wires
+// the REAL components on both sides of the seam: a real twoPhaseCoordinator
+// runs its real opportunistic sweep, and the resulting claim it actually writes
+// is fed to the real Manager.guardHandoffRemoval. That seam (sweep output →
+// guard input) is exactly what isolated unit tests cannot exercise.
+//
+// Scenario (gaining worker dies mid-handoff):
+//  1. A transfer left the claim at {owner: OLD, pendingOwner: NEW, prepare} and
+//     the gaining worker NEW then died, so the claim expired.
+//  2. The real sweep resets the expired non-stable claim to
+//     {owner: OLD, state: stable, pendingOwner: ""} (it never deletes a stable
+//     claim for a still-owned partition — twophase.go maybeSweepClaims).
+//  3. The current commit still assigns the partition AWAY from OLD.
+//
+// The boundary this asserts (both directions, per the test-both-directions
+// discipline):
+//   - SAFETY: the guard BLOCKS OLD's removal — OLD must not silently drop a
+//     partition no live worker has committed.
+//   - LIVENESS (negative space): scheduleApplyRetry replays the SAME failed
+//     assignment; against a dead gaining worker the guard must keep blocking and
+//     must NOT spuriously converge on its own.
+//   - CONVERGENCE only on a NEW signal: a later assignment that returns the
+//     partition to OLD converges (no removal), and an assignment whose claim
+//     proves a DIFFERENT live worker committed releases OLD's removal.
+func TestGuardHandoffRemoval_GainingWorkerDeath_Liveness(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldOwner = "worker-old"
+		newOwner = "worker-new"
+		pid      = "p1"
+		ver      = int64(7)
+	)
+	ttl := time.Second
+	now := time.Now().UTC()
+	ctx := context.Background()
+
+	store := newCASClaimStore()
+
+	// (1) A transfer ran preparePhase (owner stays OLD, pendingOwner=NEW) but
+	// NEW's commit never landed because NEW died; the claim then expired.
+	store.seed(pid, handoff.Claim{
+		PartitionID:  pid,
+		Owner:        oldOwner,
+		PendingOwner: newOwner,
+		State:        handoff.ClaimStatePrepare,
+		Epoch:        2,
+		LastUpdated:  now.Add(-2 * ttl), // expired
+		TTLSeconds:   int64(ttl.Seconds()),
+	}, 1)
+
+	// (2) Run the REAL sweep via a real two-phase coordinator. SweepInterval=0
+	// forces a sweep on every Apply; an empty→empty assignment performs no
+	// prepare/commit work, so only the opportunistic sweep touches the store.
+	coord := handoff.New(handoff.Config{
+		Store:         store,
+		Now:           func() time.Time { return now },
+		SweepInterval: 0,
+		TTL:           ttl,
+		MaxRetries:    1,
+		BaseBackoff:   time.Millisecond,
+		MaxBackoff:    2 * time.Millisecond,
+	}, true)
+	require.NoError(t, coord.Apply(ctx, oldOwner, types.Assignment{}, types.Assignment{}))
+
+	// The sweep must have produced the gaining-worker-death shape.
+	swept, _, err := store.Get(ctx, pid)
+	require.NoError(t, err)
+	require.Equal(t, handoff.ClaimStateStable, swept.State,
+		"sweep must reset the expired prepare claim to stable")
+	require.Equal(t, oldOwner, swept.Owner,
+		"sweep must leave the still-owning OLD worker as owner (no deletion)")
+	require.Empty(t, swept.PendingOwner,
+		"sweep must clear the dead gaining worker as pending owner")
+
+	// (3) The current commit still assigns pid away from OLD: prev owns pid,
+	// next removes it, and pid is still present in the current commit batch (a
+	// transfer, not a source deletion).
+	m, rm := newGuardManager(store, ver, pid)
+	prev := Assignment{Version: ver, Partitions: []types.Partition{part(pid)}}
+	next := Assignment{Version: ver, Partitions: nil}
+
+	// SAFETY: the guard reads the REAL swept claim ({owner: OLD, stable}) and
+	// blocks — OLD keeps serving rather than dropping an uncommitted transfer.
+	require.ErrorIs(t, m.guardHandoffRemoval(ctx, oldOwner, prev, next), handoff.ErrRemovalPending,
+		"guard must block removal of a partition whose transfer the dead gaining worker never committed")
+	require.Equal(t, 1, rm.count())
+
+	// LIVENESS (negative space): the guard re-reads the LIVE claim on every apply
+	// attempt and keeps blocking while the transfer stays uncommitted. Mutate the
+	// claim between calls to a DIFFERENT still-uncommitted shape — a fresh
+	// different-owner prepare, as if the gaining worker briefly retried prepare
+	// before dying again — and require removal to STILL block, recording the
+	// deferral again (rm.count()==2). This block-on-a-changed-claim, together
+	// with the committed-claim ALLOW in convergence path 2 below, proves the
+	// guard evaluates the CURRENT claim per call rather than caching its first
+	// verdict (a cached block could never later flip to ALLOW). That per-call
+	// re-evaluation is why scheduleApplyRetry — which replays the apply,
+	// re-reading the live claim each tick (manager_assignment.go) — cannot
+	// self-converge against an uncommitted gaining worker.
+	store.seed(pid, handoff.Claim{
+		PartitionID:  pid,
+		Owner:        newOwner,
+		PendingOwner: oldOwner,
+		State:        handoff.ClaimStatePrepare,
+		Epoch:        3,
+	}, 10)
+	require.ErrorIs(t, m.guardHandoffRemoval(ctx, oldOwner, prev, next), handoff.ErrRemovalPending,
+		"a retry observing a fresh uncommitted (different-owner prepare) claim must keep blocking "+
+			"and record the deferral again")
+	require.Equal(t, 2, rm.count())
+
+	// CONVERGENCE path 1 — a later assignment returns pid to OLD: nothing is
+	// removed, so the guard short-circuits (no removal) and the worker converges.
+	require.NoError(t, m.guardHandoffRemoval(ctx, oldOwner, prev, prev),
+		"a later assignment returning the partition to OLD must converge (no removal to guard)")
+
+	// CONVERGENCE path 2 — reassignment to a LIVE worker: once a different
+	// worker's claim proves a committed transfer, OLD's removal is released.
+	store.seed(pid, handoff.Claim{Owner: newOwner, State: handoff.ClaimStateCommit, Epoch: 4}, 11)
+	require.NoError(t, m.guardHandoffRemoval(ctx, oldOwner, prev, next),
+		"once a live worker has committed the claim, OLD's removal must be allowed")
+}

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -190,10 +190,12 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 	}
 
 	store := handoff.NewNATSClaimStore(handoffKV, "claims/")
+	m.handoffStore = store
 	m.handoffCoordinator = handoff.New(handoff.Config{
 		ConsumerUpdater:   m.consumerUpdater,
 		Metrics:           m.handoffMetrics,
 		Store:             store,
+		RemovalGuard:      m.guardHandoffRemoval,
 		TTL:               m.cfg.KVBuckets.HandoffTTL,
 		SweepInterval:     m.cfg.Handoff.SweepInterval,
 		MaxRetries:        m.cfg.Handoff.MaxRetries,

--- a/partitest/doc.go
+++ b/partitest/doc.go
@@ -7,6 +7,7 @@
 // Key utilities:
 //   - StartEmbeddedNATS: Single NATS server with JetStream
 //   - StartEmbeddedNATSCluster: 3-node NATS cluster for HA testing
+//   - StartEmbeddedNATSClusterN: N-node NATS cluster for gated HA probes
 //   - CreateJetStreamKV: Convenience wrapper for KV bucket creation
 //
 // Example usage:

--- a/partitest/nats.go
+++ b/partitest/nats.go
@@ -122,7 +122,26 @@ func StartEmbeddedNATS(t testing.TB) (*server.Server, *nats.Conn) {
 func StartEmbeddedNATSCluster(t *testing.T) ([]*server.Server, *nats.Conn) {
 	t.Helper()
 
-	const clusterSize = 3
+	return startEmbeddedNATSClusterSized(t, 3)
+}
+
+// StartEmbeddedNATSClusterN starts an N-node NATS cluster with JetStream for HA testing.
+//
+// This is useful for tests that need more than the default 3 nodes, such as
+// RF3 selective peer-fault scenarios where one replicated stream loses quorum
+// while JetStream meta quorum remains available.
+func StartEmbeddedNATSClusterN(t *testing.T, clusterSize int) ([]*server.Server, *nats.Conn) {
+	t.Helper()
+	if clusterSize < 1 {
+		t.Fatalf("clusterSize must be >= 1, got %d", clusterSize)
+	}
+
+	return startEmbeddedNATSClusterSized(t, clusterSize)
+}
+
+func startEmbeddedNATSClusterSized(t *testing.T, clusterSize int) ([]*server.Server, *nats.Conn) {
+	t.Helper()
+
 	servers := make([]*server.Server, clusterSize)
 
 	// Pre-allocate ports to avoid chicken-and-egg problem with routes

--- a/partitest/nats_test.go
+++ b/partitest/nats_test.go
@@ -73,6 +73,22 @@ func TestStartEmbeddedNATSCluster(t *testing.T) {
 	require.NotNil(t, js)
 }
 
+func TestStartEmbeddedNATSClusterN_FiveNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping cluster test in short mode")
+	}
+
+	servers, nc := StartEmbeddedNATSClusterN(t, 5)
+
+	require.Len(t, servers, 5)
+	require.NotNil(t, nc)
+	require.True(t, nc.IsConnected())
+	for i, s := range servers {
+		require.True(t, s.ReadyForConnections(5*time.Second), "server %d not ready", i)
+		require.GreaterOrEqual(t, s.NumRoutes(), 4, "server %d should have at least 4 routes", i)
+	}
+}
+
 func TestCreateJetStreamKV(t *testing.T) {
 	ctx := t.Context()
 	_, nc := StartEmbeddedNATS(t)

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -123,15 +123,16 @@ func WithUpdateRetries(n int) NatsKVOption {
 	}
 }
 
-// SourceUnavailableHook fires when the partition-source bucket is observed to
-// be missing on the live connection. The reconciler and watcher-restart paths
-// each see a distinct error from the nats.go surface — [jetstream.ErrBucketNotFound]
-// from a fresh [jetstream.JetStream.KeyValue] lookup, [jetstream.ErrStreamNotFound]
-// from a cached watcher rebind, or [nats.ErrNoResponders] from a cached
-// [jetstream.KeyValue.Get] — and all three classify to bucket-loss internally.
-// The err argument hands the original sentinel to the hook so implementations
-// can log or surface the raw cause, but **do not gate readiness on a single
-// sentinel type**: when the hook fires, the bucket is missing.
+// SourceUnavailableHook fires when the partition-source bucket is unavailable
+// on the live connection. The reconciler and watcher-restart paths each see a
+// distinct error from the nats.go surface — [jetstream.ErrBucketNotFound] from
+// a fresh [jetstream.JetStream.KeyValue] lookup, [jetstream.ErrStreamNotFound]
+// from a cached watcher rebind, [nats.ErrNoResponders] from a cached
+// [jetstream.KeyValue.Get], or [context.DeadlineExceeded] when the source
+// bucket cannot answer in time. The err argument hands the original sentinel to
+// the hook so implementations can log or surface the raw cause, but **do not
+// gate readiness on a single sentinel type**: when the hook fires, the source is
+// unavailable.
 //
 // The library does not recreate the bucket — it is caller-owned, and rebuilding
 // it requires the operator's provisioning flow. Wire this hook into your
@@ -151,7 +152,7 @@ func WithUpdateRetries(n int) NatsKVOption {
 type SourceUnavailableHook func(err error)
 
 // WithUnavailableHook registers a [SourceUnavailableHook] that fires when
-// the partition-source bucket is observed to be missing. See
+// the partition-source bucket is observed to be unavailable. See
 // [SourceUnavailableHook] for the deadlock contract and rate-limiting
 // behavior. Without a hook, the loss is still logged and the metric is
 // set (when [WithMetrics] is configured), but no escalation runs — the
@@ -170,9 +171,9 @@ func WithUnavailableHook(h SourceUnavailableHook) NatsKVOption {
 
 // WithMetrics wires a [types.SourceMetrics] collector. The source uses the
 // collector to expose its `parti_source_bucket_missing` gauge (set to 1 on
-// the first bucket-loss observation — see [SourceUnavailableHook] for the
-// empirical error surface — cleared on the next successful operation). The
-// default is [types.NopSourceMetrics].
+// the first unavailable-source observation — see [SourceUnavailableHook] for
+// the empirical error surface — cleared on the next successful operation).
+// The default is [types.NopSourceMetrics].
 //
 // Parameters:
 //   - m: SourceMetrics collector
@@ -1195,9 +1196,13 @@ func (s *NatsKV) reconcileOnce(ctx context.Context) {
 
 			return
 		}
-		// Bucket-missing escalation: see noteBucketUnavailable Godoc.
+		// Source-unavailable escalation: see noteBucketUnavailable Godoc.
 		if s.noteBucketUnavailable(err) {
-			s.logError("reconcile: source bucket missing", "error", err)
+			msg := "reconcile: source unavailable"
+			if isBucketUnavailableErr(err) {
+				msg = "reconcile: source bucket missing"
+			}
+			s.logError(msg, "error", err)
 
 			return
 		}
@@ -1394,10 +1399,15 @@ func isBucketUnavailableErr(err error) bool {
 		errors.Is(err, nats.ErrNoResponders)
 }
 
-// noteBucketUnavailable handles the bucket-missing escalation path. Returns
-// true iff err is classified as a bucket-unavailable error (see
-// isBucketUnavailableErr), so the caller can substitute a more specific
-// log line for the existing generic one.
+func isSourceUnavailableErr(err error) bool {
+	return isBucketUnavailableErr(err) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
+// noteBucketUnavailable handles the source-unavailable escalation path. Returns
+// true iff err is classified as source-unavailable (see
+// isSourceUnavailableErr), so the caller can substitute a more specific log
+// line for the existing generic one.
 //
 // On a match:
 //   - Sets the SourceBucketMissing gauge to true (idempotent — no-op if
@@ -1409,7 +1419,7 @@ func isBucketUnavailableErr(err error) bool {
 // The hook is invoked OUTSIDE unavailableMu so a long-running caller hook
 // does not block the reconcile / restart goroutine's next tick.
 func (s *NatsKV) noteBucketUnavailable(err error) bool {
-	if !isBucketUnavailableErr(err) {
+	if !isSourceUnavailableErr(err) {
 		return false
 	}
 	s.unavailableMu.Lock()

--- a/source/nats_kv_unavailable_hook_test.go
+++ b/source/nats_kv_unavailable_hook_test.go
@@ -52,6 +52,16 @@ func (r *hookRecorder) snapshot() []error {
 	return out
 }
 
+func (r *hookRecorder) last() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.errs) == 0 {
+		return nil
+	}
+
+	return r.errs[len(r.errs)-1]
+}
+
 // gaugeMetrics is a SourceMetrics implementation that exposes the
 // most-recent SetSourceBucketMissing value so tests can assert on the
 // transitions without scraping logs.
@@ -73,6 +83,14 @@ type f6aFixture struct {
 	js     jetstream.JetStream
 	ctx    context.Context
 	bucket string
+}
+
+type deadlineKV struct {
+	jetstream.KeyValue
+}
+
+func (k deadlineKV) Get(context.Context, string) (jetstream.KeyValueEntry, error) {
+	return nil, context.DeadlineExceeded
 }
 
 // newKVForF6ATest spins an embedded NATS, creates a fresh source
@@ -309,4 +327,28 @@ func TestNatsKV_F6A_DefaultCooldown_PureUnit(t *testing.T) {
 	// Non-matching error must not advance the counters or fire.
 	require.False(t, src.noteBucketUnavailable(errors.New("unrelated")))
 	require.Equal(t, int64(1), rec.calls.Load())
+}
+
+func TestNatsKV_SourceUnavailable_DeadlineExceededThreshold(t *testing.T) {
+	t.Parallel()
+
+	rec := &hookRecorder{}
+	gauge := &gaugeMetrics{}
+	src := &NatsKV{
+		kv:                  deadlineKV{},
+		key:                 "config",
+		metrics:             gauge,
+		unavailableHook:     rec.fn(),
+		unavailableCooldown: 10 * time.Millisecond,
+	}
+
+	src.reconcileOnce(t.Context())
+
+	require.Equal(t, int64(1), rec.calls.Load(),
+		"deadline-exceeded source reads must fire the source-unavailable hook")
+	require.True(t, gauge.missing.Load(),
+		"deadline-exceeded source reads must set the unavailable gauge")
+	require.ErrorIs(t, rec.last(), context.DeadlineExceeded)
+	require.False(t, isBucketUnavailableErr(rec.last()),
+		"deadline-exceeded source reads are an unavailable-source signal, not bucket deletion")
 }

--- a/test/integration/failure/full_nats_outage_test.go
+++ b/test/integration/failure/full_nats_outage_test.go
@@ -1,0 +1,160 @@
+package failure_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFullNATSOutage_UnlimitedReconnects_RecoversFleet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+
+	nc, stopNATS, restartNATS := startEmbeddedNATSOutage(t, -1)
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	rfBuildStream(t, ctx, realJS)
+	src := source.NewStatic([]types.Partition{{Keys: []string{"p0"}}})
+
+	var degradedCalls atomic.Int64
+	stack := rfBuildWorkerStackCfg(t, ctx, realJS, src, 0, fastOutageConfig, func(h *parti.Hooks) {
+		h.OnDegraded = func(_ context.Context, reason string) error {
+			if reason == "NATS connection down" {
+				degradedCalls.Add(1)
+			}
+			return nil
+		}
+	})
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 30*time.Second))
+
+	rfPublish(t, ctx, realJS, "p0", "before-outage")
+	require.Eventually(t, func() bool { return stack.consumed.Load() >= 1 },
+		15*time.Second, 100*time.Millisecond, "baseline consume failed before outage")
+
+	stopNATS(t)
+	require.Eventually(t, func() bool { return nc.Status() != nats.CONNECTED },
+		5*time.Second, 50*time.Millisecond, "client did not observe NATS outage")
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 10*time.Second))
+	require.Positive(t, degradedCalls.Load(), "OnDegraded must report NATS connection down")
+	require.Len(t, stack.mgr.CurrentAssignment().Partitions, 1,
+		"manager must retain cached assignment while NATS is down")
+
+	restartNATS(t)
+	require.Eventually(t, func() bool { return nc.Status() == nats.CONNECTED },
+		5*time.Second, 50*time.Millisecond, "client did not reconnect")
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 20*time.Second))
+
+	base := stack.consumed.Load()
+	rfPublish(t, ctx, realJS, "p0", "after-outage")
+	require.Eventually(t, func() bool { return stack.consumed.Load() > base },
+		20*time.Second, 100*time.Millisecond, "consumer did not resume after NATS restart")
+}
+
+func TestFullNATSOutage_FiniteReconnects_DegradesClosedConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	nc, stopNATS, _ := startEmbeddedNATSOutage(t, 0)
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	rfBuildStream(t, ctx, realJS)
+	src := source.NewStatic([]types.Partition{{Keys: []string{"p0"}}})
+
+	stack := rfBuildWorkerStackCfg(t, ctx, realJS, src, 0, fastOutageConfig, nil)
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 30*time.Second))
+
+	stopNATS(t)
+	require.Eventually(t, func() bool { return nc.Status() == nats.CLOSED },
+		10*time.Second, 50*time.Millisecond, "finite reconnect client did not close")
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 10*time.Second))
+	require.Never(t, func() bool { return stack.mgr.State() == parti.StateStable },
+		3*time.Second, 100*time.Millisecond,
+		"manager must not report Stable after the caller-owned NATS connection is closed")
+}
+
+func fastOutageConfig(cfg *parti.Config) {
+	cfg.DegradedBehavior.EnterThreshold = 500 * time.Millisecond
+	cfg.DegradedBehavior.ExitThreshold = 500 * time.Millisecond
+}
+
+func startEmbeddedNATSOutage(
+	t *testing.T,
+	maxReconnect int,
+) (conn *nats.Conn, stop func(*testing.T), restart func(*testing.T)) {
+	t.Helper()
+
+	port, err := getFreePortForRestart()
+	require.NoError(t, err)
+	storeDir := t.TempDir()
+
+	buildOpts := func() *server.Options {
+		return &server.Options{
+			Host:      "127.0.0.1",
+			Port:      port,
+			JetStream: true,
+			StoreDir:  storeDir,
+			NoLog:     true,
+		}
+	}
+
+	startServer := func() *server.Server {
+		ns, serr := server.NewServer(buildOpts())
+		require.NoError(t, serr)
+		go ns.Start()
+		require.True(t, ns.ReadyForConnections(5*time.Second),
+			"embedded NATS not ready for connections")
+		return ns
+	}
+
+	nsPtr := &serverHolder{srv: startServer()}
+	t.Cleanup(func() {
+		if nsPtr.srv != nil {
+			nsPtr.srv.Shutdown()
+			nsPtr.srv.WaitForShutdown()
+		}
+	})
+
+	nc, err := nats.Connect(nsPtr.srv.ClientURL(),
+		nats.Timeout(2*time.Second),
+		nats.RetryOnFailedConnect(true),
+		nats.MaxReconnects(maxReconnect),
+		nats.ReconnectWait(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { nc.Close() })
+
+	stopNATS := func(t *testing.T) {
+		t.Helper()
+		require.NotNil(t, nsPtr.srv)
+		nsPtr.srv.Shutdown()
+		nsPtr.srv.WaitForShutdown()
+		nsPtr.srv = nil
+	}
+
+	restartNATS := func(t *testing.T) {
+		t.Helper()
+		require.Nil(t, nsPtr.srv)
+		nsPtr.srv = startServer()
+	}
+
+	return nc, stopNATS, restartNATS
+}

--- a/test/integration/failure/handoff_rebalance_writefault_test.go
+++ b/test/integration/failure/handoff_rebalance_writefault_test.go
@@ -1,0 +1,226 @@
+package failure_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandoffOnlyWriteFault_RebalancePreservesOldOwners(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+	if os.Getenv("PARTI_RUN_HANDOFF_REBALANCE_PROOF") != "1" {
+		t.Skip("set PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 to run known failing proof")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+	faultJS := newWFFaultJetStream(realJS, rfHandoffBucket, fc)
+
+	rfBuildStream(t, ctx, realJS)
+
+	pids := []string{
+		"p0", "p1", "p2", "p3", "p4", "p5",
+		"p6", "p7", "p8", "p9", "p10", "p11",
+	}
+	src := newWFMutableSource(wfPartitions(pids))
+
+	stack0 := rfBuildWorkerStack(t, ctx, faultJS, src, 0)
+	stack1 := rfBuildWorkerStack(t, ctx, faultJS, src, 1)
+	stacks := make([]*rfWorkerStack, 0, 3)
+	stacks = append(stacks, stack0, stack1)
+	wfWaitStable(t, stacks, 30*time.Second)
+
+	var preOwners map[string]string
+	require.Eventually(t, func() bool {
+		preOwners = wfAssignmentOwners(stacks)
+		return len(preOwners) == len(pids) && wfClaimsMatchOwners(t, ctx, realJS, preOwners)
+	}, 30*time.Second, 100*time.Millisecond, "two-worker baseline never committed stable claims")
+
+	preCounts := wfExpectedCountsByWorker(preOwners)
+	require.NotZero(t, preCounts[stack0.mgr.WorkerID()], "worker 0 must own baseline partitions")
+	require.NotZero(t, preCounts[stack1.mgr.WorkerID()], "worker 1 must own baseline partitions")
+
+	// C2 prerequisite (executable): M7 safety is only claimed for deployments
+	// that fence the gaining worker with the processing gate. Assert the gate is
+	// actually wired — gateWired flips true during the consumer update that
+	// precedes Stable, so a baseline-stable worker that owns partitions must
+	// report CapProcessingGate. Behavioral zero-new-consumption alone is NOT a
+	// gate proof: a claim-write fault fails preparePhase before the consumer
+	// updater runs, so the gaining worker would consume nothing regardless of the
+	// gate. This guards against a future rfBuildWorkerStack change silently
+	// dropping WithProcessingGate.
+	require.NotZero(t, stack0.dyn.Capabilities()&types.CapProcessingGate,
+		"worker 0 must report CapProcessingGate (processing gate wired)")
+	require.NotZero(t, stack1.dyn.Capabilities()&types.CapProcessingGate,
+		"worker 1 must report CapProcessingGate (processing gate wired)")
+
+	fc.ArmWrites()
+	stack2 := rfBuildWorkerStack(t, ctx, faultJS, src, 2)
+	stacks = append(stacks, stack2)
+
+	require.Eventually(t, func() bool { return fc.writeFaultsInjected.Load() >= 1 },
+		30*time.Second, 25*time.Millisecond,
+		"adding the third worker did not attempt a faulted handoff claim write")
+
+	t.Logf("[%s] during handoff write fault: new worker state=%s assignment_parts=%d writeFaults=%d",
+		t.Name(), stack2.mgr.State(), len(stack2.mgr.CurrentAssignment().Partitions), fc.writeFaultsInjected.Load())
+
+	require.Never(t, func() bool {
+		if stack2.mgr.State() == parti.StateStable {
+			return true
+		}
+		return !wfClaimsMatchOwners(t, ctx, realJS, preOwners)
+	}, 3*time.Second, 100*time.Millisecond,
+		"handoff write failures must not report Stable or rewrite stable owners")
+
+	before0 := stack0.consumed.Load()
+	before1 := stack1.consumed.Load()
+	before2 := stack2.consumed.Load()
+	for _, pid := range pids {
+		rfPublish(t, ctx, realJS, pid, "during-"+pid)
+	}
+	require.Eventuallyf(t, func() bool {
+		return stack0.consumed.Load() >= before0+preCounts[stack0.mgr.WorkerID()] &&
+			stack1.consumed.Load() >= before1+preCounts[stack1.mgr.WorkerID()] &&
+			stack2.consumed.Load() == before2
+	}, 30*time.Second, 100*time.Millisecond,
+		"old owners must keep consuming their pre-fault partitions while new ownership is uncommitted; "+
+			"want old deltas=(%d,%d) got=(%d,%d) new_delta=%d preOwners=%v",
+		preCounts[stack0.mgr.WorkerID()], preCounts[stack1.mgr.WorkerID()],
+		stack0.consumed.Load()-before0, stack1.consumed.Load()-before1,
+		stack2.consumed.Load()-before2, preOwners)
+
+	fc.DisarmWrites()
+
+	require.Eventually(t, func() bool {
+		if err := wfAllStable(stacks, 0); err != nil {
+			return false
+		}
+		owners := wfAssignmentOwners(stacks)
+		return len(owners) == len(pids) &&
+			len(stack2.mgr.CurrentAssignment().Partitions) > 0 &&
+			wfClaimsMatchOwners(t, ctx, realJS, owners)
+	}, 45*time.Second, 100*time.Millisecond,
+		"after handoff writes recover, the rebalance must commit and expose the new worker")
+
+	// The gaining worker has now applied the committed rebalance, so its gate is
+	// wired too — completing the C2 assertion for the worker that actually
+	// received the transferred partitions.
+	require.NotZero(t, stack2.dyn.Capabilities()&types.CapProcessingGate,
+		"gaining worker must report CapProcessingGate after applying the committed rebalance")
+
+	baseTotal := wfConsumedTotal(stacks)
+	for _, pid := range pids {
+		rfPublish(t, ctx, realJS, pid, "after-"+pid)
+	}
+	require.Eventually(t, func() bool {
+		return wfConsumedTotal(stacks) >= baseTotal+int64(len(pids))
+	}, 30*time.Second, 100*time.Millisecond,
+		"all partitions must resume consumption after rebalance commit")
+}
+
+func wfPartitions(pids []string) []types.Partition {
+	parts := make([]types.Partition, len(pids))
+	for i, pid := range pids {
+		parts[i] = types.Partition{Keys: []string{pid}}
+	}
+
+	return parts
+}
+
+func wfWaitStable(t *testing.T, stacks []*rfWorkerStack, timeout time.Duration) {
+	t.Helper()
+	for i, s := range stacks {
+		require.NoErrorf(t, <-s.mgr.WaitState(parti.StateStable, timeout),
+			"worker %d did not reach Stable", i)
+	}
+}
+
+func wfAllStable(stacks []*rfWorkerStack, timeout time.Duration) error {
+	for _, s := range stacks {
+		if s.mgr.State() == parti.StateStable {
+			continue
+		}
+		if timeout <= 0 {
+			return context.DeadlineExceeded
+		}
+		if err := <-s.mgr.WaitState(parti.StateStable, timeout); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func wfAssignmentOwners(stacks []*rfWorkerStack) map[string]string {
+	owners := make(map[string]string)
+	for _, s := range stacks {
+		workerID := s.mgr.WorkerID()
+		for _, p := range s.mgr.CurrentAssignment().Partitions {
+			owners[p.ID()] = workerID
+		}
+	}
+
+	return owners
+}
+
+func wfExpectedCountsByWorker(owners map[string]string) map[string]int64 {
+	counts := make(map[string]int64)
+	for _, workerID := range owners {
+		counts[workerID]++
+	}
+
+	return counts
+}
+
+func wfClaimsMatchOwners(t *testing.T, ctx context.Context, realJS jetstream.JetStream, owners map[string]string) bool {
+	t.Helper()
+	for pid, owner := range owners {
+		claimOwner, stable := wfReadStableClaimOwner(t, ctx, realJS, pid)
+		if !stable || claimOwner != owner {
+			return false
+		}
+	}
+
+	return true
+}
+
+func wfReadStableClaimOwner(t *testing.T, ctx context.Context, realJS jetstream.JetStream, pid string) (string, bool) {
+	t.Helper()
+	kv, err := realJS.KeyValue(ctx, rfHandoffBucket)
+	require.NoError(t, err)
+	entry, err := kv.Get(ctx, rfClaimsPrefix+pid)
+	if err != nil {
+		return "", false
+	}
+	cl, err := handoff.UnmarshalClaim(entry.Value())
+	require.NoError(t, err)
+
+	return cl.Owner, cl.State == handoff.ClaimStateStable
+}
+
+func wfConsumedTotal(stacks []*rfWorkerStack) int64 {
+	var total int64
+	for _, s := range stacks {
+		total += s.consumed.Load()
+	}
+
+	return total
+}

--- a/test/integration/failure/handoff_removal_guard_concurrency_test.go
+++ b/test/integration/failure/handoff_removal_guard_concurrency_test.go
@@ -1,0 +1,160 @@
+package failure_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandoffRemovalGuard_NoRaceUnderConcurrentApplies is the concurrency
+// stress regression pin required by AGENTS.md for the handoff removal guard.
+//
+// The guard (Manager.guardHandoffRemoval) adds claim-store + assignment-commit
+// KV reads INSIDE the apply critical section: currentCommitPartitionSet reads
+// `assignment._commit` and each referenced `assignment._payload.*` via the
+// shared m.assignmentKV handle on every guarded apply that removes a partition.
+// Those reads run concurrently with the manager's assignment-change watcher and
+// commit watcher operating on the SAME buckets — and this repo has a documented
+// history of nats.go cached *stream concurrency races under live load
+// (manager_epoch_monitor_concurrency_test.go). The guardHandoffRemoval unit
+// tests exercise the decision logic in isolation and cannot find a race between
+// the guard's KV reads and the production watcher goroutines.
+//
+// Mechanism:
+//   - Start a real 3-worker two-phase cluster (rfBuildWorkerStack wires
+//     EnableTwoPhaseHandoff + the processing gate, so the guard is live).
+//   - Churn the partition set between a full and a reduced set every ~150ms for
+//     ~5s. Each reduction forces the leader to republish an assignment that
+//     removes partitions, so followers apply with len(removed) > 0 and the guard
+//     fans out its commit/payload KV reads while the watchers are active.
+//   - Assert no race-detector trigger (t.Failed()) and that the cluster stays
+//     live (re-converges to Stable, consumption keeps progressing).
+//
+// Scope: partition-set churn over a FIXED worker set produces GLOBAL removals,
+// so this pin races the guard's commit/payload reads on m.assignmentKV
+// (currentCommitPartitionSet) against the watchers. The guard's per-partition
+// claim-store Get is reached only for TRANSFER removals (partition still in the
+// commit batch) and is raced under -race by
+// TestHandoffOnlyWriteFault_RebalancePreservesOldOwners, which grows the worker
+// set to force real transfers. Together the two tests cover both read surfaces.
+//
+// Run under `go test -race` (the make pre-pr integration gate) to be meaningful.
+func TestHandoffRemovalGuard_NoRaceUnderConcurrentApplies(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	t.Parallel()
+
+	// 120s parent budget (matching the sibling write-fault proof) must exceed the
+	// worst-case sum of the sequential phase budgets below (30s wait + 5s soak +
+	// 45s re-converge + 30s consumption = 110s); a tighter ctx could fire
+	// mid-phase as a hard error under full-suite -race CPU load.
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	rfBuildStream(t, ctx, realJS)
+
+	fullPIDs := []string{"p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9", "p10", "p11"}
+	reducedPIDs := fullPIDs[:8] // dropping 4 partitions forces removals on republish
+
+	// Each worker gets its own watchable source instance so that whichever worker
+	// wins leadership reliably receives the re-list signal (wfMutableSource.Watch
+	// returns a single per-instance channel; sharing one instance across workers
+	// would let a follower drain the leader's signal).
+	const workerCount = 3
+	sources := make([]*wfMutableSource, workerCount)
+	stacks := make([]*rfWorkerStack, workerCount)
+	for i := range workerCount {
+		sources[i] = newWFMutableSource(wfPartitions(fullPIDs))
+		stacks[i] = rfBuildWorkerStack(t, ctx, realJS, sources[i], i)
+	}
+	wfWaitStable(t, stacks, 30*time.Second)
+
+	maxVersion := func() int64 {
+		var v int64
+		for _, s := range stacks {
+			if cv := s.mgr.CurrentAssignment().Version; cv > v {
+				v = cv
+			}
+		}
+
+		return v
+	}
+	initialVersion := maxVersion()
+
+	setAll := func(pids []string) {
+		parts := wfPartitions(pids)
+		for _, s := range sources {
+			s.set(parts)
+		}
+	}
+
+	// Soak: alternate the partition set to drive a steady stream of guarded
+	// applies (with removals on every step down) concurrent with the assignment
+	// and commit watchers. Publish along the way so the consumer pull path adds
+	// further concurrent KV traffic against the same connection.
+	soak, soakCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer soakCancel()
+	ticker := time.NewTicker(150 * time.Millisecond)
+	defer ticker.Stop()
+	reduced := false
+	pub := 0
+	for {
+		stop := false
+		select {
+		case <-soak.Done():
+			stop = true
+		case <-ticker.C:
+			reduced = !reduced
+			if reduced {
+				setAll(reducedPIDs)
+			} else {
+				setAll(fullPIDs)
+			}
+			rfPublish(t, ctx, realJS, fullPIDs[pub%len(fullPIDs)], "soak")
+			pub++
+		}
+		if stop {
+			break
+		}
+	}
+
+	// Non-vacuity: the churn must have driven real rebalances (and thus guarded
+	// applies), not silently no-op'd — the assignment version must have advanced.
+	require.Greater(t, maxVersion(), initialVersion,
+		"partition-set churn must advance the assignment version (guarded applies actually fired)")
+
+	// Settle on the full set and require the cluster to re-converge — proves the
+	// guarded-apply churn did not wedge the fleet, only stressed the race window.
+	setAll(fullPIDs)
+	require.Eventually(t, func() bool {
+		return wfAllStable(stacks, 0) == nil &&
+			len(wfAssignmentOwners(stacks)) == len(fullPIDs)
+	}, 45*time.Second, 200*time.Millisecond,
+		"cluster must re-converge to a full stable assignment after the guarded-apply soak")
+
+	// Liveness sanity: consumption still flows after the soak.
+	baseTotal := wfConsumedTotal(stacks)
+	for _, pid := range fullPIDs {
+		rfPublish(t, ctx, realJS, pid, "post-soak-"+pid)
+	}
+	require.Eventually(t, func() bool {
+		return wfConsumedTotal(stacks) >= baseTotal+int64(len(fullPIDs))
+	}, 30*time.Second, 100*time.Millisecond,
+		"all partitions must resume consumption after the guarded-apply soak")
+
+	require.False(t, t.Failed(),
+		"race detector or a sub-assertion failed during the guarded-apply soak; "+
+			"check stderr for WARNING: DATA RACE — the guard's commit/payload KV reads "+
+			"share m.assignmentKV with the assignment and commit watcher goroutines")
+}

--- a/test/integration/failure/quorum_loss_tier2_test.go
+++ b/test/integration/failure/quorum_loss_tier2_test.go
@@ -1,0 +1,214 @@
+package failure_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRF3SelectivePeerFault_HandoffQuorumLoss(t *testing.T) {
+	if os.Getenv("PARTI_RUN_QUORUM_LOSS_TIER2") != "1" {
+		t.Skip("set PARTI_RUN_QUORUM_LOSS_TIER2=1 to run")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+
+	servers, nc := partitest.StartEmbeddedNATSClusterN(t, 5)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const bucket = "tier2-handoff"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		Storage:  jetstream.FileStorage,
+		Replicas: 3,
+	})
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "claims/p0", []byte(`{"partition_id":"p0","owner":"w1","state":"stable","epoch":1}`))
+	require.NoError(t, err)
+
+	info := rf3BucketStreamInfo(t, ctx, kv)
+	require.NotNil(t, info.Cluster, "RF3 bucket must expose cluster metadata")
+	streamPeers := streamPeerNames(info.Cluster)
+	require.Len(t, streamPeers, 3, "RF3 bucket must have three stream peers")
+	t.Logf("rf3 bucket cluster leader=%s replicas=%s peers=%s",
+		info.Cluster.Leader, peerNames(info.Cluster.Replicas), strings.Join(streamPeers, ","))
+
+	metaLeader := jetStreamMetaLeaderName(t, servers)
+	peersToStop := chooseStreamPeersToStop(streamPeers, metaLeader)
+	require.Len(t, peersToStop, 2, "probe needs two non-meta stream peers to stop")
+	t.Logf("meta leader=%s selected stopped peers=%s", metaLeader, strings.Join(peersToStop, ","))
+
+	stopped := stopBucketPeers(t, servers, peersToStop)
+	t.Logf("stopped handoff bucket peers=%s", strings.Join(stopped, ","))
+
+	require.Eventually(t, func() bool { return nc.Status() == nats.CONNECTED },
+		10*time.Second, 100*time.Millisecond, "client did not reconnect to surviving peers")
+
+	require.Eventually(t, func() bool {
+		accountErr := probeErr(ctx, time.Second, func(ctx context.Context) error {
+			_, err := js.AccountInfo(ctx)
+			return err
+		})
+		return accountErr == nil
+	}, 10*time.Second, 100*time.Millisecond,
+		"JetStream meta quorum should remain available after stopping two of five nodes")
+
+	results := []probeSurfaceResult{
+		runProbeSurface(ctx, "kv-get", func(ctx context.Context) error {
+			_, err := kv.Get(ctx, "claims/p0")
+			return err
+		}),
+		runProbeSurface(ctx, "kv-put", func(ctx context.Context) error {
+			_, err := kv.Put(ctx, "claims/p1", []byte(`{"partition_id":"p1","owner":"w2","state":"stable","epoch":1}`))
+			return err
+		}),
+		runProbeSurface(ctx, "kv-status", func(ctx context.Context) error {
+			_, err := kv.Status(ctx)
+			return err
+		}),
+	}
+
+	errorCount := 0
+	for _, result := range results {
+		t.Logf("tier2 surface=%s class=%s err=%v matrix=M1/M7", result.surface, result.class, result.err)
+		if result.err != nil {
+			errorCount++
+		}
+	}
+	require.Positive(t, errorCount,
+		"selective peer fault did not produce an observable handoff-bucket error surface")
+}
+
+func rf3BucketStreamInfo(t *testing.T, ctx context.Context, kv jetstream.KeyValue) *jetstream.StreamInfo {
+	t.Helper()
+	status, err := kv.Status(ctx)
+	require.NoError(t, err)
+	bs, ok := status.(*jetstream.KeyValueBucketStatus)
+	require.True(t, ok)
+	require.NotNil(t, bs.StreamInfo())
+
+	return bs.StreamInfo()
+}
+
+func stopBucketPeers(t *testing.T, servers []*server.Server, peers []string) []string {
+	t.Helper()
+	serversByName := make(map[string]*server.Server, len(servers))
+	for _, srv := range servers {
+		serversByName[srv.Name()] = srv
+	}
+
+	stopped := make([]string, 0, len(peers))
+	for _, peer := range peers {
+		srv := serversByName[peer]
+		require.NotNilf(t, srv, "bucket peer %q not found in embedded cluster", peer)
+		srv.Shutdown()
+		srv.WaitForShutdown()
+		stopped = append(stopped, peer)
+	}
+
+	return stopped
+}
+
+func streamPeerNames(cluster *jetstream.ClusterInfo) []string {
+	seen := make(map[string]struct{}, len(cluster.Replicas)+1)
+	names := make([]string, 0, len(cluster.Replicas)+1)
+	if cluster.Leader != "" {
+		names = append(names, cluster.Leader)
+		seen[cluster.Leader] = struct{}{}
+	}
+	for _, peer := range cluster.Replicas {
+		if _, ok := seen[peer.Name]; ok {
+			continue
+		}
+		names = append(names, peer.Name)
+		seen[peer.Name] = struct{}{}
+	}
+
+	return names
+}
+
+func peerNames(peers []*jetstream.PeerInfo) string {
+	names := make([]string, len(peers))
+	for i, peer := range peers {
+		names[i] = peer.Name
+	}
+
+	return strings.Join(names, ",")
+}
+
+func jetStreamMetaLeaderName(t *testing.T, servers []*server.Server) string {
+	t.Helper()
+	for _, srv := range servers {
+		if srv.JetStreamIsLeader() {
+			return srv.Name()
+		}
+	}
+	t.Fatal("no JetStream meta leader found")
+
+	return ""
+}
+
+func chooseStreamPeersToStop(streamPeers []string, metaLeader string) []string {
+	selected := make([]string, 0, 2)
+	for _, peer := range streamPeers {
+		if peer == metaLeader {
+			continue
+		}
+		selected = append(selected, peer)
+		if len(selected) == 2 {
+			return selected
+		}
+	}
+
+	return selected
+}
+
+type probeSurfaceResult struct {
+	surface string
+	class   string
+	err     error
+}
+
+func runProbeSurface(parent context.Context, surface string, fn func(context.Context) error) probeSurfaceResult {
+	err := probeErr(parent, 3*time.Second, fn)
+	return probeSurfaceResult{
+		surface: surface,
+		class:   classifyProbeErr(err),
+		err:     err,
+	}
+}
+
+func probeErr(parent context.Context, timeout time.Duration, fn func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	return fn(ctx)
+}
+
+func classifyProbeErr(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context-deadline-exceeded"
+	case errors.Is(err, nats.ErrNoResponders):
+		return "nats-no-responders"
+	case errors.Is(err, nats.ErrTimeout):
+		return "nats-timeout"
+	default:
+		return fmt.Sprintf("%T", err)
+	}
+}

--- a/test/integration/failure/wedged_storage_probe_test.go
+++ b/test/integration/failure/wedged_storage_probe_test.go
@@ -1,0 +1,165 @@
+package failure_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWedgedStorage_ReadOnlyFileStore_RecordsOperationSurfaces(t *testing.T) {
+	if os.Getenv("PARTI_RUN_WEDGED_STORAGE_PROBE") != "1" {
+		t.Skip("set PARTI_RUN_WEDGED_STORAGE_PROBE=1 to run")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	storeDir := t.TempDir()
+	nc, shutdown := startFileStoreNATS(t, storeDir)
+	defer shutdown()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:   "wedged-rf1",
+		Storage:  jetstream.FileStorage,
+		Replicas: 1,
+	})
+	require.NoError(t, err)
+	rev, err := kv.Put(ctx, "existing", []byte("before"))
+	require.NoError(t, err)
+
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "WEDGED",
+		Subjects:  []string{"wedged.>"},
+		Storage:   jetstream.FileStorage,
+		Replicas:  1,
+		Retention: jetstream.LimitsPolicy,
+	})
+	require.NoError(t, err)
+	consumer, err := js.CreateConsumer(ctx, "WEDGED", jetstream.ConsumerConfig{Durable: "wedged"})
+	require.NoError(t, err)
+
+	require.NoError(t, chmodTree(storeDir, 0o555))
+	defer func() {
+		if err := chmodTree(storeDir, 0o755); err != nil {
+			t.Logf("restore store permissions: %v", err)
+		}
+	}()
+
+	results := []probeSurfaceResult{
+		runProbeSurface(ctx, "kv-keys", func(ctx context.Context) error {
+			_, err := kv.Keys(ctx)
+			return err
+		}),
+		runProbeSurface(ctx, "kv-get", func(ctx context.Context) error {
+			_, err := kv.Get(ctx, "existing")
+			return err
+		}),
+		runProbeSurface(ctx, "kv-watch", func(ctx context.Context) error {
+			watcher, err := kv.Watch(ctx, "existing", jetstream.UpdatesOnly())
+			if err != nil {
+				return err
+			}
+			return watcher.Stop()
+		}),
+		runProbeSurface(ctx, "kv-create", func(ctx context.Context) error {
+			_, err := kv.Create(ctx, "created-after-readonly", []byte("value"))
+			return err
+		}),
+		runProbeSurface(ctx, "kv-update", func(ctx context.Context) error {
+			_, err := kv.Update(ctx, "existing", []byte("after"), rev)
+			return err
+		}),
+		runProbeSurface(ctx, "kv-put", func(ctx context.Context) error {
+			_, err := kv.Put(ctx, "put-after-readonly", []byte("value"))
+			return err
+		}),
+		runProbeSurface(ctx, "kv-bucket-create", func(ctx context.Context) error {
+			_, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+				Bucket:   "wedged-new-rf1",
+				Storage:  jetstream.FileStorage,
+				Replicas: 1,
+			})
+			return err
+		}),
+		runProbeSurface(ctx, "stream-info", func(ctx context.Context) error {
+			_, err := stream.Info(ctx)
+			return err
+		}),
+		runProbeSurface(ctx, "stream-publish", func(ctx context.Context) error {
+			_, err := js.Publish(ctx, "wedged.p0", []byte("value"))
+			return err
+		}),
+		runProbeSurface(ctx, "stream-create", func(ctx context.Context) error {
+			_, err := js.CreateStream(ctx, jetstream.StreamConfig{
+				Name:     "WEDGED_NEW",
+				Subjects: []string{"wedged-new.>"},
+				Storage:  jetstream.FileStorage,
+				Replicas: 1,
+			})
+			return err
+		}),
+		runProbeSurface(ctx, "consumer-info", func(ctx context.Context) error {
+			_, err := consumer.Info(ctx)
+			return err
+		}),
+	}
+
+	errorCount := 0
+	for _, result := range results {
+		t.Logf("wedged-storage surface=%s class=%s err=%v matrix=M12", result.surface, result.class, result.err)
+		if result.err != nil {
+			errorCount++
+		}
+	}
+	if errorCount == 0 {
+		t.Log("wedged-storage probe observed no errors after chmod; embedded server may retain writable file handles")
+	}
+}
+
+func startFileStoreNATS(t *testing.T, storeDir string) (*nats.Conn, func()) {
+	t.Helper()
+	port, err := getFreePortForRestart()
+	require.NoError(t, err)
+
+	ns, err := server.NewServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      port,
+		JetStream: true,
+		StoreDir:  storeDir,
+		NoLog:     true,
+	})
+	require.NoError(t, err)
+	go ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second), "embedded NATS not ready")
+
+	nc, err := nats.Connect(ns.ClientURL(),
+		nats.Timeout(2*time.Second),
+		nats.MaxReconnects(-1),
+	)
+	require.NoError(t, err)
+
+	return nc, func() {
+		nc.Close()
+		ns.Shutdown()
+		ns.WaitForShutdown()
+	}
+}
+
+func chmodTree(root string, mode os.FileMode) error {
+	return filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, mode)
+	})
+}

--- a/types/metrics_collector.go
+++ b/types/metrics_collector.go
@@ -65,6 +65,17 @@ type ManagerMetrics interface {
 	//   - workerID: Stable worker identifier (caller passes m.WorkerID()).
 	//   - version: The candidate assignment's Version field.
 	RecordApplyAttempt(workerID string, version int64)
+
+	// RecordHandoffRemovalPending records one deferral of a handoff transfer
+	// removal by the manager's removal guard: the worker was about to remove a
+	// partition subject during a rebalance, but the gaining worker had not yet
+	// committed its ownership claim, so the removal was blocked (the apply
+	// returns ErrRemovalPending and is retried). A sustained rate indicates a
+	// transfer that is stuck before commit.
+	//
+	// Parameters:
+	//   - workerID: Stable worker identifier (caller passes m.WorkerID()).
+	RecordHandoffRemovalPending(workerID string)
 }
 
 // AuditMetrics defines metrics for the leader-side apply audit (§4.2) and the

--- a/types/state.go
+++ b/types/state.go
@@ -38,8 +38,11 @@ const (
 	// StateEmergency indicates an error condition requiring intervention.
 	StateEmergency
 
-	// StateDegraded indicates operating with cached data due to NATS connectivity issues.
-	// The system continues processing with last known good assignments while NATS is unavailable.
+	// StateDegraded indicates Parti has detected a fault that makes fresh
+	// coordination, source, or consumer state unreliable. Workers continue with
+	// last known safe local state where possible; the OnDegraded reason determines
+	// whether the intended response is ride-through, in-process recovery,
+	// readiness rotation, or operator-owned recovery.
 	StateDegraded
 
 	// StateShutdown indicates graceful shutdown is in progress.


### PR DESCRIPTION
## Summary
Closes the confirmed auto-healing fault-model gaps with a documented fault
matrix, source-grounded fixes, and focused proofs.

- **fix(source):** classify a sustained source-bucket timeout as a
  source-unavailable signal (hook + gauge) without false bucket-deletion semantics.
- **feat(handoff):** worker-side removal guard — during a handoff-bucket-only
  write outage in a rebalance, block a transfer removal until the live claim
  proves a *different* owner committed (fail-closed positive allow-predicate),
  routed through apply-retry without entering the degraded circuit. Bounded
  commit-set cache + a worker-scoped deferral metric.
- **test:** the handoff write-fault rebalance proof now PASSES with the
  processing gate wired (opt-in); plus full-NATS-outage recovery, a removal-guard
  -race pin, and gated RF3 / wedged-storage probes; N-node embedded cluster helper.
- **docs:** fault matrix (M1–M12), fix plans, findings index, operator reason
  taxonomy, and the StateDegraded policy godoc.

## Test Plan
- `make pre-pr` (lint + unit `-race` + integration `-race`) — green, 0 data races
- `PARTI_RUN_HANDOFF_REBALANCE_PROOF=1 go test ./test/integration/failure -run TestHandoffOnlyWriteFault_RebalancePreservesOldOwners` — PASSES (was the known-failing proof; the worker-side guard closes it)

## Notes
- A leader-side capability gate was tried and **removed** (bootstrap deadlock);
  mixed-version safety is a rollout contract, not an in-process gate. See the
  Implementation Outcome header in
  `docs/plans/auto-healing-gap-closure/02-g4-handoff-rebalance-fix-plan.md`.
- The handoff rebalance proof stays opt-in behind
  `PARTI_RUN_HANDOFF_REBALANCE_PROOF=1` to keep a 30–45s timing test out of the
  default CI suite.
