### PR TITLE
fix(manager): reset KV-error circuit on healthy heartbeat to stop degraded flapping

### DIFF
--- a/config.go
+++ b/config.go
@@ -195,12 +195,16 @@ type DegradedBehaviorConfig struct {
 	// Default: 5 seconds.
 	ExitThreshold time.Duration `yaml:"exitThreshold" default:"5s" validate:"gte=0"`
 
-	// KVErrorThreshold is the number of consecutive KV operation errors that trigger degraded mode.
+	// KVErrorThreshold is the number of KV operation errors within KVErrorWindow
+	// that trigger degraded mode. Whole-bucket-loss errors accumulate across the
+	// window; connected-but-KV-unavailable timeouts are reset by any successful
+	// periodic KV op while not degraded, so for that class it is a consecutive
+	// run with no intervening success rather than blips summed across the window.
 	// Default: 5 errors.
 	KVErrorThreshold int `yaml:"kvErrorThreshold" default:"5" validate:"gte=0"`
 
-	// KVErrorWindow is the time window for counting consecutive KV errors.
-	// Errors outside this window are not counted.
+	// KVErrorWindow is the time window for counting KV errors toward
+	// KVErrorThreshold. Errors outside this window are not counted.
 	// Default: 30 seconds.
 	KVErrorWindow time.Duration `yaml:"kvErrorWindow" default:"30s" validate:"gte=0"`
 

--- a/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/00-fix-plan.md
@@ -240,8 +240,12 @@ reaches claim-lost shutdown, and a deadline/`ErrNoResponders` reaches the new re
 from the intended periodic KV-op call-sites (heartbeat / election / assignment-watcher /
 commit-watcher / stableid-renew) — NOT from the handoff apply path (see the apply-path
 boundary correction above).
-**Open decision:** is entering Degraded on transient read timeouts desirable, or does it
-cause Degraded flapping on brief blips? Tunable via `KVErrorThreshold`/`KVErrorWindow`.
+**Open decision — RESOLVED** (see [`04-fd1-flapping-decision.md`](04-fd1-flapping-decision.md)):
+entering Degraded on transient timeouts *did* flap, but via cross-blip accumulation
+(no success-reset on the Stable path), not the threshold alone. Fixed by a class-aware
+healthy-op success-reset (heartbeat success clears only the transient F-D1 entries;
+whole-bucket-loss entries still accumulate). The narrower sustained-single-bucket case
+(Finding A) is deferred.
 
 ---
 
@@ -412,8 +416,10 @@ not big-bang before or defer after).
 ## 7. Open decisions for review
 (F-D2b mechanism — event-driven, consumer-local — and F-D3 option 3a are now **decided** in
 the body above; they are no longer open.)
-1. F-D1: is auto-Degraded on transient read timeouts desirable (alerting value) vs flapping
-   risk? Default `KVErrorThreshold`/`KVErrorWindow` tuning.
+1. ~~F-D1: is auto-Degraded on transient read timeouts desirable (alerting value) vs flapping
+   risk? Default `KVErrorThreshold`/`KVErrorWindow` tuning.~~ **RESOLVED** — see
+   [`04-fd1-flapping-decision.md`](04-fd1-flapping-decision.md). Fixed via a class-aware
+   healthy-op success-reset; Finding A (sustained single-bucket flap) deferred.
 2. Should pull-gating additionally **fail-open after a bounded suppression timeout** as a
    last-resort safety net, independent of the resolver fix? (Overlaps the known-deferred
    "resolver fail-open" follow-up.)

