### PR TITLE
test(simulation): cover KV and handoff fault gaps

### DIFF
--- a/.github/workflows/simulation-stress.yml
+++ b/.github/workflows/simulation-stress.yml
@@ -229,8 +229,8 @@ jobs:
 
   sim-bucket-lifecycle:
     runs-on: ubuntu-latest
-    # 3 scenarios × ~3m + setup ≈ 11m worst case; 15m gives headroom.
-    timeout-minutes: 15
+    # 4 scenarios: 3 x ~3m + 90s + setup ~= 13m worst case; 18m gives headroom.
+    timeout-minutes: 18
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -246,7 +246,7 @@ jobs:
         # bucket-recreate epoch fence.
         run: |
           set -e
-          for scn in chaos_bucket_delete chaos_bucket_recreate chaos_bucket_peer_takeover; do
+          for scn in chaos_bucket_delete chaos_bucket_recreate chaos_bucket_peer_takeover chaos_kv_unavailable; do
             echo "::group::${scn}"
             ./tmp/simulation \
               --config "test/simulation/configs/${scn}.yaml" \
@@ -262,6 +262,7 @@ jobs:
           path: |
             failure_report.json
             tmp/chaos_bucket_*.log
+            tmp/chaos_kv_unavailable.log
 
   sim-natskv-source:
     runs-on: ubuntu-latest
@@ -338,8 +339,8 @@ jobs:
 
   sim-publisher-handoff:
     runs-on: ubuntu-latest
-    # 4 scenarios: 90s + 90s + 60s + 90s ≈ 6m + setup ≈ 7m; 11m gives headroom.
-    timeout-minutes: 11
+    # 6 scenarios: 90s + 90s + 60s + 90s + 90s + 2m ~= 10m + setup ~= 11m; 16m gives headroom.
+    timeout-minutes: 16
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -352,10 +353,10 @@ jobs:
       - name: Run Publisher & Handoff Scenarios
         # Phase 5 (Gaps 10a, 10b) + Phase 6 (Gap 5) — producer disconnect,
         # assignment-commit CAS storm, handoff bucket MaxAge contract,
-        # orphan stable-claim drift.
+        # orphan stable-claim drift, and handoff claim write-fault recovery.
         run: |
           set -e
-          for scn in chaos_producer_disconnect chaos_assignment_cas_storm handoff_precreate_maxage handoff_orphan_stable_claim; do
+          for scn in chaos_producer_disconnect chaos_assignment_cas_storm handoff_precreate_maxage handoff_orphan_stable_claim chaos_handoff_startup_write_fault chaos_handoff_version_write_fault; do
             echo "::group::${scn}"
             ./tmp/simulation \
               --config "test/simulation/configs/${scn}.yaml" \
@@ -372,6 +373,7 @@ jobs:
             failure_report.json
             tmp/chaos_producer_*.log
             tmp/chaos_assignment_*.log
+            tmp/chaos_handoff_*.log
             tmp/handoff_*.log
 
   sim-process-mode:

--- a/docs/superpowers/plans/2026-05-31-simulation-kv-handoff-faults.md
+++ b/docs/superpowers/plans/2026-05-31-simulation-kv-handoff-faults.md
@@ -1,0 +1,170 @@
+# Simulation KV and Handoff Faults Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add simulation coverage for connected-but-KV-unavailable timeouts and handoff claim write-fault self-healing.
+
+**Architecture:** Add one reusable simulation fault controller in `test/simulation/cmd/simulation` that wraps the JetStream handle handed to workers. Chaos events arm the controller for bounded windows. Existing degraded/source/oracle gates remain the final authority, with small new counters only where the current gates cannot express non-vacuity.
+
+**Tech Stack:** Go, NATS JetStream `jetstream.JetStream` / `jetstream.KeyValue` wrappers, existing simulation YAML scenarios, existing coordinator oracles.
+
+---
+
+## File Structure
+
+- Create `test/simulation/cmd/simulation/kv_fault_chaos.go`: reusable fault controller, JetStream/KV wrappers, and chaos handlers.
+- Modify `test/simulation/internal/coordinator/chaos.go`: add `kv_unavailable` and `handoff_claim_write_fault` chaos event constants and default params.
+- Modify `test/simulation/cmd/simulation/main.go`: install the wrapper before worker construction, route new chaos events, and include new final-gate counters.
+- Modify `test/simulation/internal/config/config.go`: add optional `chaos.faults` knobs for startup-armed faults.
+- Create configs:
+  - `test/simulation/configs/chaos_kv_unavailable.yaml`
+  - `test/simulation/configs/chaos_handoff_startup_write_fault.yaml`
+  - `test/simulation/configs/chaos_handoff_version_write_fault.yaml`
+- Add focused unit tests in `test/simulation/cmd/simulation/kv_fault_chaos_test.go`.
+
+## Design
+
+Use a single `simKVFaultController` shared by all workers in all-in-one mode. The wrapper faults only selected KV bucket operations while leaving the underlying NATS connection connected. This mirrors the integration seams in `test/integration/manager/manager_kv_read_unavailable_test.go` and `test/integration/failure/startup_writefault_test.go`, but applies through the real simulation worker/manager path.
+
+The controller supports three fault selectors:
+
+- `kv-unavailable`: fault all active read/write ops on selected buckets with `context.DeadlineExceeded`.
+- `handoff-claims-write`: fault only `Create`, `Update`, and `Put` for keys under `claims/` in the handoff bucket.
+
+The final gates will remain positive:
+
+- `kv_unavailable_expected_missing == 0` through `DegradedReasonOracle` expectations for `kv-unavailable`.
+- `handoff_claim_write_fault_injected > 0` for non-vacuity.
+- Handoff scenarios must still satisfy the existing message, ownership, overlap, degraded, and gap gates.
+
+## Tasks
+
+### Task 1: Add the fault controller and unit tests
+
+**Files:**
+- Create: `test/simulation/cmd/simulation/kv_fault_chaos.go`
+- Create: `test/simulation/cmd/simulation/kv_fault_chaos_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that construct a real embedded NATS KV bucket, wrap it with `newSimKVFaultJetStream`, and assert:
+
+```go
+func TestSimKVFaultController_KVUnavailableFaultsSelectedBucket(t *testing.T)
+func TestSimKVFaultController_HandoffClaimWriteFaultOnlyClaimsWrites(t *testing.T)
+func TestSimKVFaultController_DisarmRestoresKV(t *testing.T)
+```
+
+- [ ] **Step 2: Run red test**
+
+Run: `go test ./test/simulation/cmd/simulation -run 'TestSimKVFaultController'`
+
+Expected: compile failure because the controller does not exist.
+
+- [ ] **Step 3: Implement minimal wrapper**
+
+Implement:
+
+```go
+type simKVFaultMode string
+type simKVFaultController struct { ... }
+type simKVFaultJetStream struct { jetstream.JetStream; fc *simKVFaultController }
+type simKVFaultKeyValue struct { jetstream.KeyValue; bucket string; fc *simKVFaultController }
+```
+
+Override `KeyValue`, `CreateKeyValue`, `CreateOrUpdateKeyValue`, and KV `Get`, `Put`, `Create`, `Update`.
+
+- [ ] **Step 4: Run green test**
+
+Run: `go test ./test/simulation/cmd/simulation -run 'TestSimKVFaultController'`
+
+Expected: pass.
+
+### Task 2: Wire `kv_unavailable` into simulation
+
+**Files:**
+- Modify: `test/simulation/internal/coordinator/chaos.go`
+- Modify: `test/simulation/cmd/simulation/main.go`
+- Create: `test/simulation/configs/chaos_kv_unavailable.yaml`
+
+- [ ] **Step 1: Add failing dispatch/scenario tests**
+
+Add tests that verify `scenarioHasKVUnavailable` detects both random and scheduled events, and that `kv_unavailable` is recognized as all-in-one only.
+
+- [ ] **Step 2: Run red test**
+
+Run: `go test ./test/simulation/cmd/simulation -run 'TestScenarioHasKVUnavailable|TestKVUnavailable'`
+
+Expected: compile or assertion failure.
+
+- [ ] **Step 3: Implement event wiring**
+
+Add `KVUnavailableEvent ChaosEvent = "kv_unavailable"`, generate default `duration`, `buckets`, and `expect_degraded` params, install `aioKVFaults`, and route the event to `handleKVUnavailableFault`.
+
+- [ ] **Step 4: Add scenario config**
+
+Create `chaos_kv_unavailable.yaml` with three workers, short duration, scheduled sustained `kv_unavailable` against election/heartbeat/stableid buckets, and an expected `kv-unavailable` degraded reason.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `go test ./test/simulation/cmd/simulation -run 'TestSimKVFaultController|TestScenarioHasKVUnavailable|TestKVUnavailable'`
+
+Expected: pass.
+
+### Task 3: Wire handoff claim write-fault scenarios
+
+**Files:**
+- Modify: `test/simulation/internal/coordinator/chaos.go`
+- Modify: `test/simulation/cmd/simulation/main.go`
+- Create: `test/simulation/configs/chaos_handoff_startup_write_fault.yaml`
+- Create: `test/simulation/configs/chaos_handoff_version_write_fault.yaml`
+
+- [ ] **Step 1: Add failing tests**
+
+Add tests that verify startup-armed claim fault config arms the controller before workers start, and that `handoff_claim_write_fault` is detected by a scenario helper.
+
+- [ ] **Step 2: Run red test**
+
+Run: `go test ./test/simulation/cmd/simulation -run 'TestHandoffClaimWriteFault|TestScenarioHasHandoffClaimWriteFault'`
+
+Expected: compile or assertion failure.
+
+- [ ] **Step 3: Implement startup and scheduled wiring**
+
+Add `HandoffClaimWriteFaultEvent`, startup config under `chaos.faults`, and event handling that arms claim-write fault plus optional heartbeat-write fault for a bounded duration.
+
+- [ ] **Step 4: Add scenario configs**
+
+Add a startup scenario that arms claim-write fault at process start and disarms automatically, plus a version-advance scenario that schedules `scale_down` while claim writes are faulted.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `go test ./test/simulation/cmd/simulation -run 'TestSimKVFaultController|TestHandoffClaimWriteFault|TestScenarioHasHandoffClaimWriteFault'`
+
+Expected: pass.
+
+### Task 4: Validation
+
+**Files:** all touched Go/config files.
+
+- [ ] **Step 1: Format**
+
+Run: `gofmt -w test/simulation/cmd/simulation/kv_fault_chaos.go test/simulation/cmd/simulation/kv_fault_chaos_test.go test/simulation/cmd/simulation/main.go test/simulation/internal/coordinator/chaos.go test/simulation/internal/config/config.go`
+
+- [ ] **Step 2: Go fix affected packages**
+
+Run: `go fix ./test/simulation/cmd/simulation ./test/simulation/internal/coordinator ./test/simulation/internal/config`
+
+- [ ] **Step 3: Targeted tests**
+
+Run: `go test ./test/simulation/cmd/simulation ./test/simulation/internal/coordinator ./test/simulation/internal/config`
+
+- [ ] **Step 4: Simulation package tests**
+
+Run: `go test ./test/simulation/...`
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+
+Expected: all commands pass before the work is called complete.

--- a/test/simulation/cmd/simulation/kv_fault_chaos.go
+++ b/test/simulation/cmd/simulation/kv_fault_chaos.go
@@ -1,0 +1,448 @@
+package main
+
+import (
+	"context"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/arloliu/parti/v2/test/simulation/internal/config"
+	"github.com/arloliu/parti/v2/test/simulation/internal/coordinator"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	defaultHandoffBucket = "parti-handoff"
+	handoffClaimPrefix   = "claims/"
+)
+
+type simKVFaultController struct {
+	mu sync.RWMutex
+
+	kvUnavailableBuckets map[string]struct{}
+	handoffClaimWrite    bool
+	kvUnavailableToken   uint64
+	handoffClaimToken    uint64
+
+	kvUnavailableInjected     atomic.Int64
+	handoffClaimWriteInjected atomic.Int64
+}
+
+func newSimKVFaultController() *simKVFaultController {
+	return &simKVFaultController{
+		kvUnavailableBuckets: make(map[string]struct{}),
+	}
+}
+
+func (fc *simKVFaultController) armKVUnavailable(buckets []string) uint64 {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	fc.kvUnavailableToken++
+	fc.kvUnavailableBuckets = make(map[string]struct{}, len(buckets))
+	for _, bucket := range buckets {
+		if bucket == "" {
+			continue
+		}
+		fc.kvUnavailableBuckets[bucket] = struct{}{}
+	}
+
+	return fc.kvUnavailableToken
+}
+
+func (fc *simKVFaultController) armHandoffClaimWrite() uint64 {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	fc.handoffClaimToken++
+	fc.handoffClaimWrite = true
+
+	return fc.handoffClaimToken
+}
+
+func (fc *simKVFaultController) disarm() {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	fc.kvUnavailableToken++
+	fc.handoffClaimToken++
+	clear(fc.kvUnavailableBuckets)
+	fc.handoffClaimWrite = false
+}
+
+func (fc *simKVFaultController) disarmKVUnavailable(token uint64) bool {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	if token != fc.kvUnavailableToken {
+		return false
+	}
+	clear(fc.kvUnavailableBuckets)
+
+	return true
+}
+
+func (fc *simKVFaultController) disarmHandoffClaimWrite(token uint64) bool {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	if token != fc.handoffClaimToken {
+		return false
+	}
+	fc.handoffClaimWrite = false
+
+	return true
+}
+
+func (fc *simKVFaultController) isKVUnavailableArmed(bucket string) bool {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+
+	_, ok := fc.kvUnavailableBuckets[bucket]
+
+	return ok
+}
+
+func (fc *simKVFaultController) isHandoffClaimWriteArmed() bool {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+
+	return fc.handoffClaimWrite
+}
+
+func (fc *simKVFaultController) shouldFaultKVUnavailable(bucket string) bool {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+
+	_, ok := fc.kvUnavailableBuckets[bucket]
+	if ok {
+		fc.kvUnavailableInjected.Add(1)
+	}
+
+	return ok
+}
+
+func (fc *simKVFaultController) shouldFaultHandoffClaimWrite(bucket, key string) bool {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+
+	ok := fc.handoffClaimWrite && bucket == defaultHandoffBucket && strings.HasPrefix(key, handoffClaimPrefix)
+	if ok {
+		fc.handoffClaimWriteInjected.Add(1)
+	}
+
+	return ok
+}
+
+type simKVFaultJetStream struct {
+	jetstream.JetStream
+
+	fc *simKVFaultController
+}
+
+func newSimKVFaultJetStream(inner jetstream.JetStream, fc *simKVFaultController) jetstream.JetStream {
+	if fc == nil {
+		return inner
+	}
+
+	return &simKVFaultJetStream{JetStream: inner, fc: fc}
+}
+
+func (js *simKVFaultJetStream) KeyValue(ctx context.Context, bucket string) (jetstream.KeyValue, error) {
+	kv, err := js.JetStream.KeyValue(ctx, bucket)
+	if err != nil {
+		return kv, err
+	}
+
+	return js.wrapKV(kv, bucket), nil
+}
+
+func (js *simKVFaultJetStream) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := js.JetStream.CreateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return js.wrapKV(kv, cfg.Bucket), nil
+}
+
+func (js *simKVFaultJetStream) CreateOrUpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := js.JetStream.CreateOrUpdateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return js.wrapKV(kv, cfg.Bucket), nil
+}
+
+func (js *simKVFaultJetStream) wrapKV(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
+	return &simKVFaultKeyValue{
+		KeyValue: kv,
+		bucket:   bucket,
+		fc:       js.fc,
+	}
+}
+
+type simKVFaultKeyValue struct {
+	jetstream.KeyValue
+
+	bucket string
+	fc     *simKVFaultController
+}
+
+func (kv *simKVFaultKeyValue) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Get(ctx, key)
+}
+
+func (kv *simKVFaultKeyValue) GetRevision(ctx context.Context, key string, revision uint64) (jetstream.KeyValueEntry, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.GetRevision(ctx, key, revision)
+}
+
+func (kv *simKVFaultKeyValue) Put(ctx context.Context, key string, value []byte) (uint64, error) {
+	if kv.shouldFaultWrite(key) {
+		return 0, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Put(ctx, key, value)
+}
+
+func (kv *simKVFaultKeyValue) PutString(ctx context.Context, key string, value string) (uint64, error) {
+	if kv.shouldFaultWrite(key) {
+		return 0, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.PutString(ctx, key, value)
+}
+
+func (kv *simKVFaultKeyValue) Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error) {
+	if kv.shouldFaultWrite(key) {
+		return 0, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Create(ctx, key, value, opts...)
+}
+
+func (kv *simKVFaultKeyValue) Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	if kv.shouldFaultWrite(key) {
+		return 0, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Update(ctx, key, value, revision)
+}
+
+func (kv *simKVFaultKeyValue) Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Delete(ctx, key, opts...)
+}
+
+func (kv *simKVFaultKeyValue) Purge(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Purge(ctx, key, opts...)
+}
+
+func (kv *simKVFaultKeyValue) Watch(ctx context.Context, keys string, opts ...jetstream.WatchOpt) (jetstream.KeyWatcher, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Watch(ctx, keys, opts...)
+}
+
+func (kv *simKVFaultKeyValue) WatchAll(ctx context.Context, opts ...jetstream.WatchOpt) (jetstream.KeyWatcher, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.WatchAll(ctx, opts...)
+}
+
+func (kv *simKVFaultKeyValue) WatchFiltered(ctx context.Context, keys []string, opts ...jetstream.WatchOpt) (jetstream.KeyWatcher, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.WatchFiltered(ctx, keys, opts...)
+}
+
+func (kv *simKVFaultKeyValue) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Keys(ctx, opts...)
+}
+
+func (kv *simKVFaultKeyValue) History(ctx context.Context, key string, opts ...jetstream.WatchOpt) ([]jetstream.KeyValueEntry, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.History(ctx, key, opts...)
+}
+
+func (kv *simKVFaultKeyValue) Status(ctx context.Context) (jetstream.KeyValueStatus, error) {
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.Status(ctx)
+}
+
+func (kv *simKVFaultKeyValue) shouldFaultWrite(key string) bool {
+	return kv.fc.shouldFaultKVUnavailable(kv.bucket) ||
+		kv.fc.shouldFaultHandoffClaimWrite(kv.bucket, key)
+}
+
+func bucketListFromParam(v any, defaults []string) []string {
+	switch buckets := v.(type) {
+	case []string:
+		return nonEmptyBuckets(buckets, defaults)
+	case []any:
+		out := make([]string, 0, len(buckets))
+		for _, bucket := range buckets {
+			if s, ok := bucket.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return nonEmptyBuckets(out, defaults)
+	case string:
+		return nonEmptyBuckets(strings.Split(buckets, ","), defaults)
+	default:
+		return slices.Clone(defaults)
+	}
+}
+
+func nonEmptyBuckets(buckets, defaults []string) []string {
+	out := make([]string, 0, len(buckets))
+	for _, bucket := range buckets {
+		bucket = strings.TrimSpace(bucket)
+		if bucket != "" {
+			out = append(out, bucket)
+		}
+	}
+	if len(out) == 0 {
+		return slices.Clone(defaults)
+	}
+
+	return out
+}
+
+func handleKVUnavailableFault(
+	ctx context.Context,
+	fc *simKVFaultController,
+	coord *coordinator.Coordinator,
+	params map[string]any,
+) {
+	if fc == nil {
+		log.Print("[Chaos] kv_unavailable requested but fault controller is not installed")
+		return
+	}
+
+	defaultBuckets := []string{"parti-election", "parti-heartbeat", "parti-stableid"}
+	buckets := bucketListFromParam(params["buckets"], defaultBuckets)
+	duration := durationFromParams(params, "duration", 20*time.Second)
+	expectDegraded := boolFromParams(params, "expect_degraded", true)
+
+	if expectDegraded && coord != nil {
+		if o := coord.DegradedReasonOracle(); o != nil {
+			o.ExpectAfter("kv_unavailable:"+strings.Join(buckets, ","), []string{"kv-unavailable"}, duration+30*time.Second, "", false)
+		}
+	}
+
+	log.Printf("[Chaos] kv_unavailable: arming buckets=%v duration=%v expect_degraded=%v", buckets, duration, expectDegraded)
+	token := fc.armKVUnavailable(buckets)
+	time.AfterFunc(duration, func() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if fc.disarmKVUnavailable(token) {
+			log.Printf("[Chaos] kv_unavailable: disarmed buckets=%v", buckets)
+		}
+	})
+}
+
+func handleHandoffClaimWriteFault(ctx context.Context, fc *simKVFaultController, params map[string]any) {
+	if fc == nil {
+		log.Print("[Chaos] handoff_claim_write_fault requested but fault controller is not installed")
+		return
+	}
+
+	duration := durationFromParams(params, "duration", 20*time.Second)
+	log.Printf("[Chaos] handoff_claim_write_fault: arming duration=%v", duration)
+	token := fc.armHandoffClaimWrite()
+	time.AfterFunc(duration, func() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if fc.disarmHandoffClaimWrite(token) {
+			log.Print("[Chaos] handoff_claim_write_fault: disarmed")
+		}
+	})
+}
+
+func handoffClaimWriteFaultInjected() int64 {
+	if aioKVFaults == nil {
+		return 0
+	}
+
+	return aioKVFaults.handoffClaimWriteInjected.Load()
+}
+
+func installStartupKVFaults(ctx context.Context, fc *simKVFaultController, cfg *config.Config) {
+	if fc == nil || cfg == nil {
+		return
+	}
+	if !cfg.Chaos.Faults.HandoffClaimWriteOnStart {
+		return
+	}
+	duration := cfg.Chaos.Faults.HandoffClaimWriteDuration
+	if duration <= 0 {
+		duration = 20 * time.Second
+	}
+	log.Printf("[Chaos] startup handoff_claim_write_fault: arming duration=%v", duration)
+	token := fc.armHandoffClaimWrite()
+	time.AfterFunc(duration, func() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if fc.disarmHandoffClaimWrite(token) {
+			log.Print("[Chaos] startup handoff_claim_write_fault: disarmed")
+		}
+	})
+}
+
+func boolFromParams(params map[string]any, key string, defaultValue bool) bool {
+	v, ok := params[key]
+	if !ok {
+		return defaultValue
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return defaultValue
+	}
+
+	return b
+}

--- a/test/simulation/cmd/simulation/kv_fault_chaos_test.go
+++ b/test/simulation/cmd/simulation/kv_fault_chaos_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/test/simulation/internal/config"
+	"github.com/arloliu/parti/v2/test/simulation/internal/coordinator"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimKVFaultController_KVUnavailableFaultsSelectedBucket(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	fc := newSimKVFaultController()
+	wrapped := newSimKVFaultJetStream(js, fc)
+
+	kv, err := wrapped.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "parti-heartbeat"})
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "heartbeat.worker-0", []byte("ok"))
+	require.NoError(t, err)
+
+	fc.armKVUnavailable([]string{"parti-heartbeat"})
+	_, err = kv.Get(ctx, "heartbeat.worker-0")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	_, err = kv.Put(ctx, "heartbeat.worker-0", []byte("faulted"))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, int64(2), fc.kvUnavailableInjected.Load())
+
+	other, err := wrapped.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "parti-assignment"})
+	require.NoError(t, err)
+	_, err = other.Put(ctx, "assignment.worker-0", []byte("ok"))
+	require.NoError(t, err)
+}
+
+func TestSimKVFaultController_HandoffClaimWriteFaultOnlyClaimsWrites(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	fc := newSimKVFaultController()
+	wrapped := newSimKVFaultJetStream(js, fc)
+	kv, err := wrapped.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "parti-handoff"})
+	require.NoError(t, err)
+
+	fc.armHandoffClaimWrite()
+	_, err = kv.Create(ctx, "claims/p0", []byte("claim"))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	_, err = kv.Put(ctx, "metadata/p0", []byte("metadata"))
+	require.NoError(t, err)
+
+	_, err = kv.Get(ctx, "metadata/p0")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), fc.handoffClaimWriteInjected.Load())
+}
+
+func TestSimKVFaultController_HandoffClaimWriteDoesNotFaultClaimCleanup(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	fc := newSimKVFaultController()
+	wrapped := newSimKVFaultJetStream(js, fc)
+	kv, err := wrapped.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "parti-handoff"})
+	require.NoError(t, err)
+
+	_, err = kv.Put(ctx, "claims/delete", []byte("claim"))
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "claims/purge", []byte("claim"))
+	require.NoError(t, err)
+
+	fc.armHandoffClaimWrite()
+	require.NoError(t, kv.Delete(ctx, "claims/delete"))
+	require.NoError(t, kv.Purge(ctx, "claims/purge"))
+	require.Zero(t, fc.handoffClaimWriteInjected.Load(), "cleanup ops must not count as claim write faults")
+}
+
+func TestSimKVFaultController_DisarmRestoresKV(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	fc := newSimKVFaultController()
+	wrapped := newSimKVFaultJetStream(js, fc)
+	kv, err := wrapped.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "parti-heartbeat"})
+	require.NoError(t, err)
+
+	fc.armKVUnavailable([]string{"parti-heartbeat"})
+	_, err = kv.Put(ctx, "heartbeat.worker-0", []byte("faulted"))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	fc.disarm()
+	rev, err := kv.Put(ctx, "heartbeat.worker-0", []byte("ok"))
+	require.NoError(t, err)
+	require.Positive(t, rev)
+
+	_, err = kv.Get(ctx, "missing")
+	require.True(t, errors.Is(err, jetstream.ErrKeyNotFound), "non-fault errors should pass through after disarm")
+}
+
+func TestHandleKVUnavailableFaultArmsAndAutoDisarms(t *testing.T) {
+	fc := newSimKVFaultController()
+	params := map[string]any{
+		"buckets":  []any{"parti-heartbeat"},
+		"duration": "20ms",
+	}
+
+	handleKVUnavailableFault(context.Background(), fc, nil, params)
+	require.True(t, fc.isKVUnavailableArmed("parti-heartbeat"))
+
+	require.Eventually(t, func() bool {
+		return !fc.isKVUnavailableArmed("parti-heartbeat")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandleKVUnavailableFaultOverlappingTimersKeepNewestFaultArmed(t *testing.T) {
+	fc := newSimKVFaultController()
+
+	handleKVUnavailableFault(context.Background(), fc, nil, map[string]any{
+		"buckets":  []any{"parti-heartbeat"},
+		"duration": "30ms",
+	})
+	time.Sleep(10 * time.Millisecond)
+	handleKVUnavailableFault(context.Background(), fc, nil, map[string]any{
+		"buckets":  []any{"parti-stableid"},
+		"duration": "120ms",
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	require.False(t, fc.isKVUnavailableArmed("parti-heartbeat"))
+	require.True(t, fc.isKVUnavailableArmed("parti-stableid"))
+
+	require.Eventually(t, func() bool {
+		return !fc.isKVUnavailableArmed("parti-stableid")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandleHandoffClaimWriteFaultOverlappingTimersKeepNewestFaultArmed(t *testing.T) {
+	fc := newSimKVFaultController()
+
+	handleHandoffClaimWriteFault(context.Background(), fc, map[string]any{"duration": "30ms"})
+	time.Sleep(10 * time.Millisecond)
+	handleHandoffClaimWriteFault(context.Background(), fc, map[string]any{"duration": "120ms"})
+
+	time.Sleep(50 * time.Millisecond)
+	require.True(t, fc.isHandoffClaimWriteArmed())
+
+	require.Eventually(t, func() bool {
+		return !fc.isHandoffClaimWriteArmed()
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestScenarioHasChaosEvent(t *testing.T) {
+	cfg := &config.Config{
+		Chaos: config.ChaosConfig{
+			Enabled: true,
+			Events:  []string{string(coordinator.HandoffClaimWriteFaultEvent)},
+		},
+	}
+	require.True(t, scenarioHasChaosEvent(cfg, coordinator.HandoffClaimWriteFaultEvent))
+	require.False(t, scenarioHasChaosEvent(cfg, coordinator.KVUnavailableEvent))
+
+	cfg = &config.Config{
+		Chaos: config.ChaosConfig{
+			ScheduledEvents: []config.ScheduledChaosEvent{
+				{At: time.Second, Event: string(coordinator.KVUnavailableEvent)},
+			},
+		},
+	}
+	require.True(t, scenarioHasChaosEvent(cfg, coordinator.KVUnavailableEvent))
+}
+
+func TestScenarioHasHandoffClaimWriteFault(t *testing.T) {
+	cfg := &config.Config{
+		Chaos: config.ChaosConfig{
+			ScheduledEvents: []config.ScheduledChaosEvent{
+				{At: time.Second, Event: string(coordinator.HandoffClaimWriteFaultEvent)},
+			},
+		},
+	}
+	require.True(t, scenarioHasHandoffClaimWriteFault(cfg))
+
+	cfg = &config.Config{
+		Chaos: config.ChaosConfig{
+			Faults: config.FaultsConfig{
+				HandoffClaimWriteOnStart: true,
+			},
+		},
+	}
+	require.True(t, scenarioHasHandoffClaimWriteFault(cfg))
+}
+
+func TestInstallStartupKVFaultsArmsHandoffClaimWrite(t *testing.T) {
+	fc := newSimKVFaultController()
+	cfg := &config.Config{
+		Chaos: config.ChaosConfig{
+			Faults: config.FaultsConfig{
+				HandoffClaimWriteOnStart:  true,
+				HandoffClaimWriteDuration: 20 * time.Millisecond,
+			},
+		},
+	}
+
+	installStartupKVFaults(context.Background(), fc, cfg)
+	require.True(t, fc.isHandoffClaimWriteArmed())
+
+	require.Eventually(t, func() bool {
+		return !fc.isHandoffClaimWriteArmed()
+	}, time.Second, 10*time.Millisecond)
+}

--- a/test/simulation/cmd/simulation/main.go
+++ b/test/simulation/cmd/simulation/main.go
@@ -43,6 +43,7 @@ var (
 	aioScaleUpOnce    int
 	aioMinWorkers     int
 	aioMaxWorkers     int
+	aioKVFaults       *simKVFaultController
 
 	// procCfg holds the active config in process-orchestrator mode so chaos
 	// handlers can resolve per-worker StableID overrides without threading
@@ -347,6 +348,9 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 	if err != nil {
 		return fmt.Errorf("failed to get JetStream: %w", err)
 	}
+	kvFaults := newSimKVFaultController()
+	js = newSimKVFaultJetStream(js, kvFaults)
+	installStartupKVFaults(ctx, kvFaults, cfg)
 
 	// Pre-create coordination KV buckets to avoid thundering herd on startup
 	// when many workers ensure the same buckets concurrently.
@@ -570,6 +574,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 	aioRegistry = goroutineRegistry
 	aioMinWorkers = cfg.Chaos.MinWorkers
 	aioMaxWorkers = cfg.Chaos.MaxWorkers
+	aioKVFaults = kvFaults
 
 	// Create chaos controller if enabled
 	var chaosCtrl *coordinator.ChaosController
@@ -679,9 +684,12 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 		}
 
 		workerCfg := worker.Config{
-			ID:                  workerID,
-			NC:                  workerNC,
-			JS:                  js,
+			ID: workerID,
+			NC: workerNC,
+			JS: js,
+			JetStreamWrapper: func(workerJS jetstream.JetStream) jetstream.JetStream {
+				return newSimKVFaultJetStream(workerJS, kvFaults)
+			},
 			PartitionCount:      cfg.Partitions.Count,
 			PartitionWeights:    weights,
 			AssignmentStrategy:  cfg.Workers.AssignmentStrategy,
@@ -1089,6 +1097,9 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 					invariantsErr = fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
 						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
 				}
+				if invariantsErr == nil && scenarioHasHandoffClaimWriteFault(cfg) && handoffClaimWriteFaultInjected() == 0 {
+					invariantsErr = errors.New("handoff_claim_write_fault_injected=0: scenario expected at least one claim write to fault")
+				}
 				if invariantsErr == nil {
 					log.Printf("Stability invariants passed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
 						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
@@ -1205,6 +1216,12 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 					// shutdown-invariant counters demand. TriggerFailure
 					// is idempotent via failureOnce, safe to call even if
 					// an earlier critical failure already wrote the report.
+					coord.TriggerFailure("Stability invariants failed at shutdown", invariantsErr)
+
+					return invariantsErr
+				}
+				if scenarioHasHandoffClaimWriteFault(cfg) && handoffClaimWriteFaultInjected() == 0 {
+					invariantsErr := errors.New("handoff_claim_write_fault_injected=0: scenario expected at least one claim write to fault")
 					coord.TriggerFailure("Stability invariants failed at shutdown", invariantsErr)
 
 					return invariantsErr
@@ -2010,7 +2027,7 @@ func handleChaosEvent(
 	case coordinator.BucketDeleteEvent, coordinator.BucketRecreateEvent, coordinator.BucketPeerTakeoverEvent,
 		coordinator.WatcherStallEvent, coordinator.StableIDClaimStealEvent,
 		coordinator.ProducerDisconnectEvent, coordinator.AssignmentCASStormEvent, coordinator.AssignmentBucketDeleteEvent,
-		coordinator.HandoffOrphanClaimWriteEvent:
+		coordinator.HandoffOrphanClaimWriteEvent, coordinator.KVUnavailableEvent, coordinator.HandoffClaimWriteFaultEvent:
 		// Process-mode dispatch is intentionally a log-and-skip per the
 		// plan's risk note (lines 386-388). Whole-bucket actions in
 		// process mode would need cross-process visibility into the
@@ -2043,7 +2060,7 @@ func handleGoroutineChaos( //nolint:cyclop,gocyclo,funlen,revive // dispatch gro
 			log.Printf("[Chaos] Skipping %s: no active workers", event)
 			return
 		}
-	case coordinator.ScaleUpEvent, coordinator.ProducerCrashEvent, coordinator.BucketDeleteEvent, coordinator.BucketRecreateEvent, coordinator.WatcherStallEvent, coordinator.StableIDTinyPoolRespawnEvent, coordinator.ProducerDisconnectEvent, coordinator.AssignmentCASStormEvent, coordinator.AssignmentBucketDeleteEvent, coordinator.HandoffOrphanClaimWriteEvent, coordinator.WorkerResumeEvent:
+	case coordinator.ScaleUpEvent, coordinator.ProducerCrashEvent, coordinator.BucketDeleteEvent, coordinator.BucketRecreateEvent, coordinator.WatcherStallEvent, coordinator.StableIDTinyPoolRespawnEvent, coordinator.ProducerDisconnectEvent, coordinator.AssignmentCASStormEvent, coordinator.AssignmentBucketDeleteEvent, coordinator.HandoffOrphanClaimWriteEvent, coordinator.WorkerResumeEvent, coordinator.KVUnavailableEvent, coordinator.HandoffClaimWriteFaultEvent:
 		_ = 0 // Dummy op to make branch different
 	default:
 		// Fallback for any other events
@@ -2279,6 +2296,12 @@ func handleGoroutineChaos( //nolint:cyclop,gocyclo,funlen,revive // dispatch gro
 		obsWindow := durationFromParams(params, "observation_window", 60*time.Second)
 		handleHandoffOrphanClaimWrite(ctx, obsWindow)
 
+	case coordinator.KVUnavailableEvent:
+		handleKVUnavailableFault(ctx, aioKVFaults, aioCoord, params)
+
+	case coordinator.HandoffClaimWriteFaultEvent:
+		handleHandoffClaimWriteFault(ctx, aioKVFaults, params)
+
 	case coordinator.WorkerResumeEvent:
 		// Phase 7b: process-mode only. All-in-one mode has no frozen-process
 		// equivalent (workers are goroutines), so this is a no-op here.
@@ -2467,9 +2490,12 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 	}
 
 	wcfg := worker.Config{
-		ID:                          workerID,
-		NC:                          workerNC,
-		JS:                          aioJS,
+		ID: workerID,
+		NC: workerNC,
+		JS: aioJS,
+		JetStreamWrapper: func(workerJS jetstream.JetStream) jetstream.JetStream {
+			return newSimKVFaultJetStream(workerJS, aioKVFaults)
+		},
 		PartitionCount:              aioCfg.Partitions.Count,
 		PartitionWeights:            aioWeights,
 		AssignmentStrategy:          aioCfg.Workers.AssignmentStrategy,
@@ -3001,6 +3027,24 @@ func scenarioHasScheduledEvent(cfg *config.Config, want coordinator.ChaosEvent) 
 	return false
 }
 
+func scenarioHasChaosEvent(cfg *config.Config, want coordinator.ChaosEvent) bool {
+	if cfg == nil {
+		return false
+	}
+	if scenarioHasScheduledEvent(cfg, want) {
+		return true
+	}
+	if cfg.Chaos.Enabled {
+		for _, ev := range cfg.Chaos.Events {
+			if coordinator.ChaosEvent(ev) == want {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // scenarioHasLongDisconnect reports whether the configured scenario
 // could fire a network_disconnect_long event — either via the random
 // chaos ticker (cfg.Chaos.Events listing "network_disconnect_long")
@@ -3011,21 +3055,18 @@ func scenarioHasScheduledEvent(cfg *config.Config, want coordinator.ChaosEvent) 
 // long_disconnect_skipped == 0. Scenarios that never schedule one
 // are exempt from this gate.
 func scenarioHasLongDisconnect(cfg *config.Config) bool {
+	return scenarioHasChaosEvent(cfg, coordinator.NetworkDisconnectLongEvent)
+}
+
+func scenarioHasHandoffClaimWriteFault(cfg *config.Config) bool {
 	if cfg == nil {
 		return false
 	}
-	if scenarioHasScheduledEvent(cfg, coordinator.NetworkDisconnectLongEvent) {
+	if cfg.Chaos.Faults.HandoffClaimWriteOnStart {
 		return true
 	}
-	if cfg.Chaos.Enabled {
-		for _, ev := range cfg.Chaos.Events {
-			if coordinator.ChaosEvent(ev) == coordinator.NetworkDisconnectLongEvent {
-				return true
-			}
-		}
-	}
 
-	return false
+	return scenarioHasChaosEvent(cfg, coordinator.HandoffClaimWriteFaultEvent)
 }
 
 // workerStateShutdownInt mirrors coordinator.workerStateShutdown (the int

--- a/test/simulation/configs/chaos_handoff_startup_write_fault.yaml
+++ b/test/simulation/configs/chaos_handoff_startup_write_fault.yaml
@@ -1,0 +1,51 @@
+# Startup handoff claim write-fault scenario.
+#
+# The simulation arms the handoff claims/* write fault before workers are
+# constructed, so the initial two-phase handoff apply path sees
+# context.DeadlineExceeded while NATS remains connected. The scenario must
+# inject at least one claim write fault and then recover through the normal
+# message, ownership, degraded, and gap gates after the fault clears.
+
+simulation:
+  duration: 90s
+  mode: all-in-one
+  cooldown: 30s
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 6
+  message_rate_per_partition: 1
+  distribution: uniform
+
+producers:
+  count: 1
+
+workers:
+  count: 3
+  assignment_strategy: WeightedConsistentHash
+  enforce_exclusive_consumption: true
+  processing_delay:
+    min: 1ms
+    max: 5ms
+
+chaos:
+  enabled: true
+  interval: "3600s-3601s"
+  events: []
+  faults:
+    handoff_claim_write_on_start: true
+    handoff_claim_write_duration: 10s
+
+coordinator:
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 30s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/chaos_handoff_version_write_fault.yaml
+++ b/test/simulation/configs/chaos_handoff_version_write_fault.yaml
@@ -1,0 +1,58 @@
+# Per-version handoff claim write-fault scenario.
+#
+# A scheduled handoff_claim_write_fault overlaps a scale-down event. Scale-down
+# forces a new assignment version and ownership movement while writes to
+# parti-handoff claims/* fail with context.DeadlineExceeded. The non-vacuity
+# gate requires at least one claim write to fault, and the existing
+# message/ownership/gap gates must still pass after recovery.
+
+simulation:
+  duration: 2m
+  mode: all-in-one
+  cooldown: 30s
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 10
+  message_rate_per_partition: 1
+  distribution: uniform
+
+producers:
+  count: 1
+
+workers:
+  count: 3
+  assignment_strategy: WeightedConsistentHash
+  enforce_exclusive_consumption: true
+  processing_delay:
+    min: 1ms
+    max: 5ms
+
+chaos:
+  enabled: true
+  interval: "3600s-3601s"
+  events: []
+  min_workers: 2
+  scheduled_events:
+    - at: 35s
+      event: handoff_claim_write_fault
+      params:
+        duration: 20s
+    - at: 40s
+      event: scale_down
+      params:
+        count: 1
+
+coordinator:
+  gap_aging: 90s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 60s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/chaos_kv_unavailable.yaml
+++ b/test/simulation/configs/chaos_kv_unavailable.yaml
@@ -1,0 +1,56 @@
+# Connected-but-KV-unavailable simulation scenario.
+#
+# A scheduled kv_unavailable fault returns context.DeadlineExceeded from
+# election / heartbeat / stableid KV operations while the NATS connection stays
+# connected. The DegradedReasonOracle expects "kv-unavailable" and the normal
+# message/ownership gates must still pass after the fault clears.
+
+simulation:
+  duration: 90s
+  mode: all-in-one
+  cooldown: 30s
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 6
+  message_rate_per_partition: 1
+  distribution: uniform
+
+producers:
+  count: 1
+
+workers:
+  count: 3
+  assignment_strategy: WeightedConsistentHash
+  processing_delay:
+    min: 1ms
+    max: 5ms
+
+chaos:
+  enabled: true
+  interval: "3600s-3601s"
+  events: []
+  scheduled_events:
+    - at: 20s
+      event: kv_unavailable
+      params:
+        duration: 20s
+        expect_degraded: true
+        buckets:
+          - parti-election
+          - parti-heartbeat
+          - parti-stableid
+
+coordinator:
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 30s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/internal/config/config.go
+++ b/test/simulation/internal/config/config.go
@@ -308,6 +308,23 @@ type ChaosConfig struct {
 	// Storage carries Phase 8 / Gap 9 storage-assertion and
 	// burst-after-quiet (Gap 13) scenario knobs.
 	Storage StorageChaosConfig `yaml:"storage"`
+
+	// Faults carries startup-armed fault injection knobs. Scheduled chaos
+	// events are usually preferred; this is only for faults that must be
+	// active before the initial worker Start path.
+	Faults FaultsConfig `yaml:"faults"`
+}
+
+// FaultsConfig configures startup-armed fault injection.
+type FaultsConfig struct {
+	// HandoffClaimWriteOnStart arms the handoff claims/* write fault before
+	// workers are constructed. This lets startup-apply scenarios fault the
+	// first two-phase claim write.
+	HandoffClaimWriteOnStart bool `yaml:"handoff_claim_write_on_start"`
+
+	// HandoffClaimWriteDuration controls how long the startup claim-write
+	// fault remains armed. Defaults to 20s when omitted.
+	HandoffClaimWriteDuration time.Duration `yaml:"handoff_claim_write_duration"`
 }
 
 // HandoffChaosConfig configures Phase 6 / Gap 5 handoff-bucket chaos primitives.

--- a/test/simulation/internal/coordinator/chaos.go
+++ b/test/simulation/internal/coordinator/chaos.go
@@ -151,6 +151,17 @@ const (
 	// state change) increments orphan_stable_claim_drift and fails the
 	// scenario. All-in-one only; process-mode logs and skips.
 	HandoffOrphanClaimWriteEvent ChaosEvent = "handoff_orphan_claim_write"
+
+	// KVUnavailableEvent faults selected manager-owned KV buckets with
+	// context.DeadlineExceeded while leaving the NATS connection connected.
+	// This exercises the connected-but-KV-unavailable / quorum-loss path
+	// that should enter Degraded with reason "kv-unavailable".
+	KVUnavailableEvent ChaosEvent = "kv_unavailable"
+
+	// HandoffClaimWriteFaultEvent faults writes to handoff claims/* keys
+	// while leaving reads and non-claim keys available. This exercises
+	// startup and version-advance apply retry/self-heal paths.
+	HandoffClaimWriteFaultEvent ChaosEvent = "handoff_claim_write_fault"
 )
 
 // ChaosController manages chaos event injection.
@@ -307,6 +318,8 @@ func (cc *ChaosController) injectEvent() {
 }
 
 // generateEventParams generates parameters for a specific chaos event.
+//
+//nolint:cyclop // exhaustive switch over chaos-event defaults; complexity grows linearly.
 func (cc *ChaosController) generateEventParams(event ChaosEvent) map[string]any {
 	params := make(map[string]any)
 
@@ -442,6 +455,17 @@ func (cc *ChaosController) generateEventParams(event ChaosEvent) map[string]any 
 		// 60s (= 2 × default Handoff.SweepInterval). Scenarios override
 		// via the YAML scheduled_events params.
 		params["observation_window"] = 60 * time.Second
+
+	case KVUnavailableEvent:
+		// Sustained connected-but-KV-unavailable fault. The dispatcher faults
+		// these buckets while the NATS connection itself stays up.
+		params["duration"] = 20 * time.Second
+		params["buckets"] = []string{"parti-election", "parti-heartbeat", "parti-stableid"}
+		params["expect_degraded"] = true
+
+	case HandoffClaimWriteFaultEvent:
+		// Claim-write fault window; scenarios choose the exact schedule.
+		params["duration"] = 20 * time.Second
 
 	default:
 		// Unknown event type, return empty params
@@ -582,6 +606,10 @@ func (e ChaosEvent) String() string {
 		return "Assignment Bucket Delete (parti-assignment, Gap 10b alias)"
 	case HandoffOrphanClaimWriteEvent:
 		return "Handoff Orphan Claim Write (Gap 5; stable-claim sweep skip)"
+	case KVUnavailableEvent:
+		return "KV Unavailable (connected KV timeout)"
+	case HandoffClaimWriteFaultEvent:
+		return "Handoff Claim Write Fault"
 	default:
 		return fmt.Sprintf("Unknown Event: %s", string(e))
 	}

--- a/test/simulation/internal/worker/worker.go
+++ b/test/simulation/internal/worker/worker.go
@@ -150,6 +150,7 @@ type Config struct {
 	ID                  string
 	NC                  *nats.Conn
 	JS                  jetstream.JetStream
+	JetStreamWrapper    func(jetstream.JetStream) jetstream.JetStream
 	PartitionCount      int
 	PartitionWeights    []int64
 	AssignmentStrategy  string
@@ -445,6 +446,9 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop,gocyclo // dispatc
 	js, err := jetstream.New(cfg.NC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init JetStream: %w", err)
+	}
+	if cfg.JetStreamWrapper != nil {
+		js = cfg.JetStreamWrapper(js)
 	}
 
 	dynamic, err := consumer.NewDynamic(


### PR DESCRIPTION
## Summary
- add simulation fault injection for connected KV timeouts and handoff claim write failures
- add focused simulation scenarios for startup and per-version handoff recovery
- wire the scenarios into simulation stress CI with non-vacuous injection gates

## Test Plan
- go test ./test/simulation/...
- make lint
- git diff --check