--- a/docs/plans/auto-healing-quorum-loss-fix/04-fd1-flapping-decision.md
+++ b/docs/plans/auto-healing-quorum-loss-fix/04-fd1-flapping-decision.md
@@ -1,0 +1,124 @@
+# F-D1 Flapping — Decision Record
+
+- **Date:** 2026-05-31
+- **Status:** DECIDED & IMPLEMENTED.
+- **Resolves:** the open decision in [`00-fix-plan.md`](00-fix-plan.md) §2 and §7.1
+  — *"is auto-Degraded on transient read timeouts desirable, or does it cause
+  Degraded flapping on brief blips? Tunable via `KVErrorThreshold` /
+  `KVErrorWindow`."*
+
+## Question
+
+F-D1 auto-enters `Degraded` (reason `kv-unavailable`) when sustained
+connected-but-KV-unavailable timeouts (`context.DeadlineExceeded` /
+`nats.ErrNoResponders`) accumulate from the manager's periodic KV-op sites
+(heartbeat / election / assignment-watcher / stableid-renew / commit). The
+blast radius of a *spurious* `Degraded` is real: `OnDegraded` may be wired to a
+readiness probe that rotates pods, and a leader's recovery-grace suppresses
+emergency rebalance on each entry. So the question is whether the circuit flaps
+under merely *transient* blips, and whether the answer is tuning or a mechanism
+change.
+
+## Investigation
+
+A probe (`test/integration/failure/`, since folded into the regression test
+below) drove an intermittent heartbeat-bucket timeout pattern (4s faulted / 8s
+healed × 4 blips) and counted `OnDegraded` entries per `DegradedBehavior`
+preset:
+
+| preset | KVErrorThreshold | flaps over 4 blips | recovered |
+|---|---|---|---|
+| aggressive | 3 | 7 | ✅ all → Stable |
+| balanced | 5 | 5 | ✅ |
+| conservative | 10 | 3 | ✅ |
+
+The **conservative** result is the tell: a single 4s blip at 500ms cadence is
+~8 faulted heartbeats — *below* its threshold of 10 — yet it still flapped 3×.
+That can only be cross-blip accumulation. Two findings explain the curve:
+
+- **Finding A — recover-on-wrong-signal.** Recovery
+  (`attemptRecoveryFromDegraded`) exits `Degraded` on connectivity uptime
+  (`ExitThreshold`) **plus a successful assignment-bucket read** — *not* on the
+  failing op recovering. A heartbeat-write timeout doesn't drop the connection,
+  so the worker can exit while heartbeat writes still fault, re-accumulate, and
+  re-degrade. This is the within-blip re-degradation that pushes aggressive to
+  7 > 4 blips.
+- **Finding B — no success-reset on the Stable path.** The error counter only
+  reset on degraded-recovery, never on a successful KV op while `Stable`. So the
+  circuit was **N-in-window**, not the **consecutive** errors the config doc
+  claimed. Intermittent blips *summed* within `KVErrorWindow` across healthy
+  periods — exactly the conservative 3-flap surprise.
+
+## Decision
+
+**Fix Finding B; defer Finding A.** Finding B is the dominant lever on
+*intermittent-transient* flapping (the precise worry in the open decision), and
+its fix is small and contained. Finding A (flapping under a *sustained* fault on
+a non-assignment bucket) is narrower and touches the contract-pinned recovery
+path, so it is a separate follow-up taken only if observed.
+
+### What shipped (Finding B)
+
+A **class-aware** healthy-op success-reset:
+
+1. `manager_degraded.go` — the KV-error window (`kvErrorWindow`) now tags each
+   entry by class (`kvErrorEvent{at, transient}`): `transient` = an F-D1
+   `ErrKVUnavailable`-wrapped timeout; non-transient = whole-bucket loss
+   (connectivity / degrading-JetStream).
+2. `Manager.recordKVHealthyOp` clears **only the transient entries** on a
+   successful periodic KV op while not degraded (no-op while degraded). The
+   whole-bucket-loss entries are retained.
+3. `heartbeat.Publisher.SetOnSuccess` fires after each successful periodic
+   heartbeat publish; the manager wires it to `recordKVHealthyOp`. The heartbeat
+   is the highest-frequency periodic KV op, so its success is the natural
+   "heartbeat KV is serving" signal.
+
+Result: a run of connected-but-KV-unavailable timeouts only trips `Degraded`
+when **no success intervenes** — true consecutive-error semantics. The config
+doc on `KVErrorThreshold` was corrected to match.
+
+### Explicit semantic narrowing (accepted)
+
+Because the heartbeat-success reset is *global* over the transient class, a
+healthy heartbeat now clears F-D1 timeouts attributed to *slower* sources
+(election / stableid / assignment) before they reach threshold. So F-D1 now
+trips primarily on a **sustained run of heartbeat-KV failures with no
+intervening success**. A sustained quorum-loss on a *non-heartbeat* bucket that
+surfaces **only** as F-D1 timeouts (not as a whole-bucket
+`ErrBucketNotFound`/connectivity error) may no longer trip via F-D1 alone — it
+relies on the whole-bucket classification, or on the deferred Finding A
+follow-up (per-source counters / verify-the-failing-op-recovered). This is a
+deliberate, documented coverage change, scope-consistent with deferring A.
+
+**Whole-bucket loss of any bucket still trips** (AGENTS.md contract 1): those
+entries are non-transient and accumulate untouched even while heartbeat keeps
+succeeding. This is pinned by a new guard the existing all-buckets-wipe test
+cannot catch (it kills heartbeat too, so no success fires).
+
+### Tuning
+
+The presets are unchanged. With Finding B fixed, the thresholds now mean what
+they say (consecutive transient errors), so the defaults are the right knobs for
+an operator who wants F-D1 more/less eager; no preset retune was warranted.
+
+## Tests
+
+- `TestFD1_IntermittentKVTimeouts_NoFlap` (`test/integration/failure/`) —
+  intermittent sub-threshold heartbeat blips with recovery between must NOT
+  degrade. **RED on parent** (cross-blip accumulation trips), GREEN with the fix.
+- `TestManager_PartialBucketLoss_HeartbeatHealthy`
+  (`test/integration/manager/`) — wipes every bucket *except* heartbeat; all
+  workers must still degrade. Proves the class-aware reset does not mask a
+  whole-bucket loss when an unaffected bucket keeps succeeding.
+- `TestManager_recordKVHealthyOp` (unit) — clears only transient entries,
+  retains whole-bucket entries, no-op while degraded.
+
+## Deferred (Finding A)
+
+If a sustained quorum-loss on a single non-heartbeat bucket is observed to
+flap or to escape F-D1, take it up as a separate follow-up: candidates are a
+post-recovery cooldown (don't re-degrade for N seconds after exiting),
+verifying the *failing* op recovered before exiting `Degraded`, or per-source
+error counters so a heartbeat success resets only heartbeat-attributed errors.
+All touch the recovery path the cross-feature contracts pin, so they go through
+the full plan → review → impl loop.

--- a/internal/heartbeat/publisher.go
+++ b/internal/heartbeat/publisher.go
@@ -69,14 +69,15 @@ type Publisher struct {
 	capsFn func() uint32
 
 	// mu guards lifecycle fields: started, ticker, metrics, workerID.
-	mu      sync.Mutex
-	started bool
-	stopCh  chan struct{}
-	doneCh  chan struct{}
-	ticker  *time.Ticker
-	logger  types.Logger
-	metrics types.WorkerMetrics
-	onError atomic.Pointer[func(error)]
+	mu        sync.Mutex
+	started   bool
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+	ticker    *time.Ticker
+	logger    types.Logger
+	metrics   types.WorkerMetrics
+	onError   atomic.Pointer[func(error)]
+	onSuccess atomic.Pointer[func()]
 
 	// inFlight guards concurrent publish attempts; set atomically before
 	// spawning the goroutine, cleared when the goroutine completes.
@@ -171,6 +172,27 @@ func (p *Publisher) SetOnError(fn func(error)) {
 		return
 	}
 	p.onError.Store(&fn)
+}
+
+// SetOnSuccess registers a callback invoked after each successful periodic
+// heartbeat publish (the background loop only — not the initial Start publish or
+// PublishNow, mirroring SetOnError). The manager wires this to its degraded-mode
+// circuit's healthy-op reset so a run of intermittent KV-unavailable timeouts
+// only trips Degraded when no success intervenes.
+//
+// Safe to call concurrently with the running publish goroutine; the update is
+// atomic and the hot path reads without locking. Passing nil clears the
+// callback. The callback must not block on the Publisher's own lifecycle
+// (do not call Stop from inside it).
+//
+// Parameters:
+//   - fn: Callback invoked after a successful publish; ignored if nil
+func (p *Publisher) SetOnSuccess(fn func()) {
+	if fn == nil {
+		p.onSuccess.Store(nil)
+		return
+	}
+	p.onSuccess.Store(&fn)
 }
 
 // SetAppliedAssignment records a successfully applied assignment.
@@ -337,6 +359,9 @@ func (p *Publisher) publishLoop() {
 					}
 				} else {
 					p.recordMetric(true)
+					if onSuccess := p.onSuccess.Load(); onSuccess != nil {
+						(*onSuccess)()
+					}
 				}
 			})
 		}

--- a/manager.go
+++ b/manager.go
@@ -169,20 +169,20 @@ type Manager struct {
 	startupAssignmentApplied atomic.Bool
 
 	// Degraded mode tracking
-	degradedSince          atomic.Int64  // UnixNano when degraded mode entered; 0 = not degraded
-	lastAssignmentAt       atomic.Int64  // UnixNano of last successful assignment fetch; 0 = never
-	lastAssignment         atomic.Value  // []Partition - cached assignment during degraded
-	connMonitorOnce        sync.Once     // ensures single connection monitor goroutine
-	postStableMonitorsOnce sync.Once     // ensures startPostStableMonitors fires exactly once
-	startedAt              time.Time     // absolute wall-clock anchor for StartupTimeout budget; set in prepareStart
-	startupWatchdogFired   atomic.Bool   // guards startStartupTimeoutWatchdog (one-shot)
-	connMonitorStop        chan struct{} // channel to stop connection monitor
-	connDownSince          atomic.Int64  // UnixNano when connectivity lost; 0 = up
-	connUpSince            atomic.Int64  // UnixNano when connectivity restored; 0 = none
-	kvErrorCount           atomic.Int32  // consecutive KV error count
-	kvErrorWindow          []time.Time   // timestamps of recent KV errors (protected by mu)
-	recoveryGraceStart     atomic.Int64  // UnixNano when recovery grace period started; 0 = not in grace
-	inRecoveryGrace        atomic.Bool   // true during recovery grace period
+	degradedSince          atomic.Int64   // UnixNano when degraded mode entered; 0 = not degraded
+	lastAssignmentAt       atomic.Int64   // UnixNano of last successful assignment fetch; 0 = never
+	lastAssignment         atomic.Value   // []Partition - cached assignment during degraded
+	connMonitorOnce        sync.Once      // ensures single connection monitor goroutine
+	postStableMonitorsOnce sync.Once      // ensures startPostStableMonitors fires exactly once
+	startedAt              time.Time      // absolute wall-clock anchor for StartupTimeout budget; set in prepareStart
+	startupWatchdogFired   atomic.Bool    // guards startStartupTimeoutWatchdog (one-shot)
+	connMonitorStop        chan struct{}  // channel to stop connection monitor
+	connDownSince          atomic.Int64   // UnixNano when connectivity lost; 0 = up
+	connUpSince            atomic.Int64   // UnixNano when connectivity restored; 0 = none
+	kvErrorCount           atomic.Int32   // count of KV errors in the current window (protected by mu)
+	kvErrorWindow          []kvErrorEvent // recent KV errors, class-tagged (protected by mu)
+	recoveryGraceStart     atomic.Int64   // UnixNano when recovery grace period started; 0 = not in grace
+	inRecoveryGrace        atomic.Bool    // true during recovery grace period
 
 	// Lifecycle management
 	ctx    context.Context
@@ -396,7 +396,7 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 		consumerUpdater: options.consumerUpdater,
 		capReporter:     asCapabilityReporter(options.consumerUpdater),
 		connMonitorStop: make(chan struct{}),
-		kvErrorWindow:   make([]time.Time, 0, cfg.DegradedBehavior.KVErrorThreshold),
+		kvErrorWindow:   make([]kvErrorEvent, 0, cfg.DegradedBehavior.KVErrorThreshold),
 		// Initialize internal components with Nop implementations
 		idClaimer:  stableid.NewNop(),
 		election:   election.NewNopElection(),

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -19,6 +19,22 @@ import (
 // reason is preserved.
 const degradedReasonKVUnavailable = "kv-unavailable"
 
+// kvErrorEvent is one entry in the degraded-circuit error window.
+//
+// transient marks an F-D1 connected-but-KV-unavailable timeout (an
+// [ErrKVUnavailable]-wrapped deadline / no-responders from a periodic KV-op
+// site). A successful periodic KV op while not degraded clears ONLY the
+// transient entries (see [Manager.recordKVHealthyOp]), giving the F-D1 circuit
+// consecutive-error semantics. Whole-bucket-loss entries (connectivity /
+// degrading-JetStream, transient=false) are never cleared by a healthy op, so
+// they still accumulate to the threshold — preserving the AGENTS.md contract
+// that whole-bucket loss reliably drives every worker Degraded even when an
+// unaffected bucket (e.g. heartbeat) keeps succeeding.
+type kvErrorEvent struct {
+	at        time.Time
+	transient bool
+}
+
 // ErrKVUnavailable marks a KV operation that failed because its backing
 // bucket is reachable on the live NATS connection but cannot serve the op
 // (deadline / no-responders) — the quorum-loss condition the connection-status
@@ -164,14 +180,16 @@ func (m *Manager) recordKVError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Add error timestamp
-	m.kvErrorWindow = append(m.kvErrorWindow, now)
+	// Add error timestamp, tagged with its class so a healthy-op success can
+	// later clear the transient (F-D1) entries while leaving whole-bucket-loss
+	// entries to accumulate.
+	m.kvErrorWindow = append(m.kvErrorWindow, kvErrorEvent{at: now, transient: kvUnavailable})
 
 	// Remove errors outside the window
 	windowStart := now.Add(-m.cfg.DegradedBehavior.KVErrorWindow)
 	validIdx := 0
-	for i, t := range m.kvErrorWindow {
-		if t.After(windowStart) {
+	for i, e := range m.kvErrorWindow {
+		if e.at.After(windowStart) {
 			validIdx = i
 			break
 		}
@@ -218,13 +236,55 @@ func (m *Manager) recordKVOpError(err error) {
 	m.recordKVError(markKVUnavailable(err))
 }
 
-// recordKVSuccess records a successful KV operation and resets error count.
+// recordKVSuccess clears the ENTIRE degraded-circuit error window (both
+// transient and whole-bucket entries). It is the full reset used by the recovery
+// path (attemptRecoveryFromDegraded) after a healthy assignment read confirms KV
+// is serving again, so a freshly-recovered worker does not instantly re-trip on
+// stale window entries.
 func (m *Manager) recordKVSuccess() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.kvErrorWindow = m.kvErrorWindow[:0]
 	m.kvErrorCount.Store(0)
+}
+
+// recordKVHealthyOp clears the transient (F-D1 [ErrKVUnavailable]) entries from
+// the degraded-circuit window on a successful periodic KV op while the worker is
+// not degraded. This gives the F-D1 circuit consecutive-error semantics: a run
+// of connected-but-KV-unavailable timeouts only trips Degraded if no success
+// intervenes, instead of summing intermittent blips across KVErrorWindow.
+//
+// Whole-bucket-loss entries (connectivity / degrading-JetStream) are retained,
+// so a sustained whole-bucket loss still accumulates to the threshold even while
+// an unaffected high-frequency op (the heartbeat publisher) keeps succeeding —
+// preserving the AGENTS.md whole-bucket-loss contract.
+//
+// It is a no-op while degraded: recordKVError already short-circuits there so the
+// window is not growing, and the early return keeps the hot heartbeat-success
+// path (every HeartbeatInterval) off m.mu once a real outage is in progress.
+func (m *Manager) recordKVHealthyOp() {
+	if m.degradedSince.Load() != 0 {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.kvErrorWindow) == 0 {
+		return
+	}
+
+	kept := m.kvErrorWindow[:0]
+	for _, e := range m.kvErrorWindow {
+		if !e.transient {
+			kept = append(kept, e)
+		}
+	}
+	m.kvErrorWindow = kept
+
+	windowLen := min(len(kept), 0x7FFFFFFF)
+	m.kvErrorCount.Store(int32(windowLen)) // #nosec G115 - bounded above
 }
 
 // enterDegraded transitions the manager to degraded mode.

--- a/manager_degraded_test.go
+++ b/manager_degraded_test.go
@@ -113,6 +113,73 @@ func TestManager_recordKVError(t *testing.T) {
 	})
 }
 
+// TestManager_recordKVHealthyOp pins the F-D1 healthy-op success-reset: a
+// successful periodic KV op while not degraded clears ONLY the transient
+// (connected-but-KV-unavailable) error entries, leaving whole-bucket-loss
+// entries to accumulate. This is what gives the F-D1 circuit consecutive-error
+// semantics without masking a whole-bucket loss when an unaffected bucket keeps
+// succeeding.
+func TestManager_recordKVHealthyOp(t *testing.T) {
+	logger := logging.NewNop()
+	nopMetrics := metrics.NewNop()
+	cfg := Config{
+		DegradedBehavior: DegradedBehaviorConfig{
+			// High threshold so recording errors never trips Degraded here —
+			// this test isolates the window bookkeeping, not the trip path.
+			KVErrorThreshold: 100,
+			KVErrorWindow:    10 * time.Second,
+		},
+		DegradedAlert: DegradedAlertConfig{AlertInterval: 1 * time.Minute},
+	}
+
+	t.Run("clears only transient entries", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+
+		m.recordKVError(nats.ErrTimeout)                  // whole-bucket (connectivity)
+		m.recordKVOpError(context.DeadlineExceeded)       // transient (F-D1)
+		m.recordKVOpError(context.DeadlineExceeded)       // transient (F-D1)
+		require.Equal(t, int32(3), m.kvErrorCount.Load()) // sanity
+
+		m.recordKVHealthyOp()
+
+		require.Equal(t, int32(1), m.kvErrorCount.Load(),
+			"only the whole-bucket entry must survive a healthy op")
+		require.Len(t, m.kvErrorWindow, 1)
+		require.False(t, m.kvErrorWindow[0].transient,
+			"the surviving entry must be the whole-bucket-loss one")
+	})
+
+	t.Run("no-op while degraded", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+
+		// Record BEFORE marking degraded (recordKVError short-circuits while degraded).
+		m.recordKVError(nats.ErrTimeout)            // whole-bucket
+		m.recordKVOpError(context.DeadlineExceeded) // transient
+		require.Equal(t, int32(2), m.kvErrorCount.Load())
+
+		m.degradedSince.Store(time.Now().UnixNano())
+		m.recordKVHealthyOp()
+
+		require.Equal(t, int32(2), m.kvErrorCount.Load(),
+			"a healthy op while degraded must not touch the window")
+		require.Len(t, m.kvErrorWindow, 2)
+	})
+
+	t.Run("empty window is a no-op", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+
+		m.recordKVHealthyOp()
+		require.Equal(t, int32(0), m.kvErrorCount.Load())
+		require.Empty(t, m.kvErrorWindow)
+	})
+}
+
 func TestManager_enterDegraded_rejectsShutdown(t *testing.T) {
 	logger := logging.NewNop()
 	nopMetrics := metrics.NewNop()

--- a/manager_election.go
+++ b/manager_election.go
@@ -422,6 +422,14 @@ func (m *Manager) startHeartbeat(kv jetstream.KeyValue) error {
 	// A connected-but-KV-unavailable timeout (quorum loss) is marked so the
 	// heartbeat-publish path degrades too — the connection monitor misses it.
 	publisher.SetOnError(m.recordKVOpError)
+	// Feed publish successes into the degraded-mode circuit's healthy-op reset so
+	// the F-D1 (connected-but-KV-unavailable) circuit has consecutive-error
+	// semantics: intermittent heartbeat-KV timeouts with a success between them
+	// do not accumulate across KVErrorWindow into a spurious Degraded. The
+	// heartbeat is the highest-frequency periodic KV op, so its success is the
+	// natural "heartbeat KV is serving" signal; whole-bucket-loss entries are
+	// untouched (see Manager.recordKVHealthyOp), preserving that contract.
+	publisher.SetOnSuccess(m.recordKVHealthyOp)
 	// Wire the capability function so the publisher reads the live bitmask on
 	// every heartbeat composition, reflecting runtime wire-up state.
 	publisher.SetCapabilitiesFn(m.Capabilities)

--- a/test/integration/failure/degraded_recovery_rearm_concurrency_test.go
+++ b/test/integration/failure/degraded_recovery_rearm_concurrency_test.go
@@ -40,7 +40,7 @@ func TestDegradedRecovery_Rearm_NoRace(t *testing.T) {
 	realJS, err := jetstream.New(nc)
 	require.NoError(t, err)
 	fc := &wfFaultController{}
-	faultJS := newWFFaultJetStreamDual(realJS, rfHandoffBucket, rfHeartbeatBucket, fc)
+	faultJS := newWFFaultJetStreamDual(realJS, fc)
 
 	rfBuildStream(t, ctx, realJS)
 

--- a/test/integration/failure/fd1_success_reset_test.go
+++ b/test/integration/failure/fd1_success_reset_test.go
@@ -1,0 +1,104 @@
+package failure_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFD1_IntermittentKVTimeouts_NoFlap pins the F-D1 success-reset fix
+// (Finding B). It drives an INTERMITTENT connected-but-KV-unavailable pattern on
+// the heartbeat bucket — each fault blip is deliberately sized BELOW the
+// KV-error threshold, but the blips fall within a single KVErrorWindow. A worker
+// that never resets its error counter on a healthy KV op (the parent behavior)
+// SUMS the blips across the window and trips Degraded even though no single blip
+// is sustained enough to warrant it. The fix clears the transient (F-D1) error
+// entries on each successful heartbeat publish while not degraded, giving the
+// circuit consecutive-error semantics: only a sustained run with no intervening
+// success trips.
+//
+// Sizing (TestConfig HeartbeatInterval=500ms, KVErrorThreshold=10,
+// KVErrorWindow=30s):
+//   - blipOn=3s  => ~6 faulted heartbeats per blip, < threshold 10.
+//   - blipOff=3s => the heartbeat recovers and emits a success (which, with the
+//     fix, clears the prior blip's transient entries within one interval).
+//   - cycles=3   => parent accrues ~18 errors inside the 30s window and trips;
+//     the fix keeps each blip independent (~6 < 10) and never trips.
+//
+// On the parent base this FAILS: the cross-blip accumulation drives the worker
+// Degraded (flaps >= 1). With the fix it is GREEN (flaps == 0).
+func TestFD1_IntermittentKVTimeouts_NoFlap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	const (
+		blipOn   = 3 * time.Second // ~6 faulted heartbeats: below threshold 10
+		blipOff  = 3 * time.Second // heal long enough for a success-reset
+		cycles   = 3               // ~18 errors total inside the 30s window
+		healTail = 8 * time.Second // final heal so the worker ends Stable
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	fc := &wfFaultController{}
+	// Fault only the heartbeat bucket (all writes, DeadlineExceeded) — the pure
+	// F-D1 connected-but-KV-unavailable trigger. The NATS connection stays up.
+	faultJS := newWFFaultJetStreamDual(realJS, fc)
+
+	rfBuildStream(t, ctx, realJS)
+	src := newWFMutableSource([]types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}})
+
+	var flaps atomic.Int64
+	stack := rfBuildWorkerStackCfg(t, ctx, faultJS, src, 0,
+		func(cfg *parti.Config) {
+			// One blip (~6 errors) must stay below threshold; the cross-blip
+			// sum (~18) must exceed it within the window.
+			cfg.DegradedBehavior.KVErrorThreshold = 10
+			cfg.DegradedBehavior.KVErrorWindow = 30 * time.Second
+		},
+		func(h *parti.Hooks) {
+			h.OnDegraded = func(_ context.Context, _ string) error {
+				flaps.Add(1)
+				return nil
+			}
+		},
+	)
+
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 30*time.Second),
+		"worker must reach Stable before the intermittent fault pattern")
+
+	for range cycles {
+		fc.ArmHeartbeat()
+		time.Sleep(blipOn)
+		fc.DisarmWrites()
+		time.Sleep(blipOff)
+	}
+
+	// Non-vacuity: the heartbeat fault must have actually fired across the blips,
+	// otherwise flaps==0 would pass trivially.
+	require.GreaterOrEqual(t, fc.heartbeatFaultsInjected.Load(), int64(cycles*4),
+		"heartbeat fault never fired enough times — the probe is vacuous")
+
+	// The fix: intermittent sub-threshold blips with a healthy gap between them
+	// must NOT degrade. On the parent base the cross-blip accumulation trips.
+	require.Equal(t, int64(0), flaps.Load(),
+		"intermittent sub-threshold KV timeouts with recovery between blips must not enter Degraded")
+
+	// And the worker must still be Stable after a final heal.
+	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, healTail),
+		"worker must remain Stable after the intermittent fault pattern clears")
+}

--- a/test/integration/failure/latched_version_advance_test.go
+++ b/test/integration/failure/latched_version_advance_test.go
@@ -62,7 +62,7 @@ func TestLatchedWorkerVersionAdvance_DoesNotReportStableUncommitted(t *testing.T
 
 	// Dual-fault JS: handoff bucket faults claims/* writes; heartbeat bucket
 	// faults all writes (drives the KV-error circuit from any active state).
-	faultJS := newWFFaultJetStreamDual(realJS, rfHandoffBucket, rfHeartbeatBucket, fc)
+	faultJS := newWFFaultJetStreamDual(realJS, fc)
 
 	rfBuildStream(t, ctx, realJS)
 

--- a/test/integration/failure/startup_writefault_test.go
+++ b/test/integration/failure/startup_writefault_test.go
@@ -88,6 +88,11 @@ type wfFaultController struct {
 	// the injected error. Lets the test assert the fault genuinely fired
 	// (non-vacuous) before disarming.
 	writeFaultsInjected atomic.Int64
+
+	// heartbeatFaultsInjected counts how many heartbeat-bucket writes actually
+	// returned the injected error. Lets a test assert the heartbeat fault
+	// genuinely fired (non-vacuous), mirroring writeFaultsInjected.
+	heartbeatFaultsInjected atomic.Int64
 }
 
 // ArmWrites enables the claim-write fault and resets the counter.
@@ -116,9 +121,15 @@ func (fc *wfFaultController) shouldFaultWrite() bool {
 	return true
 }
 
-// shouldFaultHeartbeat reports whether a heartbeat-bucket write should fault.
+// shouldFaultHeartbeat reports whether a heartbeat-bucket write should fault
+// and counts it when it does, so a test can assert the fault fired non-vacuously.
 func (fc *wfFaultController) shouldFaultHeartbeat() bool {
-	return fc.heartbeatArmed.Load()
+	if !fc.heartbeatArmed.Load() {
+		return false
+	}
+	fc.heartbeatFaultsInjected.Add(1)
+
+	return true
 }
 
 // wfFaultJetStream wraps a real jetstream.JetStream. Only the handoff-bucket KV
@@ -136,11 +147,12 @@ func newWFFaultJetStream(inner jetstream.JetStream, handoffBucket string, fc *wf
 }
 
 // newWFFaultJetStreamDual wraps BOTH the handoff bucket (claims-key writes only)
-// AND the heartbeat bucket (all writes). The dual fault drives the KV-error
+// AND the heartbeat bucket (all writes), using the fixed test bucket constants
+// rfHandoffBucket / rfHeartbeatBucket. The dual fault drives the KV-error
 // threshold circuit even when the worker's calculator has moved state out of
 // WaitingAssignment, enabling reliable Degraded entry without the startup watchdog.
-func newWFFaultJetStreamDual(inner jetstream.JetStream, handoffBucket, heartbeatBucket string, fc *wfFaultController) *wfFaultJetStream {
-	return &wfFaultJetStream{JetStream: inner, handoffBucket: handoffBucket, heartbeatBucket: heartbeatBucket, fc: fc}
+func newWFFaultJetStreamDual(inner jetstream.JetStream, fc *wfFaultController) *wfFaultJetStream {
+	return &wfFaultJetStream{JetStream: inner, handoffBucket: rfHandoffBucket, heartbeatBucket: rfHeartbeatBucket, fc: fc}
 }
 
 func (f *wfFaultJetStream) wrap(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
@@ -397,7 +409,7 @@ func TestStartupWriteFault_DegradedRecoveryDoesNotReportStableUncommitted(t *tes
 	// Dual-fault JS: handoff bucket faults claims/* writes; heartbeat bucket
 	// faults all writes. This drives the KV-error threshold circuit even when
 	// the calculator has moved state out of WaitingAssignment.
-	faultJS := newWFFaultJetStreamDual(realJS, rfHandoffBucket, rfHeartbeatBucket, fc)
+	faultJS := newWFFaultJetStreamDual(realJS, fc)
 
 	rfBuildStream(t, ctx, realJS)
 

--- a/test/integration/manager/manager_live_bucket_loss_test.go
+++ b/test/integration/manager/manager_live_bucket_loss_test.go
@@ -234,3 +234,105 @@ func TestManager_LiveNATSBucketLoss_OnDegradedHook(t *testing.T) {
 	}
 	t.Logf("OnDegraded hook fired %d/%d times; reasons=%v", len(collected), clusterSize, collected)
 }
+
+// TestManager_PartialBucketLoss_HeartbeatHealthy is the masking guard for the
+// F-D1 healthy-op success-reset. It wipes every Parti-managed KV bucket EXCEPT
+// heartbeat, leaving the heartbeat bucket alive so the heartbeat publisher keeps
+// succeeding every interval and firing recordKVHealthyOp.
+//
+// The success-reset clears ONLY the transient (F-D1) error entries; whole-bucket-
+// loss errors (degrading-JetStream / connectivity, here ErrBucketNotFound from
+// the wiped stableid / election / assignment buckets) must still accumulate to
+// the threshold and drive every worker Degraded. If the reset were class-blind
+// (clearing the whole window on any heartbeat success), the surviving heartbeat
+// would mask the loss of the other buckets and the workers would never degrade.
+//
+// The all-buckets wipe in TestManager_LiveNATSBucketLoss CANNOT catch this: there
+// the heartbeat bucket is also gone, so the heartbeat publish fails and never
+// emits the success that would expose a class-mixing bug. This test keeps
+// heartbeat healthy on purpose.
+func TestManager_PartialBucketLoss_HeartbeatHealthy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	cfg := testutil.IntegrationTestConfig()
+	partitions := testutil.CreateTestPartitions(10)
+	src := source.NewStatic(partitions)
+	assignStrat := strategy.NewConsistentHash()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	cluster := &testutil.WorkerCluster{
+		Workers:  make([]*parti.Manager, 0),
+		Config:   cfg,
+		Source:   src,
+		Strategy: assignStrat,
+		NC:       nc,
+		JS:       js,
+		T:        t,
+	}
+	for range 3 {
+		cluster.AddWorker(ctx)
+	}
+	defer cluster.StopWorkers()
+
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(15 * time.Second)
+	cluster.VerifyExactlyOneLeader()
+	t.Log("phase 1: stable")
+
+	// Wipe every Parti bucket EXCEPT heartbeat. The heartbeat bucket stays alive
+	// so the heartbeat publisher keeps succeeding and firing the healthy-op reset.
+	wiped := []string{
+		cfg.KVBuckets.StableIDBucket,
+		cfg.KVBuckets.ElectionBucket,
+		cfg.KVBuckets.AssignmentBucket,
+	}
+	for _, b := range wiped {
+		if err := js.DeleteKeyValue(ctx, b); err != nil &&
+			!errors.Is(err, jetstream.ErrBucketNotFound) {
+			t.Fatalf("failed to wipe bucket %s: %v", b, err)
+		}
+	}
+	wipedAt := time.Now()
+	t.Logf("phase 2: wiped %d non-heartbeat buckets at %s", len(wiped), wipedAt.Format(time.RFC3339Nano))
+
+	// Confirm the wipe happened and the heartbeat bucket is still present (the
+	// surviving success signal whose masking we are guarding against).
+	_, err = js.KeyValue(ctx, cfg.KVBuckets.AssignmentBucket)
+	require.ErrorIs(t, err, jetstream.ErrBucketNotFound)
+	_, err = js.KeyValue(ctx, cfg.KVBuckets.HeartbeatBucket)
+	require.NoError(t, err, "heartbeat bucket must stay alive so its success-reset can run")
+
+	// Despite the healthy heartbeat clearing transient entries every interval, the
+	// whole-bucket-loss errors from the wiped buckets must still drive every worker
+	// Degraded within the bounded window.
+	const degradedWithin = 25 * time.Second
+	require.Eventually(t, func() bool {
+		active := cluster.GetActiveWorkers()
+		if len(active) != 3 {
+			return false
+		}
+		degraded := 0
+		for _, mgr := range active {
+			if mgr.State() == types.StateDegraded {
+				degraded++
+			}
+		}
+
+		return degraded == 3
+	}, degradedWithin, 500*time.Millisecond,
+		"all 3 workers must still enter Degraded within %s despite a healthy heartbeat bucket", degradedWithin)
+
+	t.Logf("phase 3: all workers Degraded within %s — class-aware reset did not mask the loss",
+		time.Since(wipedAt).Round(100*time.Millisecond))
+}


### PR DESCRIPTION
## Problem

The F-D1 degraded circuit auto-enters `Degraded` (reason `kv-unavailable`) on sustained connected-but-KV-unavailable timeouts from the periodic KV-op sites. Investigation found it flaps more than the thresholds suggest: a probe at the `conservative` preset (threshold 10) tripped 3× under a pattern where each fault blip was only ~8 heartbeats — below threshold. The cause is **cross-blip accumulation**: there was no success-reset on the Stable path, so the circuit was effectively "N errors within `KVErrorWindow`", not the documented consecutive run. Intermittent blips summed across the window. With `OnDegraded` potentially wired to a readiness probe, a brief KV blip could rotate pods and suppress leader rebalance on each spurious entry.

## Fix

A **class-aware** healthy-op success-reset:

- Each error-window entry is tagged by class (`kvErrorEvent{at, transient}`): a connected-but-KV-unavailable timeout is `transient`; a whole-bucket-loss error (connectivity / degrading-JetStream) is not.
- `Manager.recordKVHealthyOp` clears **only the transient entries** on a successful periodic KV op while not degraded (no-op while degraded), giving that class consecutive-error semantics.
- `heartbeat.Publisher.SetOnSuccess` fires on each successful periodic publish and is wired to `recordKVHealthyOp` — the heartbeat is the highest-frequency periodic KV op, so its success is the natural "KV is serving" signal.
- Whole-bucket-loss entries are never cleared by a healthy op, so a sustained whole-bucket loss still accumulates to the threshold even while an unaffected bucket keeps succeeding (**AGENTS.md cross-feature contract 1 preserved**).

### Accepted narrowing

The heartbeat-success reset is global over the transient class, so F-D1 now trips primarily on a sustained run of heartbeat-KV failures with no intervening success. A sustained quorum-loss on a *non-heartbeat* bucket surfacing only as F-D1 timeouts relies on the whole-bucket classification or a deferred follow-up. Documented in `docs/plans/auto-healing-quorum-loss-fix/04-fd1-flapping-decision.md`, which also resolves the §7.1 open decision.

## Tests

- `TestFD1_IntermittentKVTimeouts_NoFlap` — intermittent sub-threshold blips with recovery between must not degrade. **RED on parent** (flaps=1 via cross-blip accumulation), **GREEN** with the fix (flaps=0).
- `TestManager_PartialBucketLoss_HeartbeatHealthy` — wipes every bucket *except* heartbeat; all workers must still degrade. Proves the class-aware reset does not mask a whole-bucket loss (a case the existing all-buckets-wipe test cannot catch).
- `TestManager_recordKVHealthyOp` (unit) — clears only transient entries, retains whole-bucket, no-op while degraded.

## Validation

`make pre-pr` green on the commit: `make lint` 0 issues, `make test` (`-race`), `make test-integration` (`-race`) — including all 3 cross-feature contracts (`TestManager_LiveNATSBucketLoss`, `..._OnDegradedHook`, `TestStableID_StaleKeyTakeover_Reclaim`). Independent post-impl review verdict: **merge** (zero P0/P1/P2).
