### PR TITLE
Auto-healing: close degraded recovery-exit gaps and persist the heartbeat bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Auto-healing gap-closure follow-up to the v2.5.0 self-healing work: three
+verified recovery-exit gaps — where a worker returned to `Stable` while the
+fault that degraded it still persisted — are closed, and the heartbeat KV
+bucket joins election and assignment on `FileStorage` so a single-node NATS
+restart no longer flaps the fleet.
+
+### Changed
+
+- **Heartbeat KV bucket defaults to `FileStorage`** (was `MemoryStorage`).
+  With `MemoryStorage` the heartbeat stream was lost on a single-node
+  JetStream restart; the heartbeat publisher's `Put` then kept failing
+  against the dead stream and the fleet oscillated `Degraded`↔`Stable`.
+  Persisting the bucket lets the stream survive the restart. The added
+  write IOPS is a flat, partition-count-independent term measured within
+  the provisioned envelope already accepted for the v2.5.0 election-bucket
+  switch (see `docs/plans/iops-investigation/`). Election and assignment
+  buckets were already `FileStorage`.
+
+  **Existing clusters need a one-time manual migration** —
+  `EnsureKVBucketWithRetry` is get-first and does not upgrade an existing
+  `MemoryStorage` bucket. Until migrated, an existing bucket keeps
+  `MemoryStorage`, so a single-node NATS restart still loses its heartbeat
+  stream — but the heartbeat-reachability guard below now holds such a worker
+  in terminal `Degraded` (loud, rotatable) instead of flapping, and a rotation
+  re-creates the bucket as `FileStorage`, completing the migration. See
+  "Heartbeat Bucket Storage Migration" in `docs/OPERATIONS.md`.
+
+### Fixed — recovery exit no longer heals on the wrong signal
+
+The degraded→`Stable` recovery exit was trigger-blind: it returned to `Stable`
+on a healthy *assignment* read even while a *different* fault still persisted.
+Each fix below ANDs an additive guard onto the existing
+`currentAssignmentApplied` commitment guard (which is unchanged):
+
+- **Bucket wipe-and-recreate stays degraded.** A wiped-and-recreated
+  Parti-owned control-plane bucket left the epoch-fence mismatch permanent,
+  but the exit healed on a version-monotonic republish into the
+  recreated-empty bucket. A live per-tick epoch re-probe now refuses the exit
+  while any owned bucket's stream `Created` differs from the value captured at
+  `Start`; the worker stays terminally `Degraded` for restart/rotation.
+- **Connected-but-KV-unavailable stalls stay degraded.** A heartbeat /
+  election / stableID op stall degrades with reason `kv-unavailable`, but the
+  exit re-read only the unaffected assignment bucket. The exit now requires a
+  heartbeat `Put` success stamped *after* the degrade before leaving a
+  `kv-unavailable` degrade. Reason-scoped, so a `startup-timeout` degrade
+  still recovers on the commitment guard alone.
+- **Claim-loss self-stop documented.** An outage exceeding `WorkerIDTTL` ages
+  out the worker-ID lease; on reconnect the worker surfaces a bare
+  `ErrClaimLost` and self-stops to `StateShutdown` (split-brain-safe — a peer
+  may hold the slot). This was already the behavior; `docs/OPERATIONS.md` now
+  documents the bound and that recovery is orchestrator rotation.
+- **Heartbeat-bucket loss stays degraded (no flap).** A *missing* heartbeat
+  stream — e.g. a single-node restart of an un-migrated `MemoryStorage`
+  bucket — degrades with the whole-bucket-loss reason
+  `KV error threshold exceeded`, which the `kv-unavailable` gate does not
+  cover and which the recreate re-probe does not catch (a missing stream is
+  not a recreate), so the fleet flapped `Degraded`↔`Stable`. A
+  heartbeat-bucket reachability check now refuses the recovery exit while the
+  bucket's stream is missing/unreachable, holding the worker terminally
+  `Degraded` for rotation regardless of the degrade reason.
+
 ## [v2.5.0] - 2026-05-24
 
 Two themes: **self-healing under NATS infrastructure churn** — manager

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -129,6 +129,21 @@ recovery, rotation, or caller-owned recovery.
 | `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | Recover the stream or rotate workers according to application ownership. |
 | `source-unavailable:<bucket>` | caller-owned source bucket unavailable | Caller/operator recovers the source bucket; Parti does not recreate it. |
 
+**Recovery bound — worker-ID lease (`WorkerIDTTL`).** M5 recover-to-Stable across
+a NATS outage is bounded by `WorkerIDTTL` (default 75s; the stableID bucket
+`MaxAge` is reconciled to it). An outage that exceeds `WorkerIDTTL` ages out the
+worker-ID lease; on reconnect the renewal sees a revision mismatch, surfaces a
+bare `ErrClaimLost`, and the worker **self-stops to `StateShutdown`** — the
+deliberate split-brain-safe behavior, since a peer may have taken the slot. The
+boundary is minute-scale at defaults (renewal cadence ~`WorkerIDTTL/3`; purge at
+last-renewal + `WorkerIDTTL`), so a ~1-minute blip can rotate the **whole fleet**
+(every disconnected worker crosses the boundary together). Recovery is
+orchestrator rotation (the readiness probe sees `StateShutdown` and the pod is
+replaced); Parti does not auto-reclaim a lease that aged out, because at the
+`ErrClaimLost` surface it cannot distinguish "my lease expired, slot empty" from
+"a peer took the slot". Raise `WorkerIDTTL` above the worst-case outage to move
+the boundary.
+
 ### KV Bucket Pre-Creation (Optional)
 
 Parti auto-creates KV buckets, but you can pre-create them for custom settings:
@@ -642,6 +657,57 @@ nats kv info parti-<cluster>-election | grep -i storage  # expect "File"
 
 After the migration a single-node restart in a 3-replica cluster
 no longer causes leadership churn.
+
+### Heartbeat Bucket Storage Migration
+
+The heartbeat bucket's default storage type changed from `MemoryStorage` to
+`FileStorage` so the heartbeat stream survives a single-node NATS restart.
+Previously, a single-node restart dropped the `MemoryStorage` heartbeat
+stream; the heartbeat publisher's `Put` then kept failing against the dead
+stream and the fleet flapped `Degraded`↔`Stable` without ever holding Stable.
+
+**Existing clusters need a one-time bucket replacement** because
+`EnsureKVBucketWithRetry` is get-first — it does not upgrade an existing
+`MemoryStorage` bucket to `FileStorage`.
+
+**Until migrated, an existing bucket keeps `MemoryStorage`,** so a single-node
+NATS restart still loses its heartbeat stream. The heartbeat-reachability
+recovery guard holds such a worker in **terminal `Degraded`** — it does not
+flap back to `Stable`. (A missing heartbeat stream degrades with the
+whole-bucket-loss reason `KV error threshold exceeded`, and the guard refuses
+the recovery exit while the bucket is unreachable.) This is loud and
+rotatable: `OnDegraded → readiness probe → pod rotation` rotates the worker,
+and because the lost bucket no longer exists, the rotating pod re-creates it
+as `FileStorage` — so a rotation completes the migration automatically. You
+can also migrate explicitly during a maintenance window (below) instead of
+waiting for a restart to trigger it.
+
+Migration steps, during a planned maintenance window:
+
+```bash
+# 1. Delete the bucket (also removes the backing KV_<bucket> stream).
+nats kv rm parti-<cluster>-heartbeat
+
+# 2. Paranoia check — confirm the backing stream is gone.
+nats stream ls | grep KV_parti-<cluster>-heartbeat  # expect no output
+
+# 3. Recreate as FileStorage (match your HeartbeatTTL and replica count).
+nats kv add parti-<cluster>-heartbeat --storage=file --ttl=15s --replicas=1
+
+# 4. Rolling restart of Parti workers (any order is fine).
+```
+
+Workers that observed the deletion enter degraded via the epoch fence (reason
+`bucket-recreated:parti-<cluster>-heartbeat`) and, with the Phase-1 live epoch
+re-probe, stay terminally `Degraded`. The existing
+`OnDegraded → readiness probe → pod rotation` path (plus the rolling restart
+in step 4) completes the migration.
+
+Post-migration verification:
+
+```bash
+nats kv info parti-<cluster>-heartbeat | grep -i storage  # expect "File"
+```
 
 ### Tuning OperationTimeout vs ElectionTimeout
 

--- a/docs/plans/auto-healing-gap-closure/05-deep-investigation.md
+++ b/docs/plans/auto-healing-gap-closure/05-deep-investigation.md
@@ -1,0 +1,516 @@
+# Auto-Healing Gap — Deep Investigation (Synthesis)
+
+- **Date:** 2026-06-01
+- **HEAD:** `2453306` on worktree `auto-heal-gap-investigation` (content-identical to `main`).
+- **Scope:** READ-ONLY. No production code was changed. This report synthesizes 5
+  family/exit-gate findings (each independently re-derived AND adversarially verified) plus
+  2 cross-cutting surveys. Every claim cites `file:line` or a test name; INFERENCE is flagged
+  as such.
+- **Governing rule used throughout:** where an investigation note's headline and its
+  adversarial verification note diverge, **the verification conclusion governs.** Several
+  load-bearing recommendations below differ from the louder first-pass headline for this
+  reason (Family A fix form; C-mech1 fix reasoning; C-mech2 decision gate). These are called
+  out explicitly.
+- **Detailed source notes** (read for full depth) live under
+  `docs/plans/auto-healing-gap-closure/investigation-notes/`:
+  `family-a-epoch.md`(+`-verify`), `family-b-kvunavail.md`(+`-verify`),
+  `family-c-mech1.md`(+`-verify`), `family-c-mech2.md`(+`-verify`),
+  `exit-gate-unification.md`(+`-verify`), `survey-contracts.md`, `survey-completeness.md`.
+- **Cross-model review (2026-06-01):** an independent reviewer (codex `gpt-5.5`, reasoning `xhigh`,
+  read-only) verified every load-bearing claim against the code and returned **sound-with-fixes**,
+  agreeing with all mechanisms (A re-probe, B reason-scoped gate, C-mech1 doc-only, C-mech2 Opt D,
+  the exit-gate refutation, and NP-10). Its corrections — one factual error in §4 and three
+  precision-of-wording points (C-mech1 §1, C3 §4, NP-10 §5/§7) — were independently re-verified and
+  folded in below, tagged "(cross-model review)". Review artifact: `tmp/codex-review-last.md`.
+
+---
+
+## 0. Method + current-HEAD reproduction status
+
+Method: each gap is an executable env-gated proof; the investigator re-ran the failing
+proofs and the controls **serially** on HEAD `2453306`. The `.out` evidence is under
+`tmp/repro-current-head/` (`SUMMARY.txt` + per-proof `.out`). The deep investigation then
+independently re-derived each root cause from code, ran an adversarial refutation pass, and
+mapped contract/test impact.
+
+**Every confirmed gap reproduces on HEAD `2453306`. No expected-FAIL proof secretly PASSED.**
+
+| Proof | Property | Verdict on HEAD 2453306 | Evidence |
+|---|---|---|---|
+| **NP-2** | one bucket recreated under a live worker must stay *terminally* Degraded | **FAIL (gap)** `degradedToStable=9, otherDegrades=0, finalState=Degraded, connected=true` | `np2.out:4,7` |
+| **NP-1** | operator wipes+recreates **all** buckets under live 3-worker fleet must not heal in-process | **FAIL (gap)** `healed=[0 1 2]`, all end Stable on empty buckets, ~67s | `SUMMARY.txt:7`, `np1.out` |
+| **NP-3b** | sustained connected-but-KV-unavailable must not falsely exit Degraded | **FAIL (gap)** `re-entries=9, injected=36`, CONNECTED, 13.0s | `np3b.out:4,8` |
+| **NP-8 mech1** | 3-mgr fleet across NATS restart, outage ≥ WorkerIDTTL | **FAIL (gap)** `manager[1] failed to reach Stable: context deadline exceeded`, 40.3s | `np8_mech1.out:8` |
+| **NP-8 mech2** | 3-mgr fleet, MemoryStorage heartbeat-bucket loss | **FAIL (gap)** reaches all-Stable then HOLD trips ~12s, CONNECTED | `np8_mech2.out` (`:325` reach passes, `:327` HOLD fails) |
+| NP-3a | KV-unavailable then **cleared** → recovers and holds (positive control) | **PASS** 9.68s | `np3a.out` |
+| NP-6 / NP-7 | finite-reconnect close / unlimited-reconnect single-worker recover | **PASS** | `np6_np7.out` |
+
+The NP-3a PASS is decisive: it proves NP-3b's exit is a *false* exit, not a dead recovery
+path. The NP-2/NP-3b CAS argument is irrefutable — `enterDegraded` CAS-guards `degradedSince`
+(`manager_degraded.go:309`), so N Degraded entries require N−1 intervening `exitDegraded`
+calls; 9–10 entries ⇒ a genuine oscillation, not a single transition.
+
+---
+
+## 1. Per-family deep findings
+
+### Family A — epoch-fence re-degrade + recover-on-wrong-signal flap (NP-2, NP-1)
+
+**Verdict: CONFIRMED (root cause) + CORRECTED (report fix framing) + CAVEATED (recommended
+fix form).**
+
+**Root cause, re-derived (two interacting facts):**
+- **(i) The epoch fence never re-captures `ep.created`.** `captureBucketEpoch` writes the
+  cached Created **once** at Start (`manager_setup.go:627`; only writers of `m.bucketEpochs`
+  are the map-init `:613` and `:627` — verified by grep). `checkBucketEpochs`
+  (`manager_setup.go:669-693`, read directly) reads the **live** Created via the cached probe
+  handle (`:677`), fires `enterDegraded("bucket-recreated:"+bucket)` on `!live.Equal(ep.created)`
+  (`:684,689`), then returns (`:690`) — **never updating `ep.created`.** The mismatch is
+  permanent for the process lifetime; every tick re-fires. (The cached `ep.kv` handle
+  transparently re-binds to the recreated stream — proven by NP-2 firing 10×; if the stale
+  handle errored, `:679-682` would `continue` and the fence would never fire.)
+- **(ii) Recovery exits on the wrong signal.** `attemptRecoveryFromDegraded`
+  (`manager_degraded.go:376-416`, read directly) reads ONLY `assignment.<workerID>`
+  (`refreshAssignmentFromNATS` → `manager_assignment.go:1567-1568`) and gates exit solely on
+  `currentAssignmentApplied(cur)` (`:408-415`). The comment at `:405-406` confirms this is
+  **reason-agnostic by design** ("keys on commitment STATE, not the degraded reason"). It
+  **never consults `m.bucketEpochs`** — the wipe signal is structurally invisible to the exit.
+
+The 10s epoch tick and the 1s recovery tick fight → sustained Degraded↔Stable flap, violating
+the documented terminal-Degraded contract (`docs/OPERATIONS.md:126,750-762`: bucket-recreated ⇒
+rotate; Parti deliberately does not self-heal). Orthogonal to `421f13c`/`recordKVHealthyOp`
+(the fence calls `enterDegraded` directly, never touching `kvErrorWindow`).
+
+**Why NP-1 RESTS Stable (not just flaps) — added, the report omits this.** The publisher's
+in-memory `currentVersion` (`assignment_publisher.go:106,345`) is only ever **raised** by
+`DiscoverHighestVersion` (`:882-884,917-919`), never lowered. After the wipe the leader keeps
+its pre-wipe version and republishes a *higher* version into the empty bucket; the worker
+genuinely re-applies it, satisfying `currentAssignmentApplied` against actually-committed-but-
+on-wiped-coordination-state data. The false-healthy is **structural and version-monotonic**,
+not a counter-reset artifact (`np1.out`: worker-0 shows `Stable→Rebalancing→Stable` post-wipe).
+This is the worst outcome: a readiness probe marks the pod Ready while handoff claims, commit
+history, and the worker-ID lease were wiped.
+
+**Fix options:**
+
+| Option | Mechanism | Passes NP-2/NP-1? | Notes |
+|---|---|---|---|
+| **A-reprobe** (RECOMMENDED) | In `attemptRecoveryFromDegraded` before `exitDegraded`, `AND` `!epochMismatchOutstanding()`, a live re-probe of each `m.bucketEpochs` entry against cached `ep.created`. Keep `ep.created` permanently stale (load-bearing). | **Yes (both)** | **No pre-arm window** — `ep.created` is pinned, so any post-recreate exit attempt refuses inline. Cost: one `BucketStreamCreated` probe per bucket per recovery tick while Degraded + a probe-error policy decision (`checkBucketEpochs:679-682` currently swallows probe errors with `continue`). |
+| **A-latch** | Latch `m.epochFenceTripped` at `manager_setup.go:689`, `AND !tripped` into the exit gate. | **NP-2 yes; NP-1 NOT established** | **Verification caveat (governs):** the latch arms only on the first post-recreate fence *observation*, which ticks every **10s** in NP-1 (`OperationTimeout` default `config.go:410`, NOT overridden), while recovery runs every **1s** and the leader republish is not Degraded-gated. A ~10s pre-arm window exists where a higher-version republish + 1Hz recovery can exit before the latch arms → risks failing `require.Empty(healed)` (`np1_..._test.go:248`). Use only if armed before any post-recreate exit. |
+| **A-recapture (Opt-1)** | Re-capture `ep.created` after firing so the fence latches once. | **Fails BOTH alone** | Standalone it CEMENTS false-healthy: stops re-degrade, worker rests Stable on the wiped bucket → strictly WORSE than the flap (removes the Degraded windows a readiness probe needs). Only acceptable layered on a recovery-exit guard, where it merely quiets log spam — and is likely **unnecessary** because a never-exiting guard keeps `degradedSince` set so `enterDegraded`'s CAS self-suppresses repeats. |
+
+**Recommended fix:** **A-reprobe** — gate `exitDegraded` on a live `epochMismatchOutstanding()`
+re-probe, preserving the permanently-stale `ep.created` as the terminal-Degraded signal.
+Legitimate recovery is via process restart (re-runs `ensureKVBucket → captureBucketEpoch`,
+`docs/OPERATIONS.md:760-762`). **The fix's test must assert NP-1's FIRST exit is blocked**, not
+merely that the worker eventually settles Degraded.
+
+**Report discrepancies (all verified):**
+- `04-proof-findings.md:278` "the proofs are agnostic to which fix lands" is **FALSE** — Opt-1
+  alone fails both proofs; only an exit-gate fix passes.
+- `:275-282` presents Opt-1/Opt-2 as co-equal "Either…or…" alternatives. They are not: the
+  exit-gate fix is necessary; Opt-1 standalone is strictly worse than status quo.
+- `:51-52,280-282` "a single fix could close both A and B" — same *function*, **different
+  predicates** (see §2).
+
+**Residual risk:** A-reprobe's only cost is the per-tick probe + a probe-error policy decision
+(refuse-exit-on-probe-error is conservative and matches the M4 terminal intent). The latched
+variant's NP-1 sufficiency was NOT settled empirically (read-only; no patched-build run). C1
+entry untouched (`np1.out` shows `kv-unavailable` first on every worker, then `bucket-recreated:*`).
+
+---
+
+### Family B — recover-on-wrong-signal under sustained connected-but-KV-unavailable (NP-3b)
+
+**Verdict: CONFIRMED (root cause) + CORRECTED (report "single fix closes A+B" is loose).** This
+is the explicitly-deferred "Finding A" from the F-D1 work made executable.
+
+**Root cause, re-derived.** Recovery is driven by connection **uptime**, not the failing op:
+`monitorNATSConnection` ticks 1s (`manager_degraded.go:79`) → `checkConnectionHealth` (`:97`);
+the connection never drops under a KV-unavailable fault, so once up for `ExitThreshold` it calls
+`attemptRecoveryFromDegraded` every tick. That exits on a successful assignment read +
+`currentAssignmentApplied` — **never checking the heartbeat/election/stableid op that triggered
+the degrade recovered**. NP-3b excludes the assignment bucket from the fault set
+(`np3_..._test.go:142-147`), so the read succeeds → false exit. `recordKVSuccess` (`:393`) then
+wipes the entire `kvErrorWindow`, resetting the re-degrade clock; the still-faulting heartbeat
+re-accumulates to `KVErrorThreshold` → re-degrade → flap. `recordKVHealthyOp` (421f13c) cannot
+help: it fires only on heartbeat Put **success** (the heartbeat bucket is itself faulting) and
+early-returns while degraded (`:267-269`).
+
+**NP-9 contrast (verified):** NP-9 faults the assignment bucket AND its Watch
+(`np9_..._test.go:184-189,142-148`), so `refreshAssignmentFromNATS` FAILS at `:383` → early
+return → never reaches `exitDegraded`. That is why NP-9 recovers cleanly (1 entry / 1 exit) and
+does not flap. The defective gate is *accidentally correct* in NP-9 because the assignment
+bucket is part of the same quorum loss.
+
+**The crux for the fix (the report misses this): there is no off-the-shelf "failing op" signal.**
+`kvErrorWindow` is a flat `[]kvErrorEvent{at, transient}` (`manager.go:204`,
+`manager_degraded.go:33-36`) with **no source tag**; the degrade reason is passed transiently to
+`enterDegraded` (`:300`) and **never persisted**. The only per-source success signal in
+production is the heartbeat `SetOnSuccess` (`manager_election.go:432`).
+
+**Fix options:**
+
+| Candidate | Mechanism | Passes NP-3b `require.Zero`? | Notes |
+|---|---|---|---|
+| **2 — reason-scoped heartbeat-success-since-degrade gate** (RECOMMENDED B-only) | New `m.lastHeartbeatSuccessAt` stamped unconditionally on heartbeat Put success; new `m.lastDegradedReason` set in `enterDegraded`; gate `if reasonIsKVUnavailable && lastHeartbeatSuccessAt <= degradedSince { return }`. | **Yes** | **Reason-scoping is load-bearing:** `attemptRecoveryFromDegraded` is the SINGLE recovery exit for ALL reasons; an UNCONDITIONAL gate **regresses NP-5** (VERIFIED — `newTestManager` never starts a heartbeat publisher, `manager_commit_state_machine_test.go:163`; NP-5 calls `attemptRecoveryFromDegraded` directly `np5...:158` expecting Degraded→Stable). So it is **not a one-liner** — it forces persisting the degrade reason that does not exist today. |
+| 1 — post-recovery cooldown | Suppress re-entry for N seconds after exit. | **No** (allows ≥1 false exit; `require.Zero` is zero exits, not slower) | Also risks C1 bounded re-entry if not class-scoped. Reject as standalone. |
+| 3 — per-source error counters / degrade-cause registry | Tag `kvErrorEvent` by source; add success hooks to election/stableid/assignment. | Yes | 100+ LOC across ≥4 files + subsystems with no success hook today. Heaviest; the honest unified A+B substrate (epoch fence registers a `bucket-recreated` cause). |
+
+**Recommended fix (B-only):** **Candidate 2, reason-scoped.** Smallest correct surface that
+passes NP-3b, preserves C1 (entry contract; whole-bucket loss enters with reason `"KV error
+threshold exceeded"` `:215`, not `kv-unavailable`, so the gate does not apply), preserves the
+f-d1 class-aware reset (separate signal), keeps NP-9/NP-3a recovery, and does NOT regress NP-5.
+
+**Report discrepancy:** `04-proof-findings.md:52` "a single fix to the exit gate could close both
+A and B" is **loose** — the exit *defect* is shared, but the re-degrade *trigger* and thus the
+fixing *predicate* differ (B: kv-unavailable threshold; A: epoch fence fired directly,
+bypassing `kvErrorWindow`). The report is internally inconsistent: `:52` oversells, `:282` walks
+it back. (Numeric drift, not a correctness issue: report cited `degradedExits=9, injected=34`;
+HEAD re-run shows `re-entries=9, injected=36`.)
+
+**Residual risk (verified):** (1) **Ordering hazard** — `m.lastDegradedReason` must be set BEFORE
+or atomically with the `degradedSince` CAS (`:309`), else the 1s tick can read a stale/empty
+reason and allow one false exit on the first degrade. Mitigate by ordering or treating
+empty-reason as gate-applies. (2) Heartbeat-only proxy: an election-only/stableid-only sustained
+fault with healthy heartbeat could open the gate early — argued (not proven) to be already let
+through by the shipped f-d1 narrowing, so no *new* regression. (3) B-only; does not close A.
+Fix not prototyped; mandatory on landing: ungate NP-3b + re-run ungated NP-5, NP-9,
+`LiveNATSBucketLoss` (ideally `-race`).
+
+---
+
+### Family C mechanism 1 — claim-loss self-stop on outage ≥ WorkerIDTTL (NP-8)
+
+**Verdict: CONFIRMED (mechanism, WAD direction) + CORRECTED (boundary magnitude, fleet outcome,
+C2 pin) + CAVEATED (fix reasoning + attribution evidence).**
+
+**Root cause, re-derived.** The stableID bucket MaxAge is reconciled to `WorkerIDTTL`
+(`config.go:366-369`; `reconcileStableIDBucketMaxAge`, `manager_setup.go:354-373`; bucket is
+FileStorage `:92`). Renewal runs at `max(ttl/3,100ms)` (`claimer.go:491-493`) = 25s at the 75s
+default; the server purges the key at `last-renewal+75s`. During an outage renewal Updates fail
+with connectivity errors routed harmlessly to `recordKVOpError`. When the outage exceeds
+`WorkerIDTTL` the key is purged; on reconnect the next `kv.Update(key,val,staleLastRevision)`
+hits "wrong last sequence: 0" → nats.go surfaces `jetstream.ErrKeyExists` (wire pinned by
+`TestClaimer_WireContract_RevisionMismatchIsErrKeyExists`, `claimer_test.go:650-681`). `renew()`
+returns **bare** `ErrClaimLost` (`claimer.go:365-368`) with no connectivity/not-found sentinel.
+`onClaimerError` (`manager_election.go:106-127`, read directly): `ErrClaimLost` true,
+`IsConnectivityError`/`IsDegradingJetStreamError` both false → `claimLostShutdown` (`:118`) →
+terminal `StateShutdown` (NP-4 confirms a second `Start` returns `ErrAlreadyStarted`).
+
+The **conflation locus** (`claimer.go:365-368`) collapses "a peer bumped my revision (key
+present)" and "my lease aged out (slot empty)" into the identical bare error, routed identically.
+The code *could* distinguish them with a follow-up `kv.Get` (absent ⇒ expired-no-peer;
+fresh-value+different-revision ⇒ peer holds it) but does not attempt it. In NP-8 every worker is
+disconnected, so **no peer can have taken over**, yet all 3 self-stop — the pure unnecessary-loss
+case.
+
+**Fix options:**
+
+| Option | What | Risk |
+|---|---|---|
+| **0 — doc-only** (RECOMMENDED near-term) | Document M5 recover-to-Stable is bounded by WorkerIDTTL; an outage past it self-stops the worker (StateShutdown) ⇒ orchestrator rotation. Re-purpose the NP-8 mech-1 proof to assert StateShutdown so it becomes a regression guard. | None to code. |
+| 1 — ID-layer safe re-claim alone | `kv.Get` before self-stop; atomic `kv.Create` if absent. | **Do NOT ship alone** — resuming from stale cached assignment may double-process partitions the fleet rebalanced (in a *partial* outage). |
+| 2 — full in-process re-claim + assignment re-bootstrap | Re-claim + drop cache + re-enter `waitForAssignment`. | Only behaviorally-safe in-process fix; re-implements restart semantics; needs a new data-plane proof. |
+| 3 — raise effective trigger via config guidance | Set WorkerIDTTL above worst-case outage. | Palliative; relocates the boundary. |
+
+**Recommended fix:** **Option 0 (doc-only)** near-term, with corrected framing. Never ship Option
+1 in isolation.
+
+**Corrections (verified):**
+- **Boundary is minute-scale (~50-75s at defaults), NOT "multi-minute"** (report `:160,251,286`).
+  Renewal cadence 25s; purge at last-renewal+75s ⇒ phase-dependent ~50-75s. Materially more
+  reachable than implied.
+- **Operational outcome is fleet-wide.** The mechanism is per-worker, but all disconnected
+  workers cross the boundary together and all self-stop for zero ID contention — one ~1-minute
+  blip rotates the entire fleet.
+- **C2 pin mis-cited.** The brief cites `TestStableID_StaleKeyTakeover_Reclaim`; that test is at
+  the `stableid.Claimer` level (reclaim half only) and does NOT exercise `onClaimerError`
+  self-stop routing. The real pins are `TestManager_StopsItselfWhenClaimLost`
+  (`manager_claimer_error_test.go:135-172`) and `TestOnClaimerError_ClaimLostStopsWorker` (`:53-86`).
+
+**Caveats from adversarial verification (governing):**
+- **Fix-reasoning correction.** The investigation's split-brain steelman ("heartbeat expired
+  ~35-60s earlier ⇒ fleet already rebalanced ⇒ Option 1 double-processes") is **FALSE for the
+  NP-8 full-fleet case**: with every worker (incl. the leader) disconnected, no successful
+  worker-enumeration or rebalance can run. (cross-model review precision: a leader's calculator may
+  still be *running* — `manager.go:607`, `manager_election.go:329` — but `heartbeatKV.Keys` fails
+  (`worker_monitor.go:167-175`), so it cannot enumerate workers or rebalance during the outage; the
+  earlier "no calculator runs" phrasing was imprecise.) Nothing rebalances during the outage. The double-processing risk exists only in a **partial** outage (one worker partitioned,
+  leader survives). The doc-only **conclusion survives** on the weaker correct grounds
+  (orchestrator rotation heals cleanly; an in-process re-claim needs an unproven partial-outage
+  data-plane proof), but the **justification must be re-grounded** away from full-fleet split-brain.
+- **Attribution is INFERENCE.** The gated proof instruments only `OnStateChanged`/`OnDegraded`
+  (no Shutdown/OnError hook) and runs **both** mechanisms simultaneously (WorkerIDTTL=5s AND
+  MemoryStorage heartbeat loss). Mech-1 attribution rests on the cross-test WorkerIDTTL contrast
+  (5s never-Stable vs 30s reaches-Stable-then-flaps) — sound but an inference. The empirical
+  "bare ErrClaimLost fired" chain rests on a single un-captured diagnostic (`04-proof-findings.md:135`,
+  absent from all `.out` files). The wire-contract test covers the *present-key* revision-mismatch,
+  not the exact *purged-key* "wrong last sequence: 0" case. Low residual risk (MaxAge purge is the
+  documented design premise), not zero. **Recommend adding StateShutdown/OnError instrumentation.**
+
+---
+
+### Family C mechanism 2 — MemoryStorage heartbeat-bucket loss → fleet flap (NP-8)
+
+**Verdict: CONFIRMED (gap is real, flap as severe as claimed) + CORRECTED (report MISNAMES the
+driver, so its Opt B is ineffective).**
+
+**Root cause, re-derived.** After a single-node NATS restart only the MemoryStorage heartbeat
+bucket's stream is gone (`manager_setup.go:156`, verified); election/assignment/stableid/handoff
+are FileStorage and survive. Two ticks fight:
+- **Re-degrade driver = the heartbeat PUBLISHER Put**, not the calculator. Every worker runs a
+  heartbeat publisher (`startHeartbeat`, `manager.go:602`, leadership-independent). The cached-handle
+  Put fails against the dead stream → `onError` → `recordKVOpError` (`manager_election.go:424`) →
+  `recordKVError` → after `KVErrorThreshold` (5) within `KVErrorWindow` re-`enterDegraded` (~2.5s
+  at the 500ms test interval). **This fires on every worker** — the gap is fleet-wide, not
+  leader-specific.
+- **Recovery tick = `attemptRecoveryFromDegraded`**, which reads only the surviving FileStorage
+  assignment bucket and exits to Stable — the **same recover-on-wrong-signal exit defect** as
+  Families A/B. The exit gate NEVER reads the heartbeat bucket.
+
+**Driver mis-attribution (substantive, verified by elimination):** the calculator's "failed to
+list heartbeat keys" error (`internal/assignment/worker_monitor.go:175`) is **swallowed** — poll
+path logs Error (`:282-284`), watcher path logs Error (`:396`), audit logs Debug (`calculator_audit.go:60-63`);
+grep of `recordKVError|recordKVOpError|SetOnError` over `internal/assignment/*.go` returns nothing.
+A full `enterDegraded(` caller enumeration leaves only `recordKVError` (threshold) able to fire
+post-reconnect on heartbeat-only loss, and only the publisher Put feeds it. The report names the
+loudest **log line**, not the driver. (Reason string is likely `kv-unavailable` via
+`nats.ErrNoResponders` on a cached Put, `source/nats_kv.go:1381-1383`, not "KV error threshold
+exceeded" — flap is identical either way.)
+
+**Fix options:**
+
+| Opt | Mechanism | Verdict |
+|---|---|---|
+| **D — heartbeat bucket → FileStorage** (`manager_setup.go:156`) | Stream survives restart: no flap, no epoch trip, no recreate race, **no Family A coupling**. One line. | **Decision-gated on IOPS.** If the IOPS measurement clears, **Opt D dominates** all other options. Do NOT transfer M1.9's "IOPS-free" finding — that is the **election** bucket; heartbeat is the highest-frequency KV op (M2.A flags per-op state file as dominant cost). **Run the IOPS measurement FIRST.** |
+| **C — gate the recovery exit on heartbeat-op health** | Shared with the Families A/B exit-gate fix. | Minimal *correctness* fix, but **alone leaves the fleet stuck-Degraded** (MemoryStorage never returns on its own) → **fails the proof's reach-all-Stable assertion** (`np8_..._test.go:325`). Requires a product/test-contract decision (auto-heal vs fail-safe-hold), not a mechanical ungate. |
+| **A/B′ — recreate the bucket on reconnect** | Restores auto-heal so Opt C passes the existing proof. | **Trips Family A's currently-dormant heartbeat epoch fence** (`checkBucketEpochs:679-682` `continue` on probe error today; a recreate gives a new `Created` → `enterDegraded("bucket-recreated:heartbeat")` fleet-wide). **Cannot land independently of Family A's fix** — must re-capture/re-probe the heartbeat epoch atomically. |
+| **B (report's alt) — calculator tolerates empty heartbeat list** | — | **REJECT.** Fixes a non-driver; flap persists. Also empty≠missing (empty already tolerated `worker_monitor.go:170-173`; the failure is a *missing stream* `:175 → calculator.go:1213`). |
+
+**Recommended fix:** **Run the IOPS measurement first** (the real decision gate). **If it clears,
+Opt D** (one line, decoupled from Family A). **If not, Opt C** (gate the exit) + **Opt A/B′**
+(recreate the bucket), co-designed with Family A's epoch-fence fix, OR Opt C alone with docs
+("MemoryStorage heartbeat loss requires re-provision/rotation").
+
+**Residual risk:** Driver attribution is code-only, not test-captured (NopLogger
+`testutil/nats.go:306`; empty hooks `np8_..._test.go:293`) — add a reason-capturing OnDegraded
+hook to make it test-backed. **RF3 topology remains the single biggest open uncertainty:** a real
+RF3 rolling restart that keeps replicated MemoryStorage alive may not hit mech-2 (severity drops
+to Low) — unmeasured (see §6).
+
+---
+
+## 2. The exit-gate unification question (adversarial verdict)
+
+**Task instruction honored: do not default to the tidy "one fix".**
+
+**Verdict: the report's §1 claim splits in two —**
+- **S1 (shared SYMPTOM): CONFIRMED.** Both A and B exit through the trigger-blind
+  `attemptRecoveryFromDegraded` on a healthy assignment read while a different trigger persists.
+  Verified: the function reads neither `m.bucketEpochs` (A's state) nor any per-source KV-op
+  health (B's state); `currentAssignmentApplied` is a commitment gate, reason-agnostic by design
+  (`manager_degraded.go:405-406`).
+- **S2 (shared FIX — "a single fix to the exit gate closes both"): REFUTED.** The families need
+  **separate, independent** predicates (at most coordinated-but-separate).
+
+**The decisive refutation — the timeout-interpretation conflict (framing-proof, not predicate-
+phrasing).** A's epoch detector treats an op timeout as **non-actionable**: `checkBucketEpochs`
+logs "probe failed; relying on next tick" and `continue`s WITHOUT degrading (`manager_setup.go:679-682`,
+read directly); only a successful read with a *different* Created is actionable. B's KV-op
+detector treats the **same timeout as THE fault**: `markKVUnavailable` wraps
+`context.DeadlineExceeded`/`nats.ErrNoResponders` into `ErrKVUnavailable`
+(`manager_degraded.go:67-69`) which `recordKVError` accumulates. A single unified "re-validate
+every bucket before exit" routine must either block-on-timeout (B-correct, but wedges A on a
+transient probe error — the exact false-positive `:679-682` avoids) or ignore-on-timeout
+(A-correct, but B's fault becomes invisible and NP-3b still false-exits). **No single
+timeout-interpretation is correct for both** ⇒ two mechanisms with opposite error-handling.
+
+Three reinforcing reasons:
+1. **Structurally disjoint triggers.** A enters via `enterDegraded("bucket-recreated:<b>")` fired
+   directly from `checkBucketEpochs` (`manager_setup.go:689`), never touching `kvErrorWindow`
+   (NP-2 hard-codes this isolation: `KVErrorThreshold` default, `otherDegrades==0`
+   `np2_..._test.go:81-83,190-192`). B enters entirely via `recordKVError`/`kvErrorWindow`.
+2. **A KV-op-recovered gate is structurally BLIND to A** — a bucket recreate is never a KV-op
+   error, so there is no "failing op" to verify recovered.
+3. **Opposite desired outcomes.** B must AUTO-HEAL once the op clears (NP-3a PASSES). A must
+   NEVER auto-heal — terminal Degraded for pod rotation (NP-2 asserts `finalState==StateDegraded`).
+
+**Conclusion:** A+B is **one function edited, TWO independent predicates** (A: epoch-mismatch
+outstanding; B: failing-op-recovered), **ADDITIVE to the existing `currentAssignmentApplied`
+guard — never a replacement** (survey-contracts §4; the commitment guard is pinned by
+`TestAttemptRecovery_LatchedVersionAdvance_RearmsAtNewVersion` and removing it reopens the
+latched-version false-Stable bug). A shared PR for review economy is fine; the conjuncts are
+independently testable and independently necessary. **Do NOT read "one fix closes both" as "one
+predicate closes both."**
+
+---
+
+## 3. Cross-family interactions
+
+| Interaction | Severity | Detail |
+|---|---|---|
+| **C-mech2-recreate × Family A epoch fence** | **HIGH (the headline)** | `captureBucketEpoch` runs for EVERY bucket incl. heartbeat (`manager_setup.go:265,156`). The fence is **dormant on heartbeat today** (probe errors → Debug+`continue`, `:679-682`). Any in-process recreate of the heartbeat bucket gives a new `Created`, **activating the dormant fence fleet-wide** (`enterDegraded("bucket-recreated:heartbeat")` `:684-690`) — trading the heartbeat flap for an epoch-fence flap. **A C-mech2 recreate fix CANNOT land before Family A's epoch fix** (or must re-capture/re-probe the heartbeat epoch atomically). **Opt D (FileStorage) avoids this entirely** — no new stream Created. |
+| A & B share `attemptRecoveryFromDegraded` exit block | medium | Both fixes edit `manager_degraded.go:408-415`; independent ANDed conjuncts, no shared state/ordering. |
+| C1 (whole-bucket loss) vs A/B exit guards | medium | Strongest regression-test surface. C1's recover-able path FAILS the assignment Get in `refreshAssignmentFromNATS` and bails at `:383-387` **before** either guard — verified by tracing `TestManager_LiveNATSBucketLoss` (wipes assignment bucket, asserts entry only, no exit assertion). Re-run C1 `-race` to confirm the guards are not reached on the recoverable path. |
+| C1(mech1) safe-reclaim × C2 self-stop | **HIGH (if pursued)** | A re-claim-on-reconnect fix must fire ONLY when the claim aged out with no peer holding it; indistinguishable at the `ErrClaimLost` surface from a peer takeover unless it re-reads the current holder. Getting it wrong reopens split-brain. (Doc-only avoids this.) |
+| Broad re-provision × C2 (X2) | medium | A broad reconnect re-provision of the **stableID** bucket could reclassify a legitimate peer takeover's `ErrClaimLost` as degrading-JetStream → degraded-and-ride instead of self-stop. Scope any C-mech2 fix to the heartbeat bucket only. |
+| f-d1 `recordKVHealthyOp` (421f13c) | none | Entry/clear side, no-op while degraded (`manager_degraded.go:267`); exit uses `recordKVSuccess` (`:393`) — different function. Exit-gate fixes cannot touch the f-d1 reset (only B-candidate-3 would). |
+
+---
+
+## 4. Contract & test-impact matrix (from survey-contracts)
+
+Contracts pinned by (corrected): **C1** `TestManager_LiveNATSBucketLoss` /
+`TestManager_PartialBucketLoss_HeartbeatHealthy`; **C2** `TestManager_StopsItselfWhenClaimLost`
+/ `TestOnClaimerError_ClaimLostStopsWorker` (NOT `TestStableID_StaleKeyTakeover_Reclaim`, which is
+claimer-level reclaim only); **C3** `TestManager_F1_BucketRecreate_TripsDegraded` (the strongest
+once-per-entry pin — single-tick `require.Len(reasons, 1)`,
+`manager_epoch_fence_test.go:125-135`) / `TestManager_LiveNATSBucketLoss_OnDegradedHook` (collects
+`clusterSize` reasons but does not itself assert no-duplicates after collection); **C4**
+`manager_startup_async*_test.go`.
+
+Note (corrected by cross-model review): the test NAME `TestManager_BucketRecreated_EntersDegraded`
+(brief / `01-fault-matrix.md:12`) **does not exist** — the real epoch-entry tests are
+`TestManager_F1_BucketRecreate_TripsDegraded` / `TestManager_F1_HappyPath_NoDegraded` in
+`manager_epoch_fence_test.go`. The earlier claim that the FILE
+`test/integration/manager/manager_bucket_recreate_test.go` does not exist was **WRONG**: that file
+**does** exist but contains `TestManager_Restart_AfterNATSBucketLoss` (`:44`) — a restart-recovery
+test, not an epoch-entry test.
+
+T=touches, R=risk-regress, X=cross-family collision; blank=no interaction.
+
+| Fix | C1 | C2 | C3 | C4 | Recovery `AttemptRecovery_*` suite | Epoch entry (F1) | f-d1 reset | Cross-family |
+|---|---|---|---|---|---|---|---|---|
+| A: re-probe / refuse-exit-on-mismatch | R (C1 wants terminal; guard not reached on recover-able path — verified) | | T (exit/re-entry timing; terminal ⇒ 1 entry) | | T/R (shared exit block) | T (needs "mismatch outstanding") | | shares exit block with B |
+| A: re-capture `ep.created` | | | R (one entry per recreate; F1 ticks once) | | | T/R (edits `checkBucketEpochs`; F1 HappyPath must stay green) | | removes the X that recreate-on-reconnect creates |
+| B: reason-scoped heartbeat-success gate | R med (must not regress C1 entry; reason-scoped so it does not apply to "KV error threshold exceeded") | R low | R (fewer fires, once-per-entry) | | T/R high (changes exit predicate; reason plumbed) | | | X with A (same block, ADDITIVE) |
+| B: per-source counters | R med (PartialBucketLoss sums multi-bucket entries) | R low | | T low | T high (rewrites `kvErrorWindow`) | | T/R high (the f-d1 surface) | independent of A |
+| C1(mech1): safe-reclaim | R low | **R HIGH** (split-brain) | | | | | | X with reconnect claim path |
+| C1(mech1): doc-only | | | | | | | | none |
+| C2(mech2): recreate-on-reconnect | R med (`LiveNATSBucketLoss` forbids in-process recreate) | | R med (new Created) | | | **X HIGH** (re-arms epoch fence) | | **X HIGH** with Family A — land AFTER A's fix |
+| C2(mech2): heartbeat→FileStorage (Opt D) | R (changes PartialBucketLoss semantics) | | | | | | | independent of A; IOPS gate |
+
+**Single highest-leverage, lowest-risk lever:** the reason/epoch-aware exit gate in
+`attemptRecoveryFromDegraded` (two ADDITIVE conjuncts) — it closes the exit half of A and all of
+B and cannot regress C1 (which asserts entry, not exit) or the f-d1 reset (different function),
+provided it keys on the still-failing op/epoch rather than "any non-empty error window".
+
+---
+
+## 5. Completeness — the attempt to break §4 "no additional gap"
+
+**§4's claim is breakable.** New gap **NP-10 — leader-side silent worker-enumeration stall**
+(severity High, **confidence Medium** — code-derived, NOT harness-proven):
+
+If the heartbeat-bucket **`Keys` scan times out** (`DeadlineExceeded`) while the worker's own
+single-key heartbeat **`Put` keeps succeeding** (a realizable asymmetry: stream-wide scan vs
+single-subject append under partial quorum/load), then `WorkerMonitor.GetActiveWorkers` wraps it
+as "failed to list heartbeat keys" (`worker_monitor.go:175`); `Calculator.getActiveWorkers` only
+caches/degrades for `IsConnectivityError` (`calculator.go:1197-1213`) and returns a bare error
+otherwise (`:1213`); the poll loop logs and continues (`worker_monitor.go:282-284`). The
+calculator has **no wiring into the degraded circuit**. Empirically (scratch test, removed):
+`IsConnectivityError(context.DeadlineExceeded)` is **false** (bare and wrapped),
+`IsDegradingJetStreamError` is **false** — so the scan deadline is classified by neither and is
+logged-only. Result: a leader holds `StateStable` (own Put/assignment-read/election-renew all
+succeed) while **blind to worker topology**, serving assignments from stale/empty membership — a
+**false-healthy leader**. This is the leader-side analog of NP-3b but with NO circuit, so it is
+**silent (does not even flap)**. Distinct from C-mech2 (a *missing* stream `ErrStreamNotFound`,
+which DOES degrade via the Put) and from "leader-only NATS partition" (which drops the connection;
+this is connection-UP with a per-op deadline). Not covered by §4's dismissals.
+
+**Minimal fix direction:** route sustained enumeration failure into the manager's degraded circuit
+with the same `markKVUnavailable` / `recordKVOpError` semantics the manager's own KV-op sites use.
+NOTE (cross-model review — wiring caveat): `markKVUnavailable`/`recordKVOpError` live on the
+**manager** side, and `assignment.Config` has **no error-callback seam** today
+(`internal/assignment/config.go:35-150`; `manager_assignment.go:132-151`). So the fix is NOT a call
+from inside `internal/assignment`; it must add an explicit manager→calculator error hook (or
+equivalent wiring) to surface sustained enumeration failure to the manager circuit without creating
+an import cycle. Add a focused gated proof (Keys-only deadline on the heartbeat bucket on the
+leader; assert the leader neither degrades nor serves a correct assignment).
+
+**Cleared (not gaps):** `monitorCommitChanges` feeds `recordKVOpError` on watch-restart failure
+(`manager_assignment.go:636`); `monitorCalculatorState` is a pure local state mirror with no
+independent KV dependency.
+
+---
+
+## 6. Open uncertainties + how to settle (priority-ordered)
+
+| # | Uncertainty | How to settle | Priority |
+|---|---|---|---|
+| 1 | **C-mech2 IOPS cost of heartbeat→FileStorage (Opt D)** | Measure heartbeat-bucket FileStorage IOPS at production cadence (highest-freq KV op). This is the **C-mech2 fix decision gate** — do NOT transfer M1.9 (election bucket). | **HIGH — run first** |
+| 2 | **RF3 rolling-restart preserves replicated MemoryStorage?** | NEW gated test on `partitest.StartEmbeddedNATSClusterN(t,5)`: MemoryStorage Replicas:3 heartbeat bucket + real 3-mgr fleet + one-node-at-a-time rolling restart; assert holds-Stable AND heartbeat stream `Created` unchanged. The existing `quorum_loss_tier2_test.go` is a data-plane KV probe (no fleet, no MemoryStorage bucket, no rolling restart) and **cannot** be reused as-is — only the cluster helper is. Discriminates C-mech2 severity (Low if survives, fleet-gap if not). | **HIGH** |
+| 3 | **`-race -count=5` over the 5 gated flap proofs** | Run NP-1/2/3b/8mech1/8mech2 under `-race -count=5` to establish a clean concurrency baseline (the exit-gate fixes land on the hot `kvErrorWindow`/`degradedSince` paths + hook goroutines). Cheap; do before AND after any fix. | **MEDIUM (cheap)** |
+| 4 | **C-mech1 attribution + wire surface** | Add StateShutdown/OnError instrumentation to the NP-8 mech-1 proof (stop the attribution being an inference); add a wire test for the *purged-key* "wrong last sequence: 0" → ErrKeyExists case. | MEDIUM |
+| 5 | **C-mech2 re-degrade reason string** | Add a reason-capturing OnDegraded hook to the mech-2 proof (kv-unavailable vs "KV error threshold exceeded"). Flap identical either way; doc accuracy only. | LOW |
+| 6 | **NP-9 arbitration race (which reason wins)** | Parameterize the NP-9 test sweeping `KVErrorThreshold` vs `watcherMaxAttempts`. Both outcomes are valid Degraded entries — doc accuracy, not correctness. | LOW |
+
+---
+
+## 7. Recommended fix sequencing for the follow-up FIX session
+
+Dependency-ordered. **Bold edges are hard blockers.**
+
+**Phase 0 — measure/baseline (run before committing to any fix):**
+1. **IOPS measurement** for heartbeat→FileStorage (gates the C-mech2 path choice).
+2. **RF3 tier2 rolling-restart proof** (gates C-mech2 severity).
+3. **`-race -count=5` baseline** over the 5 gated proofs.
+
+**Phase 1 — independent, low-coupling fixes (parallelizable):**
+- **Family B:** reason-scoped heartbeat-success exit gate (Candidate 2) in
+  `attemptRecoveryFromDegraded`, ADDITIVE to `currentAssignmentApplied`. Validate: ungate NP-3b;
+  re-run **ungated NP-5**, NP-9, NP-3a, C1 (`-race`).
+- **Family A:** epoch-aware exit gate via **live `epochMismatchOutstanding()` re-probe** (NOT the
+  latch — verification: the latch has a ~10s NP-1 pre-arm race) in the same exit block. Test must
+  assert NP-1's **first** exit is blocked. Validate: NP-2, NP-1, C1, F1 entry tests (`-race`).
+  > A and B co-edit `manager_degraded.go:408-415` as two independent ANDed conjuncts — one PR for
+  > review economy is fine; they share no state.
+- **Family C mech 1:** **doc-only** + re-purpose the proof to assert `StateShutdown` + add
+  Shutdown/OnError instrumentation. No code-path change. Re-ground the rationale on orchestrator
+  rotation, not full-fleet split-brain.
+
+**Phase 2 — C-mech2 (depends on Phase 0 results):**
+- **If IOPS clears → Opt D** (heartbeat→FileStorage). One line; **decoupled from Family A**; no
+  recreate race. Update `PartialBucketLoss` semantics + the `manager_setup.go:116-117` doc comment.
+- **Else → Opt C (exit gate) + Opt A/B′ (recreate).** **Opt A/B′ recreate MUST land AFTER Family A's
+  epoch fix** (re-capture/re-probe the heartbeat epoch atomically, or it re-arms the fence
+  fleet-wide). Or Opt C alone + docs (terminal Degraded ⇒ re-provision; this requires rewriting
+  the NP-8 mech-2 proof expectation from reach-Stable to hold-Degraded — a product decision).
+
+**Phase 3 — completeness:**
+- **NP-10:** add a gated proof + wiring that surfaces sustained heartbeat-enumeration failure into
+  the degraded circuit via a new manager→calculator error-hook seam (NOT a call from inside
+  `internal/assignment` — see §5). Independent of Phases 1–2.
+
+**What blocks what (DAG):**
+- Phase 0 #1/#2 **block** the C-mech2 path choice.
+- Family A's epoch fix **blocks** C-mech2-via-recreate (NOT C-mech2-via-Opt-D).
+- Family A and Family B are mutually independent (coordinated-but-separate; same function).
+- C-mech1 (doc), NP-10, and Family A/B are otherwise independent.
+
+---
+
+## 8. Confidence + what bounds it
+
+**Overall: High on the code-derived mechanisms and reproduction; Medium on two extrapolations.**
+
+| Finding | Confidence | What bounds it |
+|---|---|---|
+| All four gaps reproduce on HEAD 2453306 | **Very high** | Real `.out` files; CAS argument makes N-entry oscillation irrefutable. |
+| Family A root cause (both halves + version-monotonicity) | **High (verified code)** | Anchors read directly (`manager_degraded.go:376-416`, `manager_setup.go:669-693`). |
+| Family A: **latched** Opt-2 sufficiency for NP-1 | **Low (INFERENCE, contested)** | The ~10s pre-arm race was NOT settled empirically (read-only; no patched-build run). The **re-probe** variant is recommended precisely because it has no pre-arm window. |
+| Family B root cause + NP-5 regression of an unconditional gate | **High** | NP-5 regression is VERIFIED by code reading (`newTestManager` never starts heartbeat), not a patched run. |
+| Family B: candidate 2 not prototyped | **Medium (until run)** | Verification trace is code+proofs, not a patched binary. Mandatory: ungate NP-3b + re-run NP-5/NP-9/C1. |
+| C-mech1 mechanism | **High** | Wire surface, routing, boundary math all verified. |
+| C-mech1: **attribution within the proof** | **Medium (INFERENCE)** | Proof runs both mechanisms, no Shutdown/OnError hook; "bare ErrClaimLost fired" rests on one un-captured diagnostic (`04-proof-findings.md:135`); wire test covers the adjacent present-key case. |
+| C-mech1: doc-only justification | conclusion High, **reasoning corrected** | Full-fleet split-brain steelman is FALSE (no leader rebalances); conclusion survives on orchestrator-rotation grounds. |
+| C-mech2 driver = publisher Put | **High (code by elimination)** | Attribution is code-only, not test-captured (NopLogger + empty hooks) — add a reason-capturing hook to make it test-backed. |
+| C-mech2 production severity | **Medium** | RF3 topology unmeasured — the single biggest open uncertainty. |
+| Exit-gate unification = independent | **High** | Timeout-interpretation conflict + structurally disjoint triggers + opposite outcomes, all verified. |
+| NP-10 (new gap) | **Medium** | Code-derived + empirical classification check; NOT harness-proven. |
+
+**Every place a recommendation rests on inference rather than verified code** is flagged inline
+above (Family-A latched sufficiency, Family-B candidate-2 not-run, C-mech1 attribution + Layer-2
+double-processing, C-mech2 RF3 topology + reason string, NP-10 not-harness-proven). All four gaps
+themselves and all four root-cause mechanisms are verified code, not inference.

--- a/docs/plans/auto-healing-gap-closure/06-deep-gap-fix-plan.md
+++ b/docs/plans/auto-healing-gap-closure/06-deep-gap-fix-plan.md
@@ -1,0 +1,886 @@
+# Auto-Healing Deep-Gap Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three well-verified auto-healing gap families from `05-deep-investigation.md` — Family A (epoch-fence recreate flap), Family B (connected-but-KV-unavailable flap), and Family C (NATS-restart non-heal) — by adding two additive, reason/epoch-aware predicates to the single recovery-exit gate, documenting the claim-loss self-stop boundary, and removing the heartbeat-bucket-loss flap.
+
+**Architecture:** The recovery exit `attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`) is trigger-blind: it exits Degraded on a healthy *assignment* read while a *different* fault (a bucket recreate, or a heartbeat/election/stableid op stall) still persists. The fix keeps the existing `currentAssignmentApplied` commitment guard and adds two **independent ANDed conjuncts** in the same function — a cheap reason-scoped heartbeat-recovery check (Family B) evaluated first, then a live epoch re-probe (Family A). Family C mechanism 1 (claim-loss self-stop past `WorkerIDTTL`) is documented as intended (orchestrator rotation), and mechanism 2 (MemoryStorage heartbeat-bucket loss) is removed by a storage-class change that is decision-gated on a Phase-0 IOPS measurement, with a fully-specified fallback.
+
+**Tech Stack:** Go (go1.26), NATS JetStream KV, the existing `partitest`/`internal/testutil` embedded-NATS helpers, `test/integration/manager`, `test/integration/failure`, the env-gated proof suite (`PARTI_RUN_NP*`), and `docs/OPERATIONS.md`.
+
+---
+
+## Source of truth & scope
+
+- **Spec:** `docs/plans/auto-healing-gap-closure/05-deep-investigation.md` (this plan implements its §7 sequencing). Read §1 (per-family findings), §2 (exit-gate refutation), §3 (cross-family interactions), §4 (contract/test matrix) before editing.
+- **In scope:** Phase 0 (measurement/baseline), Phase 1 (Families A + B + C-mech1), Phase 2 (Family C-mech2).
+- **Out of scope — carved out to `07-np10-enumeration-stall-plan.md`:** the new gap **NP-10** (silent leader-side heartbeat-enumeration stall). Rationale below in [NP-10 deferral](#np-10-deferred-to-07--why). The investigation report's §7 marks NP-10 "independent of Phases 1–2"; it is also materially more entangled than §5 implied (see deferral note) and must not hold up the well-verified A/B/C fixes.
+- **All four gaps reproduce on HEAD `2453306`** (evidence: `tmp/repro-current-head/SUMMARY.txt`; report §0). The failing proofs already exist and are env-gated; this plan ungates each one as its matching fix lands.
+
+## Invariant
+
+The recovery exit must remain **additive**: every conjunct it gains is ANDed onto the existing `currentAssignmentApplied` commitment guard, never replaces it. A worker exits Degraded→Stable only when *all* of: (a) the current assignment is applied+acked, (b) no kv-unavailable degrade has an un-recovered failing op, and (c) no Parti-owned bucket wipe-and-recreate is outstanding. Removing any one conjunct must reopen exactly one proof (the `AttemptRecovery_*` suite pins (a); NP-3b pins (b); NP-1/NP-2 pin (c)).
+
+## File Map
+
+- Modify: `manager.go:192-206` — add two degraded-tracking fields (`lastDegradedReason`, `lastHeartbeatSuccessAt`).
+- Modify: `manager_degraded.go:266-288` — stamp `lastHeartbeatSuccessAt` in `recordKVHealthyOp`.
+- Modify: `manager_degraded.go:300-337` — set `lastDegradedReason` in `enterDegraded` AFTER the successful `degradedSince` CAS (winner-only); clear it in the rollback branch.
+- Modify: `manager_degraded.go:340-373` — clear `lastDegradedReason` in `exitDegraded` before clearing `degradedSince`.
+- Modify: `manager_degraded.go:408-416` — add the Family B then Family A conjuncts to the exit gate; add the new `epochMismatchOutstanding` helper.
+- Modify: `manager_setup.go:104-119,156` — (Phase 2, Branch D only) heartbeat bucket `MemoryStorage`→`FileStorage` + the storage-choice doc comment.
+- Modify: `docs/OPERATIONS.md` — (Phase 1) M5/claim-loss boundary doc; (Phase 2) heartbeat storage migration runbook.
+- Modify: `test/integration/manager/np3_kv_unavailable_recovery_test.go` — ungate NP-3b.
+- Modify: `test/integration/manager/np1_live_recreate_returns_stable_test.go` — ungate NP-1.
+- Modify: `test/integration/failure/np2_epoch_fence_return_to_stable_test.go` — ungate NP-2.
+- Modify: `test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go` — re-purpose NP-8 mech-1 to assert `StateShutdown` + add Shutdown/OnError instrumentation.
+- Create: `test/integration/failure/rf3_heartbeat_rolling_restart_test.go` — (Phase 0) the RF3 replicated-MemoryStorage rolling-restart discriminator.
+- Modify (Branch D): `test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go` — ungate NP-8 mech-2.
+
+---
+
+## Phase 0 — Measurement & baseline (gates Phase 2; NOT TDD-shaped)
+
+These tasks produce decisions/baselines, not code under test. Structure is: run the measurement → record the result in this doc → apply the decision rule. They MUST complete before Phase 2 is started; they are independent of Phase 1.
+
+### Task 0.1: Measure heartbeat-bucket FileStorage IOPS (the C-mech2 decision gate)
+
+**Files:** none (measurement + record the result + decision in this section).
+
+- [ ] **Step 1: Measure**
+
+Using the methodology in `docs/plans/iops-investigation/` (the same harness that produced the M1.x/M2.x cells), measure the steady-state **write IOPS added by the heartbeat bucket when it is `FileStorage`** at the production `HeartbeatInterval` and target fleet size. The heartbeat publisher is the highest-frequency periodic KV op (one `Put` per worker per `HeartbeatInterval`), so this is NOT the election-bucket number — do NOT transfer M1.9 (election bucket, ~2% noise). Report §6 #1; reference cell `M2.A` (per-op consumer state file is the dominant cost) for the cost model.
+
+- [ ] **Step 2: Record + apply Decision Rule DR-1**
+
+Record in this doc (replace the bracketed values):
+
+```
+hb_fs_iops      = ESTIMATE: ~2-4 IOPS cluster-summed at W=5, R=3 (production HeartbeatInterval=5s);
+                  flat in partition count N. Bounded above by ~4-5 IOPS (the measured
+                  M1.2-minus-M1.9 all-four-KV-buckets FileStorage delta). Linear in fleet
+                  size W: ~4-8 at W=10, ~20-40 at W=50 (R=3). At production server-default
+                  R=1 the per-pod figure is roughly 1/3 of the R=3 cluster sum and stays
+                  low-single-digit for W up to 50. NOT a measured-this-session block-IOPS
+                  number — see methodology note below.
+pvc_headroom    = [operator-supplied — not obtainable in this session]
+DR-1 decision   = Branch D (operator-selected). hb_fs_iops is a negligible flat,
+                  partition-count-independent term well within any cloud-SSD floor;
+                  the FileStorage switch sits inside the same envelope already accepted
+                  for the v2.5.0 election-bucket switch. Paired with the Branch-C
+                  reachability conjunct (see Phase 2 SELECTED note) to cover the
+                  manual-migration interim for existing MemoryStorage clusters.
+```
+
+**Methodology note (measured vs estimated; W-dependence; partition-independence).**
+
+*What is measured (source: `docs/plans/iops-investigation/findings.md`, focused runs `m19-*` and `m2-*`, R=3, `nats:2.12.6`, ext4, capture-window means, CV < 5%).* The IOPS-investigation harness over-rides **every** Parti KV bucket — including heartbeat — with its single `--kv-storage` knob (`test/iops-investigation/cmd/harness/harness.go:179-185`, line 183; pre-create → `storageverify.Verify` → spawn-workers path in `cmd/harness/main.go:183-222`). The harness runs `--workers 5` by default (`cmd/harness/main.go:59`), matching the operator's reported 5-worker cluster. Therefore cell **M1.9** ("all parti KV buckets `Storage = memory`", −2%/−1% vs the M1.2 file-backed baseline → a flat **~4-5 IOPS** cluster-summed delta) *does* exercise the heartbeat bucket file↔memory: heartbeat was on **FileStorage** in the M1.2 baseline arm and **MemoryStorage** in the M1.9 arm. M1.9 is thus a direct empirical **upper bound** on `hb_fs_iops` — it is the combined FileStorage cost of heartbeat + election + stableID + assignment, of which heartbeat is the highest-frequency (and so dominant) sub-component. (Note: the report §5 "CRITICAL nuance" that heartbeat was MemoryStorage in both M1.9 arms is correct about *production* — `manager_setup.go:156` hardcodes MemoryStorage — but is **wrong about the rig**, which over-rides it; the nuance reasoned from the production hardcode and assumed it carried into the harness. It did not. The valid half of the caution still holds: `hb_fs_iops` is unrelated to the dominant per-partition consumer-state-file cost of M2.A.) Cell **M2.B** independently corroborates: its 2.3-IOPS residual is explicitly "parti's constant coordination floor (heartbeat / stable-ID / election KV puts on R=3)" and is **flat in N** — that flat-in-N result is the *evidence* (not just an assertion) that `hb_fs_iops` is partition-count-independent.
+
+*What is estimated (analytical, this session — not measured here).* (1) Apportioning the ~4-5 IOPS M1.9 bundle down to heartbeat-alone (~2-4 IOPS): heartbeat is W=5 Puts every 5s = 1 Put/s fleet-wide, vs election ~1 Put/3.3s (one leader renewing at `ElectionTimeout/3`, `manager_election.go:221`) and the slower stableID renewal, so heartbeat carries the largest share of the bundle. (2) The W-scaling: heartbeat Put rate = W / HeartbeatInterval Puts/s into a single shared FileStorage stream (one per-worker key, History=1, MaxAge=HeartbeatTTL=15s; each Put is a stream append + index/meta update + the MaxAge expiry of the prior revision — `internal/heartbeat/publisher.go:405-419`, `internal/kvbuckets/builder.go`), so block-write IOPS is linear in W: ~4-8 at W=10, ~20-40 at W=50 (R=3). (3) The R=3→R=1 adjustment: the rig is R=3 throughout; production heartbeat stays server-default R=1 (`manager_setup.go:148`), so the per-pod write IOPS that PVC headroom actually sees is ~1/3 of the R=3 cluster sum.
+
+**Partition-independence — the key framing for DR-1.** `hb_fs_iops` is a **flat additive cost**, independent of partition count N (it is fleet-size-bound: one Put per worker per HeartbeatInterval into one shared stream). This is in deliberate contrast to the dominant per-partition consumer-state-file cost (cell M2.A, the ~80% IOPS driver, which scales 0.117 IOPS/partition). Switching heartbeat to FileStorage adds a flat low-single-digit-to-tens-of-IOPS term that does not grow with N, and at production R=1 sits far under any cloud-SSD sustained-IOPS floor (e.g. GCP pd-balanced 100GB ≈ 600 IOPS) for fleets up to W=50. The operator supplies `pvc_headroom` and applies DR-1 below; the value above does not pre-empt that decision.
+
+**Decision Rule DR-1:** if `hb_fs_iops` fits within `pvc_headroom` — i.e. the heartbeat→FileStorage switch stays inside the same provisioned-IOPS envelope already accepted for the election-bucket `MemoryStorage`→`FileStorage` switch (`manager_setup.go:108-113`), scaled for heartbeat frequency — choose **Branch D** (Task 2.1). Otherwise choose **Branch C** (Task 2.2). If `pvc_headroom` cannot be obtained, default to **Branch C** (the conservative branch that does not add durable IOPS) and note the assumption.
+
+> This rule is the complete answer to "this can't be verified statically": the plan does not need the number to be implementation-ready — Phase 2 specifies BOTH branches and DR-1 selects between them.
+
+### Task 0.2: RF3 replicated-MemoryStorage rolling-restart discriminator
+
+**Files:**
+- Create: `test/integration/failure/rf3_heartbeat_rolling_restart_test.go`
+
+This settles report §6 #2: does a real RF3 cluster whose replicated `MemoryStorage` heartbeat bucket survives a one-node-at-a-time rolling restart avoid mechanism 2 entirely (severity drops to Low), or does the fleet still flap? It REUSES only the `partitest.StartEmbeddedNATSClusterN(t,5)` cluster helper (added in `00-fix-plan.md` Task 5); it is NOT a reuse of `quorum_loss_tier2_test.go` (that is a data-plane KV probe with no fleet, no MemoryStorage bucket, no rolling restart).
+
+- [ ] **Step 1: Write the gated discriminator test**
+
+```go
+package failure_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRF3HeartbeatRollingRestart_HoldsStable discriminates C-mech2 severity.
+// A 5-node cluster hosts an RF3 (Replicas:3) MemoryStorage heartbeat bucket and
+// a real 3-manager fleet. We restart nodes ONE AT A TIME (rolling), keeping
+// JetStream + the replicated bucket quorum alive. If replicated MemoryStorage
+// survives the rolling restart, the fleet must HOLD all-Stable AND the heartbeat
+// stream Created must not change (no recreate). If it flaps, C-mech2 is a real
+// fleet gap at RF3 too and Branch C/D must land.
+func TestRF3HeartbeatRollingRestart_HoldsStable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+	if os.Getenv("PARTI_RUN_RF3_HB_ROLLING_RESTART") == "" {
+		t.Skip("opt-in RF3 discriminator (C-mech2 severity); set PARTI_RUN_RF3_HB_ROLLING_RESTART=1 to run")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 180*time.Second)
+	defer cancel()
+
+	servers, nc := partitest.StartEmbeddedNATSClusterN(t, 5)
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.DegradedBehavior.EnterThreshold = 500 * time.Millisecond
+	cfg.DegradedBehavior.ExitThreshold = 500 * time.Millisecond
+	// Replicate the Parti control-plane buckets so a single-node restart keeps quorum.
+	cfg.KVBuckets.Replicas = 3
+
+	src := source.NewStatic(testutil.CreateTestPartitions(6))
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	for range 3 {
+		cluster.AddWorkerWithOptions(ctx, parti.WithHooks(&parti.Hooks{}))
+	}
+	cluster.StartWorkers(ctx)
+	require.NotNil(t, cluster.WaitForLeader(15*time.Second))
+	cluster.WaitForPartitionCoverage(6, 15*time.Second)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	hbBefore := rf3HeartbeatCreated(t, ctx, js, cfg)
+
+	allStable := func() bool {
+		for _, m := range cluster.GetActiveWorkers() {
+			if m.State() != types.StateStable {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Rolling restart: stop+start each node in turn, waiting for cluster health
+	// between steps so quorum is never lost.
+	for i := range servers {
+		partitest.RestartClusterNode(t, servers, i)
+		require.Eventually(t, allStable, 30*time.Second, 200*time.Millisecond,
+			"fleet must stay Stable across rolling restart of node %d", i)
+	}
+
+	// HOLD: no flap after the rolling restart completes.
+	require.Never(t, func() bool { return !allStable() }, 8*time.Second, 200*time.Millisecond,
+		"fleet must HOLD all-Stable after the RF3 rolling restart")
+	// Discriminator: the replicated MemoryStorage heartbeat stream must not have
+	// been recreated (a changed Created => quorum was lost => C-mech2 still bites).
+	require.Equal(t, hbBefore, rf3HeartbeatCreated(t, ctx, js, cfg),
+		"replicated heartbeat stream Created must be unchanged (no recreate) across the rolling restart")
+}
+```
+
+- [ ] **Step 2: Add the helpers the test references**
+
+If `cfg.KVBuckets.Replicas`, `partitest.RestartClusterNode`, or an `rf3HeartbeatCreated` reader do not already exist, add them in this step (do not leave them as references). `rf3HeartbeatCreated` opens a JetStream KV handle for `cfg.KVBuckets.HeartbeatBucket` and returns `kvutil.BucketStreamCreated`. `RestartClusterNode` stops `servers[i]`, waits for it to drain, then starts a replacement on the same routes/port (mirror `startEmbeddedNATSOutage`'s restart half, per node). If the cluster helper genuinely cannot do an in-place single-node restart, downgrade this task to a documented manual runbook in this doc and `log`/note that the discriminator was not automated — do not silently skip it.
+
+- [ ] **Step 3: Run + record**
+
+```bash
+PARTI_RUN_RF3_HB_ROLLING_RESTART=1 go test ./test/integration/failure -run TestRF3HeartbeatRollingRestart_HoldsStable -count=1 -v
+```
+
+Record in this doc: `RF3 rolling-restart verdict = [HOLDS (C-mech2 severity Low) | FLAPS (C-mech2 real at RF3)]`. This does NOT change DR-1 (Branch D still dominates if IOPS clears); it sizes the residual severity if Branch C is chosen.
+
+> **RESOLUTION (not automated; moot for the chosen branch).** `partitest` has no
+> exported in-place single-node restart for a *clustered* node — `StartEmbeddedNATSClusterN`
+> (`partitest/nats.go:133`) allocates per-node ports + `t.TempDir()` StoreDir internally and
+> does not surface them, and `startClusterNode` (`:190`) is unexported and needs the
+> ports/routes it can't reach; there is no `RestartClusterNode`. Building the discriminator
+> would require extending `partitest` (expose per-node ports + a restart helper that re-creates
+> a node on the same port/routes). Per Task 0.2 Step 2, this task is therefore **downgraded to a
+> documented manual runbook** rather than silently skipped. **It is moot for the chosen branch:**
+> Branch D makes the heartbeat bucket `FileStorage`, which survives a single-node restart
+> *unconditionally* (independent of replication factor), so the "does replicated MemoryStorage
+> survive a rolling restart" question only sized the residual severity of **Branch C**, which was
+> not chosen. `RF3 rolling-restart verdict = NOT AUTOMATED (partitest lacks in-place node
+> restart); moot for the chosen Branch D`. Manual runbook: stand up a real 5-node NATS cluster
+> with an RF3 MemoryStorage heartbeat bucket + a 3-worker fleet, restart nodes one at a time
+> waiting for cluster health between steps, and observe whether the fleet holds all-Stable and
+> the heartbeat stream `Created` is unchanged.
+
+### Task 0.3: `-race` baseline over the five gated flap proofs
+
+**Files:** none (baseline record).
+
+- [ ] **Step 1: Establish the pre-fix concurrency baseline**
+
+The Phase-1 fixes land on the hot `kvErrorWindow`/`degradedSince` paths plus hook goroutines; capture a clean `-race` baseline first so a post-fix race is attributable.
+
+```bash
+PARTI_RUN_NP1_LIVE_RECREATE_PROOF=1 PARTI_RUN_NP2_EPOCH_FLAP_PROOF=1 \
+PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF=1 PARTI_RUN_NP8_FLEET_OUTAGE_PROOF=1 \
+PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF=1 \
+  go test -race ./test/integration/manager ./test/integration/failure \
+  -run 'TestNP1_LiveBucketRecreate|TestNP2|TestNP3_KVUnavailable|TestNP8FleetNATSOutage' -count=1
+```
+
+Expected: the five proofs FAIL their assertions (gaps), but with **NO `-race` data-race report**. Record any pre-existing race separately — it is not introduced by this plan. (Re-run the same command after Phase 1 and Phase 2; the only delta should be assertions flipping FAIL→PASS.)
+
+---
+
+## Phase 1 — Exit-gate fixes (Families A + B) and C-mech1 documentation
+
+Families A and B co-edit `attemptRecoveryFromDegraded`. They share NO state and are independently testable; one branch/PR for review economy is fine. Implement **B first** (Task 1.1) because its conjunct is a cheap atomic read that must be evaluated before A's network re-probe; Task 1.2 then shows the **full combined exit block**.
+
+### Task 1.1: Family B — reason-scoped recover-on-wrong-signal gate (NP-3b)
+
+**Files:**
+- Modify: `manager.go:192-206`
+- Modify: `manager_degraded.go:266-288` (`recordKVHealthyOp`)
+- Modify: `manager_degraded.go:300-337` (`enterDegraded` — store reason after CAS)
+- Modify: `manager_degraded.go:340-373` (`exitDegraded` — clear reason before `degradedSince`)
+- Modify: `manager_degraded.go:408-416` (`attemptRecoveryFromDegraded`)
+- Test: `test/integration/manager/np3_kv_unavailable_recovery_test.go`
+
+- [ ] **Step 1: Confirm the reproducer fails on the parent commit**
+
+NP-3b already exists and is env-gated. Confirm it FAILS unmodified (the gap) before changing any production code:
+
+```bash
+PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF=1 go test ./test/integration/manager \
+  -run 'TestNP3_KVUnavailable_(HeldArmed_DoesNotFalselyExitToStable|Disarm_ReturnsAndHoldsStable)' -count=1 -v
+```
+
+Expected: `HeldArmed` FAILS (`require.Zero(degradedExits())` is non-zero — the false-exit flap); `Disarm` PASSES (positive control). This is the proof the fix must flip.
+
+- [ ] **Step 2: Add the two degraded-tracking fields**
+
+In `manager.go`, in the "Degraded mode tracking" block (after `kvErrorWindow`, around `:204`):
+
+```go
+	// lastDegradedReason holds the reason string of the active degrade. Written by
+	// the WINNING enterDegraded immediately AFTER the degradedSince CAS (losers
+	// never write it, so there is no loser-clobber) and cleared to "" by
+	// exitDegraded BEFORE it clears degradedSince. The reason-scoped recovery gate
+	// treats an empty reason as "this entry's reason is not yet observable" and
+	// stays degraded that tick — closing the tiny post-CAS-pre-store window via the
+	// degradedSince happens-before, without converting degradedSince to a record.
+	// atomic.Value of string ("" when never degraded / between an exit and the next
+	// entry's store).
+	lastDegradedReason atomic.Value
+	// lastHeartbeatSuccessAt is the UnixNano of the most recent successful
+	// heartbeat Put (stamped unconditionally in recordKVHealthyOp, even while
+	// degraded). The reason-scoped gate uses it to confirm the failing
+	// connected-but-KV-unavailable op recovered AFTER we degraded. 0 = never.
+	lastHeartbeatSuccessAt atomic.Int64
+```
+
+- [ ] **Step 3: Stamp `lastHeartbeatSuccessAt` on heartbeat success**
+
+In `manager_degraded.go`, `recordKVHealthyOp` — stamp BEFORE the degraded early-return so it updates while degraded (that is the signal the heartbeat bucket recovered):
+
+```go
+func (m *Manager) recordKVHealthyOp() {
+	// Stamp the heartbeat-success time unconditionally: the reason-scoped
+	// recovery gate needs to observe a heartbeat Put succeeding AFTER a
+	// kv-unavailable degrade. This must run even while degraded (the
+	// window-clear below intentionally does not).
+	m.lastHeartbeatSuccessAt.Store(time.Now().UnixNano())
+
+	if m.degradedSince.Load() != 0 {
+		return
+	}
+	// ... existing transient-entry clear unchanged ...
+```
+
+- [ ] **Step 4: Own the degrade reason atomically with the winning entry (enterDegraded + exitDegraded)**
+
+The reason MUST be written only by the CAS winner and cleared on exit before `degradedSince`, so a losing concurrent `enterDegraded` can never clobber the active reason and a recovery tick never reads a stale reason from a previous entry. (There are many degrade reasons — `NATS connection down`, `startup-timeout`, `assignment-watcher-exhausted`, `stream-missing-recovery-exhausted`, `bucket-recreated:*`, `kv-unavailable` — so a pre-CAS write is NOT safe: a loser could overwrite a real `kv-unavailable` reason with another and skip the reason-scoped gate.)
+
+In `manager_degraded.go`, `enterDegraded` — store the reason AFTER the successful CAS (winner-only), and clear it on the rollback path:
+
+```go
+func (m *Manager) enterDegraded(reason string) {
+	// Reject degraded entry from terminal Shutdown state.
+	if m.State() == StateShutdown {
+		return
+	}
+
+	now := time.Now()
+
+	// Atomically claim the degraded-entry slot.
+	if !m.degradedSince.CompareAndSwap(0, now.UnixNano()) {
+		return
+	}
+
+	// Only the CAS winner reaches here, so this is the sole writer of the active
+	// reason — no loser-clobber. The recovery gate treats the brief
+	// CAS-won-but-reason-not-yet-stored window as "" and stays degraded that tick.
+	m.lastDegradedReason.Store(reason)
+
+	// Attempt validated state transition. Roll back BOTH reason and degradedSince
+	// on failure (clear reason BEFORE degradedSince so the happens-before holds).
+	if !m.transitionState(StateDegraded) {
+		m.lastDegradedReason.Store("")
+		m.degradedSince.Store(0)
+		return
+	}
+	// ... existing hook / metric / alert-monitor unchanged ...
+```
+
+In `manager_degraded.go`, `exitDegraded` — clear the reason BEFORE clearing `degradedSince` (`:356`):
+
+```go
+	// Clear the reason BEFORE clearing degradedSince: a subsequent enterDegraded
+	// can only win its CAS after degradedSince becomes 0, so this clear
+	// happens-before that winner's reason store — no clobber, and the gap between
+	// an exit and the next store reads as "" (gate stays that tick).
+	m.lastDegradedReason.Store("")
+	m.degradedSince.Store(0)
+```
+
+> Why this closes the window (verify the happens-before): `exitDegraded` does `reason.Store("")` then `degradedSince.Store(0)`; the next `enterDegraded` CAS reads that 0 (synchronizes-with), then stores its reason — so the new store strictly follows the clear, and any recovery tick that observes `degradedSince != 0` with an unstored reason reads `""` and stays. The first-ever degrade reads the zero `atomic.Value` (`Load()` is nil → `""`), same path.
+
+- [ ] **Step 5: Add the Family B conjunct to the exit gate**
+
+In `manager_degraded.go`, `attemptRecoveryFromDegraded`, between the `currentAssignmentApplied` block (`:408-412`) and `m.exitDegraded()` (`:415`):
+
+```go
+	cur := m.CurrentAssignment()
+	if !m.currentAssignmentApplied(cur) {
+		m.scheduleApplyRetry(cur)
+		return
+	}
+
+	// The degrade reason is written by the winning enterDegraded just after its
+	// CAS (Step 4). An empty read means this entry's reason is not yet observable
+	// (or we raced an exit) — stay degraded this tick rather than risk skipping a
+	// reason-scoped gate below. One-tick delay only.
+	reason, _ := m.lastDegradedReason.Load().(string)
+	if reason == "" {
+		return
+	}
+
+	// Family B — reason-scoped recover-on-wrong-signal gate. A kv-unavailable
+	// degrade is a connected-but-KV-unavailable op stall on the heartbeat /
+	// election / stableid buckets; the commitment guard above reads only the
+	// (unaffected) assignment bucket, so it cannot tell the failing op recovered.
+	// Require a heartbeat Put success stamped AFTER we degraded. Reason-scoped:
+	// a non-kv-unavailable degrade (e.g. "startup-timeout", NP-5) recovers via
+	// the commitment guard alone — an UNCONDITIONAL gate regresses NP-5, which
+	// has no heartbeat publisher so lastHeartbeatSuccessAt stays 0. Cheap atomic
+	// reads, evaluated before the Family A network re-probe added in Task 1.2.
+	if reason == degradedReasonKVUnavailable {
+		hbAt := m.lastHeartbeatSuccessAt.Load()
+		since := m.degradedSince.Load()
+		if hbAt == 0 || hbAt <= since {
+			m.logger.Debug("recovery: heartbeat KV not recovered since kv-unavailable degrade; staying Degraded",
+				"last_heartbeat_success_unixnano", hbAt, "degraded_since_unixnano", since)
+			return
+		}
+	}
+
+	// Success - exit degraded mode
+	m.exitDegraded()
+```
+
+Why it passes both NP-3b forks: while the fault is **armed**, the heartbeat `Put` keeps timing out → `recordKVHealthyOp` never fires → `lastHeartbeatSuccessAt <= degradedSince` → stay Degraded → `degradedExits()==0`. On **disarm**, the heartbeat `Put` succeeds → `lastHeartbeatSuccessAt > degradedSince` → gate opens → recover and HOLD.
+
+- [ ] **Step 6: Ungate NP-3b**
+
+In `np3_kv_unavailable_recovery_test.go`, delete the `PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF` skip block (`:227-230`) so the now-passing proof runs in the default suite as a regression guard. Leave the `testing.Short()` skip.
+
+- [ ] **Step 7: Run NP-3b + the NP-5 / NP-9 / NP-3a-Disarm regressions (`-race`)**
+
+```bash
+go test -race ./test/integration/manager \
+  -run 'TestNP3_KVUnavailable_(HeldArmed_DoesNotFalselyExitToStable|Disarm_ReturnsAndHoldsStable)' -count=1
+go test -race . -run 'TestNP5_BlockedApplyStartupTimeout_RecoversToStableAfterUnblock' -count=1
+go test -race ./test/integration/manager -run 'TestManager_LiveNATSBucketLoss|TestManager_KVUnavailable_EntersDegraded' -count=1
+```
+
+Expected: all PASS, no `-race` report. **NP-5 is the load-bearing regression** — it degrades with reason `"startup-timeout"` (`manager_np5_blocked_apply_recovery_test.go:122`) and has no heartbeat publisher; the reason-scope must let it recover via the commitment guard (its ASSERTION 4, `:160`, must still reach Stable).
+
+- [ ] **Step 8: Commit**
+
+```bash
+make lint
+git diff --check
+git add manager.go manager_degraded.go test/integration/manager/np3_kv_unavailable_recovery_test.go
+git commit -m "fix(degraded): gate recovery exit on heartbeat recovery for kv-unavailable
+
+A connected-but-KV-unavailable op stall degrades with reason kv-unavailable,
+but the recovery exit only re-reads the unaffected assignment bucket and so
+falsely returns to Stable while heartbeat/election/stableid still fault. Require
+a heartbeat Put success stamped after the degrade before exiting a kv-unavailable
+degrade; reason-scoped so a startup-timeout degrade still recovers on the
+commitment guard alone."
+```
+
+### Task 1.2: Family A — live epoch re-probe exit gate (NP-2, NP-1)
+
+**Files:**
+- Modify: `manager_degraded.go` (add `epochMismatchOutstanding`; add the A conjunct after the B conjunct)
+- Test: `test/integration/failure/np2_epoch_fence_return_to_stable_test.go`, `test/integration/manager/np1_live_recreate_returns_stable_test.go`
+
+- [ ] **Step 1: Confirm both reproducers fail on the parent commit**
+
+```bash
+PARTI_RUN_NP2_EPOCH_FLAP_PROOF=1 go test ./test/integration/failure -run 'TestNP2' -count=1 -v
+PARTI_RUN_NP1_LIVE_RECREATE_PROOF=1 go test ./test/integration/manager -run 'TestNP1_LiveBucketRecreate' -count=1 -v
+```
+
+Expected: NP-2 FAILS (`require.Zero(degradedToStable)` and/or `require.Equal(StateDegraded, finalState)` violated, `:204,:212`); NP-1 FAILS (`require.Empty(healed)` violated, `:248` — workers heal to Stable on the recreated-empty buckets).
+
+- [ ] **Step 2: Add the `epochMismatchOutstanding` helper**
+
+In `manager_degraded.go` (it already imports `context`, `time`, `errors`; add `"github.com/arloliu/parti/v2/kvutil"` to the import block — the same helper `manager_setup.go` uses):
+
+```go
+// epochMismatchOutstanding reports whether any Parti-owned bucket's LIVE
+// stream-Created no longer matches the value captured at Start — i.e. a
+// wipe-and-recreate is still in effect. It is the Family A recovery-exit guard:
+// the commitment guard can be satisfied by a version-monotonic republish into a
+// recreated-empty bucket, so the exit must additionally refuse while a recreate
+// is outstanding (terminal Degraded => restart/rotation, docs/OPERATIONS.md).
+//
+// This is a LIVE re-probe (not a latch) so there is no pre-arm window: the
+// epoch-fence monitor ticks every OperationTimeout (10s) while recovery ticks
+// every 1s, so a latch could arm after a faster recovery had already exited.
+//
+// Probe errors are NOT actionable and are skipped (mirroring checkBucketEpochs'
+// continue-on-error): only a successful read with a DIFFERENT Created is a
+// recreate. A missing/timing-out bucket is the connection monitor's / Family B's
+// concern, not Family A's — this keeps the two exit conjuncts independent (see
+// 05-deep-investigation.md §2, the timeout-interpretation conflict).
+//
+// Concurrency: m.bucketEpochs is written only at Start (captureBucketEpoch) and
+// is read-only afterward, so ranging it from this (connection-monitor) goroutine
+// is race-free — the SAME lock-free-read contract checkBucketEpochs relies on.
+// This holds ONLY while nothing mutates the map after Start; Phase-2 Branch
+// C-recreate (Task 2.2) would mutate it, and if selected MUST add a dedicated
+// bucketEpochs lock taken by every reader (this helper AND checkBucketEpochs) and
+// post-Start writer. It opens a FRESH probe handle per bucket rather than reusing
+// ep.kv, which is owned by the monitorBucketEpochs goroutine and is not safe to
+// share across goroutines (nats.go KeyValue handles cache *stream state).
+func (m *Manager) epochMismatchOutstanding(ctx context.Context) bool {
+	if m.js == nil {
+		return false
+	}
+	for bucket, ep := range m.bucketEpochs {
+		probeKV, err := m.js.KeyValue(ctx, bucket)
+		if err != nil {
+			m.logger.Debug("epoch re-probe: open handle failed; not actionable", "bucket", bucket, "error", err)
+			continue
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, m.cfg.OperationTimeout)
+		live, err := kvutil.BucketStreamCreated(probeCtx, probeKV)
+		cancel()
+		if err != nil {
+			m.logger.Debug("epoch re-probe: probe failed; not actionable", "bucket", bucket, "error", err)
+			continue
+		}
+		if !live.Equal(ep.created) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 3: Add the Family A conjunct (full combined exit block)**
+
+In `attemptRecoveryFromDegraded`, add the A conjunct AFTER the Family B conjunct from Task 1.1. The complete block (commitment guard → B → A → exit) reads:
+
+```go
+	cur := m.CurrentAssignment()
+	if !m.currentAssignmentApplied(cur) {
+		m.scheduleApplyRetry(cur)
+		return
+	}
+
+	// Reason not yet observable for this entry (winner stores it just after the
+	// CAS) — stay this tick. See Task 1.1 Step 4.
+	reason, _ := m.lastDegradedReason.Load().(string)
+	if reason == "" {
+		return
+	}
+
+	// Family B — reason-scoped recover-on-wrong-signal gate (cheap atomic reads;
+	// evaluated first so a kv-unavailable stall short-circuits before the Family A
+	// network re-probe below). See Task 1.1 for the full rationale.
+	if reason == degradedReasonKVUnavailable {
+		hbAt := m.lastHeartbeatSuccessAt.Load()
+		since := m.degradedSince.Load()
+		if hbAt == 0 || hbAt <= since {
+			m.logger.Debug("recovery: heartbeat KV not recovered since kv-unavailable degrade; staying Degraded",
+				"last_heartbeat_success_unixnano", hbAt, "degraded_since_unixnano", since)
+			return
+		}
+	}
+
+	// Family A — refuse a recovery exit while a Parti-owned bucket wipe-and-
+	// recreate is still outstanding. A live re-probe; a missing/timing-out bucket
+	// is skipped (Family B's / the connection monitor's concern), so this conjunct
+	// fires only on a CONFIRMED Created mismatch.
+	if m.epochMismatchOutstanding(m.ctx) {
+		m.logger.Warn("recovery: bucket epoch mismatch outstanding; staying Degraded for restart/rotation")
+		return
+	}
+
+	// Success - exit degraded mode
+	m.exitDegraded()
+```
+
+Why it passes NP-1/NP-2: NP-1 wipes+recreates all four buckets; after the leader's version-monotonic republish satisfies the commitment guard, the assignment bucket's live Created differs from the captured value → `epochMismatchOutstanding` returns true → no Degraded→Stable edge → `require.Empty(healed)` holds. NP-2 recreates one bucket → that bucket's Created mismatches → terminal Degraded, `degradedToStable==0`. It does NOT interfere with NP-3b: there the kv-unavailable reason makes Family B short-circuit (return) before the A re-probe runs, so the A probe never executes against the faulted buckets.
+
+- [ ] **Step 4: Ungate NP-2 and NP-1**
+
+Delete the `PARTI_RUN_NP2_EPOCH_FLAP_PROOF` skip (`np2_..._test.go:53-55`) and the `PARTI_RUN_NP1_LIVE_RECREATE_PROOF` skip (`np1_..._test.go:134-137`). Leave the `testing.Short()` skips.
+
+- [ ] **Step 5: Run NP-1/NP-2 + epoch-entry (F1) + C1 regressions (`-race`)**
+
+```bash
+go test -race ./test/integration/failure -run 'TestNP2' -count=1
+go test -race ./test/integration/manager -run 'TestNP1_LiveBucketRecreate' -count=1
+go test -race ./test/integration/manager -run 'TestManager_F1_(BucketRecreate_TripsDegraded|HappyPath_NoDegraded)' -count=1
+go test -race . -run 'TestAttemptRecovery' -count=1
+```
+
+Expected: all PASS, no `-race` report. The F1 epoch-ENTRY tests must stay green — Family A touches only the recovery EXIT and adds a read-only probe helper; `captureBucketEpoch`/`checkBucketEpochs` are unchanged (`ep.created` stays permanently stale, which is load-bearing). The `AttemptRecovery_*` suite pins the commitment guard the new conjuncts are additive to.
+
+- [ ] **Step 6: Commit**
+
+```bash
+make lint
+git diff --check
+git add manager_degraded.go test/integration/failure/np2_epoch_fence_return_to_stable_test.go test/integration/manager/np1_live_recreate_returns_stable_test.go
+git commit -m "fix(degraded): refuse recovery exit while a bucket recreate is outstanding
+
+A wiped-and-recreated Parti control-plane bucket leaves the epoch fence cached
+mismatch permanent, but the recovery exit was blind to it and returned to Stable
+on a version-monotonic republish into the recreated-empty bucket. Add a live
+per-tick epoch re-probe to the recovery exit so a worker stays terminally
+Degraded for restart/rotation; probe errors are skipped so the gate stays
+independent of the kv-unavailable gate."
+```
+
+### Task 1.3: Family C mechanism 1 — document the claim-loss self-stop boundary
+
+The claim-loss self-stop on an outage ≥ `WorkerIDTTL` is **intended** (the split-brain-safe shutdown); recovery is orchestrator rotation. This task documents the boundary and re-purposes the proof into a regression guard. **No production code path changes.**
+
+**Files:**
+- Modify: `docs/OPERATIONS.md`
+- Modify: `test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go` (`TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet`)
+
+- [ ] **Step 1: Document the bounded-recovery boundary**
+
+In `docs/OPERATIONS.md`, in the degraded/recovery section, add (corrected framing from report §1 C-mech1):
+
+```markdown
+**Recovery bound — worker-ID lease (`WorkerIDTTL`).** M5 recover-to-Stable across
+a NATS outage is bounded by `WorkerIDTTL` (default 75s; the stableID bucket
+`MaxAge` is reconciled to it). An outage that exceeds `WorkerIDTTL` ages out the
+worker-ID lease; on reconnect the renewal sees a revision mismatch, surfaces a
+bare `ErrClaimLost`, and the worker **self-stops to `StateShutdown`** — the
+deliberate split-brain-safe behavior, since a peer may have taken the slot. The
+boundary is minute-scale at defaults (renewal cadence ~`WorkerIDTTL/3`; purge at
+last-renewal + `WorkerIDTTL`), so a ~1-minute blip can rotate the **whole fleet**
+(every disconnected worker crosses the boundary together). Recovery is
+orchestrator rotation (the readiness probe sees `StateShutdown` and the pod is
+replaced); Parti does not auto-reclaim a lease that aged out, because at the
+`ErrClaimLost` surface it cannot distinguish "my lease expired, slot empty" from
+"a peer took the slot". Raise `WorkerIDTTL` above the worst-case outage to move
+the boundary.
+```
+
+- [ ] **Step 2: Re-purpose the NP-8 mech-1 proof to assert `StateShutdown` + add instrumentation**
+
+In `TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet`, the current `WaitAllManagersState(... StateStable ...)` after restart (`:187-189`) encodes the wrong expectation. Replace it (and the subsequent leader/coverage/flap assertions that assume a live fleet) with the documented `StateShutdown` outcome, and add the Shutdown/OnError instrumentation report §1 recommends:
+
+```go
+	// --- POST-RESTART: outage exceeded WorkerIDTTL, so every worker's lease aged
+	// out; on reconnect each hits a bare ErrClaimLost and self-stops. The
+	// documented contract is StateShutdown + orchestrator rotation, NOT in-process
+	// recovery to Stable. Assert the WAD self-stop so this proof guards the
+	// boundary rather than a behavior we do not provide. (GetActiveWorkers filters
+	// out Shutdown, so read the raw worker set via GetWorkers.)
+	require.Eventually(t, func() bool {
+		for _, mgr := range cluster.GetWorkers() {
+			if mgr.State() != types.StateShutdown {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 200*time.Millisecond,
+		"every worker must self-stop to StateShutdown when the outage exceeds WorkerIDTTL")
+```
+
+Add an `OnError`/shutdown counter to the per-worker hooks so the attribution is captured rather than inferred (report §1 "Attribution is INFERENCE"): record each worker's terminal reason via the existing hook surface and `t.Logf` it. Remove the now-unreachable `recovered`/`postRecoveryRedegrade`/leader-continuity/coverage assertions for this test (they assumed a surviving fleet). Update the test's doc comment to state it now guards the WAD self-stop boundary.
+
+- [ ] **Step 3: Ungate the (now-passing) mech-1 proof**
+
+Delete the `PARTI_RUN_NP8_FLEET_OUTAGE_PROOF` skip (`:56-59`). Keep `testing.Short()`.
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+go test ./test/integration/failure -run 'TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet' -count=1 -v
+make lint
+git diff --check
+git add docs/OPERATIONS.md test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go
+git commit -m "docs(degraded): document WorkerIDTTL recovery bound; assert claim-loss self-stop
+
+An outage past WorkerIDTTL ages out the worker-ID lease and the worker self-stops
+to Shutdown by design (split-brain safe). Document the bound and orchestrator-
+rotation recovery, and re-purpose the fleet-outage proof to assert the Shutdown
+outcome with terminal-reason instrumentation so it guards the boundary."
+```
+
+---
+
+## Phase 2 — Family C mechanism 2 (decision-gated; BOTH branches specified)
+
+Select the branch from **Task 0.1 / DR-1**. Phase 2 depends on Phase 0; Branch C additionally depends on Family A (Task 1.2) having landed. Exactly one of Task 2.1 / Task 2.2 is implemented; record which in this doc.
+
+> **SELECTED: Branch D (Task 2.1) + the Branch-C reachability conjunct (Task 2.2 Step 2, C-hold contract) — a hybrid, not an either/or.** DR-1 resolved to **Branch D** (operator-selected; `hb_fs_iops` is a negligible flat term, Task 0.1). But the either/or framing assumed the migration *happens* — under the chosen **manual** migration an existing `MemoryStorage` heartbeat bucket persists indefinitely, so Branch D alone leaves exactly the un-migrated single-node-restart flap gap (the heartbeat-loss degrade reason is `"KV error threshold exceeded"`, which Family B does not cover and Family A's recreate-only re-probe does not catch for a *missing* stream — verified). The Branch-C reachability conjunct (`heartbeatBucketUnavailable`) is therefore the **complement**: it holds the un-migrated interim terminally Degraded (loud, rotatable; a rotation re-creates the bucket as `FileStorage`) for existing clusters, while Branch D fixes new clusters. C-recreate (the auto-heal variant that mutates `m.bucketEpochs`) was NOT taken — the lock-free `bucketEpochs` contract is preserved. Shipped in commits `9140af6` (Branch D) and `2964949` (reachability conjunct + un-migrated verify-first proof + doc).
+
+The driver of the mech-2 flap is the **heartbeat PUBLISHER `Put`** against the dead `MemoryStorage` stream after a single-node restart (every worker, via `recordKVOpError`), NOT the calculator's "list heartbeat keys" log line (report §1 C-mech2, verified by elimination). So the report's old "calculator tolerates empty heartbeat list" idea is REJECTED — it fixes a non-driver.
+
+### Task 2.1: Branch D — heartbeat bucket `MemoryStorage` → `FileStorage` (if DR-1 = Branch D)
+
+One line; decoupled from Family A (no new stream `Created`, so it cannot re-arm the epoch fence); the bucket survives a single-node restart so neither the publisher `Put` nor the calculator list fails.
+
+**Files:**
+- Modify: `manager_setup.go:104-119,156`
+- Modify: `docs/OPERATIONS.md`
+- Test: `test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go` (`TestNP8FleetNATSOutage_HeartbeatBucketLossFlap`)
+
+- [ ] **Step 1: Confirm the reproducer fails on the parent commit**
+
+```bash
+PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF=1 go test ./test/integration/failure \
+  -run 'TestNP8FleetNATSOutage_HeartbeatBucketLossFlap' -count=1 -v
+```
+
+Expected: FAILS — either the reach-all-Stable wait times out or the HOLD check trips (`:325-328`), because the `MemoryStorage` heartbeat stream is gone after the restart and the fleet flaps.
+
+- [ ] **Step 2: Switch the heartbeat bucket to FileStorage**
+
+In `manager_setup.go`, the heartbeat `ensure` call (`:156`):
+
+```go
+	heartbeatKV, err = ensure("heartbeat", m.cfg.KVBuckets.HeartbeatBucket, m.cfg.HeartbeatTTL, jetstream.FileStorage)
+```
+
+And update the storage-choice doc comment (`:104-119`) so the rationale matches:
+
+```go
+//   - heartbeat:  FileStorage   — the heartbeat stream must survive a single-node
+//     NATS restart. With MemoryStorage the stream is lost on restart and the
+//     fleet flaps Degraded<->Stable (the publisher Put keeps failing against the
+//     dead stream). The added write IOPS was measured within the provisioned PVC
+//     envelope (see docs/plans/iops-investigation; 06-deep-gap-fix-plan Task 0.1).
+```
+
+- [ ] **Step 3: Add the migration runbook**
+
+In `docs/OPERATIONS.md`, mirror the existing election-bucket migration note: an EXISTING `MemoryStorage` heartbeat bucket is NOT auto-converted (`EnsureKVBucketWithRetry` is get-first and honors the existing config, `manager_setup.go:122-124`). Document the operator step to delete+let-recreate (or re-provision) the heartbeat bucket as FileStorage during a maintenance window, and that until then the flap persists on the old bucket.
+
+- [ ] **Step 4: Ungate NP-8 mech-2; run + the PartialBucketLoss regression**
+
+Delete the `PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF` skip (`:269-272`). Then:
+
+```bash
+go test ./test/integration/failure -run 'TestNP8FleetNATSOutage_HeartbeatBucketLossFlap' -count=1 -v
+go test ./test/integration/manager -run 'TestManager_PartialBucketLoss_HeartbeatHealthy|TestManager_LiveNATSBucketLoss' -count=1
+```
+
+Expected: mech-2 PASSES (the FileStorage heartbeat stream survives → reach AND hold all-Stable). The `PartialBucketLoss`/`LiveNATSBucketLoss` contracts must stay green — the storage class changes durability, not the loss-detection semantics; if `PartialBucketLoss` encodes a MemoryStorage assumption, update its setup to match (report §4 flags this as an `R` cell for Opt D).
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git diff --check
+git add manager_setup.go docs/OPERATIONS.md test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go
+git commit -m "fix(degraded): store the heartbeat bucket on FileStorage to survive NATS restart
+
+A single-node NATS restart dropped the MemoryStorage heartbeat stream, so the
+heartbeat publisher Put kept failing against the dead stream and the fleet
+flapped Degraded<->Stable. Persist the heartbeat bucket so the stream survives
+the restart; the added IOPS was measured within the provisioned envelope. Adds
+the get-first migration runbook for existing deployments."
+```
+
+### Task 2.2: Branch C — fail-safe-hold or recreate, on top of Phase-1 Family B (if DR-1 = Branch C)
+
+**Key interaction (verify in Step 1):** once Phase 1's Family B gate has landed, mech-2's *flap* is likely **already closed** — the heartbeat `Put` fails against the dead `MemoryStorage` stream and degrades, and IF that degrade reason is `kv-unavailable` (report §1 C-mech2 says "likely … via `nats.ErrNoResponders` on a cached Put"; report §6 #5 flags this as an OPEN uncertainty), the Family B conjunct already refuses to exit (no heartbeat success since degrade) → the fleet holds **terminally Degraded** instead of flapping. So Branch C is NOT a new flap fix; it is the decision of what to do about the now-stuck-Degraded fleet, plus a reachability backstop for the case where the reason is `"KV error threshold exceeded"` (Family B does not cover that reason). Implement only if DR-1 selected Branch C; Steps 3/4 depend on Family A (Task 1.2).
+
+**Files:**
+- Modify: `test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go` (`TestNP8FleetNATSOutage_HeartbeatBucketLossFlap`)
+- Modify (only if Step 1 finds reason ≠ `kv-unavailable`): `manager_degraded.go` (reachability conjunct)
+- Modify (C-recreate only): the reconnect path (recreate heartbeat bucket + re-capture epoch atomically)
+
+- [ ] **Step 1 (DR-2): determine the mech-2 degrade reason**
+
+Add a reason-capturing `OnDegraded` hook to `TestNP8FleetNATSOutage_HeartbeatBucketLossFlap` (it currently passes `&parti.Hooks{}`, `:293`) that records each reason into an `atomic.Value`-backed `[]string`, run it with Phase 1 landed, and record:
+
+```
+DR-2 mech-2 reason = [kv-unavailable | "KV error threshold exceeded"]
+```
+
+```bash
+PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF=1 go test ./test/integration/failure \
+  -run 'TestNP8FleetNATSOutage_HeartbeatBucketLossFlap' -count=1 -v
+```
+
+If `kv-unavailable`: Family B already holds the fleet Degraded — SKIP Step 2 (no new conjunct). If `"KV error threshold exceeded"`: do Step 2 (Family B does not apply to that reason, so without it the fleet still flaps).
+
+- [ ] **Step 2 (only if DR-2 ≠ `kv-unavailable`): add a heartbeat-reachability exit conjunct**
+
+Add to `manager_degraded.go` and wire it into the exit block (additive, after the Family A conjunct). It is NOT reason-scoped to `kv-unavailable` (that is the whole point — it backstops the `"KV error threshold exceeded"` reason), but it fires only when the heartbeat bucket is genuinely unreachable, so it cannot regress NP-5 (no heartbeat dependency there → bucket reachable → returns false) or NP-3a (fault cleared → bucket reachable):
+
+```go
+// heartbeatBucketUnavailable reports whether the heartbeat bucket's stream is
+// currently missing/unreachable (a fresh-handle Status probe; fresh handle for
+// the same goroutine-safety reason as epochMismatchOutstanding). Used as a
+// Branch-C recovery-exit backstop so a worker does not exit to Stable while its
+// heartbeat bucket is gone after a single-node restart.
+func (m *Manager) heartbeatBucketUnavailable(ctx context.Context) bool {
+	if m.js == nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, m.cfg.OperationTimeout)
+	defer cancel()
+	kv, err := m.js.KeyValue(probeCtx, m.cfg.KVBuckets.HeartbeatBucket)
+	if err != nil {
+		return true // bucket missing / unreachable
+	}
+	if _, err := kv.Status(probeCtx); err != nil {
+		return true
+	}
+	return false
+}
+```
+
+Conjunct (after Family A, before `m.exitDegraded()`):
+
+```go
+	// Branch C backstop — refuse to exit while the heartbeat bucket is gone
+	// after a single-node restart, for the reason ("KV error threshold exceeded")
+	// the Family B kv-unavailable gate does not cover.
+	if m.heartbeatBucketUnavailable(m.ctx) {
+		m.logger.Debug("recovery: heartbeat bucket unavailable; staying Degraded")
+		return
+	}
+```
+
+- [ ] **Step 3: Choose the contract — C-hold is RECOMMENDED**
+
+Record ONE in this doc:
+- **C-hold (fail-safe, no recreate) — RECOMMENDED:** the fleet stays terminally Degraded on heartbeat-bucket loss; recovery is re-provision/rotation. **No new production code mutates `m.bucketEpochs`**, so the Phase-1 lock-free-read contract is preserved. Family B (kv-unavailable reason) and/or Step 2 (other reason) already hold it Degraded. Document in `docs/OPERATIONS.md`: "MemoryStorage heartbeat-bucket loss after a single-node restart is terminal Degraded → re-provision the bucket / rotate." Then in Step 4 rewrite the mech-2 proof from reach-then-hold-**Stable** (`:325-328`) to **hold-Degraded**.
+- **C-recreate (auto-heal):** recreate the heartbeat bucket on reconnect so the heartbeat `Put` succeeds again, the gate opens, and the fleet heals — keeping the existing reach-then-hold-Stable proof. Depends on Task 1.2 AND **breaks the Phase-1 lock-free `m.bucketEpochs` contract**: re-capturing the cached epoch is a post-Start WRITE while `checkBucketEpochs` and `epochMismatchOutstanding` range the map lock-free. Holding `m.mu` is NOT sufficient — those readers do not take `m.mu`. So C-recreate additionally requires **introducing a dedicated `m.bucketEpochsMu sync.RWMutex` and converting every reader and post-Start writer to use it** (see code below). Choose C-recreate only if auto-heal of a lost MemoryStorage bucket is a hard requirement and the IOPS budget truly rules out Branch D.
+
+C-recreate concurrency change (REQUIRED if C-recreate is chosen):
+
+```go
+// Add to the Manager struct (near bucketEpochs):
+//   bucketEpochsMu sync.RWMutex // guards bucketEpochs once it is mutated post-Start (C-recreate)
+//
+// Convert the two existing lock-free readers to take RLock:
+//   - checkBucketEpochs (manager_setup.go:669): wrap the `for bucket, ep := range m.bucketEpochs`
+//     in m.bucketEpochsMu.RLock()/RUnlock() (snapshot the entries under RLock, probe outside it
+//     to avoid holding the lock across network I/O).
+//   - epochMismatchOutstanding (Task 1.2): same — snapshot {bucket: ep.created} under RLock, then
+//     probe each outside the lock.
+// captureBucketEpoch's Start-time write also takes the Lock (cheap; Start is single-goroutine).
+
+// recreateHeartbeatBucketIfMissing recreates the MemoryStorage heartbeat bucket
+// on reconnect when its stream was lost, and re-captures its epoch so the live
+// re-probe / epoch fence do not fire bucket-recreated:heartbeat against the new
+// stream. The bucketEpochs write is serialized by m.bucketEpochsMu (NOT m.mu —
+// the epoch readers do not take m.mu).
+func (m *Manager) recreateHeartbeatBucketIfMissing(ctx context.Context) error {
+	bucket := m.cfg.KVBuckets.HeartbeatBucket
+	if !m.heartbeatBucketUnavailable(ctx) {
+		return nil
+	}
+	kv, err := m.js.CreateKeyValue(ctx, BuildControlPlaneKVConfig(bucket, m.cfg.HeartbeatTTL, jetstream.MemoryStorage))
+	if err != nil {
+		return fmt.Errorf("recreate heartbeat bucket: %w", err)
+	}
+	created, err := kvutil.BucketStreamCreated(ctx, kv) // read the new Created outside the lock
+	if err != nil {
+		return fmt.Errorf("re-capture heartbeat epoch: %w", err)
+	}
+	m.bucketEpochsMu.Lock()
+	m.bucketEpochs[bucket] = bucketEpoch{kv: kv, created: created}
+	m.bucketEpochsMu.Unlock()
+	return nil
+}
+```
+
+Call it from the reconnect path (`checkConnectionHealth`'s connection-restored branch, `manager_degraded.go:122-126`), leader-gated if only the leader should recreate. Note: `captureBucketEpoch` itself is NOT reused here (it opens a fresh handle internally and assumes Start-time single-goroutine access); the inline re-capture above takes the lock explicitly.
+
+- [ ] **Step 4: Update the proof to the chosen contract; ungate; run; commit**
+
+Delete the `PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF` skip (`:269-272`). Set the proof expectation to match the chosen contract: **C-hold** → assert the fleet reaches and HOLDS all-Degraded (not Stable); **C-recreate** → keep the existing reach-then-hold-Stable assertions (`:325-328`). Run `-race`; run the `LiveNATSBucketLoss`/`PartialBucketLoss` regressions and the F1 epoch-entry tests (C-recreate touches the epoch cache). Then:
+
+```bash
+make lint
+git diff --check
+# git add the touched files; commit with a conventional message describing the
+# chosen contract, e.g. for C-hold:
+#   "docs(degraded): MemoryStorage heartbeat loss is terminal Degraded; assert hold"
+# or for C-recreate:
+#   "fix(degraded): recreate the heartbeat bucket on reconnect with atomic epoch re-capture"
+```
+
+---
+
+## NP-10 deferred to `07` — why
+
+The investigation report (§5) framed NP-10's fix as "route sustained enumeration failure into the manager's degraded circuit with the same `markKVUnavailable`/`recordKVOpError` semantics." Drafting this plan surfaced two reasons that route is **not** implementation-ready as a tail task on the A/B/C core, so NP-10 is carved out to its own proof-first plan (`07-np10-enumeration-stall-plan.md`):
+
+1. **The F-D1 transient-clear defeats the naive route.** NP-10's defining asymmetry is that the single-key heartbeat `Put` keeps **succeeding** while the stream-wide `Keys` scan times out. A successful heartbeat `Put` fires `recordKVHealthyOp`, which clears the transient (`ErrKVUnavailable`-class) entries from `kvErrorWindow` (`manager_degraded.go:266-288`). Routing the scan deadline through `recordKVOpError` adds a transient entry that the very next heartbeat success clears — so the enumeration failures never accumulate to `KVErrorThreshold`. The fix needs a path that does **not** depend on the transient window (a calculator-local consecutive-failure threshold, or a non-transient classification).
+
+2. **It needs its own reason-scoped exit gate.** Even if NP-10 degrades, `attemptRecoveryFromDegraded` would exit on the healthy assignment read while the enumeration is still stalling — the same recover-on-wrong-signal defect as Family B, but for a new reason. Closing it requires a *third* additive exit conjunct plus a calculator→manager "enumeration recovered" success signal (mirroring the heartbeat-success stamp). That is a new seam (`assignment.Config` has no error/success callback today, `internal/assignment/config.go`) and a new predicate, not a tail.
+
+NP-10 is also Medium-confidence / not-harness-proven (report §8). `07` therefore leads with building the reproducer and confirming it fails (verify-first) before any fix — if the gap cannot be reproduced, `07` stops.
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Format affected Go packages**
+
+```bash
+make fmt
+```
+
+- [ ] **Step 2: Focused checks across the touched surface**
+
+```bash
+go test . -run 'Test(AttemptRecovery|MarkKVUnavailable|RecordKVError_ReadUnavailable_Degrades|NP5_BlockedApply)' -count=1
+go test ./test/integration/manager -run 'TestManager_(F1_BucketRecreate_TripsDegraded|F1_HappyPath_NoDegraded|LiveNATSBucketLoss|KVUnavailable_EntersDegraded|PartialBucketLoss_HeartbeatHealthy)|TestNP1_LiveBucketRecreate|TestNP3_KVUnavailable' -count=1
+go test ./test/integration/failure -run 'TestNP2|TestNP8FleetNATSOutage' -count=1
+```
+
+Expected: PASS (the previously-gated NP-1/NP-2/NP-3b proofs now run by default and pass; NP-8 mech-1 asserts Shutdown; NP-8 mech-2 per the chosen Phase-2 branch).
+
+- [ ] **Step 3: `-race` re-baseline (the delta vs Task 0.3)**
+
+```bash
+go test -race ./test/integration/manager ./test/integration/failure \
+  -run 'TestNP1_LiveBucketRecreate|TestNP2|TestNP3_KVUnavailable|TestNP8FleetNATSOutage' -count=1
+```
+
+Expected: all PASS, no new `-race` report vs the Task 0.3 baseline.
+
+- [ ] **Step 4: Lint + pre-PR gate**
+
+```bash
+make lint
+git diff --check
+make pre-pr
+```

--- a/docs/plans/auto-healing-gap-closure/07-np10-enumeration-stall-plan.md
+++ b/docs/plans/auto-healing-gap-closure/07-np10-enumeration-stall-plan.md
@@ -1,0 +1,503 @@
+# NP-10 Leader Enumeration-Stall Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close NP-10 — a leader whose heartbeat-bucket `Keys` scan times out (a non-connectivity `DeadlineExceeded`) while its own single-key heartbeat `Put` keeps succeeding stays `StateStable` and blind to worker topology, serving assignments from stale/empty membership with no degraded circuit (a silent false-healthy leader). Route a *sustained* enumeration stall into the manager's degraded circuit and gate the recovery exit on enumeration recovery.
+
+**Architecture:** `Calculator.getActiveWorkers` (`internal/assignment/calculator.go:1194-1213`) degrades/caches only for `IsConnectivityError`; a `DeadlineExceeded` on the stream-wide `Keys` scan is returned bare and the worker-monitor poll loop only logs it (`internal/assignment/worker_monitor.go:282-284`), so it never reaches the manager. The fix adds a calculator-local consecutive-failure counter that, once a threshold of sustained non-connectivity enumeration failures is crossed, invokes a new manager-supplied `OnEnumerationError` callback; the manager degrades **directly** with a distinct reason and gates the recovery exit on enumeration recovery (a successful `Keys` scan / nil-error `GetActiveWorkers` after the degrade). The direct-degrade path (not the transient KV-error window) is mandatory — see the F-D1 constraint below.
+
+**Tech Stack:** Go (go1.26), NATS JetStream KV, `internal/assignment` (`Calculator`/`WorkerMonitor`/`Config`), the manager degraded circuit (`manager_degraded.go`), and the embedded-NATS test helpers.
+
+> **PRE-IMPLEMENTATION VERIFICATION (2026-06-02) — read before starting; 06 has landed.** The
+> recovery-precondition linchpin was checked (read-only) against 06-complete HEAD:
+> - **PRIMARY PATH IS VIABLE (the recovery half is NOT a permanent-Degraded trap).** `enterDegraded`
+>   (`manager_degraded.go:307`) does NOT stop the calculator or release leadership, and the
+>   worker-monitor poll loop (`worker_monitor.go:267-294`) runs on a `hbTTL/2` ticker bound to the
+>   calculator lifetime (`m.ctx`/`stopCh`), independent of manager state. In the NP-10 scenario the
+>   leader's connection is up and election renewal is a single-key op unaffected by a `Keys`-only
+>   stall, so it KEEPS leadership → keeps polling `GetActiveWorkers` → `OnEnumerationSuccess` fires
+>   when the stall clears → the reason-scoped exit gate opens. Confirmed the watch-item: the
+>   calculator keeps polling Keys while Degraded.
+> - **REQUIRED DESIGN ADDITION (not in the Stage-B plan below): a leadership-loss escape.**
+>   `stopCalculator` is called on leadership loss (`manager_election.go:274`) and that path does NOT
+>   clear `degradedSince`/the reason. So if a leader loses leadership *for any reason* while in
+>   `enumeration-stall` Degraded, its poll loop stops and the reason-scoped exit gate can never see a
+>   fresh `OnEnumerationSuccess` → **stuck Degraded** (the "gate on a capability that can't fire"
+>   deadlock, [[feedback_static_review_blessed_fatal_design]]). It is narrow (a Keys-only stall does
+>   not itself fail renewal, so it needs a *concurrent independent* leadership loss), but Stage B MUST
+>   add an escape: on leadership loss clear an `enumeration-stall` degrade (or stamp recovery), OR make
+>   the exit conjunct treat "not currently leader" as enumeration-N/A (don't block). Make the B.2 proof's
+>   RECOVERY half load-bearing (disarm → Stable + HOLD), and add a leadership-loss-while-stalled case.
+> - **The verify-first STOP gate still governs:** run the Task B.2 reproducer against the parent FIRST;
+>   if the leader does not stay falsely Stable, NP-10 is not real — STOP, do not write Stage B.
+
+---
+
+## Source of truth, confidence, and the load-bearing constraint
+
+- **Spec:** `05-deep-investigation.md` §5 (NP-10) and §8. NP-10 is **Medium confidence — code-derived, NOT harness-proven**. The empirical anchor is that `IsConnectivityError(context.DeadlineExceeded)` is false (bare and wrapped) and `IsDegradingJetStreamError(context.DeadlineExceeded)` is false (`internal/natsutil/errors.go`), so the `Keys` deadline is classified by neither and is logged-only.
+- **Verify-first is mandatory — and the fail-first gate is the END-TO-END proof (Task B.2 Step 2), not the unit test.** Two distinct kinds of test here, do not conflate them:
+  - The calculator-level Stage A.1 test is a **gap-characterization** test: it asserts the swallow (`enumErrCalls == 0`) and therefore **PASSES as written** on the parent. It documents the unit-level mechanism and seeds the fix-driver; it is NOT the fail-first reproducer.
+  - The **fail-first reproducer is the integration proof in Task B.2**: run it against the PARENT (no Stage-B production changes) and confirm it FAILS — the leader stays `StateStable` despite the sustained `Keys` stall. **If that proof does NOT fail on the parent — if the leader already degrades or stops serving stale membership on its own — STOP: NP-10 is not real and no fix should land.** Do not commit Stage B's production changes until the B.2 proof has been seen to fail on the parent.
+- **The F-D1 constraint (why the report's §5 one-liner does not work).** §5 suggested routing the stall "with the same `markKVUnavailable`/`recordKVOpError` semantics." That is **defeated by F-D1**: NP-10's defining asymmetry is that the single-key heartbeat `Put` keeps succeeding, and each success fires `recordKVHealthyOp`, which clears the transient (`ErrKVUnavailable`-class) entries from `kvErrorWindow` (`manager_degraded.go:266-288`). A scan deadline routed through `recordKVOpError` adds a transient entry that the next heartbeat success clears — so it never accumulates to `KVErrorThreshold`. **The fix MUST NOT route through the transient window.** Instead, the calculator thresholds locally (consecutive failures) and the manager degrades directly, the same shape the epoch fence uses (`checkBucketEpochs` → `enterDegraded` directly, bypassing the window).
+- **Seam constraint (no import cycle).** `markKVUnavailable`/`recordKVOpError`/`enterDegraded` live on the manager side; `internal/assignment` must not import the manager package. The fix adds plain `func` callback fields to `assignment.Config` (matching the existing `LeaderRevision`/`LeaderCheck`/`Now` optional-callback pattern) that the manager sets in `startCalculator` (`manager_assignment.go:132-151`). assignment never imports manager → cycle-free.
+
+## File Map
+
+- Modify: `internal/assignment/config.go:131-153` — add `OnEnumerationError func(error)`, `OnEnumerationSuccess func()`, `EnumerationFailureThreshold int` (+ default in `SetDefaults`).
+- Modify: `internal/assignment/calculator.go:67-161` — add an `enumFailures int` counter (guarded by `c.mu`).
+- Modify: `internal/assignment/calculator.go:1194-1245` — record/reset enumeration failures in `getActiveWorkers`.
+- Modify: `manager_degraded.go` — add `degradedReasonEnumerationStall` const, the manager-side handler + success stamp, the `lastEnumerationSuccessAt` field usage, and the reason-scoped exit conjunct.
+- Modify: `manager.go:192-206` — add `lastEnumerationSuccessAt atomic.Int64`.
+- Modify: `manager_assignment.go:132-151` — wire `OnEnumerationError`/`OnEnumerationSuccess`.
+- Create: `internal/assignment/calculator_enumeration_stall_test.go` — the calculator-level reproducer + fix-driver.
+- Create: `test/integration/failure/np10_enumeration_stall_test.go` — the end-to-end false-healthy-leader proof (gated).
+
+## Invariant
+
+A sustained non-connectivity enumeration failure (a `Keys`-scan `DeadlineExceeded` that single-key ops do not share) must become observable as `StateDegraded` on the affected leader, and the leader must NOT exit Degraded until enumeration succeeds again. A transient (single) enumeration failure must NOT degrade (no spurious flap), and the connectivity-error path must stay owned by the existing circuit (heartbeat `Put` `SetOnError` → `recordKVOpError`), unchanged.
+
+---
+
+## Stage A — Reproduce the gap (verify-first) and drive the seam at the calculator level
+
+### Task A.1: Calculator-level reproducer — the enumeration deadline is swallowed today
+
+**Files:**
+- Create: `internal/assignment/calculator_enumeration_stall_test.go`
+
+- [ ] **Step 1: Write the op-selective Keys-timeout fault KV + the swallow proof**
+
+```go
+package assignment
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// keysTimeoutKV wraps a real KeyValue and, when armed, makes Keys() block until
+// the caller's context deadline (returning context.DeadlineExceeded) while every
+// other op — notably Put/Get — passes through unchanged. This is NP-10's exact
+// asymmetry: the stream-wide scan times out, single-key ops do not.
+type keysTimeoutKV struct {
+	jetstream.KeyValue
+	armed atomic.Bool
+}
+
+func (k *keysTimeoutKV) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	if k.armed.Load() {
+		<-ctx.Done()
+		return nil, ctx.Err() // context.DeadlineExceeded under the monitor's bounded ctx
+	}
+	return k.KeyValue.Keys(ctx, opts...)
+}
+
+// TestGetActiveWorkers_EnumerationDeadline_IsSwallowed pins the NP-10 gap at the
+// calculator level: a Keys()-only DeadlineExceeded is neither a connectivity nor
+// a degrading-JetStream error, so getActiveWorkers returns it bare and nothing
+// (no callback, no degrade) observes it. Predicted verdict (pre-fix): the error
+// is returned but OnEnumerationError is never invoked.
+func TestGetActiveWorkers_EnumerationDeadline_IsSwallowed(t *testing.T) {
+	t.Parallel()
+
+	// Build a Calculator over a real embedded-NATS heartbeat KV wrapped by
+	// keysTimeoutKV. (Use the package's existing calculator test scaffolding to
+	// construct a minimal valid Config; see calculator_test.go helpers.)
+	fault := &keysTimeoutKV{KeyValue: newTestHeartbeatKV(t)}
+	var enumErrCalls atomic.Int64
+	c := newTestCalculator(t, func(cfg *Config) {
+		cfg.HeartbeatKV = fault
+		cfg.OnEnumerationError = func(error) { enumErrCalls.Add(1) } // wired but, pre-fix, never called
+	})
+
+	fault.armed.Store(true)
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	_, _, err := c.getActiveWorkers(ctx)
+	require.Error(t, err, "a Keys-scan deadline must surface as an error")
+	require.NotErrorIs(t, err, context.Canceled)
+
+	// THE GAP (pre-fix): the deadline is classified by neither IsConnectivityError
+	// nor IsDegradingJetStreamError, so getActiveWorkers returns it bare and the
+	// enumeration-error callback is never invoked — the manager never learns.
+	require.Zero(t, enumErrCalls.Load(),
+		"pre-fix: a swallowed enumeration deadline must not reach any degrade signal (this is the gap)")
+}
+```
+
+> The helpers `newTestHeartbeatKV` / `newTestCalculator` stand in for the package's existing calculator test scaffolding — if equivalents already exist (e.g. in `calculator_test.go`), reuse them; otherwise add minimal ones in this step. `OnEnumerationError` is referenced here to make the proof legible; Task A.2 Step 1 adds the field, so write this test and the field together if the package will not compile otherwise.
+
+- [ ] **Step 2: Run — confirm the swallow**
+
+```bash
+go test ./internal/assignment -run TestGetActiveWorkers_EnumerationDeadline_IsSwallowed -count=1 -v
+```
+
+Expected: PASS as written (it asserts the *gap* — `enumErrCalls == 0`). This proof flips meaning after Task A.2: the fix makes a *sustained* run cross the threshold and call the callback, which a follow-up assertion (Task A.2 Step 4) checks.
+
+### Task A.2: Add the seam and the calculator-local threshold
+
+**Files:**
+- Modify: `internal/assignment/config.go`
+- Modify: `internal/assignment/calculator.go`
+- Modify: `internal/assignment/calculator_enumeration_stall_test.go`
+
+- [ ] **Step 1: Add the Config callbacks + threshold**
+
+In `internal/assignment/config.go`, in the "Optional dependencies" block (after `LeaderCheck`, `:152`):
+
+```go
+	// OnEnumerationError, if set, is invoked when worker enumeration (the
+	// heartbeat Keys scan in WorkerMonitor.GetActiveWorkers) has failed
+	// EnumerationFailureThreshold times in a row with a non-connectivity error —
+	// notably a context.DeadlineExceeded on the stream-wide scan while single-key
+	// heartbeat Puts still succeed (NP-10). The manager wires this to a DIRECT
+	// degrade (NOT the transient KV-error window, which a succeeding heartbeat Put
+	// would clear). When nil, sustained enumeration failure remains logged-only
+	// (back-compat / test default). Must be safe for concurrent use.
+	OnEnumerationError func(err error)
+
+	// OnEnumerationSuccess, if set, is invoked on every SUCCESSFUL worker
+	// enumeration — i.e. whenever the heartbeat Keys scan (GetActiveWorkers)
+	// returns a nil error — REGARDLESS of the F10-A worker-credibility decision
+	// (it fires even when a sharply-shrunk result is treated as suspicious). The
+	// manager stamps it as the "enumeration recovered" signal its recovery exit
+	// gate keys on. Must be safe for concurrent use.
+	OnEnumerationSuccess func()
+
+	// EnumerationFailureThreshold is the number of consecutive non-connectivity
+	// enumeration failures before OnEnumerationError fires. Default: 3 (also applied
+	// to any value < 1, so a zero/negative config cannot fire on the first failure).
+	// Set explicitly to 1 to fire on the first failure (no debounce).
+	EnumerationFailureThreshold int
+```
+
+In `SetDefaults` (after the worker-shrink defaults, `:236`) — clamp `< 1`, not just `== 0`, so a negative value cannot fire immediately:
+
+```go
+	if c.EnumerationFailureThreshold < 1 {
+		c.EnumerationFailureThreshold = 3
+	}
+```
+
+- [ ] **Step 2: Add the counter field**
+
+In `internal/assignment/calculator.go`, in the `Calculator` struct near `workerShrunkObservations` (`:161`):
+
+```go
+	// enumFailures is the running count of consecutive non-connectivity
+	// enumeration (heartbeat Keys scan) failures. Crossed against
+	// EnumerationFailureThreshold to fire OnEnumerationError; reset to zero on any
+	// successful enumeration (nil-error GetActiveWorkers, before F10-A handling).
+	// Guarded by c.mu (same as workerShrunkObservations).
+	enumFailures int
+```
+
+- [ ] **Step 3: Record/reset around the enumeration result**
+
+In `getActiveWorkers`, the swallowed non-connectivity error branch (`calculator.go:1213`):
+
+```go
+		// Sustained non-connectivity enumeration failure (NP-10): the poll loop
+		// only logs this and no caller routes it to the degraded circuit. Threshold
+		// locally and, once sustained, surface it via OnEnumerationError so the
+		// manager can degrade directly (a transient-window route would be cleared by
+		// the still-succeeding heartbeat Put — see 07-...-plan F-D1 constraint).
+		c.recordEnumerationFailure(err)
+
+		return nil, false, err
+```
+
+Reset/signal recovery **immediately after `c.monitor.GetActiveWorkers(ctx)` returns a nil error** (`calculator.go:1195`), BEFORE the F10-A worker-shrink credibility handling — NOT on the later "healthy fresh" path. The enumeration STALL has recovered the moment the `Keys` scan succeeds; whether F10-A then treats the result as suspicious (returning cached+`fresh=false`, `calculator.go:1227-1243`) is an orthogonal worker-credibility decision. Placing the reset on the fresh-only path would leave a recovered-but-suspicious scan stuck in the enumeration-stall degrade:
+
+```go
+	workers, err := c.monitor.GetActiveWorkers(ctx)
+	if err != nil {
+		if natsutil.IsConnectivityError(err) {
+			// ... existing cached-fallback / ErrDegraded, unchanged ...
+		}
+		c.recordEnumerationFailure(err) // NP-10: increment + maybe fire (added above)
+		return nil, false, err
+	}
+	// Enumeration succeeded: the Keys-scan stall (if any) has recovered. Reset the
+	// NP-10 counter and signal recovery HERE — before F10-A suspicious-shrink
+	// handling — so a recovered-but-suspicious scan still clears the stall degrade.
+	c.resetEnumerationFailures()
+
+	// ... existing F10-A recordWorkerObservation / suspicious-shrink handling ...
+```
+
+Add the two helpers:
+
+```go
+// recordEnumerationFailure increments the consecutive enumeration-failure
+// counter and invokes OnEnumerationError once the threshold is reached/exceeded.
+// Firing while already over the threshold is intentional and harmless: the
+// manager's enterDegraded is idempotent (CAS short-circuits while degraded).
+func (c *Calculator) recordEnumerationFailure(err error) {
+	if c.OnEnumerationError == nil {
+		return
+	}
+	c.mu.Lock()
+	c.enumFailures++
+	fire := c.enumFailures >= c.EnumerationFailureThreshold
+	c.mu.Unlock()
+	if fire {
+		c.OnEnumerationError(err)
+	}
+}
+
+// resetEnumerationFailures clears the consecutive-failure counter and signals
+// enumeration recovery. Called on every SUCCESSFUL enumeration — right after a
+// nil-error GetActiveWorkers, before F10-A suspicious-shrink handling — NOT only
+// on the fresh==true path (a recovered-but-suspicious scan must still clear).
+func (c *Calculator) resetEnumerationFailures() {
+	c.mu.Lock()
+	c.enumFailures = 0
+	c.mu.Unlock()
+	if c.OnEnumerationSuccess != nil {
+		c.OnEnumerationSuccess()
+	}
+}
+```
+
+> Connectivity errors take the existing `IsConnectivityError` branch (cached fallback / `ErrDegraded`) and do NOT touch `enumFailures` — that fault class is already owned by the manager circuit via the heartbeat `Put` `SetOnError`. Only the swallowed non-connectivity branch increments.
+
+- [ ] **Step 4: Extend the reproducer to prove the threshold fires (fix-driver)**
+
+Add to `calculator_enumeration_stall_test.go`:
+
+```go
+// TestGetActiveWorkers_SustainedEnumerationDeadline_FiresCallback proves the fix:
+// EnumerationFailureThreshold consecutive Keys deadlines invoke OnEnumerationError
+// exactly once at the crossing, and a subsequent healthy scan invokes
+// OnEnumerationSuccess and resets the counter.
+func TestGetActiveWorkers_SustainedEnumerationDeadline_FiresCallback(t *testing.T) {
+	t.Parallel()
+
+	fault := &keysTimeoutKV{KeyValue: newTestHeartbeatKV(t)}
+	var enumErr, enumOK atomic.Int64
+	c := newTestCalculator(t, func(cfg *Config) {
+		cfg.HeartbeatKV = fault
+		cfg.EnumerationFailureThreshold = 3
+		cfg.OnEnumerationError = func(error) { enumErr.Add(1) }
+		cfg.OnEnumerationSuccess = func() { enumOK.Add(1) }
+	})
+
+	fault.armed.Store(true)
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		_, _, _ = c.getActiveWorkers(ctx)
+		cancel()
+	}
+	require.GreaterOrEqual(t, enumErr.Load(), int64(1),
+		"a sustained enumeration deadline must fire OnEnumerationError once the threshold is crossed")
+
+	// Recovery: a healthy scan resets the counter and signals success.
+	fault.armed.Store(false)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	_, _, err := c.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.Positive(t, enumOK.Load(), "a healthy enumeration must signal recovery")
+}
+```
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+go test ./internal/assignment -run 'TestGetActiveWorkers_(EnumerationDeadline_IsSwallowed|SustainedEnumerationDeadline_FiresCallback)' -count=1 -v
+make lint
+git diff --check
+git add internal/assignment/config.go internal/assignment/calculator.go internal/assignment/calculator_enumeration_stall_test.go
+git commit -m "feat(assignment): surface sustained heartbeat-enumeration stalls via a callback
+
+A heartbeat Keys-scan deadline is neither a connectivity nor a degrading-
+JetStream error, so getActiveWorkers returned it bare and the poll loop only
+logged it. Add a consecutive-failure threshold that invokes a new optional
+OnEnumerationError callback once a non-connectivity enumeration failure is
+sustained, plus an OnEnumerationSuccess recovery signal."
+```
+
+---
+
+## Stage B — Degrade the leader and gate its recovery exit
+
+### Task B.1: Manager-side direct degrade + reason-scoped recovery exit
+
+**Files:**
+- Modify: `manager.go:192-206`
+- Modify: `manager_degraded.go`
+- Modify: `manager_assignment.go:132-151`
+
+- [ ] **Step 1: Add the enumeration-success stamp field**
+
+In `manager.go`, in the "Degraded mode tracking" block:
+
+```go
+	// lastEnumerationSuccessAt is the UnixNano of the most recent healthy worker
+	// enumeration (set via the calculator's OnEnumerationSuccess). The recovery
+	// exit gate keys on it to confirm a heartbeat-enumeration-stall degrade
+	// recovered before exiting. 0 = never.
+	lastEnumerationSuccessAt atomic.Int64
+```
+
+- [ ] **Step 2: Add the reason const + handler + stamp**
+
+In `manager_degraded.go`, near `degradedReasonKVUnavailable` (`:20`):
+
+```go
+// degradedReasonEnumerationStall is the distinct enterDegraded reason for a
+// sustained leader-side worker-enumeration (heartbeat Keys scan) stall that the
+// connectivity/degrading classifiers miss (NP-10). Kept separate so the recovery
+// exit can require an enumeration success before exiting, and so the operator
+// surface distinguishes it from a kv-unavailable op stall.
+const degradedReasonEnumerationStall = "heartbeat-enumeration-stall"
+```
+
+Add the manager handler + success stamp (the calculator has already thresholded, so the handler degrades DIRECTLY — bypassing the transient `kvErrorWindow`, mirroring the epoch fence):
+
+```go
+// onEnumerationStall is wired to the calculator's OnEnumerationError. The
+// calculator fires it only after EnumerationFailureThreshold consecutive
+// non-connectivity enumeration failures, so the stall is already sustained:
+// degrade directly. enterDegraded is idempotent (CAS), so repeated calls while
+// degraded are no-ops.
+func (m *Manager) onEnumerationStall(err error) {
+	m.logger.Warn("sustained heartbeat-enumeration stall; entering degraded", "error", err)
+	m.enterDegraded(degradedReasonEnumerationStall)
+}
+
+// recordEnumerationSuccess is wired to the calculator's OnEnumerationSuccess. It
+// stamps the recovery signal the exit gate keys on.
+func (m *Manager) recordEnumerationSuccess() {
+	m.lastEnumerationSuccessAt.Store(time.Now().UnixNano())
+}
+```
+
+- [ ] **Step 3: Add the reason-scoped exit conjunct**
+
+In `attemptRecoveryFromDegraded`, add a third additive conjunct (after the Family A epoch re-probe conjunct from `06-deep-gap-fix-plan.md` Task 1.2, before `m.exitDegraded()`). REUSE the `reason` variable already read at the top of the exit block in `06` (do NOT re-read with `:=` — the empty-reason guard from `06` Task 1.1 Step 5 has already returned if `reason == ""`, so this conjunct only ever sees a fully-observable reason):
+
+```go
+	// NP-10 — reason-scoped enumeration-recovery gate. A heartbeat-enumeration
+	// stall degrade must not exit on the healthy assignment read while the Keys
+	// scan is still timing out (the leader would resume serving stale membership).
+	// Require an enumeration success stamped AFTER we degraded. Reason-scoped so
+	// other degrade reasons are unaffected. `reason` is the hoisted variable from
+	// 06's exit block (already guarded for "").
+	if reason == degradedReasonEnumerationStall {
+		ensAt := m.lastEnumerationSuccessAt.Load()
+		since := m.degradedSince.Load()
+		if ensAt == 0 || ensAt <= since {
+			m.logger.Debug("recovery: worker enumeration not recovered since stall degrade; staying Degraded",
+				"last_enumeration_success_unixnano", ensAt, "degraded_since_unixnano", since)
+			return
+		}
+	}
+
+	// Success - exit degraded mode
+	m.exitDegraded()
+```
+
+> **Depends on `06`.** This conjunct assumes `06`'s exit block already exists, including the hoisted `reason` read + the empty-reason guard, AND the `lastDegradedReason` ownership protocol (`06` Task 1.1 Step 4: the winning `enterDegraded` stores the reason AFTER its CAS; `exitDegraded` clears it before `degradedSince`). NP-10 introduces a NEW reason (`degradedReasonEnumerationStall`) that the manager's `onEnumerationStall` handler degrades with directly — so it relies on that ownership being atomic with the entry, exactly as `kv-unavailable` does. If `07` is implemented before `06` lands, port the full ownership protocol (not just the field) here first, or the new reason can be clobbered and skip this gate. State the dependency in the PR.
+
+- [ ] **Step 4: Wire the callbacks in `startCalculator`**
+
+In `manager_assignment.go`, in the `assignment.Config{...}` literal (`:132-151`), add:
+
+```go
+		OnEnumerationError:    m.onEnumerationStall,
+		OnEnumerationSuccess:  m.recordEnumerationSuccess,
+```
+
+### Task B.2: End-to-end false-healthy-leader proof
+
+**Files:**
+- Create: `test/integration/failure/np10_enumeration_stall_test.go`
+
+- [ ] **Step 1: Write the gated end-to-end proof**
+
+Build a real fleet on an op-selective fault JetStream that times out `Keys()` on the heartbeat bucket only (the integration analog of `keysTimeoutKV`, applied at the JetStream layer so the manager's own heartbeat KV is affected). Assert the gap (pre-fix) and the fix (post-fix) in one gated test:
+
+```go
+//go:build integration
+// (mirror the package's existing gating/build conventions; gate with
+// PARTI_RUN_NP10_ENUM_STALL_PROOF and testing.Short() like the sibling proofs.)
+
+// TestNP10_LeaderEnumerationStall_DegradesNotSilent proves a leader whose
+// heartbeat Keys scan sustains DeadlineExceeded (while its single-key Put keeps
+// succeeding) enters Degraded("heartbeat-enumeration-stall") instead of sitting
+// StateStable blind to topology, and recovers once the scan succeeds again.
+//
+// Oracle:
+//   1. Bring up a 3-manager fleet; identify the leader; reach all-Stable + coverage.
+//   2. Arm a Keys-only timeout on the heartbeat bucket (Put/Get/election stay healthy).
+//   3. PRE-FIX EXPECTATION (the gap): the leader stays StateStable (no degrade) —
+//      this is what fails today; the assertion below requires it to DEGRADE.
+//   4. POST-FIX: within ~EnumerationFailureThreshold poll intervals the leader
+//      enters Degraded with reason "heartbeat-enumeration-stall", and the
+//      connection stays CONNECTED throughout (this is not a connectivity loss).
+//   5. Disarm the Keys timeout; assert the leader returns to Stable and HOLDS it.
+```
+
+Provide the full fault wrapper + fleet wiring + assertions when implementing (no placeholder): the wrapper embeds `jetstream.JetStream`, returns a `KeyValue` wrapper for the heartbeat bucket whose `Keys` blocks-until-deadline when armed, and passes through everything else. Record terminal reason via an `OnDegraded` hook and assert `reason == "heartbeat-enumeration-stall"`.
+
+- [ ] **Step 2: Run the proof against the parent commit first (verify-first)**
+
+Before Stage B's production changes are present, run the proof and confirm the leader does NOT degrade (the gap). If it already degrades or stops serving stale membership, STOP — NP-10 is not real; revert Stage B and record the finding.
+
+```bash
+git stash   # park Stage B production changes if interleaved
+PARTI_RUN_NP10_ENUM_STALL_PROOF=1 go test ./test/integration/failure -run TestNP10_LeaderEnumerationStall_DegradesNotSilent -count=1 -v
+git stash pop
+```
+
+Expected (parent): FAIL — leader stays Stable (the gap).
+
+- [ ] **Step 3: Run with the fix + regressions (`-race`); commit**
+
+```bash
+PARTI_RUN_NP10_ENUM_STALL_PROOF=1 go test -race ./test/integration/failure -run TestNP10_LeaderEnumerationStall_DegradesNotSilent -count=1
+go test -race . -run 'TestAttemptRecovery|TestNP5_BlockedApply' -count=1
+go test -race ./internal/assignment -run 'TestGetActiveWorkers' -count=1
+make lint
+git diff --check
+git add manager.go manager_degraded.go manager_assignment.go test/integration/failure/np10_enumeration_stall_test.go
+git commit -m "fix(degraded): degrade a leader on a sustained heartbeat-enumeration stall
+
+A leader whose heartbeat Keys scan sustains a non-connectivity deadline while its
+single-key Put still succeeds used to stay Stable and serve stale membership.
+Degrade directly with a distinct reason when the calculator reports a sustained
+enumeration stall, and gate the recovery exit on a successful enumeration since the degrade."
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Format + focused checks**
+
+```bash
+make fmt
+go test ./internal/assignment -run 'TestGetActiveWorkers|TestCalculator' -count=1
+go test . -run 'Test(AttemptRecovery|NP5_BlockedApply)' -count=1
+```
+
+- [ ] **Step 2: `-race` + lint + pre-PR**
+
+```bash
+go test -race ./internal/assignment . -count=1
+make lint
+git diff --check
+make pre-pr
+```
+
+Expected: PASS. NP-10's gated end-to-end proof stays opt-in (`PARTI_RUN_NP10_ENUM_STALL_PROOF`) until verified stable, matching the sibling proof convention.

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/exit-gate-unification-verify.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/exit-gate-unification-verify.md
@@ -1,0 +1,191 @@
+# Exit-Gate Unification — ADVERSARIAL VERIFICATION of the "separate fixes" finding
+
+- **Date:** 2026-06-01
+- **HEAD:** 2453306 (branch `auto-heal-gap-investigation`)
+- **Reviewer task:** REFUTE the finding's verdict (separate fixes for Families A and B);
+  default to "A and B need SEPARATE fixes" and only confirm unification if refutation of
+  separateness fails. The finding itself already argues for separate fixes, so my job is the
+  mirror: try hard to *resurrect* a single unified exit-gate fix and see whether it survives.
+- **Verdict:** **CONFIRMED-WITH-CAVEATS.** The finding's separate-fixes conclusion holds. I
+  could not construct a single unified exit-gate mechanism that survives the code. The
+  finding's *strongest* argument is not the one it leads with (§2.2 "opposite outcomes",
+  which is collapsible); the load-bearing, framing-proof argument is the
+  **timeout-interpretation conflict** (below), which I verified directly in code. Two
+  corrections to the finding's overconfidence are recorded in §4.
+
+---
+
+## 1. What I independently re-verified in code (anchors confirmed on 2453306)
+
+- **Exit gate is trigger-blind (S1 shared symptom — CONFIRMED).**
+  `attemptRecoveryFromDegraded` (manager_degraded.go:376-416) consults only
+  `refreshAssignmentFromNATS` (a single `Get(assignment.<workerID>)` from `m.assignmentKV`,
+  manager_assignment.go:1561-1571) and `currentAssignmentApplied` (a commitment-state
+  compare, manager_assignment.go:1208-1217). It reads neither `m.bucketEpochs` (A) nor
+  `m.kvErrorWindow` / any per-source KV-op health (B). Verified line-by-line.
+- **`currentAssignmentApplied` is a commitment gate, not a trigger gate** (manager_assignment.go:1208-1217):
+  compares `committedAssignmentOrEmpty()` vs the snapshot on `(Version, LeaderRevision,
+  PartitionSetDigest, source-rev-when-known)`. Both NP-2 and NP-3a/b arm their fault only
+  AFTER Stable (np3 test:180-186; NP-2 reaches Stable at np2 test:124-126 before the recreate
+  at :150-159), so `committed == snapshot` and the guard PERMITS the exit. Confirmed.
+- **Triggers are structurally disjoint.**
+  - A: `enterDegraded("bucket-recreated:" + bucket)` fired directly from `checkBucketEpochs`
+    (manager_setup.go:689). This path NEVER calls `recordKVError` and NEVER touches
+    `kvErrorWindow`. NP-2 hard-codes the isolation: leaves `KVErrorThreshold` default
+    (np2 test:81-83) and asserts `otherDegrades == 0` (np2 test:190-192). The .out shows
+    `otherDegrades=0` (np2.out:4). So A is provably not a `kvErrorWindow` event.
+  - B: `recordKVOpError` → `markKVUnavailable` → `recordKVError` → `kvErrorWindow` append →
+    threshold → `enterDegraded("kv-unavailable")` (manager_degraded.go:235-237, 144-226,
+    wired at manager_election.go:126; assignment watcher sites). Entirely a `kvErrorWindow`
+    event.
+- **No shared fault registry exists in production code.** Grep for `bucketEpochs` /
+  `degradedReason` over non-test `*.go`: the only persistent per-trigger state is
+  `m.bucketEpochs` (manager.go:110-116) for A and `m.kvErrorWindow` for B. The degrade
+  *reason* is a transient string handed to `enterDegraded` and discarded — only
+  `test/simulation/.../worker.go:947,980` caches it, never production. So a "verify the
+  trigger recovered" gate genuinely has no existing common substrate to build on. Confirmed.
+- **C2 isolation (peer takeover) is real** (manager_election.go:106-127): `ErrClaimLost` with
+  a non-connectivity / non-degrading cause routes to `claimLostShutdown`, NEVER through
+  `attemptRecoveryFromDegraded`. Neither family's fix touches it. Confirmed.
+
+The proof `.out` evidence matches the report verbatim: NP-2 `degradedToStable=9
+otherDegrades=0 finalState=Degraded connected=true` (np2.out:4); NP-3b `degradedExits=9
+injected=36` connected (np3b.out:6,8); NP-3a PASS (np3a.out:4). Non-vacuity and isolation
+guards are present and load-bearing in both tests (np2 test:165-167,172-174,190-197;
+np3 test:255-260,267-268).
+
+---
+
+## 2. The decisive refutation of unification: the TIMEOUT-INTERPRETATION CONFLICT
+
+The finding leads with §2.2 "opposite desired outcomes" (A: never exit; B: exit once op
+recovers). A sharp reader collapses that: *it is ONE rule — "exit iff the triggering fault
+has cleared" — applied to two faults, one permanent-by-construction (A), one transient (B).*
+Under that reframing "opposite outcomes" dissolves into "same predicate, different fault
+persistence," and the unification argument looks alive again.
+
+So I went after the **strongest** unification candidate, a genuinely single routine (NOT the
+"add both conjuncts" strawman the finding already dismissed as a labeling artifact):
+
+> **U′:** before `exitDegraded`, re-validate EVERY Parti-owned bucket with one uniform check —
+> "the bucket's stream-`Created` matches the cached epoch AND a probe op against it succeeds."
+> Exit only if every bucket passes.
+> This *looks* unified: NP-2 (Created mismatch → stay), NP-3b (op fails → stay), NP-3a (both
+> pass → exit). One routine, one rule, all buckets.
+
+**U′ dies on the code, not on semantics.** A and B respond *oppositely to the same
+observable* — an op timeout against a bucket:
+
+- **Epoch detection (A) treats a timeout as NON-ACTIONABLE.** `checkBucketEpochs` on a probe
+  error logs `"epoch fence: probe failed; relying on next tick"` and `continue`s WITHOUT
+  degrading (manager_setup.go:679-682). Only a *successful* read returning a different
+  `Created` is actionable (`if !live.Equal(ep.created)`, :684-689).
+- **KV-op detection (B) treats a timeout as THE FAULT ITSELF.** `markKVUnavailable` wraps a
+  bare `context.DeadlineExceeded` / `nats.ErrNoResponders` into `ErrKVUnavailable`
+  (manager_degraded.go:67-69); `recordKVError` admits exactly that and accumulates it toward
+  the threshold (manager_degraded.go:164-167, 186).
+
+Now run U′ under B's fault (NP-3b): re-validating the heartbeat bucket makes the
+`BucketStreamCreated` read itself **time out** (the heartbeat bucket is in the fault set,
+np3 test:142-147). U′ must decide what a timeout means:
+- If U′ **blocks on the timeout** → correct for B, but it now blocks on a *transient probe
+  error*, exactly the false-positive `checkBucketEpochs` was written to avoid (:679-682). It
+  would wedge a worker Degraded forever on a single slow epoch probe — a regression A's own
+  monitor explicitly refuses.
+- If U′ **ignores the timeout** ("rely on next tick", A-correct) → B's fault is invisible to
+  the gate; NP-3b still false-exits.
+
+There is no single interpretation of a timeout that is correct for both. To get both right U′
+must **tag which check the timeout belongs to** — i.e. split into an epoch-probe check (error
+⇒ ignore) and a KV-op-health check (error ⇒ fault present). That tagging IS two mechanisms
+with opposite error-handling sharing only an `if`-body. **Unification refuted at the
+implementation layer, independent of how abstractly the predicate is phrased.** This is the
+argument the finding should have led with; I verified every cited line.
+
+Corollary (the finding's §2.1/§2.3, re-confirmed sharper): a KV-op-recovered gate is
+structurally blind to A because a bucket recreate is never a KV-op error — there is no failing
+op to verify recovered (manager_setup.go:689 bypasses `recordKVError` entirely). And an
+epoch-mismatch gate is inert for B because B never produces a `Created` mismatch. Each gate is
+necessary and neither covers the other family.
+
+---
+
+## 3. Attacking the recommended fixes (task step c)
+
+### 3.1 A-opt-2 (epoch-aware exit guard) — strongest objection = C1 regression. DOES NOT survive.
+
+Objection: A-opt-2 adds a pre-`exitDegraded` guard in the same block C1's recoverable
+whole-bucket-loss path runs through; could it wedge `TestManager_LiveNATSBucketLoss`?
+
+**Traced the test (not inferred):** `TestManager_LiveNATSBucketLoss`
+(manager_live_bucket_loss_test.go:30-145) wipes the **assignment bucket** (line 86), CONFIRMS
+it is gone (`require.ErrorIs(... ErrBucketNotFound)`, line 100), and ASSERTS the buckets stay
+gone (lines 128-132) — workers are NEVER expected to recover to Stable; the test only checks
+Degraded *entry* within 20s and then ends. On the recovery tick `refreshAssignmentFromNATS`'s
+`Get(assignment.<workerID>)` returns `ErrBucketNotFound`, so `attemptRecoveryFromDegraded`
+bails at manager_degraded.go:383-387 **before** the exit block. **A-opt-2's guard is never
+reached on the C1 recoverable path** — confirmed by reading the test, not inferred. Same for
+`TestManager_PartialBucketLoss_HeartbeatHealthy` (assignment also wiped, line 298). The
+objection does NOT survive: A-opt-2 cannot regress C1. (Residual: a `-race` run is still owed
+because the guard reads `m.bucketEpochs` on the connection-monitor goroutine while the epoch
+monitor writes it — a real concurrency surface, not a correctness regression.)
+
+### 3.2 B-opt-1 (verify-the-failing-op-recovered gate) — does it break the NP-3a control? NO.
+
+NP-3a disarms the fault (np3 test:300); ops against heartbeat/election/stableid succeed again;
+the `kvErrorWindow` drains via `recordKVSuccess` on the next recovery tick
+(manager_degraded.go:393) AND a fresh healthy periodic op fires after `degradedSince` → the
+B-opt-1 conjunct (`kvErrorCount == 0` + last-healthy-op-after-degradedSince) passes → exit →
+NP-3a still recovers and HOLDS Stable (`require.Never(Degraded, 5s)`, np3 test:309-312).
+Verified by construction; B-opt-1 narrows *when* B exits but still allows the legitimate exit.
+The control is preserved.
+
+Residual on B-opt-1 (inherited, not introduced): the F-D1 global-window-drain inherits the
+documented semantic narrowing — a healthy heartbeat clears transient entries attributed to
+slower buckets before threshold (04-fd1-flapping-decision.md:80-91). A global drain suffices
+for the NP-3b *proof* (it faults heartbeat/election/stableid together, np3 test:142-147); a
+real single-non-heartbeat-bucket quorum loss may need per-source counters. This is a
+precision/coverage caveat on B-opt-1's strength, not a refutation of separateness.
+
+---
+
+## 4. Corrections to the finding's overconfidence (do not change the verdict)
+
+1. **"A-opt-1 alone fails NP-1" is inferred, not traced — and may be wrong in direction.**
+   In NP-1 the assignment bucket is wiped+recreated EMPTY. `refreshAssignmentFromNATS`'s
+   `Get(assignment.<workerID>)` against an empty recreated bucket would return key-not-found →
+   bail at manager_degraded.go:383-387 → **stay Degraded**, the OPPOSITE of the claimed
+   "rests Stable on empty bucket" — UNLESS the still-running leader repopulates
+   `assignment.<workerID>` before the recovery tick. The report's "all three rest Stable"
+   (04-proof-findings.md:83-93) is *current-HEAD* behavior (no `ep.created` re-capture, so the
+   epoch tick keeps the fleet alive long enough for the leader to repopulate), which does not
+   directly establish A-opt-1's behavior. The finding inherits the report's confidence here.
+   This is an A-opt-1-vs-A-opt-2 completeness question and is orthogonal to separate-vs-unified
+   — flagging it so the fix plan traces NP-1 under A-opt-1 rather than asserting it.
+
+2. The finding's discrepancy-with-report list (its 4 items) is accurate and survives scrutiny;
+   I confirmed §7.1 (04-proof-findings.md:276-282) is internally muddled (it calls A-opt-2 "the
+   shared exit fix" while also saying A "still needs the stale-`ep.created` latch addressed",
+   when under A-opt-2 the staleness must be PRESERVED as the load-bearing terminal signal) and
+   that §1 line 52 conflates shared-symptom with shared-fix.
+
+---
+
+## 5. Verdict
+
+- **Root-cause mechanism (S1 shared symptom + S2 separate fixes): HOLDS.** Verified in code,
+  not parroted. The exit gate is trigger-blind; the two triggers are structurally disjoint;
+  no shared fault registry exists; the recommended A-opt-2 / B-opt-1 are genuinely independent
+  conjuncts.
+- **Unification (the report's S2 "one fix closes A+B"): REFUTED.** The strongest single-routine
+  candidate (U′) dies on the timeout-interpretation conflict (manager_setup.go:679-682 vs
+  manager_degraded.go:67-69): the same observable (an op timeout) is non-actionable for A's
+  detector and IS the fault for B's, so no single predicate can interpret it correctly for
+  both. "One function edited, two conjuncts" is a labeling artifact, not unification.
+- **Fix attack (step c): both recommended fixes survive their strongest objections.** A-opt-2
+  cannot regress C1 (traced: C1's recoverable path bails on the failed assignment read before
+  the guard). B-opt-1 does not break the NP-3a control (window drains + healthy op ⇒ exit
+  permitted). Residual risks are concurrency (-race owed) and B-opt-1's inherited F-D1
+  coverage narrowing — neither refutes separateness.
+- **Confidence: high.** Default verdict (separate fixes) was actively challenged via the
+  hardest unification steelman I could build and survived.

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/exit-gate-unification.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/exit-gate-unification.md
@@ -1,0 +1,344 @@
+# Exit-Gate Unification — Adversarial Refutation of "one fix closes A+B"
+
+- **Date:** 2026-06-01
+- **HEAD:** 2453306 (branch `auto-heal-gap-investigation`)
+- **Assignment:** Refute (or survive the refutation of) the report's §1 claim that
+  Families A (epoch-fence recreate) and B (connected-but-KV-unavailable) **share the
+  load-bearing exit defect** in `attemptRecoveryFromDegraded`, and that "a single fix to
+  the exit gate could close BOTH A and B."
+- **Verdict:** **Confirmed-with-corrections.** The shared-*symptom* half of the report is
+  accurate; the shared-*fix* conclusion is **refuted**. The two families need **separate,
+  independent** fixes (at most coordinated-but-separate). They additionally want *opposite
+  desired outcomes* at the exit gate, so no single mechanism can satisfy both.
+
+---
+
+## 0. What the report actually claims (so the refutation is honest)
+
+§1 (04-proof-findings.md:48-52) and §7.1 (lines 276-282) make **two distinct sub-claims**.
+They must be judged separately or the verdict over/under-claims:
+
+- **Sub-claim S1 (shared symptom):** both A and B "exit to Stable on a healthy *assignment*
+  read while a *different* trigger is still firing" — the recover-on-wrong-signal exit in
+  `attemptRecoveryFromDegraded`. **This is ACCURATE** (verified below).
+- **Sub-claim S2 (shared fix):** "A single fix to the exit gate could close both A and B"
+  (with the caveat "A still needs the stale-`ep.created` latch addressed"). **This is the
+  claim under attack, and it is REFUTED.**
+
+So the correct verdict is **confirmed-with-corrections**, not a blanket `refuted`: the
+per-family root causes the report states are sound; the correction is "shared function,
+disjoint missing checks, opposite desired outcomes ⇒ no single mechanism fix."
+
+---
+
+## 1. Independent re-derivation of the recovery state machine
+
+### 1.1 The exit path is trigger-blind (the shared symptom S1 — confirmed)
+
+The recovery loop runs on the connection monitor (`monitorNATSConnection`, 1s ticker,
+`manager_degraded.go:76-94`). On each tick `checkConnectionHealth`
+(`manager_degraded.go:97-134`):
+
+- If connected and `connUpSince` has exceeded `ExitThreshold`, it calls
+  `attemptRecoveryFromDegraded` (`:128-132`). Recovery is gated on connection **uptime**,
+  not on any subsystem health.
+
+`attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`) does exactly four things:
+
+1. `if m.degradedSince.Load() == 0 { return }` — bail if not degraded (`:378`).
+2. `refreshAssignmentFromNATS()` — reads **only** `assignment.<workerID>` from
+   `m.assignmentKV` (`manager_assignment.go:1561-1568`). On error: `recordKVError(err)` +
+   return (stay degraded, `:383-387`).
+3. `recordKVSuccess()` — wipes the **entire** `kvErrorWindow` (`manager_degraded.go:393`,
+   impl `:244-250`).
+4. `cur := m.CurrentAssignment(); if !m.currentAssignmentApplied(cur) { scheduleApplyRetry;
+   return }` else `exitDegraded()` (`:408-415`).
+
+**The load-bearing fact:** this function reads **neither** `m.bucketEpochs` (Family A's
+trigger state) **nor** any per-source KV-op health (Family B's failing
+heartbeat/election/stableid). The only health signals it consults are (a) a single
+assignment-bucket Get and (b) `currentAssignmentApplied`, a *commitment-state* comparison.
+So whenever the assignment bucket is readable and the snapshot is committed, it exits —
+regardless of why the worker degraded. That is sub-claim S1, and it is **confirmed**.
+
+### 1.2 `currentAssignmentApplied` is a commitment gate, NOT a trigger gate
+
+`currentAssignmentApplied` (`manager_assignment.go:1208-1217`) compares
+`committedAssignmentOrEmpty()` against the snapshot on the applied-ack identity
+`(Version, LeaderRevision, PartitionSetDigest, source-rev-when-known)`. The
+latched-worker-commitment plan (`03-latched-worker-version-commitment-plan.md:404-407`)
+states the design intent explicitly:
+
+> "The guard keys on commitment STATE, not the degraded reason — exiting with an unapplied
+> assignment is wrong regardless of why we degraded."
+
+This is the crux of why the latched fix does **not** close either family: it was *designed*
+to be reason-agnostic. In both A and B the worker has a fully-committed snapshot
+(`committed == snapshot`), so `currentAssignmentApplied(cur) == true` and the guard
+**permits** the exit. The NP-3b harness even arms its fault *only after* Stable precisely so
+`committedAssignment == snapshot` and "the recovery path under test is the false-exit branch
+... not the stay-degraded `scheduleApplyRetry` branch" (np3 test comment,
+`np3_kv_unavailable_recovery_test.go:180-186`). So the existing exit gate's only sub-checks
+are orthogonal to both triggers.
+
+### 1.3 The two triggers are structurally DISJOINT (the wedge)
+
+Enumerating every `enterDegraded` entry surface (grep over `*.go`, non-test):
+
+- **Family A trigger:** `manager_setup.go:689` —
+  `m.enterDegraded("bucket-recreated:" + bucket)`, fired **directly** from
+  `checkBucketEpochs` (`manager_setup.go:669-693`) when the live stream-`Created` differs
+  from the cached `ep.created`. This path **never** calls `recordKVError` and **never**
+  touches `kvErrorWindow`. The NP-2 proof hard-codes this isolation: it deliberately leaves
+  `KVErrorThreshold` at default so a transient heartbeat-Put miss "cannot independently trip
+  'kv-unavailable' and mask the epoch-fence flap" (`np2_...:81-83`), and asserts
+  `otherDegrades == 0` (`:190-192`). So Family A is provably *not* a `kvErrorWindow` event.
+- **Family B trigger:** `recordKVOpError` → `markKVUnavailable` → `recordKVError` →
+  `kvErrorWindow` append → threshold → `enterDegraded("kv-unavailable")`
+  (`manager_degraded.go:235-237`, `144-225`). Wired at every periodic KV-op site: election
+  renew (`manager_election.go:126`), election ticks (`:262`, `:303`), heartbeat publisher
+  `SetOnError` (`:424`), assignment watcher (`manager_assignment.go:398`, `:437`, `:636`).
+  Family B is *entirely* a `kvErrorWindow` event.
+
+The two triggers live in **different state** (`m.bucketEpochs` map vs `m.kvErrorWindow`
+slice), are driven by **different monitors** (epoch ticker at `OperationTimeout` vs per-op
+error callbacks), and produce **different reason strings** (`bucket-recreated:<b>` vs
+`kv-unavailable`). The recovery exit gate inspects *neither*.
+
+---
+
+## 2. What a "fixed" exit gate would have to be — and why it cannot be one mechanism
+
+The natural unified candidate (task step b): **"exit only when the op(s) that TRIGGERED the
+degrade have demonstrably recovered."** Today the degrade reason is just a **string** passed
+to `enterDegraded` and discarded — there is **no per-trigger health signal** anywhere. So a
+"verify the trigger recovered" gate *requires new bookkeeping*: a record of "what made me
+degrade + is it healthy now." The question is whether **one** such mechanism can cover both.
+It cannot, for three independent reasons.
+
+### 2.1 Disjoint health probes (the trigger-recovered signals differ)
+
+- To know **Family B recovered**, the gate must observe that the *failing periodic KV op*
+  (heartbeat/election/stableid) is succeeding again. The natural signal is "the
+  `kvErrorWindow` has drained / a healthy op intervened" — i.e. the F-D1 candidates from
+  `04-fd1-flapping-decision.md:118-123`: post-recovery cooldown, verify-the-failing-op-
+  recovered, or per-source error counters. All three are expressed in **kvErrorWindow / KV-op
+  terms**.
+- To know **Family A recovered**, the gate must compare the live stream-`Created` against the
+  cached epoch — i.e. read `m.bucketEpochs`. A bucket recreate **never enters
+  `kvErrorWindow`** (§1.3), so a gate "verify the failing KV op recovered" is **structurally
+  blind to Family A**: there is no KV-op error to verify recovered. This directly answers
+  task step (c): *an exit-gate fix expressed in KV-op terms does not cover A at all.*
+
+### 2.2 Opposite desired outcomes (the deepest reason — a single predicate cannot encode both)
+
+This is the decisive refutation. The two families want the gate to do **opposite** things
+once the assignment read succeeds:
+
+- **Family B's correct behavior is to auto-heal.** Once the KV op recovers, the worker
+  **should** return to Stable. Positive control **NP-3a PASSES**
+  (`np3_...:285-313`): after disarm the manager recovers to Stable and **holds** it
+  (`require.Never(Degraded, 5s)`). B's bug is exiting *too early* (before the op recovers);
+  the fix narrows *when* it exits but still exits.
+- **Family A's correct behavior is to NEVER auto-heal.** The M4 contract is **terminal**
+  Degraded so a readiness probe rotates the pod (NP-2 asserts `finalState == StateDegraded`,
+  `np2_...:211-214`; NP-1 asserts no `Degraded→Stable` after recreate). A bucket recreate is
+  permanent-by-design data loss; recovery is a process restart, not an in-process exit
+  (`docs/OPERATIONS.md`, `manager_live_bucket_loss_test.go`).
+
+A single "exit iff trigger recovered" predicate would have to encode "trigger B is
+transiently-unhealthy (exit when it clears)" **and** "trigger A is permanently-unhealthy-by-
+design (never exit)." That *is* the per-trigger registry the task hypothesizes — and it is two
+disjoint, independently-necessary probes (kvErrorWindow drain vs epoch-Created compare) living
+in the same `if` body. "One fix" is then true only trivially (one function edited); the
+*mechanisms* are independent. There is no shared computation.
+
+### 2.3 Concrete break case (task step c — fixing B breaks/misses A)
+
+Implement the F-D1 "verify the failing KV op recovered" gate for B: before `exitDegraded`,
+require that the `kvErrorWindow` is empty *and* a fresh healthy heartbeat/election op has been
+observed. Run Family A's NP-2 against it:
+
+- The bucket recreate fires `enterDegraded("bucket-recreated:<heartbeat>")` with the
+  `kvErrorWindow` **empty** (NP-2 keeps it empty by design, §1.3).
+- The new B-gate sees an empty window + (after the heartbeat bucket is recreated, even empty)
+  succeeding heartbeat ops → "trigger recovered" → **`exitDegraded` → Stable**.
+- The epoch tick re-degrades on the next `OperationTimeout` poll → **the A flap is
+  unchanged.** The B-fix is inert for A; worse, by green-lighting "KV ops healthy" it actively
+  *permits* the wrong-direction exit A must forbid.
+
+Symmetrically, an A-gate ("refuse to exit while an epoch mismatch is outstanding", §3.2) is
+inert for B: B never has an epoch mismatch, so the A-gate always passes and B still exits on
+the wrong signal. Neither gate covers the other family. **Refutation of S2 complete.**
+
+---
+
+## 3. The stale-`ep.created` latch is genuinely orthogonal (task step d)
+
+`captureBucketEpoch` writes `ep.created` **once** at Start (`manager_setup.go:627`);
+`checkBucketEpochs` **never re-captures** it (`:669-693`). So after a recreate the cached
+value stays stale forever and every epoch tick re-fires `enterDegraded`. This is **purely a
+Family A property** — B has no epoch state at all. Two fix shapes interact with it oppositely:
+
+- **A-1 — re-capture `ep.created` after firing.** This latches the fence to fire **once**.
+  But by itself it is **actively wrong**: it stops re-degradation, so the very next recovery
+  tick exits to Stable on the (now recreated, possibly **empty**) assignment bucket and the
+  worker **rests Stable on wiped coordination data** — the NP-1 false-healthy resting state
+  (`healed=[0 1 2]`, all three rest `Stable` on empty buckets, `04-proof-findings.md:83-93`).
+  A-1 alone converts a flap into a *silent* false-healthy, which is **worse**.
+- **A-2 — refuse to exit while an epoch mismatch is outstanding.** This makes the
+  **never-re-captured staleness load-bearing in the RIGHT direction**: a permanently-stale
+  `ep.created` is exactly what keeps the mismatch detectable forever ⇒ terminal Degraded. Under
+  A-2 you do **not** want the latch "fixed" — you want the staleness **preserved** and you add
+  an epoch-aware exit check that reads `m.bucketEpochs` inside `attemptRecoveryFromDegraded`.
+
+Either way, A needs an **epoch-aware** change (re-capture, or epoch-outstanding exit check)
+that B neither needs nor benefits from. The latch is orthogonal to any KV-op exit gate and is
+**still required** regardless of what is done for B.
+
+### 3.1 Discrepancy with the report (§7.1)
+
+The report's §7.1 (lines 276-282) is **muddled on its own option 2**:
+
+> "Because Family A's exit defect is shared with Family B, a single fix to the
+> `attemptRecoveryFromDegraded` exit gate (option 2) may also resolve A's recovery half — but
+> A still needs the stale-`ep.created` latch addressed."
+
+- It frames A-2 as "the shared exit fix" while also saying "A still needs the stale-
+  `ep.created` latch addressed." Under A-2 the stale `ep.created` must be **kept**, not
+  "addressed" — preserving the staleness is what makes Degraded terminal. The phrasing is
+  backwards for its own option 2.
+- The two A options are not interchangeable as the report implies ("the proofs are agnostic to
+  which fix lands", §7.1 line 278): **A-1 alone fails NP-1** (rests Stable on empty buckets),
+  so it is not a complete fix. Only A-2 (or A-1 *plus* a recovery-exit guard) satisfies both
+  NP-2's terminal-Degraded and NP-1's no-false-healthy invariants.
+
+This is a real, citable discrepancy: the report's tidy "shared exit fix + latch on top"
+framing does not hold up against its own NP-1 evidence.
+
+---
+
+## 4. Viable fix options (mechanism, surface, blast radius, contracts, risk)
+
+### Family B options (KV-op-recovery gated)
+
+**B-opt-1 — Verify-the-failing-op-recovered exit gate.**
+- *Mechanism:* before `exitDegraded` in `attemptRecoveryFromDegraded`, additionally require
+  that the degraded-circuit window has drained AND a fresh healthy periodic op was observed
+  since the degrade (e.g. gate on `kvErrorCount == 0` plus a "last healthy heartbeat after
+  degradedSince" timestamp). Builds on the existing `recordKVHealthyOp` (421f13c) signal.
+- *Surface:* `manager_degraded.go:408-415` (add condition before `exitDegraded`); reuse
+  `kvErrorWindow`/`kvErrorCount` + a new `lastHealthyOpAt atomic.Int64`.
+- *Blast radius:* recovery exit only; runs on the connection-monitor goroutine — needs the
+  `-race` stress per AGENTS.md (template `degraded_recovery_rearm_concurrency_test.go`).
+- *Contracts:* **C1** unaffected (whole-bucket entries are non-transient and keep the worker
+  degraded — but note: under whole-bucket loss the *assignment* read also fails, so recovery
+  already bails at `:383-387` before the gate). **C2** is the worker-takeover claim path —
+  untouched. **C3** held by construction (staying degraded keeps `degradedSince` non-zero, so
+  `enterDegraded`'s CAS blocks re-fire). **C4** untouched (Start returns after sanity check).
+- *Cons / residual risk:* the F-D1 semantic-narrowing already means a non-heartbeat sustained
+  F-D1 timeout may be cleared by a healthy heartbeat before threshold
+  (`04-fd1-flapping-decision.md:80-91`); a global "window drained" gate inherits that. A
+  per-source counter variant is more precise but larger. **Structurally blind to A** (§2.3).
+
+**B-opt-2 — Post-recovery cooldown.**
+- *Mechanism:* after `exitDegraded`, suppress a re-exit for N seconds; if the trigger re-fires
+  within the cooldown the worker stays degraded longer. Cheapest, but it does not *verify*
+  recovery — it only damps the flap *frequency*. NP-3b's `require.Zero(degradedExits)` would
+  still FAIL (it allows zero exits, not slower exits). **Insufficient for the NP-3b invariant
+  as written; also blind to A.** Listed for completeness; not recommended.
+
+### Family A options (epoch-aware)
+
+**A-opt-1 — Re-capture `ep.created` after firing (latch-once).**
+- *Mechanism:* in `checkBucketEpochs`, after `enterDegraded`, set
+  `ep.created = live; m.bucketEpochs[bucket] = ep`.
+- *Surface:* `manager_setup.go:684-690`.
+- *Blast radius:* epoch monitor only.
+- *Residual risk:* **FAILS NP-1** — stops re-degradation but the recovery loop then rests the
+  worker Stable on the empty recreated bucket (false-healthy). **Not a complete fix alone**;
+  must be paired with an exit guard (A-opt-2) or it regresses NP-1 into a silent false-healthy.
+- *Contract note:* it changes the epoch fence from "re-fire every tick" to "fire once," which
+  is the *intended* one-shot; but the exit half must still be closed.
+
+**A-opt-2 — Epoch-aware exit guard (recommended for A).**
+- *Mechanism:* in `attemptRecoveryFromDegraded`, before `exitDegraded`, refuse to exit if any
+  `bucketEpoch` still shows a live-vs-cached `Created` mismatch (read `m.bucketEpochs` and
+  re-probe, or cache an `epochMismatchOutstanding atomic.Bool` set by `checkBucketEpochs`).
+  Keep `ep.created` permanently stale so the mismatch remains detectable ⇒ terminal Degraded.
+- *Surface:* `manager_degraded.go:408-415` (new pre-exit check) + a flag set at
+  `manager_setup.go:689`.
+- *Blast radius:* recovery exit + epoch monitor; both already on background goroutines —
+  `-race` stress required (template `epoch_monitor_concurrency_test.go`).
+- *Contracts:* **C1** — must verify the whole-bucket-loss tests still recover: those wipe the
+  bucket without recreating a *different* stream identity in the recovery window, and recovery
+  bails on the failed assignment read anyway, so the epoch guard is not reached on the
+  recover-able path. Verify `TestManager_LiveNATSBucketLoss` still recovers. **C3** held (stays
+  degraded ⇒ no re-fire). **C2/C4** untouched.
+- *Residual risk:* a flag-based variant must avoid a stuck-degraded false-positive if a probe
+  transiently fails (the epoch monitor already treats a probe *error* as "rely on next tick",
+  `manager_setup.go:679-682`; the guard should only block on a confirmed mismatch, not a probe
+  error). Satisfies BOTH NP-2 (terminal) and NP-1 (no false-healthy).
+
+### The unified candidate (rejected)
+
+**U — single combined exit predicate.** Add both an epoch-mismatch check AND a KV-op-recovered
+check before `exitDegraded`. This is "one function edited" but **two disjoint mechanisms** with
+**opposite intents** (A: block forever; B: block until op recovers) sharing no computation
+(§2.2). It is not a "single fix to the exit gate" in any meaningful sense — it is A-opt-2 and
+B-opt-1 implemented in the same `if`. Calling it unification is a labeling artifact.
+
+---
+
+## 5. Cross-family interactions
+
+- Both fixes edit the **same window** (`manager_degraded.go:408-415`, just before
+  `exitDegraded`). If both land they must compose: the exit fires only when **both** the
+  epoch-mismatch guard (A) AND the KV-op-recovered guard (B) pass. They are independent
+  conjuncts — no shared state, no ordering dependency — so this is *coordinated-but-separate*,
+  not unified. A single PR touching this block is reasonable for review economy, but the two
+  conjuncts are independently testable and independently necessary.
+- **C1 interaction (whole-bucket loss):** the strongest interaction risk. Both NP-2 (A) and
+  the C1 contract test (`TestManager_LiveNATSBucketLoss`) involve a missing/recreated bucket.
+  The discriminator is that C1's recover-able path fails the **assignment read** in
+  `refreshAssignmentFromNATS` and bails at `:383-387` *before* either new guard. Any fix must
+  re-run C1's two pinned tests `-race` to confirm the guards are not reached on the
+  legitimately-recoverable path. (AGENTS.md cross-feature contract requirement.)
+- **421f13c (`recordKVHealthyOp`) interaction:** it clears only *transient* entries on a
+  healthy op while not degraded. It is upstream of the *entry* side (prevents B from
+  degrading), not the *exit* side. B-opt-1 reuses its "healthy op observed" signal but for the
+  exit gate. No conflict; complementary.
+
+---
+
+## 6. Verdict
+
+- **rootCauseVerdict: confirmed-with-corrections.**
+  - Sub-claim S1 (shared *symptom* — both exit via `attemptRecoveryFromDegraded` on the
+    assignment-read signal while a different trigger persists): **confirmed.**
+  - Sub-claim S2 (shared *fix* — one exit-gate change closes both): **refuted.**
+- **Family relationship: fully independent** (at most coordinated-but-separate if both
+  conjuncts share one PR). The recovery exit gate inspects neither trigger's state; the two
+  triggers are structurally disjoint (`bucketEpochs` vs `kvErrorWindow`); the desired exit
+  outcomes are opposite (A: never exit / terminal; B: exit once the op recovers); and a
+  KV-op-recovered gate is structurally blind to A's epoch tick.
+- **A's stale-`ep.created` latch is orthogonal and still required** regardless of any B fix;
+  under the recommended A-2 the staleness is *preserved* (load-bearing), contradicting the
+  report's "the latch still needs addressing" phrasing.
+- **Recommended:** treat as two separate fixes — **A-opt-2** (epoch-aware exit guard, keep
+  `ep.created` stale) for Family A, and **B-opt-1** (verify-the-failing-op-recovered exit gate)
+  for Family B — landed with a shared `-race` regression pass on `manager_degraded.go`'s exit
+  block and a mandatory re-run of the C1 contract tests.
+
+## 7. Open questions
+
+- Does C1's `TestManager_LiveNATSBucketLoss` ever reach the recovery exit block, or does it
+  always bail on the failed assignment read? (Strongly inferred = always bails, but worth a
+  direct trace before A-opt-2 lands, since A-opt-2's guard sits in that block.)
+- For B-opt-1, is a global `kvErrorWindow`-drained gate sufficient for NP-3b, or is a
+  per-source counter required? NP-3b faults heartbeat/election/stableid together, so the
+  global gate suffices for the *proof*; a real single-non-heartbeat-bucket quorum loss (the
+  F-D1 documented coverage gap, `04-fd1-flapping-decision.md:80-91`) may need per-source.
+- A-opt-2 flag vs re-probe: a cached `epochMismatchOutstanding` flag avoids a probe in the
+  hot recovery tick but risks staleness; a re-probe is authoritative but adds a KV read per
+  recovery tick. Decide during the fix plan.

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-a-epoch-verify.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-a-epoch-verify.md
@@ -1,0 +1,264 @@
+# Adversarial verification — Family A (NP-2 + NP-1) epoch-fence finding
+
+Target: `family-a-epoch.md` (+ its JSON verdict). HEAD = `2453306` on
+`auto-heal-gap-investigation`. Read-only. Every claim cites `file:line` or a test name.
+Goal was to **refute**, not confirm. Net: the root cause holds; the finding's headline
+recommended fix (**latched** Opt-2) is **overstated as "necessary AND sufficient, high
+confidence"** — its sufficiency for NP-1 is not established and its own
+self-suppression argument is mis-stated for NP-1. The fix the finding *dismissed*
+(live re-probe at exit) is the robust one.
+
+Verdict: **confirmed-with-caveats.**
+
+---
+
+## 1. Root-cause mechanism — independently re-derived, HOLDS
+
+### Half (i): epoch fence never re-captures `ep.created` (re-arm)
+- `captureBucketEpoch` writes the cached Created exactly once: map init at
+  `manager_setup.go:613`, sole assignment at `:627`. Verified by grep — the only
+  writers of `m.bucketEpochs` are `manager_setup.go:613` and `:627`; the only reader
+  outside `manager_setup.go` is the field decl `manager.go:116`. **Zero readers in the
+  exit path.** (grep of `bucketEpochs` across non-test `.go`.)
+- `checkBucketEpochs` (`manager_setup.go:669-693`) reads live Created via cached
+  `ep.kv` (`:677`), fires `enterDegraded("bucket-recreated:"+bucket)` on
+  `!live.Equal(ep.created)` (`:684,:689`), then `return`s (`:690`) — **never updates
+  `ep.created`.** Mismatch is therefore permanent for the process lifetime.
+- Tick cadence = `OperationTimeout` (`manager_setup.go:649-652`). **Important and used
+  below: NP-2 overrides this to 1s (`np2_..._test.go:76`); NP-1 does NOT override it,
+  so it is the 10s default** (`config.go:410` `default:"10s"`; `IntegrationTestConfig`
+  does not set it).
+
+### Half (ii): recovery exits on the wrong signal
+- Connection monitor ticks 1s (`manager_degraded.go:79`); conn never drops in
+  NP-1/NP-2 so it stays on the up-branch and, once up for `ExitThreshold`, calls
+  `attemptRecoveryFromDegraded` every tick (`:130-131`).
+- `attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`) refreshes ONLY the
+  assignment bucket (`refreshAssignmentFromNATS` → `assignmentKV.Get("assignment.<id>")`,
+  `manager_assignment.go:1567-1568`) and gates exit solely on
+  `currentAssignmentApplied` (`:409`), whose predicate (`manager_assignment.go:1208-1217`)
+  compares Version/LR/digest/source-rev and **never consults `m.bucketEpochs`.** The
+  wipe signal is structurally invisible to the exit. CONFIRMED.
+
+### Exit-path completeness (a refutation attempt that FAILED — supports the finding)
+I tried to break Opt-2's sufficiency by finding a `Degraded→Stable` edge that does NOT
+go through `attemptRecoveryFromDegraded`/`exitDegraded` (which Opt-2 gates). Result:
+**there is none.**
+- Transition matrix `manager_state.go:160-171`: `StateDegraded` exits ONLY to
+  `{StateStable, StateShutdown}`.
+- The other `transitionState(StateStable)` callers cannot fire from Degraded:
+  `stopCalculator` (`manager_assignment.go:277`) only fires from
+  `Scaling/Rebalancing/Emergency` (`:271-272`); `syncStateFromCalculator`
+  (`manager_state.go:220-232`) only maps Idle→Stable from `isCalculatorOwnedActiveState`
+  (excludes Degraded); `markStartupAssignmentApplied` (`manager_startup_async.go:114-128`)
+  is CAS-once on `startupAssignmentApplied` (`:115`) — already true post-startup in
+  NP-1/NP-2 so it no-ops, and its `:128` `transitionState(StateStable)` is gated behind
+  `isCalculatorOwnedActiveState` (`:121`).
+- `exitDegraded` is the **only** `Degraded→Stable` edge, and it is reached only via
+  `attemptRecoveryFromDegraded:415`. So gating that one function covers the exit. The
+  finding's structural premise (gate the one exit) is sound. **Checked & cleared.**
+
+### Version-monotonicity sub-path (finding §(b)) — HOLDS
+`p.currentVersion` is in-memory (`assignment_publisher.go:106`); `DiscoverHighestVersion`
+only ever RAISES it (`:882-884` commit-seed, `:917-919` legacy-scan), never lowers. So
+after the wipe the leader keeps its pre-wipe version and republishes higher into the
+empty bucket. Corroborated by `np1.out`: pre-wipe versions `map[worker-0:2 worker-1:2
+worker-2:2]`, and worker-0 shows `Stable→Rebalancing→Stable` right after the wipe (a real
+recalc+republish). VERIFIED. This is a genuine addition the report omits.
+
+---
+
+## 2. Proof non-vacuity / isolation — checked, the proofs are sound
+
+**NP-2** (`np2_..._test.go`): non-vacuity guard `bucketRecreatedDegrades>=1` (`:172`);
+sanity that recreate produced a strictly-later Created (`:165`); isolation
+`otherDegrades==0` (`:190`) and `connected==true` (`:196`); primary hard invariant
+`require.Zero(degradedToStable)` (`:204`). `np2.out`: `degradedToStable=9,
+otherDegrades=0, finalState=Degraded, connected=true`. The CAS argument is valid:
+`enterDegraded` CAS-guards `degradedSince` (`manager_degraded.go:309`), so 10 entries
+require 9 intervening `exitDegraded`s — irrefutable oscillation. PROOF VALID, non-vacuous.
+
+**NP-1** (`np1_..._test.go`): non-vacuity `all 3 reach Degraded` (`:207-210`); hard
+invariant `require.Empty(healed)` where `healed` = workers with a `Degraded→Stable`
+edge strictly after `recreatedAt` (`:79-87,:248`). `np1.out`: `healed=[0 1 2]`,
+all end Stable on empty buckets. PROOF VALID. The discriminator (bucket-recreated
+fired) is logged, not gated — correct (it would otherwise couple the proof to the bug
+mechanism).
+
+One nuance I checked and discarded as a refutation: OnStateChanged and OnDegraded are
+dispatched **asynchronously** (`invokeHook` → `m.wg.Go`, `manager.go:1026-1034`), so the
+`transitions` and `reasons` slices in `np1Probe` have NO cross-goroutine ordering
+guarantee. Any argument of the form "the first `Degraded→Stable` precedes the first
+`bucket-recreated` reason because the slices are co-ordered" is **invalid**. (The proof
+itself does not rely on such co-ordering, so the proof is unaffected.)
+
+---
+
+## 3. Attack on the recommended fix — the finding's "necessary AND sufficient (high)" is OVERSTATED
+
+The finding recommends **latched** Opt-2: set `m.epochFenceTripped` at
+`manager_setup.go:689` (inside `checkBucketEpochs`, on the first post-recreate fence
+*observation*) and `AND !epochFenceTripped` into the exit gate. Three corrections, two
+of which the finding gets backwards.
+
+### 3a. Opt-1-alone-fails-both-proofs — HOLDS (the finding's strongest correct point)
+Traced against the unchanged exit gate, re-capturing `ep.created` after `enterDegraded`
+quiets the fence but leaves half (ii) intact, so the next recovery tick exits to Stable
+and the worker RESTS Stable: NP-2 `degradedToStable=1` (fails `:204`), `finalState=Stable`
+(fails `:212`); NP-1 `healed=[0 1 2]` (fails `:248`). Strictly worse than the flap
+(removes the recurring Degraded windows a readiness probe samples). This directly
+contradicts `04-proof-findings.md:278` ("the proofs are agnostic to which fix lands").
+The finding is RIGHT here, and the report IS imprecise. CONFIRMED.
+
+### 3b. The finding's self-suppression mechanism is MIS-STATED for NP-1
+The finding (family-a-epoch.md:293-298; JSON openQuestion #1) argues latched-Opt-2 is
+sufficient-and-complete because *"the first `bucket-recreated` entry sets the latch,
+then `degradedSince` stays set so `enterDegraded`'s CAS no-ops the repeat
+`bucket-recreated` entries."* **That causal chain is false in NP-1.**
+
+In NP-1 every worker is **already Degraded via `kv-unavailable`** before any
+`bucket-recreated` fires (`np1.out` reasons all start `[kv-unavailable,
+bucket-recreated:*, ...]`; the wipe trips the KV-error threshold path
+`recordKVError`→`enterDegraded` BEFORE the recreate even happens). So the
+`bucket-recreated` `enterDegraded` at `manager_setup.go:689` ALREADY no-ops on the held
+`degradedSince` — *with or without* Opt-2. The latch is armed not by a "first
+bucket-recreated entry" (there is none under latched-Opt-2 from a fresh window) but by
+the fence *observation* (`checkBucketEpochs` mismatch), independent of the CAS. The
+finding conflated NP-2 (where the first degrade IS the fence, so latch-on-entry ==
+latch-on-observation) with NP-1 (where it is not). Under latched-Opt-2 in NP-1, the
+correct statement is "**zero** bucket-recreated OnDegraded entries fire," not
+"repeats are suppressed." The finding's openQuestion #1 is mis-framed.
+
+### 3c. Latched-Opt-2 sufficiency for NP-1 is NOT ESTABLISHED — and the cadence cuts against it
+The latch arms only on the **first post-recreate fence observation**. Before that, the
+exit gate is byte-identical to unfixed code. So latched-Opt-2 fails NP-1 iff a worker
+completes a `Degraded→Stable` exit in the window **[republish lands] → [first
+post-recreate fence tick arms the latch]**.
+
+What I verified about that window:
+- The exit cannot fire in phase 2 (buckets deleted) or before the leader republishes:
+  `refreshAssignmentFromNATS` does `assignmentKV.Get("assignment.<id>")`
+  (`manager_assignment.go:1568`); on a deleted/empty bucket it errors / key-not-found,
+  so `attemptRecoveryFromDegraded` returns early (`:387` / via the predicate). So the
+  earliest possible exit is gated on the leader republish chain. (This kills a naive
+  "a pre-latch exit necessarily exists in phase 2" claim — it does not.)
+- BUT the cadences are lopsided in NP-1: the recovery loop attempts an exit **every 1s**
+  (`manager_degraded.go:79`; conn up long ago, so `ExitThreshold` is already satisfied),
+  while the epoch fence — and thus the latch — only fires **every 10s** in NP-1
+  (`OperationTimeout` default, NOT overridden; §1). NP-2's "fence fires fast" intuition
+  used a 1s fence (`np2_..._test.go:76`) and does not transfer.
+- The leader republish path is **not gated on Degraded** (no `StateDegraded`/
+  `degradedSince` guard in `manager_election.go` or `assignment_publisher.go` — grep
+  empty), and `np1.out` shows the leader actually does `Stable→Rebalancing→Stable`
+  (recalc+republish) post-wipe. `enterRecoveryGracePeriod` is entered only AFTER
+  `exitDegraded` and gates post-exit rebalancing, not the exit itself
+  (`manager_degraded.go:370,418-438`).
+
+So in NP-1 there is a **~10s window per fence period** in which the leader can
+republish a higher-version assignment and the 1-Hz recovery loop can satisfy
+`currentAssignmentApplied` and `exitDegraded` **before** the next 10s fence tick arms
+the latch. Whether the very first such exit beats the first post-recreate fence tick is
+**timing-dependent and unproven** — the finding asserts it passes NP-1 with "high
+confidence" without establishing this. The 10s fence cadence makes the window large, so
+the conservative read is that **latched-Opt-2 may still allow >=1 exit and FAIL NP-1's
+`require.Empty(healed)`.** Note the current (unfixed) `np1.out` already shows multiple
+`Degraded→Stable` edges interleaved with the 10s `bucket-recreated` ticks — direct
+evidence that exits routinely occur inside the inter-fence gaps. The latch does not
+close the FIRST such gap.
+
+### 3d. The finding INVERTED latch vs live-reprobe
+The finding calls the latch "simplest and race-free" and treats
+`epochMismatchOutstanding()` — a live re-probe of `m.bucketEpochs` at exit time
+(family-a-epoch.md:217-220) — as a lesser variant. **Backwards on "race-free."** The
+re-probe form has **no pre-arm window**: `ep.created` is pinned pre-wipe permanently
+(half (i)), so any exit attempt after the recreate sees the mismatch inline and refuses;
+before the recreate, `refreshAssignmentFromNATS` fails anyway. It is robust to placement
+and to the 10s-vs-1s cadence skew. The **latch** is precisely what introduces the
+(non-trivial, 10s-wide) race. So the robust recommendation is the form the finding
+dismissed.
+
+> Caveat on the re-probe form: it adds one `BucketStreamCreated` (stream-info) probe per
+> bucket on each 1s recovery tick while Degraded. That is a real (small) extra KV cost
+> and a possible new failure surface — but `checkBucketEpochs` already swallows probe
+> errors with `continue` (`manager_setup.go:679-682`), so an errored probe at exit time
+> should be treated conservatively (refuse exit OR fall through — design decision). Worth
+> a config/perf note, not a blocker. A cheap middle ground also exists that the finding
+> did not consider: arm the latch from the threshold/`recordKVError` path too, or set it
+> the instant ANY bucket epoch is known-stale rather than only on the fence tick — but
+> the live re-probe is the cleanest "no pre-arm window" answer.
+
+---
+
+## 4. Contract / control regressions — checked
+
+- **C1** (whole-bucket-missing → bounded Degraded entry, `TestManager_LiveNATSBucketLoss`):
+  entry is via `recordKVError`→`enterDegraded` (`manager_degraded.go:144-225`), untouched
+  by an exit-gate change. `np1.out` confirms `kv-unavailable` is the first reason on every
+  worker. UNAFFECTED by either Opt-2 form.
+- **C2** (peer claim takeover → only that worker self-stops, `onClaimerError`,
+  `manager_election.go:106-127`): different reason class; the epoch latch / re-probe is
+  set only by the epoch fence, never by `onClaimerError`. UNRELATED. UNAFFECTED.
+- **C3** (OnDegraded once per entry): IMPROVED under either form (terminal Degraded = one
+  entry, not N). Note §3b: under latched-Opt-2, NP-1 fires **zero** bucket-recreated
+  entries, which is *fine* for C3 but undercuts the finding's stated rationale for why
+  Opt-1 is unnecessary.
+- **C4** (Start returns after sanity phase): unrelated.
+- **NP-3a disarm control / NP-5 blocked-apply recovery**: both must keep exiting Degraded
+  normally. Under latched-Opt-2 the flag is set ONLY by the epoch fence, so non-epoch
+  reasons (kv-unavailable cleared, startup-timeout) still exit. Under the live-reprobe
+  form, `epochMismatchOutstanding()` returns false when no bucket was recreated (the
+  probe equals the cached created), so those recoveries also still exit. **Neither form
+  regresses NP-3a/NP-5.** (Verified by construction; not re-run — proofs are caller-owned.)
+- **NP-9** (full quorum loss incl. assignment bucket): the assignment bucket is faulting,
+  so `refreshAssignmentFromNATS` fails and recovery cannot falsely exit anyway; an
+  exit-gate AND-clause is inert there. UNAFFECTED.
+
+---
+
+## 5. Discrepancies with the finding (not just the report)
+
+1. Finding's recommended fix (**latched** Opt-2) sufficiency for NP-1 is **overstated**:
+   asserted "necessary AND sufficient, high confidence, passes NP-1" without establishing
+   the latch arms before the first post-recreate exit. The 10s NP-1 fence cadence vs 1s
+   recovery cadence makes this a real, ~10s-wide window. (§3c)
+2. Finding's self-suppression mechanism (its reason Opt-1 is "unnecessary once Opt-2
+   lands") is **mis-stated for NP-1**: `kv-unavailable` already holds `degradedSince`, so
+   the CAS already no-ops the bucket-recreated entry regardless of Opt-2; the latch is
+   armed by the fence *observation*, not a bucket-recreated *entry*. (§3b)
+3. Finding **inverted** latch-vs-reprobe: the live re-probe is the race-free form; the
+   latch is what introduces the race. (§3d)
+
+The finding's corrections of the *report* (Opt-1-alone fails both proofs; the proofs are
+NOT fix-agnostic; "one function, two predicates" for A+B; version-monotonicity) are all
+**valid and survive** — those are the finding's real contribution.
+
+---
+
+## 6. Cross-family interaction (A vs B)
+Confirmed composable: A's fence calls `enterDegraded` directly and never touches
+`kvErrorWindow` (`manager_setup.go:689`), while B (NP-3b) lives entirely in
+`recordKVError`/`kvErrorWindow`/threshold (`manager_degraded.go:144-225`). A unified
+`attemptRecoveryFromDegraded` exit gate would AND two independent predicates (A:
+epoch-mismatch-outstanding; B: failing-op-recovered). The finding's "one function, two
+predicates" framing is correct; the report's "one fix closes both" is the imprecise
+version. For A, the predicate should be the **live re-probe** (`epochMismatchOutstanding`),
+not the latch — same reasoning as §3d.
+
+---
+
+## 7. Bottom line
+- Root-cause mechanism (both halves) + version-monotonicity: **HOLDS**, independently
+  re-derived from code.
+- Proofs NP-2/NP-1: **VALID, non-vacuous, well-isolated.**
+- Opt-1-alone-fails / report-is-imprecise: **HOLDS** (finding's real win).
+- Opt-2 **necessity**: holds. Opt-2 **latched-form sufficiency for NP-1**: **NOT
+  established / likely insufficient** due to a ~10s pre-arm race; the finding's
+  "high-confidence necessary AND sufficient" is overstated.
+- Correct fix surface: gate the single exit (`attemptRecoveryFromDegraded`), but with the
+  **live re-probe** `epochMismatchOutstanding()` (the finding's dismissed variant), not
+  the latch — the re-probe has no pre-arm window. If the latch is kept for simplicity, it
+  MUST be armed before any post-recreate exit (e.g. on the first whole-bucket-loss degrade
+  or via a synchronous probe), and the fix's test must assert NP-1's FIRST exit is
+  blocked, not merely that the worker eventually settles Degraded.
+
+Verdict: **confirmed-with-caveats.**

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-a-epoch.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-a-epoch.md
@@ -1,0 +1,366 @@
+# Family A deep-dive: epoch-fence re-degrade + recover-on-wrong-signal flap (NP-2, NP-1)
+
+Investigation of the auto-healing gap where an operator wipes+recreates Parti-owned
+bucket(s) under a live worker. HEAD = `2453306` on `auto-heal-gap-investigation`.
+Read-only investigation; all cites are `file:line` against the worktree.
+
+Verdict: **confirmed-with-corrections.** Both halves of the report's root cause are
+real and verified in code. But the report's fix framing is materially wrong on one
+point: it presents opt-1 ("re-capture `ep.created`") and opt-2 ("refuse exit while
+mismatch outstanding") as co-equal alternatives and says the proofs "are agnostic to
+which fix lands" (`04-proof-findings.md:278`). **They are not.** Opt-1 alone fails
+*both* proofs and is strictly *worse* than the status quo (it converts a flap into a
+terminal false-healthy Stable). Only opt-2 yields the terminal Degraded both proofs
+require. Details below.
+
+---
+
+## (a) Both halves verified in code — exact lines
+
+### Half (i): the epoch fence never re-captures `ep.created` (the re-arm)
+
+- `captureBucketEpoch` writes the cached Created timestamp **once**, inside
+  `ensureKVBucket` at Start: `manager_setup.go:265` calls it, and it stores
+  `m.bucketEpochs[bucket] = bucketEpoch{kv: probeKV, created: created}` at
+  `manager_setup.go:627`. Nothing else ever writes `m.bucketEpochs` (grep:
+  only writers are `manager_setup.go:613` map-init and `:627` assignment; the
+  monitor goroutine `manager_startup_async.go:142` only reads).
+- `checkBucketEpochs` (`manager_setup.go:669-693`) reads the **live** Created via the
+  cached probe handle `ep.kv` (`:677`), and on mismatch (`:684 !live.Equal(ep.created)`)
+  fires `m.enterDegraded("bucket-recreated:" + bucket)` (`:689`) and `return`s
+  (`:690`). It **never updates `ep.created`.** So `ep.created` stays pinned at the
+  *original pre-wipe* Created forever; every subsequent tick re-observes the same
+  mismatch and re-fires `enterDegraded`.
+- Tick cadence = `OperationTimeout` (`manager_setup.go:649`; default 10s, set to 1s in
+  the NP-2 proof). The monitor is launched by `startPostStableMonitors`
+  (`manager_startup_async.go:142`), `postStableMonitorsOnce`-guarded.
+
+`enterDegraded` is idempotent while already degraded — it CAS-guards `degradedSince`
+(`manager_degraded.go:309`). So a *second* `bucket-recreated` OnDegraded can only fire
+**after an intervening `exitDegraded`** cleared `degradedSince` (`manager_degraded.go:356`).
+That is the irrefutable oscillation proof: NP-2 evidence
+(`tmp/repro-current-head/np2.out`) shows `bucketRecreatedDegrades=10, degradedToStable=9`
+— ten entries require nine intervening exits.
+
+> Note: the cached probe handle `ep.kv` (`manager_setup.go:615`,
+> `m.js.KeyValue(ctx, bucket)`) **transparently re-binds to the recreated stream** —
+> proven by the NP-2 evidence itself: if the stale handle errored on the recreated
+> stream, `BucketStreamCreated` would return an error, `checkBucketEpochs` would
+> `continue` at `:679-682`, and the fence would never fire. It fired 10×. So the
+> nats.go KeyValue object resolves the bucket name lazily on each `Status()` call and
+> reads the NEW stream's Created. This matters for the fix analysis in (c).
+
+### Half (ii): recovery exits on the wrong signal (assignment read, never the fence)
+
+The connection monitor ticks every 1s (`manager_degraded.go:79`). Since the
+connection never dropped in this scenario, it stays on the "connection up" branch
+(`:121-133`); once up for `ExitThreshold` (`:130`) it calls
+`attemptRecoveryFromDegraded` **every tick**.
+
+`attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`):
+1. `refreshAssignmentFromNATS()` (`:383`) — reads `assignment.<workerID>` from the
+   **assignment bucket only** (`manager_assignment.go:1567-1568`).
+2. `recordKVSuccess()` (`:393`) clears the whole KV-error window.
+3. exit gate (`:409`): `if !m.currentAssignmentApplied(cur) { scheduleApplyRetry; return }`.
+4. else `exitDegraded()` (`:415`) → `StateStable`.
+
+The exit gate `currentAssignmentApplied` (`manager_assignment.go:1208-1217`) compares
+the in-memory snapshot to `committedAssignment` on `(Version, LeaderRevision,
+PartitionSetDigest, source-rev)`. **It never consults `m.bucketEpochs` or any epoch
+mismatch.** Grep confirms `bucketEpochs` has zero readers outside
+`manager_setup.go`/`manager_startup_async.go`. So the wipe signal is *structurally
+invisible* to the exit decision. As long as the assignment bucket can satisfy the
+commitment check, recovery exits — regardless of an outstanding epoch mismatch on a
+*different* bucket (NP-2 recreates only heartbeat; the assignment bucket is intact).
+
+These two loops fight at ~1 Hz: epoch tick (1s) re-degrades, recovery tick (1s)
+re-stabilizes → sustained Degraded↔Stable flap. This violates the documented
+`bucket-recreated:<bucket>` contract: `docs/OPERATIONS.md:126` ("Restart or rotate
+workers; inspect JetStream storage before trusting the recreated bucket") and
+`:750` ("Why the process does not self-heal: Parti deliberately does not auto-recreate
+buckets from the live publish path… surfaces the problem via Degraded and leaves the
+recovery decision to the operator"). A flap back to Stable defeats that.
+
+> Report-accuracy check on the cited lines: the report says
+> "`checkBucketEpochs (manager_setup.go:684-690)`" and "cached once at `:627`" and
+> "`attemptRecoveryFromDegraded (manager_degraded.go:376-416)`". All three line ranges
+> are **correct** on HEAD. The report's mechanism description of half (i)/(ii) is
+> accurate; only the *fix framing* is wrong.
+
+Orthogonality to `421f13c`/`recordKVHealthyOp` is confirmed: the epoch fence calls
+`enterDegraded` **directly** (`manager_setup.go:689`), never touching `kvErrorWindow`,
+so `recordKVHealthyOp` (`manager_degraded.go:266-288`) is irrelevant to this family.
+The report's orthogonality claim is correct.
+
+---
+
+## (b) NP-1's false-healthy resting state — the precise WHY (version-independent)
+
+NP-1 wipes+recreates **all four** buckets empty under a live 3-worker fleet (no
+restart). Evidence (`tmp/repro-current-head/np1.out`): all 3 workers flap ~8
+Degraded↔Stable cycles, `bucket-recreated:*` fires on all three, **all three end
+`Stable` on empty recreated buckets**, run 67.7s.
+
+The report calls this "false-healthy" but does not explain *why* the workers reach a
+*resting* Stable (NP-2 keeps flapping; NP-1 settles). The structural answer:
+
+**The exit gate (`currentAssignmentApplied`) is a commitment check that never consults
+the epoch fence. Once the recreated assignment bucket can satisfy that check, recovery
+exits — and in NP-1 the *whole coordination machinery is still running against the
+empty buckets*, so it re-coordinates a genuinely-applied assignment and the workers
+rest Stable.** Two converging sub-paths produce that satisfied gate:
+
+1. **Leader re-publish at a monotonically-higher in-memory version (the dominant
+   observed path).** The publisher's version counter `p.currentVersion` is an
+   **in-memory field** (`internal/assignment/assignment_publisher.go:106`), and a fresh
+   publish proposes `p.currentVersion + 1` (`:345`). The only seeding from KV,
+   `DiscoverHighestVersion`, **only ever RAISES** the counter
+   (`assignment_publisher.go:882-884` `if commit.Version > p.currentVersion`,
+   `:917-919` `if highestVersion > p.currentVersion`) — it never lowers it. So after
+   the wipe, the empty bucket yields `highestVersion=0`, the leader keeps its pre-wipe
+   `currentVersion` (e.g. 2), and re-publishes version 3 — *higher* than anything in
+   the empty bucket. The worker's `refreshAssignmentFromNATS` reads that v3, the
+   monotonic gate accepts it (`monotonicStore` / `isApplyResultStale`,
+   `manager_assignment.go:1162-1170,1443-1456`), the apply pipeline commits it, and
+   `currentAssignmentApplied` is satisfied → `exitDegraded`. The NP-1 log corroborates:
+   worker-0 (leader) shows `Stable->Rebalancing->Stable` right after the wipe — a real
+   re-calculation+re-apply, not a no-op.
+2. **Stale in-memory snapshot survives a dropped-stale refresh (the fallback path for
+   non-leaders before a re-publish lands).** If `refreshAssignmentFromNATS` reads a
+   lower/older version, `monotonicStore` drops it as stale and returns `nil` (the
+   refresh still "succeeds"); `currentAssignmentApplied` then evaluates against the
+   *unchanged pre-wipe in-memory snapshot*, which already matches `committedAssignment`
+   → exit. The wipe is invisible either way.
+
+So the false-healthy is **structural and version-monotonic**, not a counter-reset
+artifact. NP-1 rests (vs NP-2 flapping) because in NP-1 the assignment bucket was
+*also* wiped+recreated and the live machinery promptly re-populates it with a
+genuinely-applied higher-version assignment, so after the last epoch tick observes the
+recreated assignment-bucket Created (it too is in `bucketEpochs`) and re-degrades, the
+*next* recovery exits and — once the in-memory `ep.created` mismatch no longer produces
+a *new* enterDegraded within the observation window's tail — the worker is left Stable.
+(NP-2 never settles because the heartbeat fence keeps a permanent mismatch against an
+intact assignment bucket the recovery loop keeps reading.)
+
+**Readiness / work consequence.** `StateStable` is a Ready signal
+(`docs/OPERATIONS.md:387`: `/health/ready` returns ready for Stable). A readiness probe
+marks the pod Ready. The worker then processes partitions backed by coordination state
+that was wiped: handoff ownership claims (`parti-*-handoff` bucket — pull-gated
+consumers depend on stable claims), the leader's commit log / audit history
+(`parti-*-assignment` `_commit`/`_commit_log` keys), and the worker-ID lease
+(`parti-*-stableid`). These are silently-broken invariants, not merely a stale number:
+two workers can believe they own the same partition (handoff claims gone), the leader
+audit cannot detect a behind worker (history gone), and worker-ID uniqueness is
+unenforced until TTLs re-establish. This is exactly what the
+`bucket-recreated`/"live data loss" contract exists to prevent by forcing rotation.
+
+---
+
+## (c) Opt-1 "latch once" — does it miss a second recreate? And: it does NOT fix the gap
+
+**Critical correction to the report.** Opt-1 (re-capture `ep.created` after
+`enterDegraded`) fixes *only* half (i), the re-arm. It leaves half (ii), the wrongful
+exit, fully intact. Trace it against the proof invariants:
+
+1. Epoch tick → `enterDegraded("bucket-recreated:hb")` → [opt-1: `ep.created = new`].
+2. Recovery tick (conn never dropped): `refreshAssignmentFromNATS` succeeds (NP-2:
+   assignment bucket intact) → `currentAssignmentApplied` true → `exitDegraded` →
+   **Stable**.
+3. Next epoch tick: `live == ep.created(new)` → no mismatch → no fire. Worker **rests
+   Stable.**
+
+Result: **NP-2** gets `degradedToStable = 1` (fails `require.Zero`,
+`np2_..._test.go:204`) and `finalState = Stable` (fails `require.Equal(StateDegraded)`,
+`:212`). **NP-1** each worker exits once → `healed = [0 1 2]` (fails `require.Empty`,
+`np1_..._test.go:248`). So opt-1 alone **fails both proofs** — and is strictly *worse*
+than the status quo: it removes the flap, which removes the only recurring Degraded
+windows a readiness probe could sample to rotate the pod. The current flap at least
+re-degrades; opt-1 produces a *terminal false-healthy Stable*. This squarely
+contradicts `04-proof-findings.md:278` ("the proofs… are agnostic to which fix lands").
+
+**Second-recreate re-arm question (part c, as asked):** *if* opt-1 were used as a
+complement to opt-2 (see below), the re-arm correctly handles a second recreate,
+*because the cached `ep.kv` handle transparently re-binds to the live stream* (proven
+in (a) by NP-2 firing 10× through the stale handle). After latching `ep.created = new`,
+the next `BucketStreamCreated(ep.kv)` reads the *current* live stream; a second
+operator recreate produces yet another later Created, mismatches the latched value, and
+re-fires. So detection re-arms automatically; no handle re-open is needed. The only
+window missed is a recreate that lands *between* the latch write and the same tick —
+negligible at OperationTimeout cadence. **But this is moot for closing the gap**: opt-1
+is never standalone-correct here.
+
+---
+
+## (d) Opt-2 "refuse exit while mismatch outstanding" — how does it EVER exit?
+
+It exits **only via process restart** — which is exactly the documented contract.
+
+- Since half (i) means `ep.created` is *never* re-captured in-process, an epoch
+  mismatch is **permanent** for the life of the process. Opt-2 therefore makes
+  recovery refuse `exitDegraded` forever → **terminal Degraded** in-process. Both
+  proofs pass: `degradedToStable = 0`, `finalState = Degraded` (NP-2), `healed = []`
+  (NP-1).
+- The legitimate exit is the restart path: a fresh `Start()` re-runs
+  `ensureKVBucket → captureBucketEpoch` (`manager_setup.go:265`) and re-captures
+  `ep.created` against the recreated stream, so the new process starts with a matching
+  epoch and reaches Stable normally. This is `docs/OPERATIONS.md:760-762` ("Restart the
+  workers. The restart path recreates buckets via `ensureKVBucket`… covered by
+  `TestManager_Restart_AfterNATSBucketLoss`"). So "never exit in-process" is the
+  *correct* behavior, not a defect.
+- Does `ep.created` need re-syncing for a legitimately-reprovisioned bucket? Not
+  in-process — re-sync happens at the next Start. Parti does **not** re-provision the
+  bucket from the live publish path by design (`docs/OPERATIONS.md:750`); it only
+  ensures buckets at Start (`ensureCoreKVBuckets`, `manager_setup.go:125-166`). So opt-2
+  does not strand a legitimately-recreated bucket — the operator's runbook is "rotate
+  the pod," and rotation re-syncs the epoch.
+
+**Mechanism for opt-2.** Add an "epoch mismatch outstanding" predicate and AND it into
+the exit gate. Cleanest surface: a `func (m *Manager) epochMismatchOutstanding() bool`
+that re-probes each `m.bucketEpochs` entry (or reads a latched flag set by
+`checkBucketEpochs` when it fires), then in `attemptRecoveryFromDegraded`
+(`manager_degraded.go:~408-415`) gate `exitDegraded` on `!epochMismatchOutstanding()`
+in addition to `currentAssignmentApplied`. A latched-flag variant
+(`m.epochFenceTripped atomic.Bool`, set at `manager_setup.go:689`, never cleared
+in-process) is simplest and race-free — it needs no extra KV probe on the recovery
+tick. Recommended.
+
+---
+
+## (e) Is "bucket-recreated" the right response for NP-1 (all buckets gone) vs a restart/rotation?
+
+Yes — `bucket-recreated:<bucket>` is the correct *reason*, and terminal Degraded → pod
+rotation is the correct *response*, for NP-1 just as for NP-2. The documented taxonomy
+(`docs/OPERATIONS.md:126`) classifies `bucket-recreated` as "ambiguous Parti-owned
+data loss → Restart or rotate workers; inspect JetStream storage before trusting the
+recreated bucket." NP-1 is precisely that, fleet-wide. The distinction the report draws
+(NP-1 "more severe" because it's false-healthy) is about the *outcome under the bug*,
+not about needing a different reason. A wipe+recreate is **not** a restart/rotation: in
+a restart the worker re-runs the synchronous Start phase (re-claims worker ID, re-reads
+committed assignment, re-captures epochs) before serving; in a live wipe the in-memory
+state is stale and the coordination history is gone. So the fence is the right signal;
+the bug is that recovery exits *despite* the signal. No new reason is needed; opt-2 (+
+optionally opt-1 to quiet C3 spam) restores the intended terminal-Degraded behavior.
+
+---
+
+## Fix options — mechanism, surface, blast radius, contracts, residual risk
+
+### Opt-2 (RECOMMENDED, load-bearing): gate the recovery exit on no outstanding epoch mismatch
+- **Mechanism.** Latch a flag when `checkBucketEpochs` fires
+  (`manager_setup.go:689`, e.g. `m.epochFenceTripped.Store(true)`), never cleared
+  in-process. In `attemptRecoveryFromDegraded` (`manager_degraded.go:408-415`), AND
+  `!m.epochFenceTripped.Load()` into the exit condition; on outstanding mismatch,
+  stay Degraded (do not `scheduleApplyRetry` for an epoch trip — there is nothing to
+  re-apply; just `return`).
+- **Surface.** `manager_degraded.go:~408-415` (exit gate), `manager_setup.go:689`
+  (set flag), one new atomic field in `manager.go`. ~10 lines.
+- **Blast radius.** Touches the Degraded→Stable *exit* only; entry paths untouched.
+- **Contracts.** C1 (whole-bucket-missing → bounded Degraded entry): unchanged — entry
+  is via `recordKVError`/`enterDegraded`, not the exit gate. C2 (peer claim takeover):
+  unrelated (different reason class, `onClaimerError`/`manager_election.go`). C3
+  (OnDegraded once per entry): **improved** — terminal Degraded = one entry instead of
+  N flap entries. C4 (Start returns after sanity phase): unrelated. Named tests:
+  satisfies `TestNP2EpochFence...` and `TestNP1_LiveBucketRecreate...`; must not break
+  `TestManager_F1_BucketRecreate_TripsDegraded` (entry-only, unaffected) or the
+  recovery tests for the *non-epoch* Degraded reasons (the flag is only set by the
+  epoch fence, so connection-down / kv-unavailable / startup-timeout recoveries still
+  exit normally — verify `NP-5` blocked-apply recovery and `NP-3a` disarm control still
+  pass).
+- **Residual risk.** Low. One subtlety: if a future caller wants an epoch trip to be
+  *recoverable* without restart (it currently is not, by design), the latch would have
+  to be cleared by a re-capture path — but that re-capture path does not exist and
+  building it is opt-1's job. Keep the latch un-clearable to match the documented
+  restart contract. Also: ensure the flag is set even on the *first* fence fire
+  (before any exit), so the very first recovery tick after the trip already refuses.
+
+### Opt-1 (COMPLEMENT ONLY, never standalone): re-capture `ep.created` after enterDegraded
+- **Mechanism.** After `enterDegraded` at `manager_setup.go:689`, set
+  `ep.created = live; m.bucketEpochs[bucket] = ep` so the fence stops re-firing.
+- **Surface.** `manager_setup.go:689-690` (~3 lines). Note the map write must respect
+  the concurrency contract: `checkBucketEpochs` runs on the monitor goroutine only, so
+  the write is single-writer, but `bucketEpochs` is read in the same goroutine — no
+  lock needed *if* nothing else mutates it (currently true).
+- **Blast radius.** Suppresses repeated OnDegraded spam (C3) on a sustained trip.
+- **Contracts.** C3: improved (one entry, no re-fire). But **does not** restore
+  terminal Degraded — see (c): standalone it *cements* false-healthy Stable and FAILS
+  both proofs.
+- **Residual risk.** HIGH if landed standalone (regresses the contract to terminal
+  false-healthy). SAFE only layered on top of opt-2, where it merely quiets the log
+  surface. Re-arm for a second recreate works (handle re-binds, (c)).
+- **Recommendation.** Optional. Land opt-2 first; add opt-1 only if the repeated
+  `bucket-recreated` OnDegraded entries (one per OperationTimeout tick while Degraded)
+  are deemed too noisy. With opt-2's latch, the flap is already gone (no
+  exit → `enterDegraded`'s CAS rejects re-entry), so the repeated-entry spam opt-1
+  targets **does not even occur** — `enterDegraded` short-circuits on the still-set
+  `degradedSince`. So **opt-1 is very likely unnecessary once opt-2 lands.** Verify:
+  with opt-2, after the first trip the worker never exits, so `degradedSince` stays
+  set, so `enterDegraded` at `:689` no-ops every subsequent tick → no OnDegraded spam.
+  This means **opt-2 alone is sufficient and complete.**
+
+### Opt-3 (alternative framing, broader): unify the exit gate for Families A and B
+- **Mechanism.** Both A and B are the same `attemptRecoveryFromDegraded` wrongful-exit
+  defect; the report (`04-proof-findings.md:48-52,280-282`) proposes a single exit-gate
+  fix. But the *conditions differ*: A needs "no epoch mismatch outstanding"; B (NP-3b)
+  needs "the failing op (heartbeat/election/stableid) actually recovered," not just the
+  assignment read. A unified gate must **AND both predicates** (plus the existing
+  `currentAssignmentApplied`).
+- **Surface.** Same function `manager_degraded.go:408-415`, plus B's per-source
+  recovery-verification machinery (out of scope here; see `04-fd1-flapping-decision.md`).
+- **Blast radius / risk.** Larger; A and B must be **co-designed**, not landed
+  independently, or one fix's predicate silently overrides the other's intent.
+- **Recommendation.** Land opt-2 (A's epoch predicate) and B's per-source predicate as
+  two ANDed clauses in one coordinated change. Do not let "one fix closes both" (report)
+  be read as "one *predicate* closes both."
+
+---
+
+## Cross-family interactions
+
+- **Family B (NP-3b)** shares the exact function (`attemptRecoveryFromDegraded`) and the
+  exact defect class (exit on wrong signal). The report's "a single fix to the exit gate
+  could close both" (`04-proof-findings.md:51-52`) is **half-right**: same function,
+  *different predicates* (A: epoch-mismatch; B: failing-op-recovered). They must be ANDed
+  and co-designed (opt-3). Verified: A's epoch fence calls `enterDegraded` directly and
+  never touches `kvErrorWindow`, while B lives entirely in the `kvErrorWindow`/threshold
+  path — so the two predicates are independent and composable.
+- **C1 contract** (whole-bucket-missing → bounded Degraded entry): NP-1's wipe *does*
+  also trip the threshold path first — the NP-1 log shows `kv-unavailable` as the first
+  OnDegraded reason on every worker, *then* `bucket-recreated:*`. So C1's entry still
+  fires correctly; the gap is purely on the *exit* side. Opt-2 leaves C1 entry intact.
+- **Family C (NP-8)** is distinct (claim-loss self-stop + MemoryStorage heartbeat loss);
+  no shared surface with A's exit gate.
+
+---
+
+## Discrepancies with the report (`04-proof-findings.md`)
+
+1. **`:278` "the proofs… are agnostic to which fix lands" — FALSE.** Opt-1 alone fails
+   both NP-2 and NP-1 and is strictly worse (terminal false-healthy vs flap). Only opt-2
+   passes. The proofs are *not* fix-agnostic; they specifically reward terminal Degraded.
+2. **`:275-282` presents opt-1 and opt-2 as co-equal alternatives ("Either… or…").**
+   They are not alternatives: opt-2 is necessary and sufficient; opt-1 is at best a
+   redundant complement (and likely unnecessary once opt-2 lands, since opt-2's
+   never-exit keeps `degradedSince` set, so `enterDegraded` self-suppresses the repeat
+   entries opt-1 targets).
+3. **`:51-52,280-282` "a single fix to the exit gate could close both A and B."**
+   Imprecise: same *function*, different *predicates* that must be ANDed and
+   co-designed. Not a single drop-in.
+4. **Report does not explain NP-1's *resting* (vs flapping) Stable, nor the
+   version-monotonicity mechanism.** Added in (b): in-memory `currentVersion` only ever
+   rises (`assignment_publisher.go:882-884,917-919`), so the leader re-publishes a
+   higher version into the empty bucket and the worker genuinely re-applies it. The
+   false-healthy is structural and version-independent, not a counter-reset artifact.
+5. **Line cites all correct** — `manager_setup.go:684-690`, `:627`,
+   `manager_degraded.go:376-416`, `:97-134`, `manager_assignment.go:1561-1568`,
+   `:409-415` all verified on HEAD. No stale line numbers found.
+
+## Confidence
+
+High. Both halves verified directly in code with cites; the opt-1-fails-both-proofs
+correction is derived by tracing the exact proof invariants
+(`np2_..._test.go:204,212`, `np1_..._test.go:248`) against the unchanged exit gate; the
+version-monotonicity sub-path is confirmed at `assignment_publisher.go:345,882-884,
+917-919`. The empirical FAILs (`tmp/repro-current-head/np1.out`, `np2.out`) corroborate.
+The one inference (opt-2 self-suppresses opt-1's target spam) is a direct consequence of
+`enterDegraded`'s `degradedSince` CAS (`manager_degraded.go:309`) plus opt-2's
+never-exit — strong, but worth a one-line confirmation in the eventual fix's test.

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-b-kvunavail-verify.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-b-kvunavail-verify.md
@@ -1,0 +1,204 @@
+# Adversarial verification — Family B (NP-3b) recover-on-wrong-signal finding
+
+Reviewer: independent agent. Branch `auto-heal-gap-investigation`, HEAD `2453306`.
+READ-ONLY. Goal: REFUTE the Family-B finding (root cause, proof non-vacuity, recommended
+fix). Every claim below is checked against the actual code in the worktree or a captured
+`.out`.
+
+Verdict: **confirmed-with-caveats.** I could not break the root-cause mechanism, the
+proof is non-vacuous and isolated, and the recommended fix (reason-scoped
+heartbeat-success-since-degrade exit gate) survives my strongest objections. The
+finding's discrepancy call against report line 52 is itself CORRECT and well-evidenced.
+Caveats are all narrow (see §5).
+
+---
+
+## 1. Root-cause mechanism — attempted refutation, FAILED to break
+
+Re-read the full chain in code:
+
+- Recovery driver is connection uptime, 1s tick: `monitorNATSConnection`
+  (`manager_degraded.go:79`) → `checkConnectionHealth` (`:97`) → with connection UP and
+  `connUpSince` held for `ExitThreshold`, calls `attemptRecoveryFromDegraded` every tick
+  (`:127-133`). VERIFIED.
+- `attemptRecoveryFromDegraded` (`:376-416`) gates exit on (1) `refreshAssignmentFromNATS`
+  success (`:383`) and (2) `currentAssignmentApplied(cur)` (`:409`); on success calls
+  `recordKVSuccess()` (`:393`) which wipes the ENTIRE `kvErrorWindow` (`:244-250`), then
+  `exitDegraded()` (`:415`). It NEVER inspects the failing op. VERIFIED.
+- `refreshAssignmentFromNATS` (`manager_assignment.go:1561-1599`) reads exactly one key
+  `assignment.<workerID>` from `m.assignmentKV` (`:1568`). Zero knowledge of
+  heartbeat/election/stableid. VERIFIED.
+- The fault wrapper `kuFaultKeyValue` faults `Put`/`Update`/`Create`/`Get`
+  (`manager_kv_read_unavailable_test.go:95-125`) on the `{Election, Heartbeat, StableID}`
+  buckets only (`np3...:142-147`). The assignment bucket is excluded, so its `Get`
+  succeeds while the trigger ops keep timing out. VERIFIED — this is exactly the wrong
+  signal.
+- Re-degrade half: after the false exit, `degradedSince==0` so `recordKVError`'s
+  short-circuit (`:174`) reopens; the faulting heartbeat publisher
+  (`SetOnError→recordKVOpError→recordKVError`, `manager_election.go:424`) re-accumulates
+  `ErrKVUnavailable` entries (`markKVUnavailable :58-72`, `recordKVError :186`) to
+  `KVErrorThreshold=3` → re-enter `kv-unavailable` Degraded (`:216-224`). VERIFIED.
+- `recordKVHealthyOp` (`421f13c`, `manager_degraded.go:266-288`) cannot help: it fires
+  only on heartbeat Put SUCCESS (`manager_election.go:432`, publisher `onSuccess` at
+  `internal/heartbeat/publisher.go:360-364`), and the heartbeat bucket is faulted, so
+  success never fires; it also early-returns while degraded (`:267-269`). VERIFIED.
+
+I looked for an escape path the finding missed:
+- **Could the worker hit `claimLostShutdown` and stop the flap?** NP-3b faults the
+  stableID bucket and `IntegrationTestConfig` sets `WorkerIDTTL=5s` over a ~13s window.
+  But `claimLostShutdown` fires on `stableid.ErrClaimLost` (a peer-takeover signal,
+  `manager_election.go` onClaimerError); the faulting stableID *renew* surfaces a plain
+  `DeadlineExceeded`, which routes to `recordKVOpError` (the degrade circuit), NOT to the
+  claim-lost branch. With a single worker there is no peer to trigger `ErrClaimLost`.
+  So the flap does NOT get masked by a self-stop. This is a path the finding did not
+  spell out, but it CONFIRMS rather than breaks the mechanism (the flap is the genuine
+  observed behavior). Noted as caveat §5.3.
+- **Could `currentAssignmentApplied` block the exit instead?** No — the harness arms the
+  fault only after Stable (`np3...:176-191`), so `committedAssignment==snapshot` and the
+  guard at `:409` is not taken (test design comment `:180-187`). VERIFIED; this is correct
+  isolation of the pure exit defect.
+
+Conclusion: root cause **holds**. No missed path makes it vacuous or wrong.
+
+## 2. Proof non-vacuity / isolation — verified against the test and .out
+
+`TestNP3_KVUnavailable_HeldArmed_DoesNotFalselyExitToStable`
+(`np3_kv_unavailable_recovery_test.go:223-279`):
+- Non-vacuity guards evaluated BEFORE the hard gate: `nc.IsConnected()` (`:255`),
+  `injectedMid>injectedStart` and `injectedEnd>injectedMid` (`:257-260`) — proves the
+  fault is genuinely active across the whole window, so a zero-exit result would be
+  meaningful. VERIFIED.
+- Hard gate `require.Zero(degradedExits())` (`:275`) is the single load-bearing assertion;
+  `degradedToStable` counts only `Degraded→Stable` edges via `OnStateChanged`
+  (`:62-64`). VERIFIED that this is the false-exit edge.
+- `.out` evidence (`tmp/repro-current-head/np3b.out`): `FAIL ... Should be zero, but was
+  9`, `re-entries=9 injected=36`, 13.03s. Each re-entry requires a prior false exit
+  (`enterDegraded` CAS-guards `degradedSince` at `:309`), so 9 re-entries is irrefutable
+  oscillation. VERIFIED.
+- Positive control NP-3a (`:285-313`) PASSES on main: after disarm, recovers and HOLDS
+  (`require.Never(Degraded,5s)`), proving NP-3b's exit is FALSE, not a dead path. VERIFIED
+  by construction (heartbeat resumes after `armed.Store(false)`).
+
+The proof proves what it claims. Non-vacuous, isolated.
+
+## 3. Recommended fix (Candidate 2, reason-scoped) — strongest objections
+
+**Objection A — "the gate is unnecessary; reuse `recordKVHealthyOp`."** Survives the
+finding: `recordKVHealthyOp` early-returns while degraded (`:267-269`), so it records
+nothing during a degrade and is useless as a "recovered SINCE degrade" signal. The fix
+correctly calls for a SEPARATE always-on stamp. VERIFIED the early-return exists.
+
+**Objection B — "an unconditional gate is simpler and still correct."** Does NOT survive;
+the finding is right that it regresses NP-5. VERIFIED end-to-end:
+`TestNP5_BlockedApplyStartupTimeout...` uses `newTestManager`
+(`manager_commit_state_machine_test.go:152-173`) which injects a `recordingHeartbeat`
+stub (`:163`) and never calls `startHeartbeat`/`SetOnSuccess` — no heartbeat success ever
+fires. NP-5 calls `attemptRecoveryFromDegraded()` directly (`np5...:158`) expecting
+Degraded→Stable (assertion 4, `:160-161`). Under an unconditional
+`lastHeartbeatSuccessAt <= degradedSince` gate, `lastHeartbeatSuccessAt` stays 0 →
+gate closed → assertion 4 FAILS. So reason-scoping is load-bearing, and reason-scoping
+requires new `m.lastDegradedReason` state (the reason is passed transiently to
+`enterDegraded :300` and never persisted — VERIFIED there is no `m.lastDegradedReason`
+in production today). The finding's "not a pure one-liner" honesty is correct.
+
+**Objection C — "the gate could keep the manager stuck Degraded in production."** Does NOT
+survive as a regression: if the genuine fault clears but heartbeat recovers last, the
+manager stays Degraded slightly longer — MORE conservative, the correct direction for the
+M2 keep-readiness-degraded policy. NP-3a proves it DOES open once heartbeat resumes. No
+deadlock: heartbeat publishes every `HeartbeatInterval`, so a real recovery opens the
+gate within one interval.
+
+**Objection D — "candidate 2 breaks NP-9 or C1."** Does NOT survive.
+- NP-9: VERIFIED by reading the actual test
+  (`np9_full_quorum_loss_arbitration_test.go`), NOT the finding's contrast table. The
+  fault set genuinely includes all four coordination buckets — Election, Heartbeat,
+  StableID, AND Assignment (`:184-189`) — plus a faulting `Watch()` override
+  (`:142-148`). The first OnDegraded reason is genuinely `kv-unavailable` (`:240`), the
+  fast threshold path winning the CAS as the report claims. While armed, the assignment
+  `Get` faults (`:130-136`) so `refreshAssignmentFromNATS` fails at `:383` and the exit
+  is never reached. After `disarm()` (`:253`), heartbeat (in NP-9's fault set, `:186`)
+  and assignment resume → the reason-scoped gate (reason is `kv-unavailable` → applies)
+  opens on the post-disarm heartbeat success → recovery proceeds; the test asserts
+  exactly 1 Degraded entry / 1 Stable exit (`:263-270`), preserved. Note: even if NP-9's
+  reason were NOT `kv-unavailable`, an inapplicable scoped gate simply falls through to
+  the normal exit, so NP-9 recovers either way — the gate cannot make NP-9 worse.
+- C1 (whole-bucket loss): enters Degraded with reason `"KV error threshold exceeded"`
+  (`manager_degraded.go:215`), NOT `kv-unavailable`, so the reason-scoped gate does not
+  even apply; and heartbeat never succeeds under whole-bucket loss anyway, so even if it
+  applied the gate stays closed (stickier). `TestManager_LiveNATSBucketLoss*` unaffected.
+  The fix is exit-only; the C1 ENTRY path (`recordKVError`→threshold→`enterDegraded`) is
+  untouched. VERIFIED.
+
+**Objection E — "the heartbeat-only proxy is a hole: an election-only or stableid-only
+sustained fault with healthy heartbeat opens the gate early."** This survives as a REAL
+residual but is correctly characterized by the finding: that exact shape is already let
+through by the shipped f-d1 `recordKVHealthyOp` semantic narrowing (a heartbeat success
+clears the transient election/stableid entries before they reach threshold), so candidate
+2 introduces NO NEW regression relative to the f-d1 decision. It is the one corner where
+candidates 2 and 3 diverge observably and the finding flags it as an open question with a
+proposed dedicated test. Accepted as a known, bounded residual — not a refutation.
+
+Net: the recommended fix survives. The reason-scoping is genuinely load-bearing.
+
+## 4. Discrepancy with report line 52 — INDEPENDENTLY CONFIRMED
+
+Report `04-proof-findings.md:52`: "A single fix to the exit gate could close both A and
+B." The finding calls this LOOSE/overstated. I verified this is correct:
+- Family A re-degrades via `checkBucketEpochs → enterDegraded("bucket-recreated:<b>")`
+  fired DIRECTLY (`manager_setup.go:684-690`), bypassing `kvErrorWindow` entirely, and
+  `ep.created` is never re-captured (cached once at `:627`). VERIFIED.
+- NP-2 (`np2...:150-159`) recreates the heartbeat bucket as a fresh HEALTHY MemoryStorage
+  stream and leaves `KVErrorThreshold` at default, asserting `otherDegrades==0`
+  (`:81-83, :190-192`). So after recreate heartbeat Put SUCCEEDS and the degrade reason
+  is purely `bucket-recreated:<heartbeat>`. VERIFIED.
+- Therefore a reason-scoped `kv-unavailable` exit gate (candidate 2) does NOT apply to
+  Family A's `bucket-recreated` reason, AND an unscoped heartbeat-success gate would OPEN
+  (heartbeat is healthy). Either way candidate 2 does NOT close Family A. VERIFIED.
+- The report is internally inconsistent: line 52 oversells, line 280-282 hedges ("A still
+  needs the stale-`ep.created` latch addressed"). The finding flags line 52 as the
+  imprecise one — correct.
+
+The honest unified A+B fix is candidate 3's family (per-cause registry) PLUS the Family A
+`ep.created` re-capture latch. Confirmed.
+
+## 5. Caveats on the finding (do not change the verdict)
+
+5.1 Numeric: finding/report numbers (`re-entries=9 injected=36` vs report
+`degradedExits=9 injected=34`) are same-magnitude; the `.out` matches the finding's
+numbers verbatim. Not a correctness issue.
+
+5.2 Production cadence: defaults are EnterThreshold=10s, ExitThreshold=5s,
+KVErrorThreshold=5, KVErrorWindow=30s (`config.go:191,196,204,209`). The finding lists
+"5s/10s/15s" in Exit/Enter/RGP order — consistent with the code. Mechanism identical to
+test, only cadence differs. OK.
+
+5.3 NEW observation (the finding did not spell this out): NP-3b faults the stableID bucket
+with `WorkerIDTTL=5s` over ~13s, yet does NOT self-stop via `claimLostShutdown`, because
+a faulting renew surfaces `DeadlineExceeded` (→ degrade circuit) not `ErrClaimLost`, and
+a single worker has no peer to trigger claim takeover. This CONFIRMS the flap is the
+genuine behavior and is not masked by the C2 self-stop path. Worth noting for any future
+multi-worker variant of this proof, where a peer takeover could change the dynamics.
+
+5.4 Not empirically prototyped: candidate 2 was not built/run; §6 of the finding is
+code-derived. The mandatory validation harness on landing (NP-3b ungated, NP-5 ungated,
+NP-9, LiveNATSBucketLoss) is correct and sufficient. Agreed.
+
+5.5 IMPLEMENTATION-ORDERING RISK (not a design refutation, but must be specified for the
+implementer): the reason-scoped gate reads `m.lastDegradedReason`, which the design sets
+in `enterDegraded`. The 1s recovery tick (`checkConnectionHealth → attemptRecoveryFromDegraded`)
+observes `degradedSince != 0` as the "am I degraded" trigger (`:378`). `enterDegraded`
+sets `degradedSince` via CAS at `:309` BEFORE doing anything else. If the implementation
+writes `m.lastDegradedReason` AFTER the CAS, there is a tiny window where the recovery
+tick sees `degradedSince != 0` but a stale/empty reason → `reasonIsKVUnavailable` is
+false → the gate does not apply → one false exit before the reason lands → a single flap
+on the first degrade. Mitigation: set the reason BEFORE (or atomically with) the
+`degradedSince` CAS, OR treat an empty/unknown reason conservatively as "gate applies"
+(stay degraded). A `-race` run plus the ungated NP-3b proof would catch a regression
+here. This is the one concrete way a careless implementation could reintroduce the flap.
+
+## 6. Bottom line
+
+Root cause: **holds.** Proof: **non-vacuous and isolated.** Recommended fix: **survives**
+all objections; reason-scoping is load-bearing (NP-5) and the new `m.lastDegradedReason`
+state is genuinely required. Report-line-52 discrepancy: **independently confirmed.** No
+counterexample found. Verdict: confirmed-with-caveats (all caveats narrow).

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-b-kvunavail.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-b-kvunavail.md
@@ -1,0 +1,515 @@
+# Family B (NP-3b) — recover-on-wrong-signal under sustained connected-but-KV-unavailable
+
+Independent code-derived deep dive. Investigation branch `auto-heal-gap-investigation`,
+HEAD `2453306`. READ-ONLY: no production code changed. Every claim cites `file:line`
+in the worktree
+`/home/arlo/projects/parti/.claude/worktrees/auto-heal-gap-investigation/` or a test name.
+
+This is the explicitly-deferred **"Finding A"** from
+`docs/plans/auto-healing-quorum-loss-fix/04-fd1-flapping-decision.md` (§Investigation,
+§Deferred). The proof `TestNP3_KVUnavailable_HeldArmed_DoesNotFalselyExitToStable`
+turns that deferral into an executable FAIL.
+
+---
+
+## 0. TL;DR
+
+- **(a) Wrong-signal exit CONFIRMED in code.** `attemptRecoveryFromDegraded`
+  (`manager_degraded.go:376-416`) gates the exit on (1) a successful **assignment**
+  read (`refreshAssignmentFromNATS`, `:383`) plus (2) `currentAssignmentApplied(cur)`
+  (`:409`). It NEVER checks that the op that *triggered* the degrade recovered. The
+  recovery driver is connection **uptime** (`checkConnectionHealth`,
+  `manager_degraded.go:127-133`), which is satisfied throughout — the fault never drops
+  the TCP connection. So while heartbeat/election/stableid keep timing out but the
+  assignment bucket is readable, the manager exits Degraded→Stable; the still-faulting
+  heartbeat re-accumulates to threshold → re-degrade → flap.
+
+- **(b) Three Finding-A candidates evaluated.** "Verify the failing op recovered" is
+  **not free**: there is **no per-source health signal and no stored degrade reason** to
+  gate on. The reason is a transient string handed to `enterDegraded` (`:300`) and
+  never persisted; `kvErrorWindow` is a flat `[]kvErrorEvent{at, transient}`
+  (`manager.go:204`, `manager_degraded.go:33-36`) with **no source tag**. So candidate 2
+  resolves to either (a) reuse the one existing per-source success signal — heartbeat
+  `SetOnSuccess` (`manager_election.go:432`) — as a proxy "F-D1 KV health recovered"
+  exit gate, or (b) build per-source tracking, which **collapses candidate 2 into
+  candidate 3**. **Even option (a) is not a pure one-liner:** `attemptRecoveryFromDegraded`
+  is the single recovery exit for ALL degrade reasons, so the gate MUST be reason-scoped
+  to `kv-unavailable` — and that forces storing the degrade reason (new
+  `m.lastDegradedReason`), which does not exist today. An *unconditional* gate regresses
+  **NP-5** (startup-timeout recovery, an ungated GREEN proof) — VERIFIED in §4.2/§6.
+
+- **(c) NP-9 doesn't flap because it faults the assignment bucket AND its Watch too**
+  (`np9...:188`, `:142-148`), so `refreshAssignmentFromNATS` FAILS in
+  `attemptRecoveryFromDegraded` (`:383`) → early return → never reaches `exitDegraded`.
+  NP-3b deliberately **excludes** the assignment bucket from the fault set
+  (`np3...:142-147`), so the read succeeds → false exit. Any fix must keep NP-9's clean
+  one-entry/one-exit recovery (it currently passes).
+
+- **(d) Recommendation = scope-dependent.** **B-only:** candidate 2 implemented as a
+  *reason-scoped heartbeat-success-since-degrade* exit gate — smallest surface that
+  preserves C1 (entry path untouched), preserves the f-d1 class-aware reset, holds NP-3b
+  Degraded, does NOT regress NP-5 (because reason-scoped), and still recovers NP-9.
+  **A+B unified:** the report's "single exit-gate fix closes
+  both" (04-proof-findings.md:52, 280-282) is **loose** — it is true that the *exit
+  defect* is shared, but the *fixing predicate differs by family*, so the honest unified
+  form is a generalized per-cause "degrade-cause registry" (candidate 3's family), a
+  meaningfully bigger design than a one-line exit tweak. See §5 (discrepancy) and §7.
+
+---
+
+## 1. The mechanism, re-derived from code (part a)
+
+### 1.1 The recovery driver is connection uptime, fired every 1s
+
+`monitorNATSConnection` ticks every 1s (`manager_degraded.go:79`) →
+`checkConnectionHealth` (`:97`). With the connection UP (the whole premise of the
+fault), it takes the else-branch at `:127`: once `connUpSince` has been set for
+`ExitThreshold`, it calls `attemptRecoveryFromDegraded` (`:130-132`). The connection
+never drops under a KV-unavailable fault, so `connUpSince` is set the moment the manager
+starts and `attemptRecoveryFromDegraded` fires on **every 1s tick** for the entire
+degrade.
+
+### 1.2 The exit gate checks the WRONG op
+
+`attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`):
+
+1. `:378` — bail if not degraded.
+2. `:383` — `refreshAssignmentFromNATS()`. On error: log, `recordKVError(err)`, return
+   (stay degraded). On success: continue.
+3. `:393` — `recordKVSuccess()` clears the **entire** `kvErrorWindow` (both transient and
+   whole-bucket entries — `:244-250`). This is the load-bearing aggravator: it wipes the
+   heartbeat-attributed transient entries that *were* accumulating, resetting the
+   re-degrade clock so the next flap cycle starts from zero.
+4. `:408-412` — `cur := m.CurrentAssignment(); if !currentAssignmentApplied(cur) { scheduleApplyRetry; return }`.
+5. `:415` — else `exitDegraded()` → `transitionState(StateStable)` (`:350`).
+
+`refreshAssignmentFromNATS` (`manager_assignment.go:1561-1599`) reads exactly one key:
+`assignment.<workerID>` via `m.assignmentKV.Get` (`:1568`). It touches **only the
+assignment bucket**. It has zero knowledge of heartbeat/election/stableid health.
+
+So the exit predicate is: *"connection up for ExitThreshold AND assignment-key read
+succeeds AND that assignment is already applied"*. None of the three conjuncts observes
+the failing op. In NP-3b the assignment bucket is unfaulted, all three are satisfied →
+**false exit**.
+
+### 1.3 Why the assignment-applied guard does NOT save us here
+
+The NP-3b harness arms the fault only **after** the manager reaches Stable
+(`np3...:176-191`, with `require.Equal(StateStable, ...)` at `:185` immediately before
+`fc.arm()`). At that instant `committedAssignment == snapshot`, so post-fault
+`currentAssignmentApplied(cur)` is **true** and the guard at `:409` is NOT taken — the
+test deliberately drives the `exitDegraded` branch, not the `scheduleApplyRetry`
+stay-degraded branch (test comment `np3...:180-187`). This is correct test design: it
+isolates the pure exit defect, not the bootstrap/latched-apply path that the
+applied-guard exists to cover.
+
+### 1.4 The re-degrade half (the other half of the flap)
+
+After the false exit, `degradedSince` is cleared (`exitDegraded` `:356`), so the
+`recordKVError` short-circuit at `:174` (`if m.degradedSince.Load() != 0 { return }`) no
+longer fires. The still-faulting heartbeat publisher keeps calling
+`SetOnError → recordKVOpError → recordKVError` (`manager_election.go:424`,
+`manager_degraded.go:235-237`). Each marked `ErrKVUnavailable` timeout
+(`markKVUnavailable` `:58-72`, wrapping `context.DeadlineExceeded` from
+`kuFaultKeyValue.Put` `manager_kv_read_unavailable_test.go:95-98`) re-appends to
+`kvErrorWindow` (`:186`). After `KVErrorThreshold` (=3 in the test, `np3...:129`) it
+re-enters Degraded with reason `kv-unavailable` (`:216-224`). → flap.
+
+### 1.5 Why `recordKVHealthyOp` (421f13c) cannot help
+
+`recordKVHealthyOp` (`manager_degraded.go:266-288`) fires only from heartbeat
+**Put success** (`manager_election.go:432`). Under NP-3b the heartbeat bucket is **in the
+fault set** (`np3...:145`), so heartbeat Put always returns `DeadlineExceeded`
+(`...:95-98`) → `SetOnError` path, never `SetOnSuccess`. `recordKVHealthyOp` is never
+called. The report (04-proof-findings.md:107-109) states this correctly. Additionally,
+`recordKVHealthyOp` early-returns while degraded (`:267-269`), so even on a different
+fault shape it would not record successes during a degrade.
+
+### 1.6 Empirical confirmation (re-run on HEAD 2453306)
+
+`tmp/repro-current-head/np3b.out`: `--- FAIL ... re-entries=9 injected=36` over a 13.03s
+window. `injected` rising start→mid→end (test asserts `np3...:257-260`) proves the fault
+was active throughout; `re-entries=9` means 9 Stable→Degraded re-entries, each of which
+*requires* a prior false Degraded→Stable exit. Connection stayed CONNECTED
+(`np3...:255-256`). The report cited `degradedExits=9, injected=34`; the re-run shows the
+same magnitude (re-entries=9, injected=36). **Verdict on the report's root cause for
+Family B: CONFIRMED.**
+
+---
+
+## 2. What signals actually exist to gate on (the crux of part b)
+
+I grepped the entire non-test tree for any per-source error/health bookkeeping:
+
+- `kvErrorWindow []kvErrorEvent` — `manager.go:204`. Each entry is
+  `kvErrorEvent{at time.Time, transient bool}` (`manager_degraded.go:33-36`). **No
+  source/bucket identity.** `transient` only distinguishes F-D1 timeouts from
+  whole-bucket-loss; it does NOT say *which* op faulted.
+- The degrade **reason** string (`"kv-unavailable"`, `"bucket-recreated:<b>"`,
+  `"NATS connection down"`, …) is passed to `enterDegraded(reason)` (`:300`), logged
+  (`:320-323`), and handed to the `OnDegraded` hook (`:328`). It is **never stored on the
+  Manager**. There is no `m.lastDegradedReason`. (`degradedReason` only exists in
+  `test/simulation/...`, not production.)
+- The **only** per-source success signal in production is the heartbeat
+  `Publisher.SetOnSuccess` (`internal/heartbeat/publisher.go:177-196`) wired to
+  `recordKVHealthyOp` (`manager_election.go:432`). Election renew, stableid renew, and
+  assignment refresh have **no success callback** — only error callbacks
+  (`recordKVOpError` at `manager_election.go:262,303`, `manager_assignment.go:398,437,636`).
+
+**Conclusion for part (b):** "Verify the failing op recovered" has no off-the-shelf
+"failing op" identity. The cheapest real proxy is "has a periodic heartbeat **succeeded**
+since we degraded?" — because heartbeat is the highest-frequency periodic KV op and is
+the one source that already has a success hook. Any finer-grained answer requires new
+per-source bookkeeping (candidate 3).
+
+---
+
+## 3. Why NP-9 doesn't flap but NP-3b does (part c) — and what the fix must not break
+
+| | NP-3b (Family B, flaps) | NP-9 (full quorum loss, clean) |
+|---|---|---|
+| Fault set | Election, Heartbeat, StableID (`np3...:142-147`) | Election, Heartbeat, StableID, **Assignment** (`np9...:184-189`) |
+| Watch faulted? | No — Watch passes through (`kuFaultKeyValue` has no Watch override) | **Yes** (`np9FaultKeyValue.Watch` `:142-148`) |
+| `refreshAssignmentFromNATS` during recovery | `assignmentKV.Get` **succeeds** → exit predicate satisfied | `assignmentKV.Get` **faults** (`np9...:130-136`) → `attemptRecoveryFromDegraded` returns at `:383-387` → never exits |
+| Fault lifecycle in test | **held armed** the whole window (`np3...` no disarm) | armed then **disarmed** (`np9...:233,253`) before asserting recovery |
+| Result | Degraded↔Stable flap (9 re-entries) | exactly 1 entry / 1 exit (`np9...:267-270`) |
+
+The discriminator is purely **whether the assignment Get succeeds while the trigger op is
+still faulting**. NP-9's recovery is gated by the *same* assignment read that NP-3b
+exploits — but in NP-9 that read also faults, so the wrong-signal gate happens to be
+*correct by coincidence* (the assignment bucket is part of the same quorum loss). NP-9 is
+NOT a counter-example to the defect; it's a case where the defective gate accidentally
+agrees with reality.
+
+**Fix-safety implication:** any exit-gate fix must remain *permissive* once the genuine
+fault clears. NP-9's recovery path is the watcher-independent `Get`-based refresh
+(`np9...:150-157` comment, executed after disarm). A heartbeat-success-since-degrade gate
+(candidate 2) does **not** harm NP-9: after disarm, heartbeat Put resumes succeeding
+(bucket is in the fault set but disarmed), so the gate opens and recovery proceeds. I
+verified the NP-9 fault set includes the heartbeat bucket (`np9...:186`), so a heartbeat
+success after disarm is guaranteed before the `WaitState(Stable, 20s)` at `np9...:254`.
+The control NP-3a (`np3...:285-313`) is the analogous proof for Family B: after
+`fc.armed.Store(false)` (`:300`), heartbeat resumes, recovery returns to Stable, and
+HOLDS (`require.Never(Degraded, 5s)` `:309-312`).
+
+---
+
+## 4. Fix options (part b) — full map
+
+All three are from `04-fd1-flapping-decision.md:118-123`. Common surface: the exit
+decision in `attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`) and/or the
+re-entry path (`recordKVError` / `enterDegraded`).
+
+### 4.1 Candidate 1 — post-recovery cooldown ("don't re-degrade for N seconds after exiting")
+
+- **Mechanism.** After `exitDegraded`, stamp `m.recoveredAt = now`. In `recordKVError`
+  (or `enterDegraded`), suppress re-entry for reason `kv-unavailable` while
+  `now - recoveredAt < cooldown`. Surface: `manager_degraded.go` (new field +
+  `exitDegraded` `:340-373` stamp + `recordKVError` `:144-226` suppress branch). ~25 LOC.
+- **Blast radius.** Touches the re-entry path only; the exit predicate is unchanged.
+- **Contracts.** **C1 RISK (real):** C1 says whole-bucket loss → every worker Degraded
+  within a bounded window. A blanket cooldown that also suppresses **non-transient**
+  (whole-bucket) re-entry would *delay* C1's re-entry after any prior recovery — it is
+  the only candidate that perturbs C1's bounded *re-entry* timing. Must scope the
+  cooldown to `transient`/`kv-unavailable` entries only (mirroring the class split the
+  f-d1 work already established). Even so, it does not break C1's pinning tests
+  (`TestManager_LiveNATSBucketLoss*`) — those kill heartbeat too and have no *prior*
+  recovery to start a cooldown — but it weakens the contract's worst-case bound. f-d1
+  class-aware reset: **untouched** (cooldown is orthogonal to the window).
+- **Pros.** Smallest conceptual change; no new health signal needed.
+- **Cons / residual risk.** **Does not fix the root cause** — it rate-limits the flap but
+  the manager STILL falsely exits to Stable, just less often. The false-Stable *rest
+  periods* remain, which is exactly what the M2 "keep readiness degraded under a real
+  quorum loss" policy (04-proof-findings.md:119-120) is trying to prevent. NP-3b's hard
+  gate is `require.Zero(degradedExits)` (`np3...:275`) — a cooldown that still permits ≥1
+  false exit **does not pass the proof**. Band-aid; rejected as a standalone fix.
+
+### 4.2 Candidate 2 — verify the F-D1 KV op recovered before exiting (RECOMMENDED for B-only)
+
+- **Mechanism.** Add a heartbeat-success timestamp that updates **regardless of degraded
+  state**, then gate the exit on "a heartbeat succeeded *after* we degraded". Concretely:
+  - New `m.lastHeartbeatSuccessAt atomic.Int64` (UnixNano), stamped from a new tiny
+    callback wired alongside `recordKVHealthyOp` at `manager_election.go:432` — or stamped
+    inside a thin wrapper. **Gotcha (must not reuse `recordKVHealthyOp` as-is):**
+    `recordKVHealthyOp` early-returns while degraded (`manager_degraded.go:267-269`), so
+    it records nothing during a degrade — useless as a "recovered since degrade" signal.
+    The new stamp must fire on heartbeat success unconditionally.
+  - In `attemptRecoveryFromDegraded`, before `exitDegraded` (`:415`), add the gate.
+
+  **CRITICAL — the gate MUST be reason-scoped, NOT unconditional.**
+  `attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`) is the **single recovery
+  exit for EVERY degrade reason** — `kv-unavailable`, `NATS connection down`,
+  `bucket-recreated:<b>`, **and `startup-timeout`** — not just F-D1. An *unconditional*
+  gate `if lastHeartbeatSuccessAt <= degradedSince { return }` would therefore add a
+  heartbeat-health precondition to **all** recoveries. That **regresses NP-5**
+  (`TestNP5_BlockedApplyStartupTimeout_RecoversToStableAfterUnblock`, an **ungated,
+  currently-GREEN** unit proof, 04-proof-findings.md:170-174):
+    - **VERIFIED:** NP-5 uses `newTestManager` (`manager_commit_state_machine_test.go:152-173`),
+      which injects a `recordingHeartbeat` stub (`:163`) and **never starts a real
+      publisher** — `SetOnSuccess` is never wired and no periodic heartbeat success ever
+      fires. NP-5 then calls `m.attemptRecoveryFromDegraded()` **directly**
+      (`manager_np5_blocked_apply_recovery_test.go:158`), expecting Degraded→Stable
+      (assertion 4, `:160-161`).
+    - Under an unconditional gate, `lastHeartbeatSuccessAt` stays 0, `degradedSince` is
+      non-zero, so `0 <= degradedSince` is TRUE → gate **closed** → NP-5 would NOT exit
+      to Stable → **assertion 4 FAILS.** This is a real regression in a passing contract,
+      independent of any production Start-ordering subtlety (the unit test never starts
+      heartbeat at all).
+  - **Therefore the gate must apply only to the F-D1 reason.** That requires storing the
+    degrade reason on the Manager — which **does not exist today** (§2: the reason is
+    passed transiently to `enterDegraded` `:300` and never persisted). So candidate 2
+    needs a new `m.lastDegradedReason atomic.Pointer[string]` (or an
+    `m.degradedIsKVUnavailable atomic.Bool`), set in `enterDegraded`. The gate becomes:
+    `if reasonIsKVUnavailable && lastHeartbeatSuccessAt <= degradedSince { return }`. This
+    is the **reason-scoped variant** — it is the only correct form.
+- **Surface.** `manager.go` (2 fields: stamp + reason), `manager_degraded.go:300`
+  (`enterDegraded` records the reason), `manager_election.go:432` (wire the stamp),
+  `manager_degraded.go:376-416` (reason-scoped guard). ~25-30 LOC. No change to
+  `recordKVError` threshold logic or the f-d1 window.
+- **Blast radius.** Exit path + a new degrade-reason field set in `enterDegraded`. The
+  reason field is read-only elsewhere; entry/threshold path otherwise untouched. **Note
+  the blast radius is larger than "exit path only" once the NP-5-forced reason-scoping is
+  accounted for** — storing the reason is new state on a contract-pinned struct.
+- **Contracts.**
+  - **C1 PRESERVED.** C1 is an **entry** contract; this is an **exit** gate scoped to
+    `kv-unavailable`. Whole-bucket loss enters Degraded with reason
+    `"KV error threshold exceeded"` (`manager_degraded.go:215`), NOT `kv-unavailable`, so
+    the gate does not even apply to it — and on whole-bucket loss heartbeat never succeeds
+    anyway, so even if it applied the gate would stay *closed* (stickier, never less).
+    `TestManager_LiveNATSBucketLoss*` unaffected.
+  - **C3 PRESERVED.** OnDegraded fires once per entry (`enterDegraded` CAS `:309`); this
+    fix removes spurious *exits* (and the spurious *re-entries* that each fire OnDegraded).
+    Net: fewer fires, still once-per-entry.
+  - **C2 / C4 UNAFFECTED** (claim-lost shutdown and Start-returns-after-sanity are
+    independent of this gate).
+  - **f-d1 class-aware reset PRESERVED.** `recordKVHealthyOp`'s transient-only clear is
+    untouched; the new stamp + reason are *separate* signals used only at exit.
+  - **NP-5 (startup-timeout recovery) PRESERVED** — because the gate is reason-scoped, a
+    `startup-timeout` degrade is not subject to the heartbeat-health check and recovers
+    exactly as today. This is the load-bearing reason the gate must be scoped.
+- **Pros.** Directly addresses the wrong-signal exit. Passes NP-3b's `require.Zero` gate
+  (heartbeat never succeeds while armed → gate never opens → zero exits). Recovers NP-9
+  and NP-3a (heartbeat resumes after disarm → gate opens). Does not regress NP-5. Far
+  cheaper than candidate 3's per-source matrix.
+- **Cons / residual risk.**
+  - **Needs new degrade-reason storage** (forced by NP-5, above). This is the bookkeeping
+    the fd1 doc associated with the heavier options; it is *small* here (one field + one
+    write site) but it is real, and it nudges candidate 2 a step toward candidate 3 — it
+    is no longer a pure "one-line exit guard". Be honest about this in review.
+  - **Heartbeat-only proxy.** It gates exit on *heartbeat* recovery, not on the *specific*
+    failing op. A pathological fault that knocks out **only** election or **only** stableid
+    while heartbeat stays healthy would let this gate open and exit early — a residual
+    narrower version of the same bug. But that exact shape would also have been *cleared*
+    from the f-d1 window by `recordKVHealthyOp` (heartbeat success clears transient
+    entries) and so likely never reaches the re-degrade threshold in the first place
+    (04-fd1...:81-91, the accepted "semantic narrowing"). So this residual is *consistent
+    with the already-accepted f-d1 coverage change*, not a new regression. (This is the
+    one corner where candidate 2 and candidate 3 diverge observably — see §9.)
+  - Subtle ordering: must stamp `lastHeartbeatSuccessAt` strictly *after* the Put returns
+    success; reusing the same atomic the publisher already touches avoids a new lock.
+  - Does NOT help Family A at all (see §5 / §6).
+
+### 4.3 Candidate 3 — per-source error counters / generalized degrade-cause registry
+
+- **Mechanism.** Replace the flat `kvErrorWindow` with per-source windows keyed by op
+  source (heartbeat / election / stableid / assignment / commit), OR add an explicit
+  "outstanding degrade causes" set that each trigger registers on enter and clears on its
+  own recovery. Exit refuses while any cause is outstanding. `recordKVOpError` would carry
+  a source tag (its 5 call sites already know their source:
+  `manager_election.go:262,303`, `manager_assignment.go:398,437,636`,
+  `manager_election.go:424` for heartbeat). Each source needs a **success** signal too —
+  today only heartbeat has one (`SetOnSuccess`), so this requires adding success
+  callbacks to election renew / stableid renew / assignment refresh.
+- **Surface.** Large: `kvErrorEvent` gains a source field (`manager_degraded.go:33`); all
+  5 `recordKVOpError` sites pass a source; `recordKVError`/`recordKVHealthyOp`/
+  `recordKVSuccess` become per-source; new success callbacks in election/stableid/
+  assignment subsystems. 100+ LOC across ≥4 files plus internal subsystems.
+- **Contracts.** Can preserve C1 (whole-bucket entries still accumulate per their source,
+  and a whole-bucket loss faults *all* sources so all counters trip) and the f-d1 reset
+  (per-source transient clear). But the surface area means real regression risk to the
+  exact contract-pinned paths the fd1 doc warns about (04-fd1...:122-124).
+- **Pros.** Most precise: gates exit on the actual failing source's recovery. Is the
+  *only* candidate that also gives Family A a clean lever IF the epoch fence is made to
+  register an outstanding "bucket-recreated" cause (i.e. it generalizes to the per-cause
+  registry — see §5).
+- **Cons / residual risk.** Large blast radius into subsystems (heartbeat/election/
+  stableid publishers) that currently have no success hook. The fd1 doc explicitly defers
+  this as the heaviest option (04-fd1...:119-124). Highest review/test cost.
+
+---
+
+## 5. Discrepancy with the report (be adversarial)
+
+**The report's "a single fix to the exit gate could close both A and B" is LOOSE**
+(04-proof-findings.md:48-52, restated at 280-282). Precise correction:
+
+- **Shared:** the *exit defect* — both families exit via `attemptRecoveryFromDegraded`
+  on the assignment-read signal while a different trigger still fires. TRUE.
+- **Different:** the *re-degrade trigger*, and therefore the *fixing predicate*.
+  - Family B re-degrades through `recordKVError` → `kvErrorWindow` threshold
+    (`manager_degraded.go:207-224`). A heartbeat-health exit gate (candidate 2) closes it.
+  - Family A re-degrades through `checkBucketEpochs → enterDegraded("bucket-recreated:<b>")`
+    fired **directly** (`manager_setup.go:684-690`), which **bypasses `kvErrorWindow`
+    entirely** and never touches any KV-health signal.
+
+I **verified** that NP-2 deletes+recreates the heartbeat bucket as a fresh **healthy**
+MemoryStorage stream with no fault injection (`np2...:150-159`), and deliberately leaves
+`KVErrorThreshold` at default so no `kv-unavailable` co-fires (`np2...:81-83`, asserts
+`otherDegrades=0` `np2...:188-189`). So after the recreate, heartbeat **Put succeeds**
+against the new bucket. Therefore a heartbeat-success exit gate (candidate 2) would see
+healthy heartbeats and **OPEN** — it would NOT stop Family A's flap. Family A's exit is
+driven back by the epoch tick re-firing on a stale `ep.created` (never re-captured,
+`manager_setup.go:684-690`), which a KV-health gate does not observe.
+
+**Honest unified-fix statement:** closing BOTH A and B with one mechanism requires a
+*generalized* "refuse to exit while ANY degrade cause is outstanding" gate — each
+trigger (kv-unavailable threshold, bucket-recreated epoch fence, …) registers a cause and
+clears it on its own recovery. That is candidate 3's family, NOT a one-line exit tweak.
+The report's prose understates this; the §7 deferred-fix note (04-proof-findings.md:280-282)
+*does* hedge ("but A still needs the stale-`ep.created` latch addressed"), so the report
+is internally inconsistent — the summary (line 52) oversells, the recommendation
+(line 282) walks it back. Flag the summary as the imprecise line.
+
+Otherwise the report's Family B section (04-proof-findings.md:95-120) is **accurate**: the
+wrong-signal exit, the `recordKVHealthyOp`-can't-help reasoning, the NP-9 contrast
+(line 184-185), and the NP-3a control are all confirmed against code. The cited evidence
+(`degradedExits=9, injected=34`) matches the HEAD re-run (re-entries=9, injected=36) in
+magnitude.
+
+---
+
+## 6. Verification trace (proves the recommended candidate 2 — reason-scoped variant)
+
+For the **reason-scoped** heartbeat-success-since-degrade exit gate (§4.2): the gate
+applies only when the outstanding degrade reason is `kv-unavailable`. ENTRY (C1) is
+untouched because the gate is purely an EXIT predicate. Cases 1-5 exercise the KV path;
+cases 6-7 exercise NON-KV recoveries that the reason-scoping must leave intact (the hole
+the unconditional gate would have created).
+
+1. **NP-3b held-armed** (`TestNP3_KVUnavailable_HeldArmed...`): reason is `kv-unavailable`
+   → gate applies; heartbeat Put faults the whole window → `lastHeartbeatSuccessAt` never
+   advances past `degradedSince` → gate stays closed → `require.Zero(degradedExits)`
+   (`np3...:275`) PASSES. ✔ (gated proof becomes a regression guard — ungate per
+   04-proof-findings.md:295).
+2. **NP-9 post-disarm** (`TestNP9_FullQuorumLoss...`): reason is `kv-unavailable`
+   (`np9...:240`) → gate applies; after `fc.disarm()` (`np9...:253`) heartbeat (in the
+   fault set, `np9...:186`) resumes succeeding → stamp advances past `degradedSince` →
+   gate opens → recovery proceeds. NP-9's `1 entry / 1 exit` invariant (`np9...:267-270`)
+   still holds. ✔
+3. **NP-3a disarm control** (`TestNP3_KVUnavailable_Disarm...`): reason `kv-unavailable`
+   → gate applies; heartbeat resumes after `armed.Store(false)` (`np3...:300`) → gate
+   opens → recovers and HOLDS (`require.Never(Degraded, 5s)` `:309-312`). ✔
+4. **C1 whole-bucket loss** (`TestManager_LiveNATSBucketLoss*`): reason is
+   `"KV error threshold exceeded"` (`manager_degraded.go:215`), NOT `kv-unavailable` →
+   gate does NOT apply; recovery is unchanged from today. AND the **entry** path is
+   untouched: non-transient entries still accumulate via `recordKVError`. Worker still
+   enters Degraded within the bounded window. ✔
+5. **Family A (NP-2)** — explicitly NOT covered: reason is `bucket-recreated:<heartbeat>`
+   → gate does NOT apply (and heartbeat succeeds against the recreated bucket anyway).
+   Still flaps. Confirms candidate 2 is B-only. ✔ (negative trace)
+6. **NP-5 startup-timeout recovery** (`TestNP5_BlockedApplyStartupTimeout...`, ungated,
+   GREEN): reason is `startup-timeout` → gate does NOT apply → `attemptRecoveryFromDegraded`
+   reaches `exitDegraded` exactly as today → assertion 4 (`...np5...:160-161`) still
+   PASSES. **This is the case the unconditional gate would have BROKEN** (§4.2): NP-5's
+   `newTestManager` never starts heartbeat, so an unconditional gate is unconditionally
+   closed. Reason-scoping is precisely what saves it. ✔
+7. **NATS connection-down recovery** (the EnterThreshold/ExitThreshold path,
+   `checkConnectionHealth` `:103-133`): reason `"NATS connection down"` → gate does NOT
+   apply. (On a genuine reconnect, heartbeat would resume anyway, but reason-scoping makes
+   this independent of heartbeat timing.) No regression to the connection-recovery
+   contract. ✔
+
+---
+
+## 7. Recommendation (part d) and justification against the fd1 doc
+
+**Pick by scope.**
+
+- **If this work item is Family-B-only:** implement **candidate 2** as a **reason-scoped**
+  heartbeat-success-since-degrade exit gate (§4.2) — the gate fires only for a
+  `kv-unavailable` degrade, which requires storing the degrade reason
+  (`m.lastDegradedReason`, new state set in `enterDegraded`). It is the smallest *correct*
+  surface that (i) makes NP-3b pass its `require.Zero` gate, (ii) preserves C1 (entry path
+  untouched; reason scoping means the gate does not even apply to the whole-bucket
+  `"KV error threshold exceeded"` reason), (iii) preserves the f-d1 class-aware reset
+  (separate signal), (iv) keeps NP-9/NP-3a recovery, and (v) **does not regress NP-5** —
+  the load-bearing reason it must be reason-scoped, since an unconditional gate closes
+  NP-5's heartbeat-less unit recovery (VERIFIED §4.2/§6). Its only residual — gating on
+  heartbeat rather than the *exact* failing op — is *already-accepted coverage* under the
+  f-d1 "semantic narrowing" (04-fd1...:81-91): an election/stableid-only fault that leaves
+  heartbeat healthy is the same shape the f-d1 reset already lets through, so candidate 2
+  introduces no *new* regression relative to the shipped f-d1 decision.
+
+- **If A and B are to be closed together:** do **NOT** rely on the report's implied
+  one-line shared fix. The honest unified design is **candidate 3's family** — a
+  generalized per-cause/per-source outstanding-degrade-cause registry where the epoch
+  fence also registers a `bucket-recreated` cause (and Family A *additionally* needs the
+  stale-`ep.created` re-capture latch, since even a perfect exit gate leaves the epoch
+  tick re-firing). This is bigger and touches the contract-pinned subsystems.
+
+**Why this aligns with the fd1 decision record.** The fd1 doc deferred Finding A precisely
+because it "touches the contract-pinned recovery path" and was "narrower… taken only if
+observed" (04-fd1...:54-58, 116-124). NP-3b *is* the observation that retires the
+deferral. Of the three candidates the doc lists, it explicitly frames them as a spectrum:
+cooldown (band-aid) → verify-the-failing-op (targeted) → per-source counters (heaviest).
+Candidate 2 is the doc's middle option realized in its **lightest faithful form** (reuse
+the one existing per-source success hook as the "failing op recovered" proxy), which is
+the right answer when the goal is to close B without paying candidate 3's full
+subsystem-wide cost — and it leaves the door open to upgrade to candidate 3 later if a
+single non-heartbeat-bucket quorum loss is ever observed to escape (the exact escape the
+fd1 doc flagged at 04-fd1...:87-91).
+
+**Reject candidate 1** as a standalone fix: it does not pass NP-3b's `require.Zero` gate
+and weakens C1's bounded re-entry; useful at most as a defensive add-on, not the fix.
+
+---
+
+## 8. Cross-family interactions
+
+- **Family A (NP-2/NP-1).** Shares the exit defect (§5) but NOT the re-degrade trigger.
+  Candidate 2 does not touch it. A unified close needs candidate 3 + epoch re-capture.
+  Sequencing: if both land, the epoch-fence re-capture (or an "epoch mismatch outstanding"
+  registry entry) is independent of the KV-health gate and can be reviewed separately.
+- **Family C (NP-8).** Distinct mechanisms (claim-lost self-stop / MemoryStorage
+  heartbeat-bucket loss, 04-proof-findings.md:122-164). Note one *adjacency*: NP-8 mech 2
+  is a heartbeat-bucket loss that surfaces as `"stream not found"` in the leader
+  calculator (`internal/assignment/worker_monitor.go:175,218`) — a whole-bucket
+  (non-transient) classification, NOT an F-D1 transient. So candidate 2's heartbeat-health
+  gate is irrelevant to NP-8 (the heartbeat Put there fails as whole-bucket loss, keeping
+  the gate closed — correct, it should stay degraded). No conflict.
+- **C2 (peer-claim takeover) / C4 (Start contract).** Independent of the recovery exit
+  gate; no interaction.
+- **f-d1 Finding B (recordKVHealthyOp, 421f13c).** Candidate 2 lives *beside* it (separate
+  always-on stamp vs the degraded-gated transient-clear); both keep the heartbeat as the
+  canonical "KV serving" source, so they are conceptually coherent.
+
+---
+
+## 9. Open questions / things I did NOT verify empirically
+
+- I did not *run* a prototype of candidate 2; the verification trace (§6) is derived from
+  code + the existing gated proofs, not from a patched binary. The gated proofs
+  (`PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF=1`, NP-9 ungated) are the right validation harness
+  once a fix lands. **Mandatory regression check when candidate 2 lands:** re-run the
+  ungated **NP-5** proof (`go test ./... -run TestNP5_BlockedApplyStartupTimeout`) — it is
+  the contract an unconditional gate would silently break, and reason-scoping is what keeps
+  it GREEN. Also re-run NP-9 (recovery must still complete) and the `LiveNATSBucketLoss`
+  C1 pinning tests.
+- **NP-5 regression under an unconditional gate is VERIFIED by code reading, not by a
+  patched run:** NP-5's `newTestManager` never starts a heartbeat publisher
+  (`manager_commit_state_machine_test.go:163`, injects a stub) and calls
+  `attemptRecoveryFromDegraded()` directly (`...np5...:158`), so an unconditional
+  `lastHeartbeatSuccessAt <= degradedSince` gate is unconditionally closed there. I did not
+  execute a patched binary to observe the failure; the conclusion is from the unit test's
+  construction. Confidence high but flagged as inference-from-code, not an observed fail.
+- The heartbeat-only proxy's residual (§4.2 cons) — an election/stableid-only sustained
+  fault with healthy heartbeat — is *argued* to be already-covered by the f-d1 reset, not
+  proven by a dedicated test. If A+B reviewers want certainty, add a proof that faults
+  ONLY election (heartbeat healthy) and asserts it either (a) never reaches threshold
+  (f-d1 reset wins) or (b) holds Degraded under candidate 3. This is the one corner where
+  candidate 2 and candidate 3 diverge observably.
+- `ExitThreshold`/`EnterThreshold`/`RecoveryGracePeriod` production defaults (5s/10s/15s;
+  conservative preset 10s/30s/20s — `config.go:196,191,215,250-254`) mean a *production*
+  flap period is ~seconds-to-tens-of-seconds, slower than the test's accelerated config;
+  the *mechanism* is identical, only the cadence differs (consistent with the report's
+  §6 production-extrapolation caveat).

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech1-verify.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech1-verify.md
@@ -1,0 +1,177 @@
+# Adversarial verification — Family C mech 1 (NP-8): claim-loss self-stop on outage >= WorkerIDTTL
+
+Reviewer pass date: 2026-06-01
+HEAD: 2453306 (worktree `auto-heal-gap-investigation`)
+Scope: READ-ONLY. No production code changed. Independent re-read of every cited
+anchor + the gated proof + the `.out` evidence under `tmp/repro-current-head/`.
+
+Verdict: **confirmed-with-caveats.** The root-cause code path is correctly traced
+and the cross-test WorkerIDTTL contrast genuinely isolates TTL-expiry as the cause.
+I could not refute the mechanism. Three caveats sharpen (not overturn) the finding;
+one of them materially weakens the finding's stated *reason* for its recommended fix,
+though not the fix's conclusion.
+
+---
+
+## What I verified independently (and agree with)
+
+1. **The conflation locus is real.** `claimer.go:362-368`: the renewal `kv.Update(key,
+   value, c.lastRevision.Load())` failure switch returns **bare** `ErrClaimLost`
+   (`fmt.Errorf("%w: ID %s", ErrClaimLost, wid)`, :368) for the `ErrKeyExists` case,
+   with no connectivity / not-found sentinel. The bucket-missing case (:369-371,
+   `ErrNoStreamResponse`/`ErrBucketNotFound`/`ErrStreamNotFound`) wraps a sentinel and
+   is routed to the degraded circuit instead. So "peer bumped my revision (key
+   present)" and "lease aged out (slot empty)" collapse into the identical bare error.
+
+2. **The routing is exactly as described.** `onClaimerError` (`manager_election.go:106-127`):
+   `errors.Is(err, ErrClaimLost)` true; `IsConnectivityError || IsDegradingJetStreamError`
+   both false for the bare wrap (`natsutil/errors.go:92-100` checks only
+   `ErrBucketNotFound`/stream-not-found/consumer-not-found; `:114-137` checks the
+   connectivity sentinels + the `"connection refused"`/`"i/o timeout"` text fallback —
+   the bare `ErrClaimLost` string carries none of these) → `claimLostShutdown` (:118) →
+   `m.Stop` → `StateShutdown`, terminal.
+
+3. **MaxAge==WorkerIDTTL reconciliation is real** (`config.go:366-370`,
+   `manager_setup.go:91-98` calling `reconcileStableIDBucketMaxAge` :373+). The stableID
+   bucket is **FileStorage** (`manager_setup.go:92`) and relies *entirely* on MaxAge to
+   expire abandoned claims (comment :86-90).
+
+4. **Renewal cadence / boundary math is correct.** `renewInterval = max(ttl/3, 100ms)`
+   (`claimer.go:491-493`). At 75s default → 25s cadence, purge at `last-renewal + 75s`,
+   so the triggering outage is phase-dependent **~50-75s**. The finding's correction of
+   the report's "multi-minute" to "minute-scale (~50-75s)" is accurate. This is a valid
+   correction *to the report* (04-proof-findings.md:160,:251,:286), and I confirm it.
+
+5. **Discrepancy #3 (C2 pin mis-cite) is correct and material.** I read all three tests.
+   `TestStableID_StaleKeyTakeover_Reclaim` lives in `test/integration/stableid/
+   stableid_takeover_test.go:21` and exercises the *claimer's* reclaim of a leaked key —
+   it does NOT touch `onClaimerError` self-stop routing. The actual self-stop pins are
+   `TestOnClaimerError_ClaimLostStopsWorker` (`manager_claimer_error_test.go:53-86`,
+   routing-level: feeds bare `ErrClaimLost`, asserts `claimLostShutdown` fires + OnError
+   hook) and `TestManager_StopsItselfWhenClaimLost` (`:135-172`, end-to-end: a peer `Put`
+   bumps the revision, worker reaches `StateShutdown`, consumer revoked). The task brief's
+   contract-C2 citation of the takeover-reclaim test is wrong; the finding's correction is
+   right.
+
+---
+
+## Caveat 1 (strongest) — the gated proof does NOT isolate mechanism 1; attribution is INFERENCE
+
+`TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet` instruments only `OnStateChanged`
+and `OnDegraded` (np8_..._test.go:110-132). It has **no** hook observing `StateShutdown`
+or the claim-lost `OnError`. The captured failure (`tmp/repro-current-head/np8_mech1.out:8`)
+is `manager[1] failed to reach state Stable: context deadline exceeded` at line 187 — it
+proves the **symptom** (no clean heal), not the **mechanism** (claim-loss self-stop).
+
+Crucially, **both** mechanisms are live in this single test: WorkerIDTTL=5s (mech-1 trigger)
+AND the MemoryStorage heartbeat bucket is lost on the single-node restart (mech-2 trigger,
+`manager_setup.go:156`). The test cannot tell which one prevented Stable.
+
+What *does* isolate mech-1 is the **cross-test WorkerIDTTL contrast**:
+- mech-1 proof (WorkerIDTTL=5s): never reaches Stable, fails at the all-Stable wait (:187).
+- mech-2 proof (WorkerIDTTL=30s, `np8_..._test.go:288`): DOES reach all-Stable (:325 passes
+  per `np8_mech2.out` failing only at :327, the HOLD check) then flaps.
+
+The only delta is WorkerIDTTL, and the heartbeat-flap driver (mech-2) is TTL-independent —
+so "never reaches Stable at 5s vs reaches-then-flaps at 30s" is most parsimoniously
+explained by a terminal `StateShutdown` at 5s. That is a sound **inference**, but it is an
+inference, not a direct assertion. The finding itself acknowledges this gap (its Option 0(iv)
+recommends re-purposing the proof to assert `StateShutdown`). I am hardening a gap the
+finding already flags — which is why this is a caveat, not a refutation.
+
+## Caveat 2 — the empirical "claim lost actually fired" chain rests on ONE un-captured diagnostic
+
+The only empirical confirmation that the **bare `ErrClaimLost`** (not a connectivity error)
+fired in NP-8 is the narrative `Degraded→Shutdown @8.2s with OnError: "worker ID claim lost:
+ID worker-N"` at **04-proof-findings.md:135**. I grepped: that artifact exists ONLY as prose
+in 04-proof-findings.md (:135,:147-148) and is re-quoted in the finding note (:75). It is
+**not** present in any `.out` under `tmp/` (`grep -rln "claim lost" tmp/` → none; the only
+shutdown-bearing string is in the doc). The gated proof cannot regenerate it (no OnError /
+Shutdown instrumentation). So the empirical link from "outage > WorkerIDTTL" to "bare
+ErrClaimLost fired" rests on a single un-captured diagnostic run.
+
+The related un-pinned wire link: `TestClaimer_WireContract_RevisionMismatchIsErrKeyExists`
+(`claimer_test.go:650-681`) pins `ErrKeyExists` only for a **present** key with a stale
+revision (Put v2, then Update with the v1 rev). It does **not** cover the **purged-key**
+case ("wrong last sequence: 0" — no message for the subject). If a FileStorage reload after
+restart did NOT promptly purge the aged message, the renewal Update's `lastRevision` would
+still match and renew would **succeed** → mech-1 would never fire. The finding asserts the
+purge surfaces as `ErrKeyExists` but does not pin it with a test.
+
+Assessment: residual risk **low, not zero**. NATS MaxAge purges the latest revision too
+(this is the documented premise of the stableID bucket's whole expiry/stale-takeover design,
+`manager_setup.go:86-90`, `claimer.go:195-201,224-247`), and the @8.2s diagnostic — even
+un-captured — corroborates it. But the mechanism's empirical chain is one un-captured run
+plus a wire-contract test that covers the adjacent (present-key) case, not the exact
+(purged-key) case. Flag it; do not treat it as fully pinned.
+
+## Caveat 3 — the recommended-fix REASONING is part-wrong (its conclusion survives only for partial outages)
+
+The finding's load-bearing argument for "never ship Option 1 (ID-layer re-claim) alone" is
+the split-brain steelman (note §(c),:145-165): an outage long enough to age the claim has
+expired the heartbeat ~35-60s earlier (HeartbeatTTL=15s << WorkerIDTTL, `config.go:370,381`),
+so "the fleet already rebalanced your partitions" and an in-process resume-from-cache would
+double-process.
+
+This reasoning is **false for the actual NP-8 full-fleet scenario it analyzes.** In NP-8
+*every* worker (including the leader) is disconnected during the outage. With no connected
+leader, **no calculator runs and nothing rebalances during the outage** — the leader's
+calculator path (`worker_monitor.go:167` `heartbeatKV.Keys`) cannot even execute while the
+connection is down, and on reconnect the heartbeat bucket is empty/missing (mech-2). There is
+no surviving owner for a resumed worker to double-process against. So the cited
+double-processing risk does not materialize in the full-fleet case.
+
+The risk the finding describes is real only in a **partial** outage (one worker network-
+partitioned while the fleet + leader survive and rebalance). That is a *different* scenario
+than NP-8. And even there, the finding does not trace whether a resumed worker's processing is
+genuinely novel double-processing or merely the normal handoff-fenced rebalance overlap that
+Parti's pull-gating / handoff coordinator already fences — I did not trace those internals
+either, so it is unresolved, not disproven.
+
+Net on the fix: the **objection to the finding's reasoning survives** — "heartbeat already
+expired → fleet rebalanced → Option 1 double-processes" is not the operative risk in NP-8.
+The **conclusion** ("doc-only is the right near-term call; do not ship a naive in-process
+re-claim without verifying the data plane") is still defensible on the weaker, correct
+grounds: (i) orchestrator-layer pod rotation already heals cleanly (`StateShutdown` trips the
+readiness probe; a fresh `Start` re-claims into the now-empty FileStorage slot), and (ii) any
+in-process re-claim that resumes the data plane needs its own integration proof against the
+partial-outage rebalance boundary, which does not exist. So doc-only stands; the *justification*
+must be corrected away from the full-fleet split-brain framing.
+
+---
+
+## Counterexample attempts that FAILED to break the mechanism
+
+- **"Maybe the first renew after reconnect hits a connectivity error, not ErrKeyExists, so it
+  routes to recordKVError and never self-stops."** The renewal op timeout is `ttl/2` clamped to
+  [100ms,5s] (`claimer.go:312-317`); on reconnect the connection is CONNECTED (the test gates on
+  `nc.Status()==CONNECTED` before asserting, :183-184), so the `kv.Update` reaches the server and
+  returns the revision-mismatch `ErrKeyExists`, not a connectivity timeout. Even if one tick
+  raced a connectivity error first, the **next** tick (1.67s later at ttl=5s) self-stops, because
+  nothing re-claims the purged key (`renewalLoop` :306-337 keeps ticking until `ErrClaimLost`).
+  Does not break it.
+
+- **"Maybe FileStorage reload preserves the message so the revision still matches."** Could not
+  refute by code (no test pins the purged-key wire surface); recorded as Caveat 2. The MaxAge
+  design premise and the @8.2s diagnostic make it low-risk, but it is the one un-pinned link.
+
+- **"Maybe the connectivity/degrading branch swallows it (regressing C1 if a fix touches it)."**
+  No: the bare wrap carries no sentinel, so `IsConnectivityError`/`IsDegradingJetStreamError` are
+  both false and the C1 branch (`onClaimerError:113-115` → `recordKVError`) is not entered. Any
+  fix confined to the `:117-118` else-branch leaves C1's lockstep fan-out
+  (`TestManager_LiveNATSBucketLoss`) untouched. Confirms the finding's cross-family claim.
+
+---
+
+## Bottom line
+
+Mechanism: **holds-with-caveats.** Root cause correctly re-derived; the WorkerIDTTL one-variable
+contrast isolates TTL-expiry. Two residual risks that matter: (i) mech-1 *attribution within the
+proof* is an inference (the proof has no Shutdown/OnError instrumentation; both mechanisms are
+live in it) and the empirical "bare ErrClaimLost fired" rests on one un-captured diagnostic +
+a wire test that covers the adjacent case; (ii) the finding's stated *reason* for "never ship
+Option 1 alone" (full-fleet split-brain) is wrong for NP-8 — no leader rebalances when the whole
+fleet is down — though the doc-only conclusion survives on orchestrator-rotation + unproven-data-
+plane grounds. Recommend: keep doc-only, but (a) add the `StateShutdown`/OnError instrumentation
+the finding's Option 0(iv) proposes so attribution stops being an inference, and (b) re-base the
+"don't ship Option 1 alone" justification on the partial-outage case, not the full-fleet one.

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech1.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech1.md
@@ -1,0 +1,353 @@
+# Family C, mechanism 1 (NP-8): claim-loss self-stop on outage >= WorkerIDTTL
+
+Investigation date: 2026-06-01
+HEAD: 2453306 (worktree `auto-heal-gap-investigation`, content-identical to `main`)
+Scope: READ-ONLY. No production code changed.
+
+Report verdict under review (04-proof-findings.md:156-160, :251, :286-292):
+**Low / doc-only** — `claimLostShutdown` is intended split-brain safety, per-worker not
+fleet-specific, needs a "multi-minute" outage at the 75s prod default; fix is to document
+that M5's "recover to Stable" is bounded by `WorkerIDTTL`.
+
+My verdict: **confirmed-with-corrections.** The mechanism is exactly as the report
+root-causes it, and the split-brain rationale for the *peer-takeover* case is genuinely
+sound. But the report's framing is imprecise on three load-bearing counts (see §6), and the
+deepening questions (a)-(d) expose a real conflation that a fix *could* address — it is not
+"impossible," only "not attempted." Whether to fix is a genuine design call, not a slam-dunk
+doc-only.
+
+---
+
+## 1. Independently re-derived mechanism (cite-by-cite)
+
+### 1.1 The lease ages out by MaxAge, not by peer action
+
+The stableID KV bucket's `MaxAge` is reconciled to exactly `WorkerIDTTL` on `Manager.Start`
+(`config.go:366-369`, enforced by `reconcileStableIDBucketMaxAge`, `manager_setup.go:354-373`,
+called from `ensureStableIDKV`, `manager_setup.go:91-98`). The bucket relies *entirely* on
+MaxAge to expire abandoned claims — there is no explicit delete-on-expiry; the NATS server
+purges the key once its newest revision is older than `MaxAge`.
+
+The renewal loop (`internal/stableid/claimer.go:299-338`) renews at
+`renewInterval() = max(ttl/3, 100ms)` (`claimer.go:491-493`). At the **75s default** that is
+**25s**. So a live worker's key is rewritten every 25s, and the server purges it at
+`last-renewal-time + 75s`.
+
+During a NATS outage the renewal `kv.Update` calls (`claimer.go:362`) fail with connectivity
+errors each tick. Those are correctly routed as harmless: `renew()`'s `default` branch wraps
+them generically (`claimer.go:385-387`), `onClaimerError` sees a non-`ErrClaimLost` error and
+sends it to `recordKVOpError` (`manager_election.go:126`) → the degraded circuit. No self-stop
+yet. The worker sits in Degraded ("NATS connection down", `manager_degraded.go:114`) holding
+its cached assignment (M5 proof asserts this, `full_nats_outage_test.go:53-54`).
+
+### 1.2 The self-stop fires on the *first* renewal after reconnect
+
+When the outage exceeds `WorkerIDTTL`, the key is purged server-side. On reconnect the next
+renewal tick calls `kv.Update(key, value, lastRevision)` with the **stale** non-zero
+`lastRevision` (`claimer.go:362`, value from `lastRevision.Store` at the original Claim,
+`claimer.go:182`). Because the subject now has **no** message (purged), the server's
+expected-last-subject-sequence check fails with "wrong last sequence: 0", which nats.go
+surfaces as `jetstream.ErrKeyExists` (wire contract pinned by
+`TestClaimer_WireContract_RevisionMismatchIsErrKeyExists`, `claimer_test.go:650-681`).
+
+`renew()` matches `case errors.Is(err, jetstream.ErrKeyExists)` (`claimer.go:365`) and returns
+**bare** `ErrClaimLost` — `fmt.Errorf("%w: ID %s", ErrClaimLost, wid)` (`claimer.go:368`), with
+**no** connectivity or not-found sentinel wrapped.
+
+`onClaimerError` (`manager_election.go:106-127`):
+- `errors.Is(err, stableid.ErrClaimLost)` → true (line 107).
+- `IsConnectivityError(err) || IsDegradingJetStreamError(err)` → **both false** (the bare wrap
+  carries no `ErrTimeout`/`ErrNoStreamResponse`/`ErrBucketNotFound`/`ErrStreamNotFound`; see
+  `natsutil/errors.go:92-100,114-137`).
+- → `claimLostShutdown(m)` (line 118).
+
+`claimLostShutdown` (`manager_election.go:56-81`) spawns a goroutine that calls `m.Stop` →
+`StateShutdown`, then revokes the worker consumer. This is **terminal**: `NewManager`/`Start`
+cannot be re-entered in place (NP-4 confirms a second `Start` returns `ErrAlreadyStarted`,
+04-proof-findings.md:40,176-178). Recovery requires external pod rotation.
+
+### 1.3 The self-stop is NOT gated on recovery — it always wins the race
+
+There is no grace window. On reconnect two things race: (i) the 1s connection monitor reaches
+`attemptRecoveryFromDegraded` after `ExitThreshold` uptime (`manager_degraded.go:127-132`), and
+(ii) the renewal loop fires `kv.Update`→`ErrClaimLost`→`claimLostShutdown`. `claimLostShutdown`
+fires unconditionally; nothing checks "did we just recover?" The proof shows (ii) wins:
+"all 3 workers Degraded→Shutdown @8.2s with OnError: worker ID claim lost"
+(04-proof-findings.md:135). Even if recovery won first, the *next* renewal tick would still
+self-stop, because nothing re-claims the purged key.
+
+**This is the conflation locus, verified:** the bare-`ErrClaimLost` branch at
+`claimer.go:365-368` (revision-mismatch / "wrong last sequence") is the *single* code point
+where "a peer Put/Update'd my key" (revision bumped, key present, owned by another) and "my
+lease aged out, the slot is now empty" (no message for the subject) are **collapsed into the
+identical error**. They are then routed identically by `onClaimerError:117-118`.
+
+---
+
+## 2. The deepening questions
+
+### (a) Does the code conflate "peer took my ID" with "lease expired, no peer present"?
+
+**Yes — but the precise framing matters.** The error *alone* is genuinely ambiguous: both
+surface as bare `ErrClaimLost` (§1.2). The manager does **not** *attempt* to distinguish them
+— it is not that distinguishing is impossible. A follow-up `kv.Get(key)` on reconnect *would*
+disambiguate:
+- **Key absent / no entry** (or a tombstone) ⇒ the lease aged out by MaxAge and **no peer
+  holds it** (a peer that re-Created would leave a fresh value). The slot is free.
+- **Key present with a fresh value + a revision != my `lastRevision`** ⇒ a peer holds the ID
+  (genuine takeover, must stop, C2).
+
+So the correct claim is: **current code conflates the two; it has the information available to
+distinguish them but chooses a uniform self-stop.** "Cannot distinguish" overstates it.
+
+Note the full-fleet subtlety: in NP-8 *every* worker is disconnected during the outage, so
+**no peer can possibly have taken over** — yet all 3 self-stop on reconnect
+(04-proof-findings.md:135, `healed`-style evidence). This is the unnecessary-loss case in its
+purest form: the entire fleet rotates for a transient connectivity event, with zero actual ID
+contention.
+
+### (b) Is a safe re-claim path feasible WITHOUT regressing C2? Two layers.
+
+**Layer 1 — the ID claim (feasible, low risk).** In the bare-`ErrClaimLost` else-branch
+(`onClaimerError:117-118`), before self-stopping, the claimer could `kv.Get(myID)`:
+- present+fresh+different-revision ⇒ peer takeover ⇒ `claimLostShutdown` (C2 preserved
+  exactly).
+- absent/expired ⇒ attempt an **atomic `kv.Create(myID)`** (NOT `Put` — `claimer.go:200-201`
+  documents why Create is mandatory: two reclaimers racing must not both win). On Create
+  success, store the new revision and resume renewal. On `ErrKeyExists` (a peer won the race
+  in the gap) ⇒ fall back to `claimLostShutdown`.
+
+This change lives **only** in the bare-`ErrClaimLost` branch. The connectivity/degrading
+branch (`onClaimerError:113-115` → `recordKVError`) is untouched, so the whole-bucket-loss
+fan-out (C1) and the OnDegraded-once contract (C3) are unaffected. C2's *peer-present* case
+still self-stops because the Get sees the peer's fresh value. The renewal loop already returns
+on `ErrClaimLost` (`claimer.go:329-334`), so the re-claim would need a small claimer API
+(e.g. `Reclaim(ctx)`) or to be hoisted into the manager.
+
+**Layer 2 — the assignment/data plane (this is the real blast radius).** Re-claiming the ID is
+necessary but **not sufficient** for a *safe* in-process resume. While the worker was Degraded
+it held its **cached assignment** (the partitions it owned pre-outage). But an outage long
+enough to age out the claim (>= 50-75s at defaults) has — ~35-60s earlier — already expired
+that worker's **heartbeat** (HeartbeatTTL=15s default; see §(c)), so the surviving fleet has
+**rebalanced those partitions to other workers**. If the worker re-claims its ID and resumes
+from cached assignment, it risks **transient double-processing** of partitions the fleet
+already moved. A *truly* safe in-process re-claim must also drop the cached assignment and
+re-enter `waitForAssignment` (`manager_election.go:451-486`) — i.e. replicate clean-restart
+semantics in-process. That is a substantially larger change than the ID-layer fix.
+
+There is *some* existing data-plane guard: the claim-loss ordering oracle
+(`test/simulation/internal/coordinator/claim_loss_ordering_oracle_test.go`, e.g.
+`TestClaimLossOrderingOracle_SuccessorReclaimsStableID_NoViolation:223`) fences post-takeover
+message attribution. But that protects a *successor* reclaiming a *released/abandoned* ID, not
+an in-process resume by the *original* holder; full data-plane verification of an in-process
+re-claim is **out of scope for mech-1** and would need its own proof.
+
+### (c) If doc-only is correct, *why precisely* is re-claim unsafe? The split-brain steelman.
+
+The strongest WAD argument is **not** "a peer re-Created your ID slot" (in the full-fleet case
+no peer did). It is the **HeartbeatTTL << WorkerIDTTL** gap:
+
+- Validation forces `WorkerIDTTL >= HeartbeatTTL` (`config.go:370`, tag
+  `gtefield=HeartbeatTTL`). Defaults: HeartbeatTTL=15s (`config.go:381`), WorkerIDTTL=75s, the
+  5x relationship the doc recommends (`config.go:365`).
+- Therefore *any* outage long enough to age out the stable-ID claim (>= ~50-75s) has, **~35-60s
+  earlier**, expired this worker's heartbeat. The leader's emergency-rebalance path will have
+  declared the worker dead and **reassigned its partitions** to peers that stayed up (or to a
+  re-elected leader after recovery).
+
+So the split-brain scenario is concrete: **"the fleet already declared you dead and moved your
+work."** A naive in-process re-claim+resume-from-cache would put the worker back to processing
+partitions that another worker now owns → double-processing until the next rebalance converges.
+The unconditional self-stop guarantees the rotated pod re-enters cleanly through
+`waitForAssignment` and picks up only what the *current* leader assigns it. **This is the
+legitimate core of the doc-only recommendation, and it is sound for the peer-present and the
+heartbeat-already-expired cases — which at defaults is essentially all cases that reach the
+trigger.**
+
+The orchestrator-layer rebuttal that makes doc-only defensible: in k8s, `StateShutdown` trips
+the readiness/liveness probe, the pod restarts, and `Start` re-claims into the (now-empty) ID
+slot cleanly. **The auto-heal happens at the orchestrator layer, not in-process** — which is a
+legitimate design posture for a coordination library, not a bug.
+
+### (d) Quantify the boundary. (Correcting the report's "multi-minute".)
+
+- Trigger: an outage that exceeds the time from the worker's **last successful renewal** to
+  `last-renewal + WorkerIDTTL`. Renewal cadence is `WorkerIDTTL/3` (`claimer.go:491-493`).
+- At the **75s default**: renewal every **25s**, purge at `last-renewal + 75s`. So the
+  triggering outage is between **~50s** (outage starts right before a scheduled renewal) and
+  **~75s** (outage starts right after one) — **phase-dependent, ~50-75s, NOT "multi-minute"**
+  (the report's :160 / :251 framing is imprecise; "minute-scale" is the accurate term).
+- The proof uses WorkerIDTTL=5s + ~7s outage (`np8_fleet_..._test.go:80,177` — config 5s in
+  `IntegrationTestConfig`, outage held >= 7s), which deterministically exceeds the TTL. The
+  one-variable contrast (5s vs 30s WorkerIDTTL, same ~5s outage; 04-proof-findings.md:146-153)
+  is a clean causal proof that this is **TTL expiry, not data loss**. I agree with that proof.
+- Operationally common? A **minute-scale** NATS unavailability is not everyday but is well
+  within realistic incident envelopes (cluster rolling restart that stalls, network partition,
+  control-plane upgrade). It is materially more common than the "multi-minute" framing implies.
+  Combined with the full-fleet "every worker rotates for one connectivity blip" outcome, this
+  is **not negligible** — it means a single ~1-minute NATS hiccup rotates the entire fleet.
+
+---
+
+## 3. Fix options (mechanism, surface, blast radius, contracts, residual risk)
+
+### Option 0 — Doc-only (the report's recommendation)
+
+- **Mechanism:** document on the M5/M6 matrix row that "recover to Stable" is bounded by
+  `WorkerIDTTL`; an outage >= WorkerIDTTL self-stops the worker (StateShutdown) and requires
+  orchestrator rotation. Update 01-fault-matrix / 03-findings-index and the M5 test header
+  (`full_nats_outage_test.go:18`) / OPERATIONS doc.
+- **Surface:** docs + test comments only. Ungate nothing (the proof stays a known-FAIL until a
+  behavioral fix lands, OR is re-purposed to assert the *documented* self-stop, i.e. assert
+  StateShutdown rather than StateStable).
+- **Blast radius:** zero code. **Contracts:** none touched.
+- **Pros:** honest, zero risk, matches the orchestrator-heals posture.
+- **Cons / residual risk:** leaves the full-fleet unnecessary-rotation behavior in place; a
+  ~1-minute NATS blip rotates every worker even when no ID was ever contended.
+
+### Option 1 — ID-layer safe re-claim (Layer 1 only)
+
+- **Mechanism:** in `onClaimerError`'s bare-`ErrClaimLost` else-branch
+  (`manager_election.go:117-118`), `kv.Get(myID)`; if absent/expired, atomic `kv.Create`
+  (resume renewal on success); if present-with-different-fresh-revision or Create loses the
+  race, `claimLostShutdown` as today. Likely needs a `Claimer.Reclaim(ctx)` helper in
+  `internal/stableid`.
+- **Surface:** `manager_election.go:106-127`, `internal/stableid/claimer.go` (new method),
+  `claimer.go:329-334` (renewal loop must support a re-armed claim).
+- **Blast radius:** the stableID claim path only; degraded circuit untouched.
+- **Contracts touched:** **C2** — preserved *only if* the Get-then-Create gate is airtight
+  (peer-present ⇒ stop). Must add a unit test mirroring `TestManager_StopsItselfWhenClaimLost`
+  (peer Put bumps revision ⇒ still stops) AND a new positive test (key purged, no peer ⇒
+  re-claims, stays alive). C1/C3 untouched (connectivity/degrading branch unchanged).
+- **Pros:** removes the full-fleet unnecessary rotation when no peer contends.
+- **Cons / residual risk:** **does not address Layer 2** — re-claiming the ID while resuming
+  from a stale cached assignment risks double-processing partitions the fleet already
+  rebalanced (see §(b), §(c)). **Shipping Option 1 alone is arguably worse than doc-only**: it
+  trades a clean rotation for a silent double-processing window. Do NOT ship without Layer 2.
+
+### Option 2 — Full in-process re-claim + assignment re-bootstrap (Layer 1 + Layer 2)
+
+- **Mechanism:** Option 1's ID re-claim, AND on a successful re-claim drop the cached
+  assignment, revoke the worker consumer, and re-enter `waitForAssignment` so the worker only
+  resumes partitions the *current* leader assigns. Effectively "clean restart without process
+  death."
+- **Surface:** `onClaimerError`, `claimer.go`, plus the assignment-apply / waitForAssignment
+  path (`manager_election.go:451-486`, `manager_assignment.go`), and consumer revoke
+  (`revokeWorkerConsumer`, `manager_election.go:26-34`).
+- **Blast radius:** large — touches the assignment lifecycle, the part most cross-feature
+  contracts depend on.
+- **Contracts touched:** C2 (as Option 1), plus the assignment-apply / claim-loss-ordering
+  oracle suite, plus the live-bucket-loss tests (must not regress C1). Needs an integration
+  proof that an in-process re-claim does not double-process across the rebalance boundary.
+- **Pros:** the only option that *safely* delivers in-process auto-heal across a
+  >= WorkerIDTTL outage.
+- **Cons / residual risk:** highest complexity; re-implements restart semantics in-process,
+  which is exactly what the orchestrator already does for free. The cost/benefit is poor unless
+  there is a concrete requirement to avoid pod rotation on minute-scale outages.
+
+### Option 3 — Raise the effective trigger (config/operational guidance)
+
+- **Mechanism:** guide operators to set `WorkerIDTTL` comfortably above their worst-case NATS
+  outage envelope (it already defaults to 75s; the trade-off is slower ID reclamation after a
+  genuine worker exit, `config.go:362-364`).
+- **Surface:** docs only. **Blast radius / contracts:** none.
+- **Pros:** trivial; pushes the boundary out.
+- **Cons:** does not change behavior at the boundary, just relocates it; longer TTL slows
+  legitimate stale-ID reclamation. A pure palliative.
+
+---
+
+## 4. Recommended fix
+
+**Option 0 (doc-only) as the immediate action, with the report's "multi-minute" corrected to
+"minute-scale (~50-75s at defaults)" and the full-fleet unnecessary-rotation outcome stated
+explicitly.** I agree with the report that this is the right *near-term* call, but for a
+sharper reason than the report gives: the split-brain risk is real (heartbeat already expired ⇒
+partitions already rebalanced, §(c)), so a naive in-process re-claim (Option 1 alone) would
+*introduce* a double-processing bug. The only behaviorally-safe fix is Option 2, whose
+complexity is not justified unless avoiding orchestrator rotation on minute-scale outages
+becomes a hard requirement.
+
+Concretely, doc-only should: (i) fix the M5 row to say recovery-to-Stable holds only for
+outages **< WorkerIDTTL**; (ii) state the boundary as **~50-75s at defaults** (not
+"multi-minute"); (iii) note that an outage past it self-stops **every** disconnected worker
+(StateShutdown), recovered by orchestrator rotation; (iv) re-purpose
+`TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet` to assert the *documented* self-stop
+(StateShutdown) rather than leaving it a permanent known-FAIL, so it becomes a regression guard
+for the intended behavior.
+
+If a future requirement demands in-process survival, pursue **Option 2** (never Option 1 in
+isolation).
+
+---
+
+## 5. Cross-family interactions
+
+- **Family C mech 2** (heartbeat MemoryStorage loss flap): orthogonal mechanism, but the same
+  HeartbeatTTL/WorkerIDTTL relationship that drives mech-1's split-brain argument also governs
+  mech-2 timing. A combined NATS-restart fix must handle both: claim survival (mech-1) AND
+  heartbeat-bucket reconstruction (mech-2). Note mech-2's proof deliberately raises WorkerIDTTL
+  to 30s to *exclude* mech-1 (`np8_..._test.go:286-288`), so the two are cleanly separable.
+- **Families A/B** (recover-on-wrong-signal exit in `attemptRecoveryFromDegraded`): unrelated
+  code path. Mech-1's self-stop fires via `claimLostShutdown`, never through
+  `attemptRecoveryFromDegraded`. A fix to the A/B exit gate does **not** touch mech-1.
+- **C1 (whole-bucket-missing ⇒ all Degraded):** any mech-1 fix MUST stay inside the
+  bare-`ErrClaimLost` branch (`onClaimerError:117-118`) and leave the connectivity/degrading
+  branch (`:113-115` → `recordKVError`) untouched, or it regresses the lockstep fan-out that
+  `TestManager_LiveNATSBucketLoss` pins.
+- **C2 (peer takeover ⇒ only that worker stops):** the central contract a re-claim fix risks.
+  Pinned (correctly) by `TestManager_StopsItselfWhenClaimLost` and
+  `TestOnClaimerError_ClaimLostStopsWorker` — see §6.
+- **C3 (OnDegraded once):** untouched by any mech-1 fix that stays in the self-stop branch
+  (that branch fires OnError, not OnDegraded).
+- **C4 (Start returns after sanity-check):** unrelated.
+
+---
+
+## 6. Discrepancies with the report (adversarial pass)
+
+1. **Boundary magnitude is overstated.** Report says "multi-minute" at the 75s default
+   (04-proof-findings.md:160, :251, :286). The actual trigger is **~50-75s** (phase-dependent
+   on the 25s renewal cadence; §(d)). "Minute-scale," not "multi-minute." This matters: it
+   makes the trigger materially more reachable than the report implies.
+
+2. **The full-fleet unnecessary-rotation is under-stated.** The report frames mech-1 as
+   "per-worker, not fleet-specific" (:157, :251). True that the *mechanism* is per-worker — but
+   in the NP-8 scenario **all** disconnected workers cross the boundary together and **all**
+   self-stop, even though (being all disconnected) **no peer could have taken any ID**. So the
+   operational outcome *is* fleet-wide: one minute-scale NATS blip rotates the entire fleet for
+   zero actual ID contention. The report's "per-worker" framing obscures this.
+
+3. **The C2 pin is mis-cited.** The task brief and the contract list cite
+   `TestStableID_StaleKeyTakeover_Reclaim` (`test/integration/stableid/stableid_takeover_test.go`)
+   as the C2 pin. That test only exercises the **claimer's reclaim mechanism** (a successor
+   takes over a leaked key); it does **not** test the `onClaimerError` self-stop routing at all.
+   The actual self-stop pins are **`TestManager_StopsItselfWhenClaimLost`**
+   (`manager_claimer_error_test.go:135-172`, full end-to-end peer-takeover ⇒ StateShutdown +
+   consumer revoke) and **`TestOnClaimerError_ClaimLostStopsWorker`**
+   (`manager_claimer_error_test.go:53-86`, routing-level). Any C2-risking fix must regression
+   these two, not the takeover-reclaim test.
+
+4. **"Cannot distinguish" would be too strong** (the report doesn't quite say this, but it's
+   worth pinning): the code *conflates* the two causes (§(a)), but a follow-up `kv.Get` *could*
+   distinguish them. The report's verdict is right; the reasoning should be "uniform self-stop
+   is a deliberate-or-incidental choice given available information," not "the signal is
+   irrecoverably ambiguous."
+
+5. **Agreement:** the TTL-vs-data-loss causal proof (one-variable WorkerIDTTL contrast,
+   :146-153) is sound and I independently confirm the wire surface that underpins it
+   (purge ⇒ "wrong last sequence: 0" ⇒ `ErrKeyExists` ⇒ bare `ErrClaimLost`). The
+   doc-only *direction* is defensible; only the framing needs the three corrections above.
+
+---
+
+## 7. Confidence
+
+**High.** The mechanism is a small, fully-traced code path with every step cited; the wire
+contract is pinned by an existing real-NATS test; the boundary math follows directly from
+`renewInterval` and the MaxAge reconciliation; the split-brain rationale follows from the
+`gtefield=HeartbeatTTL` validation and the default 5x ratio. The one residual uncertainty is
+**empirical**, not analytical: I did not run a re-claim prototype to confirm that an in-process
+resume would actually double-process across the rebalance boundary (Layer 2) — that is asserted
+from the assignment-lifecycle reading, and a fix would need its own integration proof. That
+uncertainty does not affect the mech-1 root-cause verdict, only the cost estimate of Option 2.

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech2-verify.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech2-verify.md
@@ -1,0 +1,299 @@
+# Adversarial verification — Family C mechanism 2 (NP-8): MemoryStorage heartbeat-bucket loss => fleet flap
+
+Reviewer pass on current HEAD (`2453306`, worktree `auto-heal-gap-investigation`).
+Read-only. Goal: REFUTE the finding `family-c-mech2.md`, not confirm it. Every claim
+below was re-derived from the cited source; I state separately what I VERIFIED in code
+vs what I INFER.
+
+**Verdict: confirmed-with-caveats.** I tried to break the root-cause mechanism, the
+proof, and the recommended fix. The note's three substantive corrections to the report
+all SURVIVE my attacks and are independently verified. I add one sharpening that makes
+the driver argument airtight (followers), one precision fix the note left as an assertion
+(the leader-side calculator path is a *true* bystander, now proven via the calc state
+machine), and one fix-critique the note under-pressed (the IOPS measurement is the actual
+decision gate between Opt D and the complex Opt C+A/B' path, not a footnote).
+
+---
+
+## 1. Root-cause mechanism — attempted refutation, result HOLDS
+
+### 1.1 The driver claim (publisher Put, not calculator list) — VERIFIED, and I strengthen it
+
+The note's central correction to the report: the re-degrade driver is the heartbeat
+**publisher `kv.Put`** wired to `recordKVOpError`, NOT the leader calculator's
+"failed to list heartbeat keys". I verified every link:
+
+- `internal/heartbeat/publisher.go:414` — `publish` does `p.kv.Put(ctx, key, value)` on a
+  cached handle; on error (`:354-359`) invokes the `onError` callback.
+- `manager_election.go:424` — `publisher.SetOnError(m.recordKVOpError)`. **VERIFIED.**
+- `manager.go:602` — `startHeartbeat` is called in the synchronous `Start` path,
+  **before** the leader-only calculator (`manager.go:607 if m.IsLeader()`), and
+  independent of leadership. So EVERY worker (leader + followers) publishes heartbeats.
+  **VERIFIED.**
+- `recordKVOpError` → `markKVUnavailable` → `recordKVError` (`manager_degraded.go:235-236`).
+  Both plausible Put error surfaces are ADMITTED:
+  - `nats.ErrNoResponders` (cached-data-op surface per `source/nats_kv.go:1381-1383`,
+    "verified vs nats.go v1.50.0"): not connectivity, not degrading-JetStream →
+    `markKVUnavailable` wraps with `ErrKVUnavailable` (`:67-68`) → admitted via
+    `kvUnavailable` (`:164-165`) → reason `kv-unavailable` (`:216-218`).
+  - `jetstream.ErrStreamNotFound`: `IsStreamNotFound` true → `IsDegradingJetStreamError`
+    true (`internal/natsutil/errors.go:92-99`) → `markKVUnavailable` returns it unchanged
+    (`:64`) → admitted (`:165`) → reason `KV error threshold exceeded`.
+  Either way, 5 errors / `KVErrorWindow` (30s) at `HeartbeatInterval=500ms` ≈ **2.5s to
+  re-trip** post-exit (`enterDegraded` at `:224`). **VERIFIED.** The note's reason-string
+  hedge (§1.4) is correct and immaterial to the flap.
+
+**Strengthening (the airtight kill for Opt B, stronger than the note's argument):**
+FOLLOWERS run no calculator at all (`startCalculator` is gated `if m.IsLeader()`,
+`manager.go:607`). Post-reconnect with the connection CONNECTED and `WorkerIDTTL=30s`
+(claim survives), every non-heartbeat bucket is FileStorage and ALIVE, so a follower's
+election/stableID/assignment ops all succeed. The ONLY op a follower runs that can fail
+is the heartbeat Put against the dead MemoryStorage stream. The proof's HOLD check
+requires ALL workers Stable (`np8..._test.go:301-308, 327`). Therefore a follower's
+publisher-Put re-degrade alone trips the HOLD — and a *calculator-only* fix (report's
+Opt B) is structurally incapable of touching a follower. This makes "Opt B cannot stop
+the fleet flap" a structural certainty, not just a wrong-driver argument.
+
+### 1.2 Is the calculator a *pure* bystander? — the note ASSERTED it; I PROVED it
+
+The note says the calculator list error is "swallowed" and the calculator is a "loud
+bystander." I verified swallowing (`worker_monitor.go:175` returns the raw error; the
+poll consumer at `:282-284` only `logger.Error`s it; no `recordKVError` wiring in
+`internal/assignment/*.go` — my grep confirms). BUT the HOLD check fails on ANY non-Stable
+state, not just Degraded, so I checked whether the leader's failed rebalance drives the
+calc state machine to a non-Idle state that `monitorCalculatorState` maps to
+Rebalancing/Emergency (manager state mapping docstring `manager_assignment.go:206`):
+
+- `rebalance` returns the "list heartbeat keys" error at `calculator.go:1542-1544`.
+- That error bubbles to `RunClaimedRebalanceErr` (`state_machine.go:368-386`), which calls
+  `sm.ReturnToIdle()` **unconditionally** (`:383`) BEFORE returning the error, emitting
+  `CalcStateIdle` (`:414`).
+- `CalcStateIdle` maps to manager `StateStable` (`monitorCalculatorState`,
+  `manager_assignment.go:206`).
+
+**Conclusion (VERIFIED, upgrades the note):** the calculator failure neither feeds the
+degraded circuit NOR drives a non-Idle calc state — the rebalance aborts and the machine
+returns to Idle. So the leader has NO second, calculator-side contributor to non-Stable;
+its only path is the same publisher-Put → `recordKVError` as the followers. The note's
+"pure bystander" is therefore exact, not overstated. (The note left this as an assertion;
+it is now proven.)
+
+### 1.3 Did anything else feed the degraded circuit post-reconnect? — enumerated, NO
+
+I re-ran the by-elimination the note relies on, widening it to ALL `recordKVOpError` /
+`recordKVError` feed sites (`grep`, production only), not just the `enterDegraded` callers:
+
+- `manager_election.go:262, 303` — election renew / follower request. Election bucket is
+  **FileStorage** (`manager_setup.go:152`), survives → these succeed post-reconnect.
+- `manager_assignment.go:398, 437, 636` — assignment watcher / session. Assignment bucket
+  **FileStorage** (`:160`), survives.
+- `manager_election.go:114, 126` — `onClaimerError` (stableID renew). StableID bucket
+  **FileStorage** (`:92`); with `WorkerIDTTL=30s` the claim survives the 5s outage (this
+  is exactly what isolates mech2 from mech1). → succeeds.
+- `manager_degraded.go:385` — `attemptRecoveryFromDegraded`'s own `refreshAssignmentFromNATS`
+  failure; assignment survived → does not fire.
+- `manager_election.go:424` — heartbeat publisher. **The only feed site hitting the dead
+  bucket.**
+
+Secondary churn path I checked (the note did not): a follower that wins leadership in
+`monitorLeadership` calls `startCalculator(... heartbeatKV)` (`manager_election.go:329`),
+and on failure releases leadership (`:330`, `releaseLeadershipAfterCalculatorFailure`).
+This could add leadership churn IF `calc.Start` fails on the missing heartbeat stream.
+But (a) this does not feed `recordKVError`, and (b) even if it induces re-election churn,
+the publisher-Put driver already trips every worker independently, so it is at most a
+secondary contributor to the *leader-identity* instability, not to the Degraded flap.
+The driver attribution is unaffected. **INFERENCE** (I did not trace whether `calc.Start`
+performs a synchronous heartbeat read that fails on a missing stream); flagged as a minor
+open item, not load-bearing.
+
+### 1.4 F-D1 reset (commit 421f13c) is genuinely irrelevant — VERIFIED
+
+`recordKVHealthyOp` clears only `transient` entries and only on a periodic KV **success**
+(`manager_degraded.go:266-288`). The only wired success feeder is the heartbeat publisher
+(`SetOnSuccess(m.recordKVHealthyOp)`, `manager_election.go:432`) — and the heartbeat is
+the very op that is failing (bucket gone). No success ever fires, so the transient
+entries accumulate uncleared. There is no other `SetOnSuccess` / healthy-op feeder in
+production (grep confirms). The note's "reset is irrelevant" holds. **VERIFIED.**
+
+### 1.5 The recover-on-wrong-signal exit — VERIFIED, same defect as Families A/B
+
+`attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`): refreshes ONLY the
+assignment bucket (`refreshAssignmentFromNATS`, FileStorage, survived), `recordKVSuccess()`
+clears the WHOLE window (`:393`), gates exit solely on `currentAssignmentApplied` (`:409`),
+then `exitDegraded` → Stable (`:415`). It NEVER reads the heartbeat bucket. `exitDegraded`
+resets `degradedSince=0` (`:356`), releasing `recordKVError`'s already-degraded
+short-circuit (`:174`), so heartbeat-Put errors re-accumulate from zero. The 1s connection
+monitor (`:79`) drives the exit on uptime ≥ ExitThreshold (`:130-131`); the link is
+CONNECTED throughout. Two ticks fight → flap. **VERIFIED.** This is structurally the same
+exit defect the report assigns to Families A/B (`04-proof-findings.md:50-52, 60-93,
+95-120`), which is why Opt C is genuinely shared.
+
+---
+
+## 2. Does the gated PROOF prove what it claims? — checked, with one important nuance
+
+I read `np8_fleet_nats_outage_leader_continuity_test.go` (both tests) and the `.out`.
+
+**Mech2 test (`...HeartbeatBucketLossFlap`, `:265-331`):**
+- Isolation from mech1: `cfg.WorkerIDTTL = 30s` (`:288`) > 5s outage (`:316`), so the
+  stableID claim survives and `claimLostShutdown` cannot fire. **Good isolation.**
+- Non-vacuity / sequencing: it FIRST asserts the fleet REACHES all-Stable
+  (`require.Eventually(np8bAllStable, 30s)`, `:325`) and THEN asserts it HOLDS
+  (`require.Never(!np8bAllStable, 8s)`, `:327`), plus connection CONNECTED (`:329`).
+  The reach assertion is the non-vacuity guard: a dead recovery path (never reaching
+  Stable) would fail at `:325`, not `:327`, and would be a different bug.
+- **Evidence (`tmp/repro-current-head/np8_mech2.out`):** failure is at **line 327**
+  ("Condition satisfied" on the `require.Never` HOLD), runtime **12.00s**. This proves the
+  fleet DID reach all-Stable (the `:325` Eventually passed) and THEN re-entered non-Stable
+  within the 8s HOLD window — i.e. a genuine flap, isolated from mech1, connection up.
+  **The proof is non-vacuous and proves: flap + mech1-isolation + connectivity-up.**
+
+**The nuance that matters for the discrepancy adjudication:** the mech2 proof uses EMPTY
+hooks (`parti.WithHooks(&parti.Hooks{})`, `:293`) and the integration config logs via
+NopLogger (`internal/testutil/nats.go:306`). So the proof captures NO `OnDegraded` reason
+and NO per-worker driver attribution. **The proof is therefore SILENT on which op is the
+driver.** It cannot discriminate the report's "calculator list error" framing from the
+note's "publisher Put" framing — both predict the same observable (reach-then-flap,
+connection up). The note's central correction (driver = publisher Put) rests 100% on
+code-reading (§1.1–1.3), which I independently re-verified. This is the honest, defensible
+statement: the test proves the flap; the code proves the driver.
+
+(Mech1 `.out` confirms it is a distinct mechanism: failure is at `:187`
+"manager[1] ... context deadline exceeded" reaching Stable — i.e. stuck Shutdown, NOT a
+flap — runtime 40s. Cleanly separated.)
+
+---
+
+## 3. Attack on the recommended fix — strongest objections
+
+The note recommends **Opt C (gate the recovery exit on heartbeat-op health) + Opt A/B'
+(restore the bucket), co-designed with Family A's `ep.created` re-capture**, and offers
+Opt D (heartbeat → FileStorage) as "simplest if IOPS clears."
+
+### 3.1 Opt A epoch-fence collision — VERIFIED, the constraint is real
+
+I confirmed the load-bearing constraint:
+- `captureBucketEpoch` caches `ep.created` ONCE at Start (`manager_setup.go:627`), never
+  re-captured.
+- `checkBucketEpochs` (`:669-693`): TODAY, with the heartbeat stream gone, the probe
+  `BucketStreamCreated` errors → `logger.Debug` + `continue` (`:679-682`) → **the fence is
+  DORMANT on heartbeat** (does NOT fire `bucket-recreated`).
+- A recreate (Opt A / Opt B' recreate variant) gives the new stream a different `Created`
+  → `!live.Equal(ep.created)` → `enterDegraded("bucket-recreated:heartbeat")` (`:684-690`).
+  Because all workers recreate against the same new stream, this fires **fleet-wide**,
+  trading the heartbeat flap for an epoch-fence Degraded (itself a flap per Family A).
+  The fence ticker runs at `OperationTimeout` (default 10s, `:649`).
+**So any recreate-based fix is unsafe unless `ep.created` is re-captured atomically with
+the recreate, winning the race against the epoch ticker.** The note's "co-design with
+Family A is mandatory" SURVIVES. This is the strongest objection to Opt A and it stands.
+
+### 3.2 Opt C-alone fails the proof as written — VERIFIED, survives
+
+Opt C without a recreate converts the flap into permanently-stuck Degraded (MemoryStorage
+never returns on its own). The proof's `:325` reach-all-Stable assertion would then FAIL
+(stuck Degraded never reaches Stable). So Opt C-alone cannot be a drop-in regression
+ungate; the proof expectation must be rewritten from auto-heal-to-Stable to
+hold-Degraded/require-rotation — a PRODUCT decision, not a mechanical ungate. The note
+states this (`:334-341`) and it is correct. **SURVIVES.** I note this is the fail-safe
+posture matching the documented live-data-loss contract (`04-proof-findings.md:88-90`).
+
+### 3.3 C1 contract is preserved — VERIFIED for Opt C and Opt A; conditional for B'
+
+- **C1 (whole-bucket-missing => all Degraded):** Opt C only changes the *exit* gate, never
+  *entry*, so it cannot suppress the entry path that C1 pins. Opt A keys on a
+  reconnect/connection-restored event; `TestManager_LiveNATSBucketLoss` deletes all
+  buckets LIVE with the connection UP and NO reconnect, so a reconnect-keyed Opt A does
+  not fire there and C1 still holds via the other wiped buckets' non-transient
+  `ErrBucketNotFound`. The note's caveat — pin the trigger to *reconnect*, not
+  *any-missing-observation* — is the right guard. **VERIFIED, SURVIVES.** Opt B' must not
+  let a Put-recreate mask C1: the other wiped buckets still produce non-transient
+  (degrading-JetStream) entries that `recordKVHealthyOp` does NOT clear
+  (`manager_degraded.go:278-284` keeps non-transient), so C1 holds — confirmed by the
+  guard `TestManager_PartialBucketLoss_HeartbeatHealthy` (cited; I did not re-run it,
+  read-only). **INFERENCE on the test's exact assertion; the masking-guard logic is
+  VERIFIED in code.**
+- **C2 / C3 / C4:** Opt C is on the recovery-exit path, orthogonal to peer-claim
+  takeover (C2, `manager_election.go:106-127`), to the once-per-entry OnDegraded fire
+  (C3, `enterDegraded` is unchanged), and to `Start` returning after sanity-check (C4).
+  **VERIFIED orthogonal.**
+
+### 3.4 The fix-critique the note under-pressed: IOPS is the actual decision gate
+
+The note's recommended path (Opt C + A/B' + Family A `ep.created` co-design) is by far the
+MOST COMPLEX option, and its ranking over the one-line Opt D rests ENTIRELY on an
+**unmeasured** heartbeat-FileStorage IOPS cost. The note correctly debunks transferring
+M1.9's "IOPS-free" finding (that is the ELECTION bucket, `manager_setup.go:113-115`;
+MEMORY.md M2.A flags the per-op state file as the dominant cost; heartbeat is the
+highest-frequency op). But the note buries the consequence in a footnote ("Opt D is the
+simplest if an IOPS measurement clears it"). The sharper statement: **if the IOPS
+measurement clears, Opt D DOMINATES** — it eliminates the flap at the source with no epoch
+trip, no recreate race, and no Family A coupling, for a one-line storage change
+(`manager_setup.go:156`), versus a three-way co-design. The IOPS measurement is therefore
+the genuine decision gate, not a footnote, and it should be run FIRST. This objection
+SURVIVES and is, in my view, the single most actionable correction to the note's fix
+ranking. (Caveat the note already makes: Opt D changes the `manager_setup.go:116-117`
+MemoryStorage rationale and `TestManager_PartialBucketLoss_HeartbeatHealthy` semantics;
+operators who pre-create the bucket override anyway, `:121-124`.)
+
+---
+
+## 4. Discrepancies with the note (mine), and adjudication of the note vs the report
+
+**Where the note is RIGHT against the report (I confirm all three substantive ones):**
+1. **Driver misnamed (substantive) — UPHELD.** Report (`04-proof-findings.md:136-144,
+   256-258`) localizes the gap to the leader's calculator "list heartbeat keys"; that path
+   is swallowed (`worker_monitor.go:282-284`) AND returns the calc machine to Idle/Stable
+   (`state_machine.go:383`, §1.2). The driver is the fleet-wide publisher Put. UPHELD and
+   strengthened (followers, §1.1; calc-Idle, §1.2).
+2. **Opt B ineffective (substantive) — UPHELD.** A calculator-only fix cannot touch a
+   follower (which runs no calculator), and the HOLD requires all workers Stable. Plus
+   empty (already tolerated, `worker_monitor.go:170-173`) ≠ missing (raw error,
+   `calculator.go:1213`). Reject Opt B as written. UPHELD.
+3. **Epoch-fence dormant→activated (sharpening) — UPHELD** (§3.1).
+4. Reason-string (minor) and IOPS-transfer (flag): UPHELD; the note has these right.
+
+**Where I correct or sharpen the NOTE:**
+- The note ASSERTS the calculator is a bystander but did not check whether the calc *state
+  machine* drives the leader non-Stable on the rebalance error. I PROVED it returns to
+  Idle (`state_machine.go:383` unconditional `ReturnToIdle`) → Stable mapping, so the
+  "pure bystander" claim is exact. (Confirms the note; closes a hole it left open.)
+- The note's strongest Opt-B refutation should be the FOLLOWER argument (§1.1), which it
+  does not make explicitly — followers run no calculator, so a calculator fix is
+  structurally incapable of stopping their flap; this is stronger than "wrong driver."
+- The note under-ranks Opt D: if IOPS clears, D dominates the complex recommended path
+  (§3.4). The IOPS measurement is the decision gate.
+
+**Where the report is NOT wrong:** its CORE verdict — fleet does not auto-heal a
+single-node MemoryStorage heartbeat-bucket loss; topology-dependent (RF3 may save it);
+needs recreate-or-tolerate — is correct, and the empirical FAIL holds. The report's error
+is purely the driver attribution and the resulting Opt B, exactly as the note says.
+
+---
+
+## 5. Residual risk / open items
+
+- **Driver attribution is code-only.** The proof is silent on the reason (empty hooks,
+  NopLogger). The publisher-Put-driver conclusion is a code-reading claim (re-verified
+  here), not a test-captured one. To make it test-backed, add a reason-capturing
+  `OnDegraded` hook to the mech2 proof (test-only change). MEDIUM confidence that the
+  reason is `kv-unavailable` vs `KV error threshold exceeded` (depends on the exact Put
+  error surface); HIGH confidence the driver is the publisher Put regardless of reason.
+- **RF3 topology (the report's biggest open item, unchanged).** Whether a real RF3 rolling
+  restart preserves the replicated MemoryStorage stream is unmeasured; needs the gated
+  `quorum_loss_tier2` 5-node harness. If RF3 preserves it, the prod severity drops.
+- **`calc.Start` on a missing heartbeat stream (minor, INFERENCE).** I did not confirm
+  whether a new leader's `startCalculator` fails synchronously on the dead stream and
+  induces leadership churn. Not load-bearing (the publisher Put already trips every worker),
+  but worth a one-line trace if leadership instability shows up in the fix's proof.
+- **Opt D IOPS measurement (the actual fix decision gate).** Must be run before committing
+  to the complex Opt C+A/B' path.
+
+## 6. Bottom line
+
+Root-cause mechanism: **HOLDS** (publisher-Put driver, recover-on-wrong-signal exit,
+fleet-wide). Proof: **non-vacuous and isolated**, but silent on the driver (driver is
+code-proven, not test-proven). Recommended fix: **survives** its strongest objections
+(epoch-fence co-design mandatory; Opt C-alone needs a product/test-contract decision; C1
+preserved), with one material sharpening — **the heartbeat-FileStorage IOPS measurement is
+the real decision gate**, and if it clears, the one-line Opt D dominates the note's complex
+recommended path. Verdict: **confirmed-with-caveats.**

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech2.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/family-c-mech2.md
@@ -1,0 +1,453 @@
+# Family C mechanism 2 (NP-8): MemoryStorage heartbeat-bucket loss => fleet flap
+
+Independent deep-dive on current HEAD (`2453306`, worktree `auto-heal-gap-investigation`).
+Read-only investigation. Every code claim cites `file:line` against the worktree source.
+
+Verdict: **confirmed-with-corrections.** The gap is real and the flap mechanism is
+exactly as severe as the report claims, but the report **misnames the load-bearing
+re-degrade driver** and, as a consequence, **its Opt B fix recommendation does not stop
+the flap.** Details below.
+
+---
+
+## 0. TL;DR of the corrections
+
+1. The re-degrade driver is the **heartbeat _publisher_ `kv.Put`**
+   (`manager_election.go:424` wires `publisher.SetOnError(m.recordKVOpError)`), NOT the
+   leader's calculator "list heartbeat keys" call. The calculator's list errors are
+   **swallowed** (logged, never fed to the degraded circuit) — see §1. The report's
+   `"failed to list heartbeat keys: stream not found"` names the loudest **log line**,
+   not the **degrade driver**. This is also why the gap is **fleet-wide, not
+   leader-specific**: every worker publishes a heartbeat, so every worker re-degrades.
+2. Because the calculator list is not the driver, the report's **Opt B
+   ("calculator path that tolerates an empty heartbeat bucket") fixes a non-driver and
+   does not stop the flap.** Worse, "empty" ≠ "missing": the calculator **already**
+   tolerates empty (`worker_monitor.go:170`), and the actual failure is a missing
+   *stream* that returns a raw error at `calculator.go:1213`. Opt B as framed is doubly
+   insufficient (§3, Opt B).
+3. The likely re-degrade **reason string is `"kv-unavailable"`**, not `"KV error
+   threshold exceeded"`. A cached `kv.Put` after stream loss surfaces
+   `nats.ErrNoResponders` (the repo's own empirically-verified surface,
+   `source/nats_kv.go:1381-1383`), which `markKVUnavailable` wraps into `ErrKVUnavailable`
+   (`manager_degraded.go:67-68`). The flap is identical for all three plausible error
+   classes, so this does not change the fix — but the report's mechanism narrative
+   implies the wrong reason. Hedged in §1.4.
+4. Opt A (recreate-on-reconnect) **does collide with Family A's epoch fence** — the report
+   is right — and I sharpen it: today the fence is **silent/dormant** on heartbeat
+   (probe errors → Debug + `continue`, `manager_setup.go:679-682`); Opt A would **activate
+   a dormant fence simultaneously on every worker** (same new stream `Created`). The two
+   fixes must be co-designed (§3, Opt A; §4).
+
+---
+
+## 1. Exact failure path (re-derived from code)
+
+### 1.1 What survives a single-node NATS restart
+
+`ensureCoreKVBuckets` (`manager_setup.go:125-166`) fixes storage per bucket:
+
+- election: `FileStorage` (`:152`)
+- heartbeat: **`MemoryStorage`** (`:156`)
+- assignment: `FileStorage` (`:160`)
+- stableID: `FileStorage` (`manager_setup.go:92`)
+- handoff: `FileStorage` (`manager_setup.go:176`)
+
+A single-node embedded restart with a persistent StoreDir reloads the FileStorage
+streams but the MemoryStorage `KV_<heartbeatBucket>` stream is **gone**. So post-restart:
+heartbeat bucket missing, all others present.
+
+### 1.2 The two ticks that fight (the flap)
+
+**Re-degrade tick — the heartbeat publisher.** Every worker runs a heartbeat
+`Publisher` (`internal/heartbeat/publisher.go`). The publish loop calls `p.kv.Put` every
+`HeartbeatInterval` (`publisher.go:414`) on a **cached** KV handle captured at Start
+(`manager_election.go:419`, `publisher.go:135`). On failure it invokes the registered
+`onError` callback (`publisher.go:354-359`), which the manager wires to
+`m.recordKVOpError` (`manager_election.go:424`). `recordKVOpError` →
+`markKVUnavailable` → `recordKVError` (`manager_degraded.go:235-236`).
+**Every** manager runs a heartbeat publisher, leadership-independent: `startHeartbeat`
+is invoked once during `Start` (`manager.go:602`) for every worker, before/independent of
+election — so this driver fires on followers and leader alike (the basis for the
+"fleet-wide, not leader-specific" correction in §5.1).
+`stream not found`/`no responders` both pass the `recordKVError` admission gate
+(`manager_degraded.go:165` admits degrading-JetStream OR `ErrKVUnavailable`), so after
+`KVErrorThreshold` (default 5, `config.go:204`) failures inside `KVErrorWindow`
+(default 30s, `config.go:209`) → `enterDegraded(...)` (`manager_degraded.go:207-224`).
+At the integration `HeartbeatInterval=500ms` (`config.go:793`) that is **~2.5 s** to
+re-trip. **This fires on every worker, leader or not.**
+
+**Recovery tick — the connection monitor.** `monitorNATSConnection` runs a 1 s ticker
+(`manager_degraded.go:79`) calling `checkConnectionHealth`. Post-reconnect the connection
+is CONNECTED, so the `!isConnected` re-degrade branch (`:103-118`) is never taken; once
+connection **uptime** ≥ `ExitThreshold` (`:130`) it calls `attemptRecoveryFromDegraded`
+(`:131`). That function:
+
+1. `refreshAssignmentFromNATS()` (`manager_degraded.go:383`) — reads **only**
+   `assignment.<workerID>` from the **assignment** bucket (`manager_assignment.go:1567-1568`),
+   which is FileStorage and **survived** → succeeds.
+2. `recordKVSuccess()` (`:393`) — clears the entire KV-error window
+   (`manager_degraded.go:244-250`).
+3. `currentAssignmentApplied(cur)` (`:409`) — assignment survived and was already applied
+   pre-outage → true → skips the re-arm.
+4. `exitDegraded()` (`:415`) → `transitionState(StateStable)` + `degradedSince.Store(0)`
+   (`manager_degraded.go:350-356`) → **Stable**.
+
+**The exit gate NEVER reads the heartbeat bucket.** This is the same
+"recover-on-wrong-signal" exit defect the report attributes to Families A and B
+(`04-proof-findings.md:60-93, 95-120`): the recovery path proves the *assignment* read
+is healthy and exits, while the *failing* op (heartbeat publish) is never checked. Once
+`degradedSince` is cleared, `recordKVError`'s "already degraded" short-circuit
+(`manager_degraded.go:174`) releases, so the heartbeat-Put errors re-accumulate from
+zero → re-degrade ~2.5 s later. Oscillation. Connection stays CONNECTED throughout
+(asserted by the proof, `np8..._test.go:329`).
+
+### 1.3 Why the calculator "list heartbeat keys" error is NOT the driver
+
+`GetActiveWorkers` returns `failed to list heartbeat keys: %w` on a non-no-keys error
+(`worker_monitor.go:175`). Tracing every consumer:
+
+- **Poll path:** `WorkerMonitor.monitorWorkers` ticker → `onChangeCb` → `pollForChanges`
+  → `observeAndDecide` → `collectWorkerObservation` → `getActiveWorkers`
+  (`calculator.go:1099,1195`). The error returns up to the poll loop, which only
+  **logs** it: `m.logger.Error("polling error", ...)` (`worker_monitor.go:282-284`).
+  The watcher path is identical: `m.logger.Error("watcher-triggered check failed", ...)`
+  (`worker_monitor.go:396`).
+- **Rebalance path:** `collectRebalanceWorkers` → `getActiveWorkersFiltered` →
+  `getActiveWorkers` (`calculator.go:1489,1319,1195`); the error bubbles to `rebalance`
+  which returns it (`calculator.go:1541-1545`) — to the state machine, again logged only.
+- **Audit path:** `auditApplied` → `GetHeartbeats`; on error it logs Debug and returns
+  (`calculator_audit.go:60-63`).
+
+`grep -n 'recordKVError\|recordKVOpError\|SetOnError' internal/assignment/*.go`
+(excluding tests) returns **nothing**: the calculator has **no wiring** into the
+manager's degraded circuit for worker-list reads.
+
+**Complete `enterDegraded` caller enumeration** (`grep -n 'enterDegraded(' *.go`,
+production), to make the "by elimination" airtight — which of these can fire
+post-reconnect on a heartbeat-only loss?
+
+1. `manager_degraded.go:114` `"NATS connection down"` — connection monitor;
+   **excluded** (link is CONNECTED post-reconnect).
+2. `manager_degraded.go:224` threshold reason — `recordKVError`; **fed by the heartbeat
+   Put** (and only heartbeat, since every other bucket survived). **This is the driver.**
+3. `manager_assignment.go:412` `assignmentWatcherDegradedReason` — keyed off the
+   **assignment** bucket watcher (FileStorage, survived). Not heartbeat.
+4. `manager_startup_async.go:47,187` `"startup-background-panic"` / `"startup-timeout"` —
+   one-shot **startup** watchdog during `Start`; not a steady-state post-recovery path.
+5. `manager_setup.go:83` `"stream-missing-recovery-exhausted"` — via `onStreamMissingError`,
+   the dynamic-consumer **event-stream** observer (`composite_updater.go:135`). Not the
+   heartbeat bucket.
+6. `manager_setup.go:689` `"bucket-recreated:<bucket>"` — epoch fence; **dormant on
+   heartbeat today** (probe errors → Debug + `continue`, §3).
+
+Of the six, only (2) can fire post-reconnect on a heartbeat-only loss, and (2) is driven
+solely by the heartbeat Put (the only heartbeat-bucket op wired to the circuit; the
+calculator reads are unwired). Hence: **publisher Put = driver; calculator list = loud
+bystander.**
+
+Note the classification asymmetry in `getActiveWorkers` (`calculator.go:1196-1213`):
+`stream not found` is **not** an `IsConnectivityError` (`internal/natsutil/errors.go:114-137`
+does not match it), so the cache-fallback branch (`:1197-1211`) is skipped and the raw
+error returns at `:1213`. The calculator therefore does NOT even fall back to cached
+workers on a missing stream — it just aborts the rebalance. (It would fall back only for
+a *connectivity* error.)
+
+### 1.4 The re-degrade reason string (hedged)
+
+The heartbeat publisher holds a **cached** KV handle. The repo's empirically-verified
+surface (`source/nats_kv.go:1371-1400`, "verified against nats.go v1.50.0") says a cached
+**data** op (`kv.Get`, and by extension `kv.Put`) after stream loss returns
+`nats.ErrNoResponders`, while a cached **watcher** rebind returns
+`jetstream.ErrStreamNotFound`. So the publisher Put most likely yields
+`nats.ErrNoResponders`:
+
+- `markKVUnavailable` (`manager_degraded.go:58-72`): not connectivity, not
+  degrading-JetStream, but `errors.Is(err, nats.ErrNoResponders)` → wraps with
+  `ErrKVUnavailable` → `recordKVError` sets reason **`"kv-unavailable"`**
+  (`manager_degraded.go:216-218`).
+
+If instead the Put surfaces `ErrStreamNotFound` (degrading-JetStream), the reason is
+`"KV error threshold exceeded"`. The proof's own diagnostic block calls this a CAS race
+between the two reasons (`np8..._test.go:230-238`). **Either way the flap is identical**,
+because both classes accumulate to threshold and neither is cleared by
+`recordKVHealthyOp` (there is no heartbeat *success* — the bucket is gone, so transient
+entries that `recordKVHealthyOp` would clear never get a success to clear them;
+`manager_degraded.go:266-288`). I could not capture the live reason empirically: the
+integration config uses a NopLogger (`internal/testutil/nats.go:306`) and the flap proof
+uses empty hooks (`np8..._test.go:293`), so no per-worker reason is recorded, and I must
+not modify production code to add a logger. **Recommendation: do not assert a specific
+reason; treat both as in-scope for the fix.**
+
+### 1.5 Recovery-grace interaction (minor)
+
+`exitDegraded` calls `enterRecoveryGracePeriod` only `if m.isLeader.Load()`
+(`manager_degraded.go:370-372`). Recovery grace (`RecoveryGracePeriod` default 15s,
+`config.go:215`) only gates the leader's *rebalance decisions* (`calculator.go:1063-1066`);
+it does **not** gate the heartbeat publisher or `recordKVError`, so it does **not** damp
+the flap. Followers get no grace at all. This is why the flap period (~2.5s) is far below
+RecoveryGracePeriod.
+
+---
+
+## 2. Severity / topology (part d)
+
+- **Worst case is real but topology-gated.** The single-node embedded restart loses the
+  whole MemoryStorage stream — proven (`np8_mech2.out`: HOLD check trips at ~12s,
+  connection CONNECTED). A genuine **RF3 rolling restart** that keeps a replicated
+  MemoryStorage stream alive across the node bounce would NOT lose the bucket and would
+  not hit this. The report's RF3 caveat (`04-proof-findings.md:161-164, 252`) is sound
+  and remains the single biggest open uncertainty (un-measured; reasoning only).
+  Caveat on the caveat: MemoryStorage replicas still lose all data if **all** replicas
+  bounce simultaneously or if quorum is lost during the restart, so RF3 narrows but does
+  not eliminate the worst case.
+- **heartbeat → FileStorage eliminates mech 2 at the source** (the stream survives the
+  restart, so neither the publisher Put nor the calculator list fails). **Cost is
+  unquantified, NOT IOPS-free.** The `manager_setup.go:113-115` comment cites IOPS
+  finding M1.9 for the **election** bucket only; heartbeat is the *highest-frequency* KV
+  op (every worker, every `HeartbeatInterval`), and MEMORY.md's IOPS notes identify the
+  per-op state file as the dominant cost (M2.A). Do **not** transfer M1.9's "IOPS-free"
+  conclusion to heartbeat. A FileStorage heartbeat bucket needs its own IOPS measurement
+  before adoption. (It would also change the C1/partial-loss test semantics — see §3.)
+
+---
+
+## 3. Fix options
+
+| Opt | Mechanism | Surface | Blast radius | Contracts/tests | Residual risk |
+|---|---|---|---|---|---|
+| A | recreate heartbeat bucket on reconnect | `manager_setup.go` + a reconnect/recovery hook | medium-high | **collides with Family A epoch fence (C-cross)**; touches C1 reasoning | epoch re-capture race; reconnect-storm churn |
+| B (as written) | calculator tolerates empty heartbeat list | `worker_monitor.go` / `calculator.go` | low | none | **does not stop the flap** (wrong driver) |
+| B' (corrected) | publisher Put self-heals: recreate-or-reopen handle on NotFound | `internal/heartbeat/publisher.go` + manager wiring | medium | C1, C3 | recreate race; must not mask C1 |
+| C | gate `attemptRecoveryFromDegraded` exit on heartbeat-op health | `manager_degraded.go:376-416` | medium | C1, C2, C3, C4; shared with Family A/B exit defect | turns flap into *stuck Degraded* if bucket never returns |
+| D | heartbeat bucket → FileStorage | `manager_setup.go:156` | low-code, high-ops | C1 partial-loss test, IOPS | unquantified IOPS cost |
+
+### Opt A — recreate-on-reconnect (report's primary rec)
+
+**Mechanism.** On NATS reconnect (or inside `attemptRecoveryFromDegraded`), re-run
+`ensureKVBucket` for the heartbeat bucket so a missing `KV_<heartbeat>` stream is
+recreated; the publisher's existing handle then resolves again (or is re-opened).
+
+**Where it would hook in.** There is **no existing reconnect handler** that re-ensures
+buckets — `ensureCoreKVBuckets` runs only at Start (`manager.go:568`). A natural hook is
+the connection-restored branch of `checkConnectionHealth` (`manager_degraded.go:122-126`)
+or a `nats.ReconnectHandler`. (The README recommends `MaxReconnects(-1)`, `doc.go:30-33`,
+so reconnect events are the expected recovery trigger.)
+
+**CRITICAL interaction with Family A (confirmed + sharpened).** `captureBucketEpoch` runs
+for **every** bucket including heartbeat (`ensureKVBucket:265` → `captureBucketEpoch:600`),
+caching `ep.created` **once** at Start (`:627`) and **never** re-capturing it. The epoch
+monitor probes each bucket on an `OperationTimeout` ticker (`checkBucketEpochs:669-693`):
+- **Today (no recreate):** after restart the heartbeat probe `BucketStreamCreated` errors
+  (stream gone) → the tick logs Debug and `continue`s (`:679-682`) — **the fence is
+  dormant/silent on heartbeat.** It does NOT fire `bucket-recreated`.
+- **With Opt A:** recreation gives the new stream a **different `Created`** →
+  `!live.Equal(ep.created)` → `enterDegraded("bucket-recreated:heartbeat")`
+  (`:684-690`). Opt A would thus **activate a previously-dormant fence**, and because all
+  workers recreate against the same new stream, it fires **fleet-wide simultaneously** —
+  trading the heartbeat flap for an epoch-fence Degraded (which Family A shows is itself a
+  flap, `04-proof-findings.md:58-93`). **Opt A is unsafe unless co-designed with Family A's
+  `ep.created` re-capture.** A correct Opt A must re-capture the heartbeat epoch atomically
+  with the recreate, and must win the race against the epoch ticker reading the new
+  `Created` before the re-capture lands.
+
+**C1 (whole-bucket-missing → all Degraded).** `TestManager_LiveNATSBucketLoss`
+(`manager_live_bucket_loss_test.go:83-89`) deletes **all** buckets **live** (no
+reconnect — the connection stays up). Opt A keys on a reconnect/connection-restored
+event, which does not occur in C1, so Opt A would not fire there and C1 still holds via
+the surviving non-transient errors from the other wiped buckets. **C1 is not broken by
+Opt A** — but the verdict depends on Opt A firing on a *reconnect*, not on any
+bucket-missing observation. If a future Opt A variant recreated buckets on *any* missing
+observation, it WOULD risk masking C1. Pin the trigger to reconnect.
+
+**Pros/cons.** Pro: restores the documented MemoryStorage model. Con: epoch-fence
+collision (above), reconnect-storm churn (recreate on every flap of the link), and a
+recreate race across the fleet (N workers racing to recreate the same bucket — mitigated
+by `EnsureKVBucketWithRetry` get-first, `manager_setup.go:255`).
+
+### Opt B — "calculator tolerates empty heartbeat bucket" (report's alt rec)
+
+**This does not stop the flap.** The calculator list error is not the degrade driver
+(§1.3); making the calculator tolerate the failure changes a logged error into a
+logged-and-tolerated one but leaves the publisher-Put → `recordKVError` loop intact.
+Additionally:
+- **empty ≠ missing.** `GetActiveWorkers` already maps `IsNoKeysFoundError` →
+  `[]string{}` (`worker_monitor.go:170-173`); the calculator already tolerates an
+  *empty* bucket. The failure here is a *missing stream*, which returns the raw error at
+  `worker_monitor.go:175` → `calculator.go:1213`. So "tolerate empty" addresses a case
+  that is already handled.
+- Even a "tolerate missing too" variant would only suppress an aborted rebalance, not the
+  flap. **Reject Opt B as written.**
+
+### Opt B' — publisher Put self-heals (corrected B; targets the actual driver)
+
+**Mechanism.** In the heartbeat publisher (or its `recordKVOpError` wiring), on a
+NotFound/NoResponders Put error, re-open the KV handle via `js.KeyValue` and/or recreate
+the bucket before feeding the circuit; only feed `recordKVOpError` after a bounded retry
+fails. Surface: `internal/heartbeat/publisher.go:405-420` + the manager's
+`SetOnError` wiring (`manager_election.go:424`), or a manager-side recreate before
+`recordKVOpError`.
+
+**Blast radius / contracts.** Must NOT mask **C1**: if Put-recreate runs in the
+all-buckets-wipe case it would let the heartbeat publisher succeed and fire
+`recordKVHealthyOp` — but C1 still degrades via the other wiped buckets' non-transient
+errors (`recordKVHealthyOp` only clears *transient* entries, `manager_degraded.go:278-284`;
+the wiped FileStorage buckets produce `ErrBucketNotFound` = degrading-JetStream =
+non-transient, exactly the masking guard `TestManager_PartialBucketLoss_HeartbeatHealthy`
+pins, `manager_live_bucket_loss_test.go:238-338`). C3 (OnDegraded once per entry) is
+unaffected. This variant shares Opt A's epoch-fence collision **only if** it recreates
+the bucket (vs merely re-opening the handle after NATS itself recreated it). Re-opening
+the handle without recreating avoids the epoch trip but only works if something else
+recreates the bucket — which nothing does today, so a pure re-open is insufficient.
+
+**Residual risk.** Same recreate race as Opt A; same epoch interaction if it recreates.
+This is essentially Opt A relocated to the publisher; the epoch co-design is unavoidable
+for any path that recreates the stream.
+
+### Opt C — gate the recovery exit on heartbeat-op health (shared with Family A/B)
+
+**Mechanism.** Make `attemptRecoveryFromDegraded` (`manager_degraded.go:376-416`) refuse
+to `exitDegraded` while a heartbeat-op failure is outstanding (e.g. require a recent
+heartbeat *success*, or probe the heartbeat bucket as part of the exit gate). This is the
+**same exit-gate fix** the report proposes for Families A/B
+(`04-proof-findings.md:50-52, 277-282`): a single change to the exit predicate that checks
+the *failing* op recovered, not just the assignment read.
+
+**Blast radius / contracts.** Touches the shared recovery gate, so it must preserve:
+- **C1**: still must reach Degraded on whole-bucket loss (unchanged — this only affects
+  *exit*, not entry).
+- **C4** (`Start` returns after sanity-check, not StateStable): unaffected (exit gate runs
+  post-Start).
+- **C2** (peer-claim takeover routing): unaffected (separate path, `manager_election.go:106-127`).
+- **C3**: unaffected.
+- The NP-5 recovery proof and NP-3a disarm control (`04-proof-findings.md:168-186`) must
+  still pass: the gate must still EXIT once the heartbeat bucket genuinely returns.
+
+**Pros/cons.** Pro: one fix closes the *exit* half of Families A, B, and C-mech-2. Con:
+**without a bucket-recreate, Opt C converts the flap into a permanently-stuck Degraded**
+(the MemoryStorage bucket never comes back on its own). That is arguably the *correct*
+posture ("data lost → stay Degraded, require rotation/re-provision"), matching the
+documented live-data-loss contract (`04-proof-findings.md:88-90`), but it is a behavior
+change from "flap" to "terminal Degraded" and must be paired with operator docs. Opt C is
+the cleanest *correctness* fix; pairing C (stop the false exit) with A/B' (restore the
+bucket) gives both correctness and auto-heal.
+
+**Test-contract consequence (important for ungating).** `TestNP8...HeartbeatBucketLossFlap`
+asserts the fleet **reaches** all-Stable (`np8..._test.go:325`) and then **holds** it
+(`:327`). **Opt C-alone leaves the fleet stuck-Degraded → it fails the *reach*
+assertion**, so Opt C-alone cannot be ungated as a drop-in regression guard: the proof's
+expectation must be rewritten from "auto-heal to Stable" to "hold Degraded / require
+rotation." That is a **product decision about desired behavior** (auto-heal vs.
+fail-safe-hold), not a mechanical ungate. Opt C **+** a bucket-recreate (A/B') is what
+makes the existing proof pass as written.
+
+### Opt D — heartbeat bucket → FileStorage
+
+**Mechanism.** Change `manager_setup.go:156` from `MemoryStorage` to `FileStorage`.
+
+**Pros/cons.** Pro: eliminates mech 2 at the source (stream survives restart; no flap, no
+epoch trip, no recreate race). Con: **unquantified IOPS cost** (§2 — heartbeat is the
+highest-frequency op; M1.9's "IOPS-free" applies to election, not heartbeat). Also changes
+the semantics of `TestManager_PartialBucketLoss_HeartbeatHealthy` and the
+`manager_setup.go:116-117` doc comment ("workers re-publish every interval, so a missed
+window is recovered by the next publish" — the rationale for MemoryStorage). Operators who
+pre-create the bucket with their own config already override this (`manager_setup.go:121-124`).
+
+### Recommended fix
+
+**Opt C (gate the exit) + Opt A/B' (restore the bucket), co-designed with Family A's
+`ep.created` re-capture.** Rationale: Opt C alone is the minimal *correctness* fix and is
+shared with Families A and B, but it leaves the fleet stuck-Degraded after a real
+MemoryStorage loss; pairing it with a bucket-recreate restores auto-heal. The recreate
+**must** re-capture the heartbeat epoch atomically so Family A's fence does not fire — so
+this fix **cannot land independently of Family A's fix**. If only one change is permitted,
+land **Opt C** (correctness: no false Stable while the heartbeat op is dead) and document
+that MemoryStorage heartbeat loss requires re-provision/rotation, deferring auto-heal.
+Opt D is the simplest if an IOPS measurement clears it.
+
+---
+
+## 4. Cross-family interactions
+
+- **Family A epoch fence (hard coupling).** Any fix that recreates the heartbeat bucket
+  (Opt A, Opt B' recreate variant) trips `checkBucketEpochs` →
+  `enterDegraded("bucket-recreated:heartbeat")` (`manager_setup.go:684-690`) unless
+  `ep.created` is re-captured. Family A's own fix re-captures `ep.created`
+  (`04-proof-findings.md:275-282`); the C-mech-2 recreate must reuse that re-capture and
+  win the race against the epoch ticker. **Co-design mandatory.**
+- **Family A/B shared exit defect.** Opt C *is* the report's shared exit-gate fix
+  (`04-proof-findings.md:50-52, 277-282`); one implementation can close the *exit* half of
+  all three families. The entry/latch halves differ per family.
+- **F-D1 class-aware reset (commit 421f13c).** `recordKVHealthyOp` clears only transient
+  entries (`manager_degraded.go:266-288`). In mech 2 there is no heartbeat *success* (the
+  bucket is gone), so the reset never fires and the transient `ErrKVUnavailable` entries
+  accumulate uncleared — the reset is irrelevant to this flap (confirming the report's
+  analogous note for Family B, `04-proof-findings.md:107-109`).
+- **Empty-bucket safety (part c) — two layers, both confirmed.** IF a recreate leaves the
+  heartbeat bucket *empty* (recreated, but workers have not yet re-published), a leader
+  scanning 0 workers must not revoke everyone. Two independent guards prevent that, and
+  which one is active depends on whether leadership survived the outage:
+  - **(i) `len(workers)==0` no-op — ALWAYS on.** `rebalance` short-circuits on an empty
+    worker set: "no active workers for assignment" → returns without publishing
+    (`calculator.go:1571-1577`). This holds even for a **fresh** leader (one elected
+    across the outage) whose calculator has no baseline yet. This is the load-bearing
+    guard for the realistic post-takeover path.
+  - **(ii) F10-A cached hold-current — only once a baseline exists.** If the *same* leader
+    continued and already has `lastKnownWorkerCount=3`, scanning 0 hits
+    `workerObservationSuspicious(0)` = `0 < 3*Pct` = true (`calculator.go:1294-1299`), so
+    `getActiveWorkers` returns `cached, fresh=false` (`:1228-1243`) and `observeAndDecide`
+    skips the decision on `!fresh` (`:1038-1043`). But `workerObservationSuspicious` is
+    **silent when `lastKnownWorkerCount==0`** (`calculator.go:1295`), so a fresh
+    post-takeover leader (lastKnown=0) gets NO F10-A protection — layer (i) is what saves
+    that case.
+  **So an empty heartbeat bucket does NOT cause spurious revocation**, via (i) always and
+  (ii) additionally for a continuous leader. The report's part (c) "safe unknown,
+  hold-current" path exists — but the citation must be the `len==0` no-op for the
+  realistic (new-leader) case, not F10-A.
+  The *missing-stream* (not empty) case is absorbed by neither: the error returns raw at
+  `:1213` before the F10-A counter at `:1227` runs, and aborts the rebalance before the
+  `len==0` check at `:1571` — but the missing case is also not the degrade driver, so this
+  is moot for the flap.
+
+---
+
+## 5. Discrepancies with the report (`04-proof-findings.md`)
+
+1. **Driver misnamed (substantive).** Report (`:136-144, 256-258`): "every worker that
+   becomes leader fails `failed to list heartbeat keys: nats: stream not found` in its
+   calculator." Correct: the calculator list error is **swallowed** (§1.3); the re-degrade
+   driver is the **heartbeat publisher Put** via `recordKVOpError`
+   (`manager_election.go:424`), which fires on **every worker, not just the leader**. The
+   report's framing wrongly localizes the gap to the leader.
+2. **Opt B is ineffective (substantive).** Report's deferred rec (`:289-293`): "a
+   calculator path that tolerates an empty heartbeat bucket during recovery." This fixes a
+   non-driver and conflates empty (already tolerated) with missing (§3, Opt B). Reject as
+   written.
+3. **Reason string (minor).** Report implies `"stream not found"` → "KV error threshold";
+   the cached-Put surface is more likely `nats.ErrNoResponders` → `"kv-unavailable"`
+   (§1.4). Does not change the fix.
+4. **Epoch interaction under-stated (sharpening, not contradiction).** Report does not note
+   that the heartbeat epoch fence is currently *dormant* (errors → Debug+continue) and that
+   Opt A would *activate* it fleet-wide. The collision the report relies on for Family A is
+   real and is the load-bearing constraint on Opt A.
+5. **IOPS transfer risk (flag).** The report's "(d) FileStorage" framing leans on the IOPS
+   work; M1.9's "IOPS-free" finding is about the **election** bucket
+   (`manager_setup.go:113-115`), not heartbeat. Do not transfer it.
+
+The report's core verdict — fleet does not auto-heal a single-node MemoryStorage
+heartbeat-bucket loss; topology-dependent; needs recreate-or-tolerate — is **correct**.
+The mechanism attribution and Opt B are wrong.
+
+---
+
+## 6. Open questions
+
+- Empirically confirm the re-degrade **reason** ("kv-unavailable" vs "KV error threshold
+  exceeded") by running the mech-2 proof with a real logger or a reason-capturing
+  OnDegraded hook (requires a test-only change, not production code).
+- RF3 reality (the report's biggest open item): does a real RF3 rolling restart preserve
+  the replicated MemoryStorage stream? Needs the gated `quorum_loss_tier2` 5-node harness
+  (`04-proof-findings.md:268-269`).
+- Does the heartbeat publisher's cached handle ever self-recover after NATS recreates the
+  bucket by some other means (e.g. another worker's Start re-ensuring it)? On main nothing
+  re-ensures post-Start, so no — but a fix that has *any* worker recreate the bucket would
+  let all cached handles resolve again (pending the epoch-fence trip).

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/survey-completeness.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/survey-completeness.md
@@ -1,0 +1,371 @@
+# Cross-Cutting Survey: Completeness Challenge + Uncertainty Scoping
+
+Branch/worktree: `auto-heal-gap-investigation` @ HEAD `2453306`.
+Method: independent code re-derivation against the source under this worktree,
+challenging `04-proof-findings.md` rather than parroting it. Every claim cites
+`file:line` or a test name. VERIFIED = read in code this session; INFER = reasoned
+from verified facts but not directly observed.
+
+Contract IDs (C1..C4) refer to AGENTS.md "Cross-feature contracts" (restated in
+the task brief).
+
+---
+
+## Part 0 — What I independently confirmed (so the challenges below are grounded)
+
+- **Family A mechanism (VERIFIED).** `captureBucketEpoch` writes `ep.created`
+  exactly once at Start (`manager_setup.go:627`); `checkBucketEpochs` fires
+  `enterDegraded("bucket-recreated:"+bucket)` on a `Created` mismatch and
+  `return`s, but **never re-captures** `ep.created` (`manager_setup.go:684-690`).
+  The cached epoch stays stale forever, so the `OperationTimeout`-cadence tick
+  (`monitorBucketEpochs`, default 10s) keeps re-degrading. The 1s connection
+  monitor (`checkConnectionHealth`, `manager_degraded.go:97-134`) calls
+  `attemptRecoveryFromDegraded` because the connection never dropped; that exits
+  on a healthy **assignment** read (`manager_degraded.go:383-415`). The two ticks
+  fight → flap. Report §2 Family A is **accurate**.
+
+- **Family B mechanism (VERIFIED).** `attemptRecoveryFromDegraded` gates the exit
+  solely on `refreshAssignmentFromNATS()` success + `currentAssignmentApplied(cur)`
+  (`manager_degraded.go:383,409-415`). It never checks the *failing* op recovered.
+  `recordKVHealthyOp` only clears `transient` entries on a heartbeat **Put
+  success** (`manager_degraded.go:266-288`, wired at `manager_election.go:432`), so
+  it cannot help when the heartbeat bucket itself is the faulting op. Report §2
+  Family B is **accurate**, and the "shared exit defect with Family A" framing
+  (§1) is correct.
+
+- **C2 routing (VERIFIED).** `onClaimerError` routes `ErrClaimLost` to
+  `claimLostShutdown` ONLY when the wrapped cause is neither connectivity nor
+  degrading-JetStream (`manager_election.go:107-118`); the bucket-loss sub-branch
+  feeds `recordKVError` instead. Peer takeover (bucket fine) → single-worker
+  Shutdown; whole-bucket loss → fleet-wide degraded. Matches C2.
+
+- **No reconnect-triggered bucket creation exists today (VERIFIED).** Buckets are
+  created/opened only in the synchronous Start path (`manager.go:568`
+  `ensureCoreKVBuckets`, `manager_setup.go:92/176`). No monitor goroutine
+  re-provisions on reconnect. So the C2/A interactions in Part 1 are **fix
+  risks**, not current bugs.
+
+---
+
+## PART 1 — Completeness challenge (break the §4 "no additional gap" claim)
+
+### Monitor-goroutine inventory (the search space)
+
+Started at/after Start: `monitorNATSConnection` (1s), `monitorBucketEpochs`
+(`OperationTimeout`), `monitorAssignmentChanges`, `monitorCommitChanges`,
+`monitorCalculatorState` (leader), `monitorLeadership` (`ElectionTimeout/3`),
+`monitorDegradedAlerts`, the heartbeat publisher loop (`HeartbeatInterval`), the
+`startStartupTimeoutWatchdog`, the handoff coordinator sweep, and — leader only —
+the `WorkerMonitor` (watcher + `hbTTL/2` poll) plus the `Calculator`'s
+poll/rebalance/audit loops.
+
+I checked each for the "connection up but a subsystem silently wedged /
+falsely-healthy" shape. Results:
+
+| Goroutine | Feeds degraded circuit on sustained KV error? | Evidence |
+|---|---|---|
+| `monitorAssignmentChanges` | YES (`recordKVOpError` + `assignment-watcher-exhausted`) | `manager_assignment.go:398,412` |
+| `monitorCommitChanges` | YES (`recordKVOpError`) | `manager_assignment.go:636` |
+| heartbeat publisher | YES (`SetOnError(m.recordKVOpError)`) | `manager_election.go:424` |
+| election renew/acquire | YES (`recordKVOpError`) | `manager_election.go:262,303` |
+| stableID renew | YES (via `onClaimerError`→`recordKVError`/`recordKVOpError`) | `manager_election.go:114,126` |
+| epoch monitor | YES (`enterDegraded`) | `manager_setup.go:689` |
+| **`WorkerMonitor` poll (leader)** | **NO — logged only** | `internal/assignment/worker_monitor.go:282-284` |
+| **`Calculator` worker-enumeration** | **NO — bare error, logged in caller** | `calculator.go:1213`; poll caller is logged-only |
+
+The last two rows are the break.
+
+### BREAK CANDIDATE — NP-10: leader-side silent worker-enumeration stall (False-healthy leader)
+
+**Claim:** §4's "the completeness hunt found **no** additional realistic
+in-process auto-heal gap" is too strong. There is a distinct in-process gap on the
+**leader** that none of NP-1..NP-9 exercise and that is *worse* than NP-3b because
+it does not even flap — it is fully silent.
+
+**Discriminating trigger (the scenario nobody proved).** The heartbeat bucket is
+reachable on a live connection but its **`Keys` scan times out** (quorum-loss /
+slow-RAFT / large-bucket deadline) while the worker's **own single-key heartbeat
+`Put` keeps succeeding**. This is a realizable asymmetry: a `Keys` enumeration is
+a stream-wide operation, a `Put` is a single-subject append; under partial quorum
+degradation or load the scan can deadline while the append still commits.
+
+**Why it is silent (load-bearing code facts, all VERIFIED):**
+1. `WorkerMonitor.GetActiveWorkers` returns `context.DeadlineExceeded` wrapped as
+   `"failed to list heartbeat keys: %w"` (`worker_monitor.go:175`).
+2. `Calculator.getActiveWorkers` only consults its cache / degrades for
+   `natsutil.IsConnectivityError(err)` (`calculator.go:1197-1213`). For everything
+   else it `return nil, false, err` (`:1213`).
+3. **`IsConnectivityError` does NOT match a bare `context.DeadlineExceeded`**:
+   the sentinel list (`internal/natsutil/errors.go:120-129`) does not include it,
+   and the string fallback only catches `"connection refused"` / `"i/o timeout"`
+   (`:135-136`) — not `"context deadline exceeded"`. (The manager's own KV-op
+   sites paper over this with `markKVUnavailable`, `manager_degraded.go:58-72`, but
+   the calculator/worker-monitor path has **no equivalent wrap**.)
+4. The leader's poll loop logs the returned error and continues
+   (`worker_monitor.go:282-284`); the rebalance/poll callers in the calculator
+   log and continue. **None routes to `m.recordKVError`** — the calculator has no
+   wiring into the manager degraded circuit at all (verified: no `SetOnError`
+   bridge from calculator to manager; only the heartbeat publisher, watchers,
+   election, and stableID feed it).
+
+**Consequence.** A leader whose heartbeat-scan deadlines persistently: (a) holds
+`StateStable` (its own heartbeat Put succeeds, assignment reads succeed, election
+renew succeeds — so no circuit trips); (b) is **blind to worker topology** — it
+sees `getActiveWorkers` fail, falls back to a stale cache or an empty list, and
+keeps publishing assignments computed from stale membership. A readiness probe
+marks it Ready. This is a **false-healthy leader serving stale/incorrect
+assignments**, the same failure *class* the report rates "worst" for NP-1, but
+reached by a realistic partial-degradation trigger and **without any operator
+signal**.
+
+**Relation to known findings.** This is the **leader-side analog of NP-3b**, but
+NP-3b at least *flaps* (the heartbeat Put is the faulting op there, so the circuit
+trips and re-trips). Here the scan path has **no circuit at all**, so it is
+silent. It is also adjacent to the C-mech-2 surface (§Part 2 below) but distinct:
+mech-2 is a *missing* bucket (`ErrStreamNotFound`, degrading-JetStream class,
+which DOES degrade via the heartbeat Put); NP-10 is a *reachable-but-slow* bucket
+(`DeadlineExceeded`, unclassified, which does NOT).
+
+**Severity: High. Confidence: Medium** (code-derived this session; NOT proven with
+an executable harness — that is the honest gap vs. NP-1..NP-9). A proof would
+inject a `Keys`-only deadline on the heartbeat bucket on the leader while leaving
+`Put`/assignment `Get` healthy, then assert the leader neither degrades nor holds
+a correct assignment. The report's §4 dismissals (M1 data-plane-proven, leader
+partition deferred, M10 caller-owned) do **not** cover this scan-deadline path.
+
+**Caveat / steelman of the report.** One could argue this collapses into "a
+leader-only NATS partition needs a selective-disconnect harness (deferred)." It
+does not: a *partition* drops the connection (connection monitor catches it); this
+is connection-UP with a per-operation deadline on one bucket — exactly the
+F-D1/kv-unavailable shape the manager's own sites guard but the
+calculator/worker-monitor path does not. So it is a genuinely separate omission.
+
+### Cleared (not gaps)
+
+- `monitorCommitChanges` — feeds `recordKVOpError` on watch-restart failure
+  (`manager_assignment.go:636`), same as the assignment watcher. Properly wired.
+- `monitorCalculatorState` — pure local state mirror; its only error is
+  `syncStateFromCalculator` (logged), no KV dependency that can silently wedge
+  readiness independent of the calculator itself.
+
+---
+
+## PART 1b — Cross-family interactions where fixing one gap re-opens another
+
+### Interaction X1 (Family A re-arm via recreate-on-reconnect) — the named lead
+
+If the **Family C / Family A** fix recreates a missing bucket on reconnect
+(one of the §7.3 "recreate-on-reconnect" options for mech-2, or a re-provision to
+heal NP-1), the recreated bucket's backing stream gets a **new `Created`
+timestamp**. `monitorBucketEpochs` compares the live `Created` against the
+**Start-time** cached `ep.created` (`manager_setup.go:684`, never re-captured),
+so on every *other* worker the epoch fence fires `enterDegraded("bucket-recreated:
+<b>")` — **re-opening Family A** fleet-wide. VERIFIED: the fence has no
+"recreated-by-us" suppression and no re-capture. Any recreate fix MUST also
+re-capture `ep.created` (and ideally distinguish self-recreate from operator
+wipe), or it trades C for A. This is the strongest concrete interaction.
+
+### Interaction X2 (C2 masking via broad re-provision)
+
+The task named C2 specifically. A **broad** re-provision-on-reconnect that
+recreates the **stableID** bucket would change `ErrClaimLost` classification:
+`onClaimerError` (`manager_election.go:107-118`) routes a claim loss whose cause
+is degrading-JetStream (bucket/stream missing → `IsDegradingJetStreamError`,
+`errors.go:97-99`) into the `recordKVError` whole-bucket branch, NOT into
+`claimLostShutdown`. If a reconnect handler has just recreated/emptied the
+stableID bucket, a **legitimate peer takeover** that surfaces around the same
+window could be misread as "bucket loss" → degraded-and-ride instead of the
+intended self-stop, risking split-brain (two workers believing they hold the same
+ID). This is **conditional** on a broad-recreate fix being chosen (INFER from
+verified routing); a narrow heartbeat-only recreate does not trip it. Flag it so a
+C-mech-2 fix is scoped to the heartbeat bucket, not a blanket re-provision.
+
+### Interaction X3 (exit-gate hardening vs. NP-9 arbitration / startup)
+
+The shared A/B fix candidate — "refuse to exit Degraded until the *failing* op
+recovered" — must not regress the **C4** contract (Start returns after the
+sanity phase, not StateStable) or NP-9's clean single-entry recovery. NP-9
+recovers via the watcher-independent Get-based refresh (`refreshAssignmentFromNATS`,
+`manager_assignment.go:1561-1599`) precisely because it faults the assignment
+bucket too; a per-source "did the failing op recover" gate must treat the
+assignment Get as the recovery signal for the assignment-faulting case, or it
+could deadlock recovery (no op ever re-probed). INFER; the NP-9 row in §3 already
+notes "recovery cannot falsely exit while the fault is active," so the gate has to
+preserve that property, not just add a blanket cooldown.
+
+### Asymmetry the report under-states (calibration)
+
+§1 says "a single fix to the exit gate could close both A and B." True for the
+*exit half*, but the three families want **different terminal outcomes**, so one
+fix does NOT close all three:
+- **B (kv-unavailable held):** correct outcome is **auto-recover** when KV
+  returns. Exit-gate fix + per-source recovery check is right.
+- **A (epoch recreate):** correct outcome is **terminal Degraded** (operator
+  rotation) — AND it needs the stale-`ep.created` latch fixed; the exit gate alone
+  leaves the fence re-arming.
+- **C-mech-2 (MemoryStorage heartbeat bucket gone):** nothing recreates a
+  MemoryStorage bucket in-process, so the correct outcome is **terminal Degraded
+  pending operator/recreate**, NOT auto-recover. An over-eager "auto-recover when
+  the failing op returns" would never fire (the op never returns) — which is
+  actually the *desired* terminal behavior, but only if the exit gate is the thing
+  holding it, not a flap.
+
+---
+
+## PART 1c — Mech-2 attribution: the report is IMPRECISE (not wrong)
+
+Report §2 Family C mech-2 says the flap is because "every worker that becomes
+leader fails `failed to list heartbeat keys: nats: stream not found` in its
+calculator." That attributes the **degraded *entry*** to the leader calculator.
+The calculator's enumeration error is **logged-only** and never calls
+`enterDegraded` (Part 1 table; `worker_monitor.go:282-284`, `calculator.go:1213`).
+
+The actual degraded-*entry* driver is the **heartbeat publisher's `Put`**: after a
+single-node restart the MemoryStorage heartbeat bucket's stream is gone, so the
+Put fails with `ErrStreamNotFound` (degrading-JetStream class, `errors.go:97-99`)
+→ `recordKVOpError` → `recordKVError` accumulates at the 500ms cadence to
+`KVErrorThreshold` → `enterDegraded("KV error threshold exceeded")`
+(`manager_degraded.go:207-224`). Recovery exits on the **FileStorage assignment
+read** (survives the restart) → flap. The NP-8 test's OWN comments corroborate
+this: `np8_fleet_nats_outage_leader_continuity_test.go:230-238` explicitly says
+workers "degrade with 'KV error threshold exceeded'" via the heartbeat path and
+treats the calculator's list error as a *symptom*, not the driver.
+
+**Why this matters for the fix:** it means mech-2 is **the same shared-exit defect
+as Families A and B** (recover-on-wrong-signal: assignment-read exit while the
+heartbeat op still faults), NOT a separate calculator-enumeration bug. The
+calculator's `"list heartbeat keys: stream not found"` is a real *secondary*
+symptom (the leader cannot compute a correct assignment), but it is downstream of
+the same missing bucket and does not itself drive readiness. The fix surface is
+the exit gate + a heartbeat-bucket recreate-or-stay-terminal decision — not a
+calculator change. The report's *conclusion* (mech-2 is a real fleet flap, not a
+clean heal) stands; only the mechanism sentence needs correcting.
+
+---
+
+## PART 2 — Uncertainty scoping (priority-ordered, each: needed / worth it / priority)
+
+### (i) NP-8 mech-2 on a REAL RF3 5-node cluster — does replicated MemoryStorage survive a rolling restart?
+
+**Located harness:** `test/integration/failure/quorum_loss_tier2_test.go`
+(`TestRF3SelectivePeerFault_HandoffQuorumLoss`, gated `PARTI_RUN_QUORUM_LOSS_TIER2=1`),
+plus the reusable `partitest.StartEmbeddedNATSClusterN(t, 5)` helper.
+
+**Finding (VERIFIED by reading the test):** the existing tier2 test does NOT
+settle this question and cannot be reused as-is. It is a **data-plane KV-surface
+probe**: it creates a single `Replicas:3` *handoff* bucket (FileStorage,
+`:32-37`), stops two non-meta peers (`:48-54`), and asserts that `kv.Get/Put/
+Status` produce *some* error surface (`:90-91`). It does **not** (a) start a
+3-manager Parti fleet, (b) create a **MemoryStorage** heartbeat bucket with
+Replicas>1, or (c) perform a **rolling restart** (it shuts peers down and never
+restarts them within the assertion window). Only `StartEmbeddedNATSClusterN` is
+directly reusable.
+
+**What's needed:** a new gated test on the 5-node helper that (1) pre-creates the
+heartbeat bucket as `MemoryStorage, Replicas:3` (the open question is whether
+replicated MemoryStorage survives one peer bouncing), (2) starts a real
+3-manager fleet against it, (3) **rolling-restarts** one node at a time
+(`srv.Shutdown(); restart same StoreDir/port`) keeping quorum, and (4) asserts the
+fleet holds Stable AND the heartbeat bucket's stream `Created` is unchanged (no
+silent wipe). The single-node embedded restart in
+`np8_..._HeartbeatBucketLossFlap` is the RF1 worst case; this is the RF3 control.
+
+**Worth it / priority: HIGH (the single biggest open uncertainty).** It
+discriminates the two divergent prod outcomes (replicated MemoryStorage survives →
+mech-2 is single-node-only and severity drops to Low; does not survive → mech-2 is
+a genuine fleet gap needing the recreate fix). The fix scope for C-mech-2 depends
+entirely on this answer, so it should run BEFORE committing to a mech-2 fix. Cost:
+moderate (new harness; 5-node embedded clusters are CPU-heavy — keep gated).
+
+### (ii) NP-9 arbitration race — what config/load flips "kv-unavailable wins"?
+
+**Mechanism (VERIFIED):** under full quorum loss, two paths race to win the
+`enterDegraded` CAS (`manager_degraded.go:309`):
+- **Fast path:** heartbeat/election/stableid KV ops at high cadence →
+  `recordKVError` → trips when the window hits `KVErrorThreshold` within
+  `KVErrorWindow` → reason `kv-unavailable` (when marked) or `KV error threshold
+  exceeded` (`manager_degraded.go:207-224`). At the 500ms heartbeat cadence this is
+  fast.
+- **Slow path:** the assignment watcher's bounded-retry envelope exhausts
+  (`watcherMaxAttempts` over `watcherBaseBackoff`..`watcherMaxBackoff`) →
+  `OnPermanent` → `enterDegraded("assignment-watcher-exhausted")`
+  (`manager_assignment.go:407-412`).
+
+**Knobs that flip the winner (the answer the report flagged but did not derive):**
+- Raising `DegradedBehavior.KVErrorThreshold` or shrinking `KVErrorWindow` slows
+  the fast path → the watcher-exhaustion reason can win instead.
+- Lowering the heartbeat cadence (`HeartbeatInterval`) slows fast-path
+  accumulation → same flip.
+- Shortening `watcherBaseBackoff`/`watcherMaxBackoff` or lowering
+  `watcherMaxAttempts` speeds the slow path → it can beat the threshold.
+- Load that delays the heartbeat goroutine (CPU starvation) delays the fast path
+  non-deterministically.
+The accelerated test config (sub-second thresholds, 500ms heartbeat) makes the
+fast path win deterministically; production defaults (75s WorkerIDTTL,
+`KVErrorThreshold` default) widen the window where the watcher could win.
+
+**What's needed:** a parameterized variant of
+`TestNP9_FullQuorumLoss_KVUnavailableWins...` that sweeps `KVErrorThreshold` and
+`watcherMaxAttempts` and asserts which reason wins per config — to document the
+boundary, not to "fix" it (either reason is correct policy; only the operator
+runbook text depends on which appears).
+
+**Worth it / priority: MEDIUM-LOW.** Both outcomes are valid Degraded entries with
+correct operator actions (the taxonomy table covers both). The value is
+documentation accuracy (so OPERATIONS.md does not over-promise a single reason),
+not a correctness fix. Low risk if deferred.
+
+### (iii) `-race -count=5` over the hook-goroutine-touched harness
+
+**Why (VERIFIED):** `enterDegraded` spawns `monitorDegradedAlerts`
+(`manager_degraded.go:336`) and fires `OnDegraded` from a hook goroutine
+(`:326-330`); `attemptRecoveryFromDegraded` and `recordKVError` mutate
+`kvErrorWindow` under `m.mu` while the 1s connection monitor and 500ms heartbeat
+success path (`recordKVHealthyOp`) also touch it. The flap proofs drive rapid
+Degraded↔Stable cycles through exactly these paths — a natural place for a data
+race on `kvErrorWindow`, `degradedSince`, or the per-worker hook counters in the
+tests. The report (§6) explicitly notes the proofs were run pass/fail, **not**
+`-race`.
+
+**What's needed:** run the gated proofs under race:
+`PARTI_RUN_NP2_EPOCH_FLAP_PROOF=1` (`np2_epoch_fence_return_to_stable_test.go`),
+`PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF=1` (`np3_kv_unavailable_recovery_test.go`),
+`PARTI_RUN_NP1_LIVE_RECREATE_PROOF=1` (`np1_live_recreate_returns_stable_test.go`),
+`PARTI_RUN_NP8_FLEET_OUTAGE_PROOF=1` / `PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF=1`
+(`np8_fleet_nats_outage_leader_continuity_test.go`), each with `-race -count=5
+-run <Name>`. Per the integration-test-discipline memory, monitor-goroutine
+changes need concurrency stress; the per-worker `atomic.Bool`/counter hooks in the
+NP-8 test (`recovered[]`, `badReason[]`, the flap counters) are the most likely
+race site if any are non-atomic.
+
+**Worth it / priority: MEDIUM, and CHEAP.** It is a low-cost confidence check (no
+new code), and it should be a **gate before any exit-gate fix lands** because the
+fix will add code on these exact hot paths. Do it once now to establish a clean
+race baseline, then re-run after the fix.
+
+---
+
+## Summary of challenges to `04-proof-findings.md`
+
+1. **§4 completeness claim is breakable (NP-10):** a leader-side
+   heartbeat-`Keys`-scan `DeadlineExceeded` is silently swallowed
+   (`worker_monitor.go:282-284`, `calculator.go:1213`, `IsConnectivityError`
+   misses bare `DeadlineExceeded` at `errors.go:120-136`) → false-healthy leader
+   serving stale assignments. Not covered by the §4 dismissals. High / Medium-conf.
+2. **§2 Family C mech-2 attribution is imprecise:** the degraded *entry* is the
+   heartbeat-Put threshold path, not the calculator enumeration (corroborated by
+   the test's own comments at lines 230-238). This unifies mech-2 with the A/B
+   shared-exit defect and re-scopes the fix.
+3. **§7 "one exit-gate fix closes A and B" under-states the asymmetry:** the three
+   families want different terminal outcomes (B auto-recover, A terminal + latch
+   fix, C-mech-2 terminal pending recreate).
+4. **§Recommendation "settle mech-2 on the tier2 harness" overstates reuse:** the
+   tier2 test is a data-plane KV probe with no fleet, no MemoryStorage bucket, and
+   no rolling restart; only `StartEmbeddedNATSClusterN` is reusable.
+5. **Cross-family fix risks (X1/X2):** recreate-on-reconnect re-opens Family A via
+   the never-re-captured `ep.created`; a broad re-provision can mask a C2 peer
+   takeover by reclassifying `ErrClaimLost`.
+
+Where the report is RIGHT (do not relitigate): Families A and B mechanisms,
+NP-9/NP-4/NP-5/NP-6/NP-7 verdicts, the "shared exit half" insight, and that
+mech-2 is a real fleet flap (only its mechanism sentence is off).

--- a/docs/plans/auto-healing-gap-closure/investigation-notes/survey-contracts.md
+++ b/docs/plans/auto-healing-gap-closure/investigation-notes/survey-contracts.md
@@ -1,0 +1,227 @@
+# Cross-Cutting Survey: Contract & Test-Impact Mapping for Auto-Heal Gap Fixes
+
+Branch/worktree: `auto-heal-gap-investigation` @ HEAD 2453306 (read-only investigation).
+Purpose: for every candidate fix across Families A/B/C, map which cross-feature
+contracts (AGENTS.md C1–C4) and pinning tests it would *touch*, *risk regressing*, or
+*collide with another family's fix*. This is the input the follow-up fix session needs
+to pick fixes that don't break the existing degraded/claim-loss contracts.
+
+Every claim below is `file:line` or a named test, verified in code this session.
+"VERIFIED" = read directly. "INFER" = reasoned from verified facts.
+
+---
+
+## 0. The contracts and what actually pins them (re-derived, with corrections)
+
+| Contract | Statement | Mechanism (VERIFIED) | Pinning test(s) (VERIFIED) |
+|---|---|---|---|
+| **C1** | Whole-bucket-missing => every worker enters StateDegraded within a bounded window | `recordKVError` admits connectivity / degrading-JetStream errors only (`manager_degraded.go:165-167`), accumulates `kvErrorWindow` vs `KVErrorThreshold` (`:207`), calls `enterDegraded("KV error threshold exceeded")` (`:215,224`). Whole-bucket entries are `transient=false` and are **never** cleared by `recordKVHealthyOp` (`manager_degraded.go:278-284`). | `TestManager_LiveNATSBucketLoss` (all 3 workers Degraded ≤20s, buckets stay gone), `TestManager_PartialBucketLoss_HeartbeatHealthy` (wipe all EXCEPT heartbeat; all 3 still Degraded ≤25s — the f-d1 class-aware reset guard) |
+| **C2** | Peer claim takeover => ONLY that worker enters claim-lost shutdown; others stay healthy | `onClaimerError` (`manager_election.go:106-127`): `ErrClaimLost` + NOT (connectivity OR degrading-JetStream) => `claimLostShutdown` => `StateShutdown`. Connectivity/degrading `ErrClaimLost` is routed to `recordKVError` instead (`:113-115`) so whole-bucket StableID loss degrades the fleet, not self-stops one worker. | **Unit (the real C2 routing proof):** `TestOnClaimerError_ClaimLostStopsWorker` (peer-takeover => stop + OnError), `TestOnClaimerError_TransientErrorUsesKVCircuit` (connectivity => KV circuit, no stop), `TestManager_StopsItselfWhenClaimLost` (e2e revision bump => StateShutdown + consumer revoked). **CORRECTION:** `TestStableID_StaleKeyTakeover_Reclaim` is at the `stableid.Claimer` level only — it proves the new worker reclaims the stale ID; it does NOT exercise `onClaimerError`/`claimLostShutdown` at all. The brief's "C2 pinned by TestStableID_StaleKeyTakeover_Reclaim" is **imprecise**: that test pins the *reclaim* half, the `manager_claimer_error_test.go` trio pins the *self-stop routing* half. |
+| **C3** | OnDegraded fires exactly once per Degraded entry per worker | `enterDegraded` CAS-guards `degradedSince` (`manager_degraded.go:309`); hook fires inside the won-CAS branch (`:326-330`). One entry = one hook. **Re-entry only after an intervening `exitDegraded` clears `degradedSince` to 0** (`:356`). | `TestManager_LiveNATSBucketLoss_OnDegradedHook`; also `TestManager_F1_BucketRecreate_TripsDegraded` asserts `require.Len(reasons,1)` for a single epoch tick |
+| **C4** | `Manager.Start` returns after the synchronous sanity-check phase, not after StateStable | Async path: `Start` returns post-sanity; `monitorBucketEpochs` + recovery loops run in `m.wg.Go` afterward (`manager_startup_async.go:142`). | `TestStart_*` / `manager_startup_async*_test.go`, `manager_setup_test.go` |
+
+**Key structural fact for the whole matrix (VERIFIED):** the Degraded↔Stable flap in
+Families A and B is the *same* exit defect — `attemptRecoveryFromDegraded`
+(`manager_degraded.go:376-416`) gates the exit on `currentAssignmentApplied(cur)`
+(`:409`) where `cur` comes from `refreshAssignmentFromNATS` which reads **only**
+`assignment.<workerID>` from the assignment bucket (`manager_assignment.go:1567-1568`).
+It never checks the *failing* op (epoch mismatch in A; heartbeat/election/stableid KV op
+in B) recovered. So any "exit gate" fix is the shared lever; the family-specific arming
+mechanism (stale `ep.created` in A; re-accumulating heartbeat timeouts in B) is the
+other half.
+
+---
+
+## 1. Mechanism re-derivation (independent; where I agree / disagree with 04-proof-findings.md)
+
+### Family A (NP-2 / NP-1) — epoch fence re-fires + recover-on-wrong-signal
+
+VERIFIED both halves:
+- (i) `checkBucketEpochs` fires `enterDegraded("bucket-recreated:"+bucket)` on
+  `!live.Equal(ep.created)` (`manager_setup.go:684-689`) and **never re-captures
+  `ep.created`**. `captureBucketEpoch` writes `ep.created` once (`manager_setup.go:627`),
+  only ever called from `ensureKVBucket` at Start (`manager_setup.go:265`). VERIFIED.
+- (ii) The exit defect above runs every 1s on connection uptime
+  (`manager_degraded.go:130-131`) and exits because the *assignment* bucket is intact.
+
+I **independently confirm** the report's Family A root cause. One nuance the report
+glosses (and `TestManager_F1_BucketRecreate_TripsDegraded:117-123` makes explicit):
+the cached `ep.kv` handle is opened once via `m.js.KeyValue(ctx, bucket)`
+(`manager_setup.go:615`). After a delete+recreate the JetStream client handle
+**silently re-binds to the new stream**, so `BucketStreamCreated(ep.kv)` returns the
+NEW `Created` and the mismatch is detected on every tick. If the handle did *not*
+re-bind, the probe would error and `checkBucketEpochs` would `continue` (`:679-682`)
+and never fire. So the re-fire depends on the handle re-binding — a real, verified
+behavior the F1 test models at line 121-123. This is load-bearing for the
+A:re-capture-ep.created fix (below).
+
+### Family B (NP-3b) — connected-but-KV-unavailable false exit
+
+VERIFIED: a `kv-unavailable`-class fault (`ErrKVUnavailable`-wrapped deadline/no-responders,
+`manager_degraded.go:58-72`) on heartbeat/election/stableid leaves the connection UP and
+the assignment bucket readable. Exit fires on assignment read + `currentAssignmentApplied`
+(`:409-415`). `recordKVHealthyOp` cannot save it (the heartbeat op is itself faulting,
+so no success clears the transient entries — `manager_degraded.go:266-288`). Confirmed.
+
+### Family C mech 1 (NP-8) — claim-loss self-stop on outage ≥ WorkerIDTTL
+
+VERIFIED routing: outage ≥ stableID bucket MaxAge (reconciled to `WorkerIDTTL`,
+`config.go`) ages out the claim; on reconnect `onClaimerError` sees `ErrClaimLost` that
+is NEITHER connectivity NOR degrading => `claimLostShutdown` => `StateShutdown`
+(`manager_election.go:113-119`). This is **the same C2 path** — i.e. mech-1 is C2
+firing *correctly* (the worker genuinely lost its claim), just fleet-wide. The report's
+"Low / doc-only, working-as-designed" verdict is consistent with the code. AGREE.
+
+### Family C mech 2 (NP-8) — MemoryStorage heartbeat-bucket loss => fleet flap
+
+VERIFIED: heartbeat bucket is `MemoryStorage` (`manager_setup.go:156`), gone after a
+single-node restart. The leader's calculator calls `WorkerMonitor.GetActiveWorkers`
+=> `heartbeatKV.Keys` => `"failed to list heartbeat keys: %w"`
+(`internal/assignment/worker_monitor.go:167-176`; same surface at `:212-219` for
+`GetHeartbeats`). Note `IsNoKeysFoundError` is handled as empty (`:170-173`) — but a
+**missing stream** is `ErrStreamNotFound`, NOT no-keys, so it propagates as an error.
+Confirmed.
+
+---
+
+## 2. Candidate-fix × contract/test impact matrix
+
+Columns: does the fix **touch** (T), **risk regressing** (R), or **collide with another
+family's fix** (X) the contract/test? Blank = no interaction.
+
+| Fix option | C1 (whole-bucket degrade) + `LiveNATSBucketLoss`, `PartialBucketLoss_HeartbeatHealthy` | C2 (peer-takeover self-stop) + `OnClaimerError_*`, `StopsItselfWhenClaimLost` | C3 (OnDegraded once) + `LiveNATSBucketLoss_OnDegradedHook`, `F1_BucketRecreate` | C4 (Start returns post-sanity) + `Start_*` | Recovery self-heal suite (`AttemptRecovery_*`, `RecoveryGuard_TornRead`) | Epoch entry (`F1_BucketRecreate_TripsDegraded`, `F1_HappyPath`) | f-d1 reset (`recordKVHealthyOp`) | Cross-family collision |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **A: re-capture `ep.created`** after enterDegraded | | | **R** — must keep "exactly-once per *entry*"; re-capture latches so only ONE entry per recreate. F1 ticks once so it stays green, but verify multi-tick. | | | **T/R** — directly edits `checkBucketEpochs`; `HappyPath` (no false trip) must stay green | | **X** with C2:recreate-on-reconnect (a future intended recreate would NOT re-fire — good) and with C2:tolerate-empty-heartbeat (orthogonal). Removes the X that C2:recreate-on-reconnect otherwise creates. |
+| **A: refuse-exit-on-mismatch** (gate `attemptRecoveryFromDegraded` on no outstanding epoch mismatch) | **R (high)** — see §3.1; a poorly-scoped "any-fault-blocks-exit" could keep C1 fine (C1 *wants* terminal Degraded) but could break legit NP-5/NP-9 recovery | | **T** — changes when exit (and thus future re-entry) happens; reduces flap to single entry | | **T/R** — this is the *shared* exit gate; the entire `AttemptRecovery_*` suite pins its current semantics (`Applied_ExitsToStable`, `LatchedVersionAdvance_Rearms`, `ColdZero_ExitsToStable`, `RefreshFails_ReturnsBeforeGuard`) | **T** — needs an "epoch mismatch outstanding" predicate read by recovery | | shares the lever with **B** (one exit-gate fix can close both A's and B's recover-half) |
+| **B: post-recovery cooldown** (delay exit / require N stable ticks) | **R (low)** — C1 still trips (entry path untouched); cooldown only delays *exit*, and C1 asserts entry, not fast exit | | **R (low)** — delays exit => delays the next eligible re-entry; one-per-entry invariant intact | | possibly **T** if Start waits | **T/R** — adds time/tick gating to exit; `AttemptRecovery_*` are single-call unit tests, a cooldown that needs ≥2 calls could make `Applied_ExitsToStable` exit on the 2nd call — **rewrite risk** | | shares lever with A |
+| **B: verify-failing-op-recovered** (re-probe the op that degraded before exit) | **R (medium)** — must NOT require the *assignment* op alone (that's the current bug); must probe heartbeat/election/stableid too. If it probes ALL ops it strengthens C1's *terminal* property (good) but risks never exiting on a transient | | **R (low)** — none if it only adds a probe before exit | | | **T/R (high)** — fundamentally changes the exit predicate; whole `AttemptRecovery_*` suite + `RecoveryGuard_TornRead` must be re-validated; needs to plumb "which op degraded" (reason) into recovery | | needs a reason→probe map; **X** with A (epoch mismatch is the "failing op" for A — a unified verify path could close A too) |
+| **B: per-source error counters** (separate kvErrorWindow per subsystem) | **R (medium)** — `PartialBucketLoss_HeartbeatHealthy` depends on whole-bucket entries from *multiple* wiped buckets summing to threshold while heartbeat succeeds; per-source counters must still let any single faulting source reach threshold | | **R (low)** | | **T (low)** | | **T/R (high)** — rewrites `kvErrorWindow`/`recordKVHealthyOp`/`recordKVError`; `TestManager_recordKVHealthyOp` ("clears only transient", "no-op while degraded") + `TestManager_recordKVError` are the pin | the f-d1 reset semantics (`transient` flag, class-aware clear) are exactly this surface | independent of A |
+| **C1(mech1): safe-reclaim** (on reconnect, re-claim same ID instead of self-stop when bucket is intact) | **R (low)** | **R (HIGH)** — see §3.2; this directly weakens the C2 self-stop. Must distinguish "my claim aged out, no peer took it" from "a peer took it" or it reopens split-brain. `OnClaimerError_ClaimLostStopsWorker` + `StopsItselfWhenClaimLost` are the guard | | | | | | **X** with C2:recreate-on-reconnect (both touch the reconnect claim path) |
+| **C1(mech1): doc-only** (document M5 bounded by WorkerIDTTL) | | | | | | | | none (no code change) |
+| **C2(mech2): recreate-on-reconnect** (recreate missing MemoryStorage heartbeat bucket on reconnect) | **R (medium)** — recreating a Parti-owned bucket in-process is exactly what `LiveNATSBucketLoss:128-132` forbids ("must not be auto-recreated by live workers"); a heartbeat-only carve-out must not leak to other buckets | | **R (medium)** — a recreate produces a new stream `Created` | | | **X (HIGH)** — see §3.3: a recreated heartbeat stream gets a NEW `Created`; the still-stale `ep.created` (Family A unfixed) makes the epoch fence fire `bucket-recreated:heartbeat` on the next tick => re-introduces the A flap on the very bucket this fix recreated | | **X (HIGH)** with Family A: this fix is **unsafe to land before** A:re-capture-ep.created (or it must re-capture the heartbeat epoch itself after recreate) |
+| **C2(mech2): tolerate-empty-heartbeat** (calculator path treats `ErrStreamNotFound` on heartbeat Keys as empty during recovery) | **R (medium)** — `GetActiveWorkers`/`GetHeartbeats` currently map only `IsNoKeysFoundError` to empty (`worker_monitor.go:170,214`); widening to `ErrStreamNotFound` risks the leader computing an assignment over an *empty* fleet (revoke-all) during a real heartbeat-bucket *deletion* (C1/M3), which C1 wants to be Degraded, not silently absorbed | | | | | | | independent of A (no recreate, so no new `Created`); SAFER than recreate-on-reconnect w.r.t. the epoch fence |
+
+---
+
+## 3. The three regression/collision risks worth stopping on
+
+### 3.1 Does a stricter exit-gate (A:refuse-exit / B:verify-op) regress C1 *or the f-d1 reset*?
+
+**The f-d1 reset: clean no.** VERIFIED separation of paths: a stricter exit gate lives in
+`attemptRecoveryFromDegraded`, and the recovery path's window reset is `recordKVSuccess`
+(`manager_degraded.go:393`), a full clear. The f-d1 class-aware reset is
+`recordKVHealthyOp` (`:266-288`), which runs on the *entry/clear* side (a healthy periodic
+KV op while NOT degraded) and is a **no-op while degraded** (`:267`). An exit-gate change
+cannot touch `recordKVHealthyOp` — different function, different trigger. The ONLY fix
+option that touches the f-d1 reset is **B:per-source-counters** (it rewrites the
+`kvErrorWindow`/`transient`-flag machinery), which the matrix already flags `T/R` on the
+`recordKVHealthyOp` column. So the blank f-d1 cells for every other option are backed by
+this path separation, not omission.
+
+**C1: no, if scoped to the failing op; and C1 actually *benefits*.** C1 is pinned by
+*entry* (`TestManager_LiveNATSBucketLoss` asserts all 3 reach Degraded; it does NOT
+assert they exit). A stricter exit gate can only keep them Degraded *longer*, which is
+the C1 intent ("restart/rotate", terminal). VERIFIED: `LiveNATSBucketLoss` has no
+exit/recovery assertion. **The real regression surface is the recovery *positive*
+tests**, not C1: `TestAttemptRecovery_Applied_ExitsToStable`,
+`TestAttemptRecovery_ColdZero_ExitsToStable`, NP-5 (`startup-timeout` heals), NP-9
+(full quorum loss heals after clear), NP-3a (disarm control). A gate that blocks exit
+"while any error window is non-empty" would break NP-5/NP-9/NP-3a (they legitimately
+recover). The gate must key on **the still-failing op**, not "any past error" — which
+is exactly why B:verify-failing-op-recovered needs the degrade *reason* plumbed into
+recovery (currently `attemptRecoveryFromDegraded` is reason-agnostic — VERIFIED, `:406`
+comment says "keys on commitment STATE, not the degraded reason").
+
+### 3.2 Does C1(mech1):safe-reclaim regress C2?
+
+**HIGH risk.** C2's whole value is that a *peer takeover* self-stops exactly one worker
+(`onClaimerError` => `claimLostShutdown`, pinned by `TestOnClaimerError_ClaimLostStopsWorker`
+and `TestManager_StopsItselfWhenClaimLost`). "Re-claim on reconnect instead of stop"
+must fire ONLY when the worker's own claim simply *aged out with no peer holding it* —
+indistinguishable, at the `ErrClaimLost` surface, from a peer having taken it unless the
+fix re-reads the key's current holder. Getting this wrong reopens split-brain (two
+workers, same ID). The report calls mech-1 "working-as-designed / doc-only" — I AGREE
+this is the safe call; a safe-reclaim is a genuine behavior change that must defend C2,
+not a bug fix.
+
+### 3.3 Does C2(mech2):recreate-on-reconnect collide with Family A's epoch fence?
+
+**HIGH risk, and the report does NOT call this out.** VERIFIED chain:
+`captureBucketEpoch` is invoked from `ensureKVBucket` for EVERY Parti-owned bucket
+including heartbeat (`manager_setup.go:265`, heartbeat ensured at `:156`), so the
+heartbeat bucket IS epoch-monitored. If a recreate-on-reconnect fix recreates the
+MemoryStorage heartbeat bucket in-process, the new stream gets a strictly-later
+`Created`; the epoch monitor still holds the original `ep.created` (Family A unfixed)
+and will fire `enterDegraded("bucket-recreated:heartbeat")` on the next
+`OperationTimeout` tick — re-introducing the Family A flap on the exact bucket the fix
+just restored. **Sequencing constraint:** C2:recreate-on-reconnect must NOT land before
+A:re-capture-ep.created, OR must itself re-capture the heartbeat epoch after recreating.
+The strictly-safer mech-2 option w.r.t. this collision is
+**C2:tolerate-empty-heartbeat** — it adds no new stream `Created`, so it cannot trip the
+epoch fence. (It carries its own C1/M3 risk: it must not absorb a genuine heartbeat
+*deletion* into "empty fleet".)
+
+---
+
+## 4. Recommended fix combination (lowest contract risk)
+
+INFERRED from the matrix:
+1. **Family A:** `re-capture ep.created` after `enterDegraded` (latches one entry per
+   recreate; preserves C3-once and `F1_BucketRecreate`/`F1_HappyPath`) **plus** a
+   reason-aware exit gate so recovery does not exit while an epoch mismatch is
+   outstanding. The latch alone stops the *re-arm*; without the exit-gate the worker
+   still exits once on the intact assignment bucket (false-healthy NP-1). Both halves
+   are needed for NP-1's resting-state correctness.
+2. **Family B:** `verify-failing-op-recovered`, sharing the reason-aware exit gate from
+   (1). This is the single lever the report flags as closing both A's and B's
+   recover-halves. Validate against the entire `AttemptRecovery_*` suite + NP-5/NP-9/NP-3a.
+
+**CRITICAL framing for the reason-aware exit gate — it is ADDITIVE, not a replacement.**
+The new reason/op check must be layered *on top of* the existing
+`currentAssignmentApplied(cur)` commitment-state guard (`manager_degraded.go:409`), NOT
+substituted for it. That commitment-state guard is a deliberate, documented choice
+(the `:395-407` comment + `03-latched-worker-version-commitment-plan.md`) pinned by
+`TestAttemptRecovery_LatchedVersionAdvance_RearmsAtNewVersion` and the rest of the
+`AttemptRecovery_*` suite. Removing or replacing it reopens the latched-version
+false-Stable bug. Exit must require BOTH: (a) the current assignment is applied+acked
+(existing), AND (b) the op/condition that caused this Degraded entry has actually
+recovered (new). The new gate adds a conjunct; it does not relax the existing one.
+3. **Family C mech 1:** doc-only (it is C2 firing correctly).
+4. **Family C mech 2:** prefer `tolerate-empty-heartbeat` (no epoch-fence collision) OR,
+   if recreate-on-reconnect is chosen, sequence it AFTER A:re-capture-ep.created.
+
+The single highest-leverage, lowest-risk change is the **reason-aware exit gate** in
+`attemptRecoveryFromDegraded`: it closes the recover-half of A and all of B, and (because
+C1 asserts entry not exit) cannot regress the whole-bucket-degrade contract — provided it
+keys on the still-failing op/reason rather than "any non-empty error window" (which would
+break the proven NP-5/NP-9/NP-3a recoveries).
+
+---
+
+## 5. Corrections / imprecisions found vs the brief and 04-proof-findings.md
+
+- **C2 pinning (brief):** `TestStableID_StaleKeyTakeover_Reclaim` pins the *reclaim*
+  half at the `stableid.Claimer` level; it never touches `onClaimerError`/
+  `claimLostShutdown`. The manager-level C2 routing is pinned by
+  `manager_claimer_error_test.go` (`TestOnClaimerError_ClaimLostStopsWorker`,
+  `TestOnClaimerError_TransientErrorUsesKVCircuit`, `TestManager_StopsItselfWhenClaimLost`).
+  A C1:safe-reclaim fix's regression risk lives in *those* tests, not the takeover test.
+- **C2(mech2):recreate-on-reconnect × Family A collision:** not surfaced in
+  04-proof-findings.md §7. VERIFIED via `manager_setup.go:265` + `:156`. This is a
+  hard sequencing constraint, not a soft note.
+- **04-proof-findings.md `manager_setup.go:684-690` line cites:** match HEAD
+  (`checkBucketEpochs` mismatch+enterDegraded is `:684-690`). `:627` for the single
+  `ep.created` capture is exact. No drift found.
+- **Bucket-recreate test names (brief + 01-fault-matrix.md):** the brief lists
+  `manager_epoch_fence_test.go` and `manager_bucket_recreate_test.go` as suites to anchor
+  on. VERIFIED: `manager_bucket_recreate_test.go` does **not exist** (no file, no
+  `*bucket_recreate*` glob match). The fault matrix M4 row (`01-fault-matrix.md:12`) cites
+  `TestManager_BucketRecreated_EntersDegraded`, which also does not exist by that name. The
+  real M4/epoch-entry tests are `TestManager_F1_BucketRecreate_TripsDegraded` and
+  `TestManager_F1_HappyPath_NoDegraded` in `manager_epoch_fence_test.go`. Any Family A fix
+  validates against F1, not a `BucketRecreated`-named test.
+- **NP-2 epoch-fence handle re-bind:** the report's root cause is correct but omits
+  *why* the probe keeps succeeding after recreate (the cached `ep.kv` handle silently
+  re-binds to the new stream — modeled in `F1_BucketRecreate:117-123`). This matters
+  because an alternative "the handle errors so it never re-fires" reading would falsify
+  the gap; the handle-rebind behavior is what makes Family A real.

--- a/manager.go
+++ b/manager.go
@@ -204,6 +204,21 @@ type Manager struct {
 	kvErrorWindow          []kvErrorEvent // recent KV errors, class-tagged (protected by mu)
 	recoveryGraceStart     atomic.Int64   // UnixNano when recovery grace period started; 0 = not in grace
 	inRecoveryGrace        atomic.Bool    // true during recovery grace period
+	// lastDegradedReason holds the reason string of the active degrade. Written by
+	// the WINNING enterDegraded immediately AFTER the degradedSince CAS (losers
+	// never write it, so there is no loser-clobber) and cleared to "" by
+	// exitDegraded BEFORE it clears degradedSince. The reason-scoped recovery gate
+	// treats an empty reason as "this entry's reason is not yet observable" and
+	// stays degraded that tick — closing the tiny post-CAS-pre-store window via the
+	// degradedSince happens-before, without converting degradedSince to a record.
+	// atomic.Value of string ("" when never degraded / between an exit and the next
+	// entry's store).
+	lastDegradedReason atomic.Value
+	// lastHeartbeatSuccessAt is the UnixNano of the most recent successful
+	// heartbeat Put (stamped unconditionally in recordKVHealthyOp, even while
+	// degraded). The reason-scoped gate uses it to confirm the failing
+	// connected-but-KV-unavailable op recovered AFTER we degraded. 0 = never.
+	lastHeartbeatSuccessAt atomic.Int64
 
 	// Lifecycle management
 	ctx    context.Context

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go"
 )
@@ -264,6 +265,12 @@ func (m *Manager) recordKVSuccess() {
 // window is not growing, and the early return keeps the hot heartbeat-success
 // path (every HeartbeatInterval) off m.mu once a real outage is in progress.
 func (m *Manager) recordKVHealthyOp() {
+	// Stamp the heartbeat-success time unconditionally: the reason-scoped
+	// recovery gate needs to observe a heartbeat Put succeeding AFTER a
+	// kv-unavailable degrade. This must run even while degraded (the
+	// window-clear below intentionally does not).
+	m.lastHeartbeatSuccessAt.Store(time.Now().UnixNano())
+
 	if m.degradedSince.Load() != 0 {
 		return
 	}
@@ -310,9 +317,17 @@ func (m *Manager) enterDegraded(reason string) {
 		return
 	}
 
-	// Attempt validated state transition. Roll back degradedSince on failure
-	// (can only happen from Init/ClaimingID states that forbid degraded entry).
+	// Only the CAS winner reaches here, so this is the sole writer of the active
+	// reason — no loser-clobber. The recovery gate treats the brief
+	// CAS-won-but-reason-not-yet-stored window as "" and stays degraded that tick.
+	m.lastDegradedReason.Store(reason)
+
+	// Attempt validated state transition. Roll back BOTH reason and degradedSince
+	// on failure (clear reason BEFORE degradedSince so the happens-before holds).
+	// Failure can only happen from Init/ClaimingID states that forbid degraded
+	// entry.
 	if !m.transitionState(StateDegraded) {
+		m.lastDegradedReason.Store("")
 		m.degradedSince.Store(0)
 		return
 	}
@@ -351,8 +366,13 @@ func (m *Manager) exitDegraded() {
 		return
 	}
 
-	// Clear degradedSince after a successful state transition so that future
-	// enterDegraded calls can re-arm correctly (fixes the re-entry bug).
+	// Clear the reason BEFORE clearing degradedSince: a subsequent enterDegraded
+	// can only win its CAS after degradedSince becomes 0, so this clear
+	// happens-before that winner's reason store — no clobber, and the gap between
+	// an exit and the next store reads as "" (gate stays that tick). Clearing
+	// degradedSince after a successful state transition also lets future
+	// enterDegraded calls re-arm correctly (fixes the re-entry bug).
+	m.lastDegradedReason.Store("")
 	m.degradedSince.Store(0)
 
 	m.logger.Info("exiting degraded mode",
@@ -411,8 +431,160 @@ func (m *Manager) attemptRecoveryFromDegraded() {
 		return
 	}
 
+	// The degrade reason is written by the winning enterDegraded just after its
+	// CAS (Step 4). An empty read means this entry's reason is not yet observable
+	// (or we raced an exit) — stay degraded this tick rather than risk skipping a
+	// reason-scoped gate below. One-tick delay only.
+	reason, _ := m.lastDegradedReason.Load().(string)
+	if reason == "" {
+		return
+	}
+
+	// Family B — reason-scoped recover-on-wrong-signal gate. A kv-unavailable
+	// degrade is a connected-but-KV-unavailable op stall on the heartbeat /
+	// election / stableid buckets; the commitment guard above reads only the
+	// (unaffected) assignment bucket, so it cannot tell the failing op recovered.
+	// Require a heartbeat Put success stamped AFTER we degraded. Reason-scoped:
+	// a non-kv-unavailable degrade (e.g. "startup-timeout", NP-5) recovers via
+	// the commitment guard alone — an UNCONDITIONAL gate regresses NP-5, which
+	// has no heartbeat publisher so lastHeartbeatSuccessAt stays 0. Cheap atomic
+	// reads, evaluated before the Family A network re-probe added in a later task.
+	if reason == degradedReasonKVUnavailable {
+		hbAt := m.lastHeartbeatSuccessAt.Load()
+		since := m.degradedSince.Load()
+		if hbAt == 0 || hbAt <= since {
+			m.logger.Debug("recovery: heartbeat KV not recovered since kv-unavailable degrade; staying Degraded",
+				"last_heartbeat_success_unixnano", hbAt, "degraded_since_unixnano", since)
+			return
+		}
+	}
+
+	// Family A — refuse a recovery exit while a Parti-owned bucket wipe-and-
+	// recreate is still outstanding. A live re-probe; a missing/timing-out bucket
+	// is skipped (Family B's / the connection monitor's concern), so this conjunct
+	// fires only on a CONFIRMED Created mismatch.
+	if m.epochMismatchOutstanding(m.ctx) {
+		m.logger.Warn("recovery: bucket epoch mismatch outstanding; staying Degraded for restart/rotation")
+		return
+	}
+
+	// Heartbeat-bucket reachability backstop — refuse to exit while the heartbeat
+	// bucket's stream is missing/unreachable (e.g. a single-node restart of an
+	// un-migrated MemoryStorage heartbeat bucket). NOT reason-scoped: it backstops
+	// the "KV error threshold exceeded" reason that the Family B kv-unavailable gate
+	// does not cover and that Family A (recreate-only) does not catch for a missing
+	// stream. Holds the worker terminally Degraded for rotation.
+	if m.heartbeatBucketUnavailable(m.ctx) {
+		m.logger.Warn("recovery: heartbeat bucket unavailable; staying Degraded for restart/rotation")
+		return
+	}
+
 	// Success - exit degraded mode
 	m.exitDegraded()
+}
+
+// epochMismatchOutstanding reports whether any Parti-owned bucket's LIVE
+// stream-Created no longer matches the value captured at Start — i.e. a
+// wipe-and-recreate is still in effect. It is the Family A recovery-exit guard:
+// the commitment guard can be satisfied by a version-monotonic republish into a
+// recreated-empty bucket, so the exit must additionally refuse while a recreate
+// is outstanding (terminal Degraded => restart/rotation, docs/OPERATIONS.md).
+//
+// This is a LIVE re-probe (not a latch) so there is no pre-arm window: the
+// epoch-fence monitor ticks every OperationTimeout (10s) while recovery ticks
+// every 1s, so a latch could arm after a faster recovery had already exited.
+//
+// Probe errors are NOT actionable and are skipped (mirroring checkBucketEpochs'
+// continue-on-error): only a successful read with a DIFFERENT Created is a
+// recreate. A missing/timing-out bucket is the connection monitor's / Family B's
+// concern, not Family A's — this keeps the two exit conjuncts independent.
+//
+// Cost / timing: it runs inline on the 1s connection-monitor goroutine, but ONLY
+// in the connected branch (attemptRecoveryFromDegraded is reached only after the
+// connection is up for ExitThreshold), so the common case is a few sub-ms
+// round-trips against reachable buckets (measured ~3ms for 4 buckets). Each
+// bucket's probe is hard-bounded by OperationTimeout, so the worst case is
+// len(bucketEpochs)*OperationTimeout of inline blocking — it degrades gracefully
+// rather than wedging if a bucket goes unreachable mid-tick.
+//
+// Concurrency: m.bucketEpochs is written only at Start (captureBucketEpoch) and
+// is read-only afterward, so ranging it from this (connection-monitor) goroutine
+// is race-free — the SAME lock-free-read contract checkBucketEpochs relies on. It
+// opens a FRESH probe handle per bucket rather than reusing ep.kv, which is owned
+// by the monitorBucketEpochs goroutine and is not safe to share across goroutines
+// (nats.go KeyValue handles cache *stream state).
+func (m *Manager) epochMismatchOutstanding(ctx context.Context) bool {
+	if m.js == nil {
+		return false
+	}
+	for bucket, ep := range m.bucketEpochs {
+		// Bound BOTH the handle open AND the status read with a single per-bucket
+		// deadline: js.KeyValue does a stream-info round-trip, so passing the
+		// unbounded ctx here would let it block on nats.go's internal default
+		// (~5s) instead of OperationTimeout when a bucket is unreachable — turning
+		// this into an unbounded inline stall on the connection-monitor goroutine.
+		probeCtx, cancel := context.WithTimeout(ctx, m.cfg.OperationTimeout)
+		probeKV, err := m.js.KeyValue(probeCtx, bucket)
+		if err != nil {
+			cancel()
+			m.logger.Debug("epoch re-probe: open handle failed; not actionable", "bucket", bucket, "error", err)
+			continue
+		}
+		live, err := kvutil.BucketStreamCreated(probeCtx, probeKV)
+		cancel()
+		if err != nil {
+			m.logger.Debug("epoch re-probe: probe failed; not actionable", "bucket", bucket, "error", err)
+			continue
+		}
+		if !live.Equal(ep.created) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// heartbeatBucketUnavailable reports whether the heartbeat bucket's stream is
+// currently missing or unreachable. It is the recovery-exit backstop for the
+// heartbeat-bucket-loss flap that the reason-scoped Family B gate and the
+// recreate-only Family A re-probe do not cover: a single-node restart of an
+// un-migrated MemoryStorage heartbeat bucket loses the stream, the heartbeat
+// publisher Put keeps failing, and the worker degrades with the whole-bucket-loss
+// reason "KV error threshold exceeded" (manager_degraded.go:208-225) — NOT
+// kv-unavailable (so Family B is silent) and not a Created mismatch (the stream is
+// gone, not recreated, so epochMismatchOutstanding skips it). Without this guard
+// the recovery exit heals on the unaffected assignment read and the fleet flaps.
+//
+// Unlike Family B this guard is NOT reason-scoped: it fires for ANY degrade reason,
+// but only when the heartbeat bucket is genuinely unreachable, so it cannot regress
+// a degrade whose heartbeat bucket is healthy (NP-5 startup-timeout, NP-3a disarmed
+// — bucket reachable => returns false => recovery proceeds on the prior guards).
+//
+// Cost / timing: it runs inline on the 1s connection-monitor goroutine in the
+// connected branch only, so the common case is one sub-ms KeyValue+Status round
+// trip against a reachable bucket. The single per-call deadline (OperationTimeout)
+// hard-bounds BOTH the handle open and the status read, so an unreachable bucket
+// degrades to a bounded inline stall rather than wedging the goroutine.
+//
+// Concurrency: it opens a FRESH probe handle (not a cached one) for the same
+// goroutine-safety reason as epochMismatchOutstanding — nats.go KeyValue handles
+// cache *stream state and are not safe to share across goroutines. m.js == nil
+// (unit-test managers) short-circuits to false.
+func (m *Manager) heartbeatBucketUnavailable(ctx context.Context) bool {
+	if m.js == nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, m.cfg.OperationTimeout)
+	defer cancel()
+	kv, err := m.js.KeyValue(probeCtx, m.cfg.KVBuckets.HeartbeatBucket)
+	if err != nil {
+		return true // bucket missing / unreachable
+	}
+	if _, err := kv.Status(probeCtx); err != nil {
+		return true
+	}
+
+	return false
 }
 
 // enterRecoveryGracePeriod starts the recovery grace period for the leader.

--- a/manager_degraded_recovery_selfheal_test.go
+++ b/manager_degraded_recovery_selfheal_test.go
@@ -40,6 +40,14 @@ func armDegraded(t *testing.T, committed *Assignment, snapshot Assignment) (*Man
 	}
 	m.state.Store(int32(StateDegraded))
 	m.degradedSince.Store(time.Now().UnixNano())
+	// Mirror enterDegraded's reason ownership: a real degrade always stores a
+	// reason right after the degradedSince CAS, and attemptRecoveryFromDegraded's
+	// empty-reason guard intentionally stays degraded a tick when the reason is
+	// unset. These are reason-agnostic commitment-guard recovery tests, so arm a
+	// non-kv-unavailable reason — the kv-unavailable conjunct is skipped and
+	// recovery keys on the commitment guard alone (the behavior this helper
+	// exercised before the guard existed).
+	m.lastDegradedReason.Store("NATS connection down")
 
 	return m, rh
 }

--- a/manager_epoch_reprobe_test.go
+++ b/manager_epoch_reprobe_test.go
@@ -1,0 +1,79 @@
+package parti
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEpochMismatchOutstanding_BehaviorAndTiming is the focused unit + WI-3
+// timing guard for the Family A recovery-exit re-probe. attemptRecoveryFromDegraded
+// runs on the 1s connection-monitor goroutine, so epochMismatchOutstanding's
+// per-tick blocking probe I/O is a timing concern (a real stall risk on health
+// detection if a bucket is unreachable). This test pins three regimes:
+//   - reachable + unchanged buckets: returns false, FAST (the realistic recovery
+//     scenario — buckets are reachable because the exit only runs when connected).
+//   - a recreated bucket: returns true (the wipe-and-recreate the gate must catch).
+//   - an unreachable server: returns false (probe errors are skipped, not
+//     actionable) and is BOUNDED by ~len(buckets) * OperationTimeout — it must not
+//     hang the connection-monitor goroutine.
+func TestEpochMismatchOutstanding_BehaviorAndTiming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping embedded-NATS test in short mode")
+	}
+
+	m, _, _, _ := newTestManager(t)
+	srv, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	m.js = js
+	m.cfg.OperationTimeout = 2 * time.Second
+
+	ctx := m.ctx
+	buckets := []string{"wi3-b0", "wi3-b1", "wi3-b2", "wi3-b3"}
+	for _, b := range buckets {
+		kv := partitest.CreateJetStreamKV(t, nc, b)
+		m.captureBucketEpoch(ctx, b, kv)
+	}
+	require.Len(t, m.bucketEpochs, len(buckets), "all bucket epochs must be captured")
+
+	// Regime 1: reachable + unchanged -> false, and fast (well under one
+	// OperationTimeout for all four buckets combined).
+	start := time.Now()
+	require.False(t, m.epochMismatchOutstanding(ctx),
+		"unchanged reachable buckets must not report a recreate")
+	reachableLatency := time.Since(start)
+	t.Logf("WI-3 timing: epochMismatchOutstanding over %d reachable buckets = %s", len(buckets), reachableLatency)
+	require.Less(t, reachableLatency, m.cfg.OperationTimeout,
+		"the reachable-bucket re-probe must be fast (a few round-trips), well under one OperationTimeout")
+
+	// Regime 2: recreate one bucket -> the live Created differs -> true.
+	require.NoError(t, js.DeleteKeyValue(ctx, buckets[1]))
+	_ = partitest.CreateJetStreamKV(t, nc, buckets[1])
+	require.True(t, m.epochMismatchOutstanding(ctx),
+		"a recreated bucket's live Created must mismatch the captured epoch -> outstanding")
+
+	// Regime 3 (the WI-3 worst case): the server is gone -> every probe errors and
+	// is skipped (returns false), and the whole call is BOUNDED, not a hang. Use a
+	// small OperationTimeout so the bound is tight and the test is quick.
+	m.cfg.OperationTimeout = 300 * time.Millisecond
+	srv.Shutdown()
+	srv.WaitForShutdown()
+
+	start = time.Now()
+	require.False(t, m.epochMismatchOutstanding(ctx),
+		"with the server down every probe errors and is skipped (not actionable) -> false")
+	downLatency := time.Since(start)
+	t.Logf("WI-3 timing: epochMismatchOutstanding with server DOWN over %d buckets = %s (OperationTimeout=%s each)",
+		len(buckets), downLatency, m.cfg.OperationTimeout)
+	// Hard upper bound: the per-bucket context.WithTimeout caps each probe, so the
+	// total inline block on the connection-monitor goroutine cannot exceed
+	// len(buckets)*OperationTimeout plus a small scheduling margin. This is the
+	// guarantee that the re-probe degrades gracefully rather than wedging.
+	maxBound := time.Duration(len(buckets))*m.cfg.OperationTimeout + 2*time.Second
+	require.Less(t, downLatency, maxBound,
+		"epochMismatchOutstanding must stay bounded by len(buckets)*OperationTimeout when buckets are unreachable, not hang")
+}

--- a/manager_reason_ownership_test.go
+++ b/manager_reason_ownership_test.go
@@ -1,0 +1,143 @@
+package parti
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Reason-ownership protocol (Family B). The active degrade reason is owned
+// atomically with the winning degradedSince CAS:
+//   - enterDegraded stores lastDegradedReason ONLY after the winning CAS (losers
+//     return at the CAS and never write it).
+//   - exitDegraded clears the reason BEFORE clearing degradedSince.
+//   - the recovery gate treats an empty reason as "not yet observable" and stays
+//     degraded that tick.
+//
+// These tests pin that protocol. The first is a deterministic clobber-resistance
+// proof (it FAILS on the rejected store-before-CAS design); the second is a
+// concurrent multi-reason storm whose load-bearing oracle is the race detector
+// (none of NP-3b / NP-5 / NP-9 drives multiple distinct degrade reasons racing
+// into the CAS).
+
+// TestReasonOwnership_LosersDoNotClobberWinningReason proves the P0 correction:
+// when many goroutines call enterDegraded concurrently with DIFFERENT reasons,
+// exactly one wins the degradedSince CAS and stores its reason; every loser must
+// return at the failed CAS WITHOUT writing lastDegradedReason. Storing the reason
+// before the CAS (the rejected design) would let a loser overwrite the winner's
+// reason — which would make the reason-scoped recovery gate key off the wrong
+// reason and falsely exit. Deterministic (no sleeps); also runs under -race.
+func TestReasonOwnership_LosersDoNotClobberWinningReason(t *testing.T) {
+	t.Parallel()
+
+	m, _, _, _ := newTestManager(t)
+	m.cfg.DegradedAlert.AlertInterval = time.Minute // monitorDegradedAlerts NewTicker
+	m.state.Store(int32(StateStable))               // Stable -> Degraded is valid
+
+	const winner = degradedReasonKVUnavailable
+	m.enterDegraded(winner)
+	require.Equal(t, StateDegraded, m.State(), "winner must transition to Degraded")
+	require.NotZero(t, m.degradedSince.Load(), "winner must set degradedSince")
+	require.Equal(t, winner, m.lastDegradedReason.Load(),
+		"the CAS winner is the sole reason writer")
+
+	// N concurrent losers, each with a DISTINCT reason. All lose the CAS
+	// (degradedSince is already set), so none may write lastDegradedReason.
+	const losers = 64
+	var wg sync.WaitGroup
+	for i := range losers {
+		reason := fmt.Sprintf("loser-reason-%d", i)
+		wg.Go(func() { m.enterDegraded(reason) })
+	}
+	wg.Wait()
+
+	require.Equal(t, winner, m.lastDegradedReason.Load(),
+		"a losing concurrent enterDegraded must NOT clobber the winner's active reason "+
+			"(store-after-CAS); a non-winner reason here means store-before-CAS regressed")
+	require.Equal(t, StateDegraded, m.State(), "losers must not change state")
+}
+
+// TestReasonOwnership_ConcurrentMultiReasonStorm_NoRace hammers the full protocol
+// — concurrent enterDegraded (5 distinct reasons), exitDegraded, recordKVHealthyOp
+// (the lastHeartbeatSuccessAt stamp), plus readers of the gate state — and is
+// designed to surface any data race on lastDegradedReason / degradedSince /
+// lastHeartbeatSuccessAt or any torn protocol interleaving. Load-bearing oracle:
+// the race detector. Light functional invariant: whenever degraded, the observed
+// reason is always either "" (the brief CAS-won-but-not-yet-stored / just-exited
+// window) or one of the reasons we actually entered with — never stale garbage.
+func TestReasonOwnership_ConcurrentMultiReasonStorm_NoRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrency stress in short mode")
+	}
+	t.Parallel()
+
+	m, _, _, _ := newTestManager(t)
+	m.cfg.DegradedAlert.AlertInterval = time.Minute
+	m.state.Store(int32(StateStable))
+
+	reasons := []string{
+		degradedReasonKVUnavailable,
+		"startup-timeout",
+		"NATS connection down",
+		"bucket-recreated:parti-heartbeat",
+		"assignment-watcher-exhausted",
+	}
+	valid := map[string]bool{"": true}
+	for _, r := range reasons {
+		valid[r] = true
+	}
+
+	const iters = 300
+	var wg sync.WaitGroup
+	var invalidReason sync.Map // observed bad reason -> struct{}
+
+	// Enterers: one goroutine per reason, each repeatedly attempting entry.
+	for _, r := range reasons {
+		wg.Go(func() {
+			for range iters {
+				m.enterDegraded(r)
+			}
+		})
+	}
+	// Exiters: drive Degraded -> Stable so the enterers can re-arm, exercising
+	// the clear-reason-before-degradedSince ordering under concurrency.
+	for range 3 {
+		wg.Go(func() {
+			for range iters {
+				m.exitDegraded()
+			}
+		})
+	}
+	// Heartbeat-success stampers (the lastHeartbeatSuccessAt atomic on the hot path).
+	for range 2 {
+		wg.Go(func() {
+			for range iters {
+				m.recordKVHealthyOp()
+			}
+		})
+	}
+	// Readers: read the gate state the recovery tick reads, validating the reason.
+	for range 3 {
+		wg.Go(func() {
+			for range iters {
+				if m.degradedSince.Load() != 0 {
+					reason, _ := m.lastDegradedReason.Load().(string)
+					if !valid[reason] {
+						invalidReason.Store(reason, struct{}{})
+					}
+				}
+				_ = m.lastHeartbeatSuccessAt.Load()
+			}
+		})
+	}
+	wg.Wait()
+
+	invalidReason.Range(func(k, _ any) bool {
+		t.Errorf("recovery gate observed an invalid degrade reason while degraded: %q", k)
+		return true
+	})
+	require.False(t, t.Failed(), "race detector / invalid-reason invariant tripped during the multi-reason storm")
+}

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -113,8 +113,12 @@ func (m *Manager) ensureStableIDKV(ctx context.Context, js jetstream.JetStream) 
 //     leadership churn. The switch from MemoryStorage is effectively
 //     IOPS-free at production scales (see
 //     docs/plans/iops-investigation/findings.md §M1.9).
-//   - heartbeat:  MemoryStorage — workers re-publish every HeartbeatInterval,
-//     so a missed window is recovered by the next publish.
+//   - heartbeat:  FileStorage   — the heartbeat stream must survive a single-node
+//     NATS restart. With MemoryStorage the stream was lost on restart and the
+//     fleet flapped Degraded<->Stable (the publisher Put kept failing against the
+//     dead stream). The added write IOPS is a flat, partition-count-independent
+//     term measured within the provisioned envelope (see
+//     docs/plans/iops-investigation/findings.md and 06-deep-gap-fix-plan Task 0.1).
 //   - assignment: FileStorage  — must survive NATS restart so followers
 //     joining during the outage window can receive their assignment.
 //
@@ -153,7 +157,7 @@ func (m *Manager) ensureCoreKVBuckets( //nolint:revive
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	heartbeatKV, err = ensure("heartbeat", m.cfg.KVBuckets.HeartbeatBucket, m.cfg.HeartbeatTTL, jetstream.MemoryStorage)
+	heartbeatKV, err = ensure("heartbeat", m.cfg.KVBuckets.HeartbeatBucket, m.cfg.HeartbeatTTL, jetstream.FileStorage)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/test/integration/failure/np2_epoch_fence_return_to_stable_test.go
+++ b/test/integration/failure/np2_epoch_fence_return_to_stable_test.go
@@ -2,7 +2,6 @@ package failure_test
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -49,10 +48,6 @@ import (
 func TestNP2EpochFence_NonAssignmentRecreate_DegradedDoesNotFlap(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration: skipping in short mode")
-	}
-	if os.Getenv("PARTI_RUN_NP2_EPOCH_FLAP_PROOF") == "" {
-		t.Skip("opt-in KNOWN-FAILING proof (NP-2 epoch-fence Degraded<->Stable flap); " +
-			"set PARTI_RUN_NP2_EPOCH_FLAP_PROOF=1 to run")
 	}
 
 	t.Parallel()

--- a/test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go
+++ b/test/integration/failure/np8_fleet_nats_outage_leader_continuity_test.go
@@ -2,7 +2,7 @@ package failure_test
 
 import (
 	"context"
-	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,44 +18,37 @@ import (
 
 // TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet extends the single-worker
 // M5 full-NATS-outage proof (TestFullNATSOutage_UnlimitedReconnects_RecoversFleet)
-// to a 3-MANAGER fleet sharing ONE restartable NATS connection.
+// to a 3-MANAGER fleet sharing ONE restartable NATS connection, across an outage
+// that exceeds WorkerIDTTL.
 //
-// Scenario NP-8 — KNOWN FAILING on current main (gated, opt-in). It asserts the
-// auto-heal property the single-worker M5 proof claims, but for a 3-manager fleet
-// across an outage >= WorkerIDTTL:
+// Scenario NP-8 mechanism 1 — guards the WORKING-AS-DESIGNED claim-loss self-stop
+// boundary (see docs/OPERATIONS.md "Recovery bound — worker-ID lease"). M5
+// recover-to-Stable is bounded by WorkerIDTTL: an outage that exceeds it ages out
+// the stableID worker-ID lease (the stableID bucket MaxAge is reconciled to
+// WorkerIDTTL). On reconnect each worker's renewal sees a revision mismatch,
+// surfaces a bare ErrClaimLost, and onClaimerError routes it to claimLostShutdown
+// (manager_election.go:106-118) — the deliberate split-brain-safe self-stop, since
+// a peer may have taken the slot. The documented contract is therefore NOT
+// in-process recovery to Stable; it is:
 //
 //  1. All 3 managers enter Degraded during the outage.
-//  2. All 3 managers return Stable after the server restart.
-//  3. Exactly ONE leader after recovery (continuity OR clean re-election, NOT
-//     split-brain). Leadership is dropped during the outage by design, so we LOG
-//     continuity but do NOT assert it.
-//  4. Assignments republished/observed fleet-wide (6-partition coverage holds;
-//     version does not regress).
-//  5. NO post-recovery flap.
+//  2. After the restart, every worker self-stops to StateShutdown (the lease aged
+//     out; the bare ErrClaimLost is unrecoverable in place).
+//  3. Recovery is orchestrator rotation (the readiness probe sees StateShutdown and
+//     the pod is replaced); Parti does not auto-reclaim an aged-out lease.
 //
-// WHY IT FAILS ON MAIN (see docs/plans/auto-healing-gap-closure/04-proof-findings.md,
-// finding NP-8). The fleet does NOT auto-heal across a NATS server restart, via two
-// distinct mechanisms unmasked by the single-worker M5 proof:
-//   - Outage >= WorkerIDTTL ages out the stableID claim (the bucket MaxAge is
-//     reconciled to WorkerIDTTL). On reconnect each worker hits ErrClaimLost ->
-//     claimLostShutdown (the deliberate split-brain self-stop) and ends in
-//     StateShutdown — never returning to Stable. (manager_election.go:107-118)
-//   - Even when the claim survives (WorkerIDTTL raised above the outage), the
-//     MemoryStorage heartbeat bucket is gone after a single-node restart, so the
-//     leader's calculator fails "list heartbeat keys: stream not found" and the
-//     fleet flaps Stable<->Degraded indefinitely.
+// This proof asserts the Shutdown outcome and captures each worker's terminal error
+// (the ErrClaimLost) via the OnError hook, so it GUARDS the boundary rather than a
+// behavior Parti does not provide. Raise WorkerIDTTL above the worst-case outage to
+// move the boundary (a real RF3 cluster ROLLING restart that keeps the outage under
+// WorkerIDTTL preserves the lease and may recover in-process; this single-node
+// embedded restart exercises the past-boundary worst case).
 //
-// A real RF3 cluster ROLLING restart that preserves replicated MemoryStorage and
-// keeps the outage under WorkerIDTTL may recover; this single-node embedded restart
-// exercises the worst case. Gated opt-in so it does not break `make test`; remove
-// the gate when the fix lands and it becomes a regression proof.
+// Mechanism 2 (heartbeat-bucket loss when the claim survives) is isolated by the
+// companion TestNP8FleetNATSOutage_HeartbeatBucketLossFlap below.
 func TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration: skipping in short mode")
-	}
-	if os.Getenv("PARTI_RUN_NP8_FLEET_OUTAGE_PROOF") == "" {
-		t.Skip("opt-in KNOWN-FAILING proof (NP-8 fleet does not auto-heal a NATS restart); " +
-			"set PARTI_RUN_NP8_FLEET_OUTAGE_PROOF=1 to run")
 	}
 	t.Parallel()
 
@@ -85,46 +78,31 @@ func TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet(t *testing.T) {
 
 	const np8NumWorkers = 3
 
-	// Per-worker recovery / flap / reason tracking. Each manager gets its own
-	// OnStateChanged + OnDegraded hooks. Because AddWorkerWithOptions injects the
-	// cluster tracker hooks FIRST and our WithHooks LAST, and WithHooks overwrites
-	// (options.go: o.hooks = hooks; applied in order), OUR hooks win — the cluster
-	// trackers are dropped. The cluster wait helpers read mgr.IsLeader() /
-	// CurrentAssignment() directly, not the trackers, so this is intentional.
-	recovered := make([]*atomic.Bool, np8NumWorkers)
-	postRecoveryRedegrade := make([]*atomic.Int64, np8NumWorkers)
-	badReason := make([]*atomic.Bool, np8NumWorkers) // any OnDegraded reason != "NATS connection down"
-	natsDownReasons := make([]*atomic.Int64, np8NumWorkers)
+	// Per-worker terminal-error capture. Each manager gets its own OnError hook so
+	// the bare ErrClaimLost that drives the self-stop is captured, not inferred
+	// (report §1: attribution must be captured). Because AddWorkerWithOptions
+	// injects the cluster tracker hooks FIRST and our WithHooks LAST, and WithHooks
+	// overwrites (options.go: o.hooks = hooks; applied in order), OUR hooks win —
+	// the cluster trackers are dropped. The cluster wait helpers read
+	// mgr.IsLeader() / CurrentAssignment() / mgr.State() directly, not the
+	// trackers, so this is intentional.
+	//
+	// We store the FIRST error whose text contains "claim" (the ErrClaimLost) so a
+	// later connectivity error in the reconnect window cannot clobber the
+	// attribution we want to prove. Each value is seeded with "" so the
+	// .Load().(string) in the terminal-state logf never panics on a worker that
+	// emitted no error.
+	terminalErr := make([]*atomic.Value, np8NumWorkers)
 
 	for i := range np8NumWorkers {
-		recovered[i] = &atomic.Bool{}
-		postRecoveryRedegrade[i] = &atomic.Int64{}
-		badReason[i] = &atomic.Bool{}
-		natsDownReasons[i] = &atomic.Int64{}
+		terminalErr[i] = &atomic.Value{}
+		terminalErr[i].Store("")
 
-		rec := recovered[i]
-		redeg := postRecoveryRedegrade[i]
-		bad := badReason[i]
-		downCount := natsDownReasons[i]
-
+		te := terminalErr[i]
 		hooks := &parti.Hooks{
-			OnStateChanged: func(_ context.Context, from, to types.State) error {
-				// Count Stable->Degraded transitions that happen AFTER the fleet
-				// has first recovered post-restart. A genuine post-recovery
-				// re-degrade (the heartbeat-MemoryStorage flap loop) increments
-				// this; the single intentional outage degrade does not, because
-				// it precedes the recovered flag being set.
-				if from == types.StateStable && to == types.StateDegraded && rec.Load() {
-					redeg.Add(1)
-				}
-
-				return nil
-			},
-			OnDegraded: func(_ context.Context, reason string) error {
-				if reason == "NATS connection down" {
-					downCount.Add(1)
-				} else {
-					bad.Store(true)
+			OnError: func(_ context.Context, err error) error {
+				if err != nil && strings.Contains(err.Error(), "claim") {
+					te.CompareAndSwap("", err.Error())
 				}
 
 				return nil
@@ -136,20 +114,9 @@ func TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet(t *testing.T) {
 
 	cluster.StartWorkers(ctx)
 
-	// --- Baseline: one leader, full 6-partition coverage, version snapshot. ---
-	leaderBefore := cluster.WaitForLeader(15 * time.Second).WorkerID()
+	// --- Baseline: one leader, full 6-partition coverage. ---
+	require.NotNil(t, cluster.WaitForLeader(15*time.Second), "baseline: one leader")
 	cluster.WaitForPartitionCoverage(6, 15*time.Second)
-
-	// Snapshot each active manager's pre-outage assignment version. The minimum
-	// across the fleet is the floor the post-recovery republish must not regress
-	// below (the assignment bucket is FileStorage and survives the restart).
-	var np8VersionFloor int64 = 1 << 62
-	for _, mgr := range cluster.GetActiveWorkers() {
-		if v := mgr.CurrentAssignment().Version; v < np8VersionFloor {
-			np8VersionFloor = v
-		}
-	}
-	t.Logf("pre-outage leader=%s version-floor=%d", leaderBefore, np8VersionFloor)
 
 	// Build the []ManagerWaiter once for the all-managers-state waits. We use
 	// GetActiveWorkers (mutex-guarded) rather than the raw Workers field.
@@ -183,92 +150,60 @@ func TestNP8FleetNATSOutage_LeaderContinuityRecoversFleet(t *testing.T) {
 	require.Eventually(t, func() bool { return nc.Status() == nats.CONNECTED },
 		5*time.Second, 50*time.Millisecond, "fleet did not reconnect after NATS restart")
 
-	// All 3 return Stable after the restart.
+	// --- POST-RESTART: the outage exceeded WorkerIDTTL, so every worker's lease
+	// aged out; on reconnect each hits a bare ErrClaimLost and self-stops. The
+	// documented contract is StateShutdown + orchestrator rotation, NOT in-process
+	// recovery to Stable. Assert the WAD self-stop so this proof guards the
+	// boundary rather than a behavior we do not provide. The pre-captured waiters
+	// hold the same manager refs (claimLostShutdown calls Stop, not RemoveWorker),
+	// so WaitState observes them reach Shutdown even though GetActiveWorkers would
+	// now filter them out.
 	require.NoError(t,
-		testutil.WaitAllManagersState(ctx, waiters, types.StateStable, 30*time.Second),
-		"all 3 managers must return Stable after the NATS restart")
+		testutil.WaitAllManagersState(ctx, waiters, types.StateShutdown, 30*time.Second),
+		"every worker must self-stop to StateShutdown when the outage exceeds WorkerIDTTL")
 
-	// Arm the post-recovery flap detector: from here on, any Stable->Degraded
-	// transition is a genuine re-degrade (the gap_flap symptom).
-	for _, r := range recovered {
-		r.Store(true)
+	// Terminal-reason instrumentation (report §1: attribution must be captured, not
+	// inferred): log each worker's final state and the terminal error captured via
+	// the OnError hook.
+	for i := range np8NumWorkers {
+		t.Logf("worker %d: final state=%s terminal-error=%q",
+			i, cluster.GetWorkers()[i].State(), terminalErr[i].Load())
 	}
 
-	// --- Exactly ONE leader after recovery (continuity OR clean re-election). ---
-	leaderAfter := cluster.WaitForLeader(20 * time.Second)
-	require.NotNil(t, leaderAfter, "exactly one leader must exist after recovery")
-	// DIAGNOSTIC ONLY: leadership is dropped during the outage by design, so
-	// continuity is not guaranteed and is NOT asserted.
-	t.Logf("post-recovery leader=%s continuity=%v",
-		leaderAfter.WorkerID(), leaderAfter.WorkerID() == leaderBefore)
-
-	// --- Assignments republished / observed fleet-wide. ---
-	cluster.WaitForPartitionCoverage(6, 20*time.Second)
-	// Assignment version must not regress below the pre-outage floor (FileStorage
-	// assignment bucket survives the restart; the leader republishes on recovery).
-	cluster.WaitForAssignmentVersion(np8VersionFloor, 20*time.Second)
-
-	// --- NO post-recovery flap. The catch for a fleet-wide heartbeat-MemoryStorage
-	// re-degrade loop. Two complementary checks: a sampled require.Never and the
-	// hook-driven re-degrade counters (catch transitions sampling would miss). ---
-	require.Never(t, func() bool {
-		for _, mgr := range cluster.GetActiveWorkers() {
-			if mgr.State() == parti.StateDegraded {
-				return true
+	// Attribution ASSERTED, not merely inferred (report §1): every worker's terminal
+	// error must be the bare ErrClaimLost ("worker ID claim lost"), proving the
+	// StateShutdown above is the claim-loss self-stop specifically — not some other
+	// shutdown path. claimLostShutdown drains the OnError hook via Stop before the
+	// worker reaches Shutdown, so terminalErr is populated by now; Eventually guards
+	// any residual async.
+	require.Eventually(t, func() bool {
+		for i := range np8NumWorkers {
+			s, _ := terminalErr[i].Load().(string)
+			if !strings.Contains(s, "claim") {
+				return false
 			}
 		}
 
-		return false
+		return true
 	}, 5*time.Second, 100*time.Millisecond,
-		"no manager may re-enter Degraded after the fleet recovers (heartbeat-flap loop)")
-
-	for i := range np8NumWorkers {
-		require.Zero(t, postRecoveryRedegrade[i].Load(),
-			"worker %d must not re-enter Degraded after recovery", i)
-	}
-
-	// --- Negative-space (DIAGNOSTIC ONLY): which OnDegraded reason each manager
-	// reported. The connection-status monitor fires enterDegraded("NATS connection
-	// down") for every manager once EnterThreshold of downtime elapses, but the
-	// generic KV-error circuit (recordKVError) ALSO admits connectivity errors and
-	// can reach its threshold (KVErrorThreshold=5 within KVErrorWindow=30s, ~2.5s
-	// at the 500ms heartbeat cadence) and degrade with "KV error threshold
-	// exceeded" / "kv-unavailable" — whichever trigger wins the CAS sets the
-	// reason. That race makes a per-worker "only NATS connection down" assertion a
-	// reason-string probe, not a recovery signal, so we LOG it rather than assert.
-	// The real auto-heal invariants (all-Stable, one-leader, coverage, no-flap)
-	// are asserted above and below.
-	var np8FleetDownReasons int64
-	for i := range np8NumWorkers {
-		np8FleetDownReasons += natsDownReasons[i].Load()
-		t.Logf("worker %d OnDegraded: nats-down-count=%d other-reason=%v",
-			i, natsDownReasons[i].Load(), badReason[i].Load())
-	}
-	require.Positive(t, np8FleetDownReasons,
-		"at least one manager must report \"NATS connection down\" — the outage must "+
-			"be classified as a connectivity loss somewhere in the fleet")
+		"each worker's terminal error must be the bare ErrClaimLost (worker ID claim lost)")
 }
 
 // TestNP8FleetNATSOutage_HeartbeatBucketLossFlap is the mechanism-(2) companion to
 // the self-stop proof above. It raises WorkerIDTTL ABOVE the outage so the stableID
 // claim SURVIVES (the claim-loss self-stop of mechanism 1 does NOT fire), isolating
-// the second non-auto-heal mechanism: the MemoryStorage heartbeat bucket is gone
-// after a single-node restart, so any worker that becomes leader fails
-// "list heartbeat keys: stream not found" in its calculator and the fleet oscillates
+// the second non-auto-heal mechanism: with MemoryStorage the heartbeat bucket was
+// lost after a single-node restart, so any worker that became leader failed
+// "list heartbeat keys: stream not found" in its calculator and the fleet oscillated
 // Degraded<->Stable without ever HOLDING Stable.
 //
-// KNOWN FAILING on current main (gated, opt-in). See
-// docs/plans/auto-healing-gap-closure/04-proof-findings.md finding NP-8 mechanism (2).
-// This is the worst case (full MemoryStorage loss on a single-node restart); a real
-// RF3 cluster whose replicated MemoryStorage survives a rolling restart may not hit
-// it. Gated so it does not break `make test`; remove the gate when the fix lands.
+// With FileStorage the heartbeat bucket now survives the single-node restart and the
+// fleet reaches AND holds all-Stable (the test asserts reach-all-Stable then
+// require.Never flap, which now holds). This test is the regression guard for
+// NP-8 mechanism 2. See docs/plans/auto-healing-gap-closure/04-proof-findings.md.
 func TestNP8FleetNATSOutage_HeartbeatBucketLossFlap(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration: skipping in short mode")
-	}
-	if os.Getenv("PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF") == "" {
-		t.Skip("opt-in KNOWN-FAILING proof (NP-8 mechanism 2: heartbeat-bucket-loss fleet flap); " +
-			"set PARTI_RUN_NP8_HEARTBEAT_FLAP_PROOF=1 to run")
 	}
 	t.Parallel()
 
@@ -308,8 +243,9 @@ func TestNP8FleetNATSOutage_HeartbeatBucketLossFlap(t *testing.T) {
 		return true
 	}
 
-	// Outage shorter than WorkerIDTTL (claim survives) but long enough that the
-	// single-node restart loses the MemoryStorage heartbeat bucket.
+	// Outage shorter than WorkerIDTTL (claim survives), long enough that a
+	// MemoryStorage heartbeat bucket would have been lost on the single-node
+	// restart — with the FileStorage default the stream now survives.
 	stopNATS(t)
 	require.Eventually(t, func() bool { return nc.Status() != nats.CONNECTED },
 		5*time.Second, 50*time.Millisecond, "fleet did not observe outage")
@@ -318,14 +254,15 @@ func TestNP8FleetNATSOutage_HeartbeatBucketLossFlap(t *testing.T) {
 	require.Eventually(t, func() bool { return nc.Status() == nats.CONNECTED },
 		5*time.Second, 50*time.Millisecond, "fleet did not reconnect")
 
-	// The fleet must reach all-Stable and HOLD it. On main it cannot: the leader's
-	// calculator fails "list heartbeat keys: stream not found" so the fleet
-	// oscillates Degraded<->Stable. Either the all-Stable wait times out, or it is
-	// reached transiently and the HOLD check below fails — both prove no clean heal.
+	// With the FileStorage heartbeat default the stream survives the restart, so
+	// the fleet must reach all-Stable and HOLD it. Before the fix (MemoryStorage)
+	// the stream was lost: the heartbeat publisher Put and the leader's "list
+	// heartbeat keys" failed, and the fleet oscillated Degraded<->Stable, never
+	// holding — either the all-Stable wait timed out or the HOLD check below tripped.
 	require.Eventually(t, np8bAllStable, 30*time.Second, 200*time.Millisecond,
 		"fleet must reach all-Stable after the restart")
 	require.Never(t, func() bool { return !np8bAllStable() }, 8*time.Second, 200*time.Millisecond,
-		"fleet must HOLD all-Stable; on main the missing MemoryStorage heartbeat bucket makes it flap")
+		"fleet must HOLD all-Stable; the FileStorage heartbeat stream survives the single-node restart")
 	require.True(t, nc.IsConnected(),
 		"the NATS connection must be CONNECTED throughout (mechanism 2 is not a connectivity loss)")
 }

--- a/test/integration/failure/np8_unmigrated_heartbeat_holds_degraded_test.go
+++ b/test/integration/failure/np8_unmigrated_heartbeat_holds_degraded_test.go
@@ -1,0 +1,126 @@
+package failure_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNP8FleetNATSOutage_UnmigratedHeartbeatHoldsDegraded proves the
+// un-migrated / existing-cluster path for NP-8 mechanism 2: when the
+// heartbeat bucket was pre-created as MemoryStorage (simulating an existing
+// cluster that has not yet migrated to FileStorage), a single-node NATS restart
+// loses the heartbeat stream.
+//
+// WITHOUT the heartbeat-bucket reachability guard, the worker degrades with the
+// whole-bucket-loss reason "KV error threshold exceeded" (not "kv-unavailable"),
+// so the reason-scoped Family B gate is silent, and the recreate-only Family A
+// epoch re-probe does not fire for a missing stream (not a recreate). The
+// recovery exit succeeds on the unaffected assignment read and the fleet flaps
+// Degraded<->Stable.
+//
+// WITH the reachability guard, the recovery exit refuses to proceed while the
+// heartbeat bucket's stream is missing/unreachable, holding the worker
+// terminally Degraded for rotation. On rotate the lost bucket no longer
+// exists, so the new pod re-creates it as FileStorage — completing the
+// migration automatically. This test asserts only the guard: terminal Degraded,
+// no flap.
+//
+// Verify-first order: on the conjunct-less parent the require.Never(anyStable)
+// assertion trips because the fleet flaps back to Stable after the restart.
+func TestNP8FleetNATSOutage_UnmigratedHeartbeatHoldsDegraded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	// Shared restartable connection (unlimited reconnect, stable port,
+	// FileStorage StoreDir) — same helpers as the sibling NP-8 tests.
+	nc, stopNATS, restartNATS := startEmbeddedNATSOutage(t, -1)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+	// Build the events stream on FileStorage so it survives the restart.
+	rfBuildStream(t, ctx, realJS)
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.DegradedBehavior.EnterThreshold = 500 * time.Millisecond
+	cfg.DegradedBehavior.ExitThreshold = 500 * time.Millisecond
+	// Raise WorkerIDTTL well above the outage window so the stableID claim
+	// survives (the claim-loss self-stop of mechanism 1 does NOT fire),
+	// isolating the heartbeat-bucket-loss path under test.
+	cfg.WorkerIDTTL = 30 * time.Second
+
+	// Pre-create the heartbeat bucket as MemoryStorage BEFORE starting
+	// workers, so parti's get-first EnsureKVBucketWithRetry honors the
+	// existing bucket (the "un-migrated existing cluster" path) even though
+	// the production default is now FileStorage.
+	_, err = realJS.CreateKeyValue(ctx, parti.BuildControlPlaneKVConfig(
+		cfg.KVBuckets.HeartbeatBucket, cfg.HeartbeatTTL, jetstream.MemoryStorage))
+	require.NoError(t, err, "pre-create heartbeat bucket as MemoryStorage")
+
+	src := source.NewStatic(testutil.CreateTestPartitions(6))
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	for range 3 {
+		cluster.AddWorkerWithOptions(ctx, parti.WithHooks(&parti.Hooks{}))
+	}
+	cluster.StartWorkers(ctx)
+
+	require.NotNil(t, cluster.WaitForLeader(15*time.Second), "baseline: one leader")
+	cluster.WaitForPartitionCoverage(6, 15*time.Second)
+
+	workers := cluster.GetActiveWorkers()
+	require.Len(t, workers, 3)
+
+	allDegraded := func() bool {
+		for _, m := range workers {
+			if m.State() != types.StateDegraded {
+				return false
+			}
+		}
+		return true
+	}
+	anyStable := func() bool {
+		for _, m := range workers {
+			if m.State() == types.StateStable {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Outage shorter than WorkerIDTTL (claim survives) but long enough to
+	// lose the MemoryStorage heartbeat stream on restart.
+	stopNATS(t)
+	require.Eventually(t, func() bool { return nc.Status() != nats.CONNECTED },
+		5*time.Second, 50*time.Millisecond, "fleet did not observe NATS outage")
+	time.Sleep(5 * time.Second)
+	restartNATS(t)
+	require.Eventually(t, func() bool { return nc.Status() == nats.CONNECTED },
+		5*time.Second, 50*time.Millisecond, "fleet did not reconnect after NATS restart")
+
+	// All workers must enter Degraded due to the lost MemoryStorage heartbeat
+	// bucket ("KV error threshold exceeded" whole-bucket-loss reason).
+	require.Eventually(t, allDegraded, 30*time.Second, 200*time.Millisecond,
+		"un-migrated MemoryStorage heartbeat loss must drive the whole fleet Degraded")
+
+	// The heartbeat-bucket reachability guard must HOLD terminal Degraded —
+	// no flap back to Stable. On the conjunct-less parent the recovery exit
+	// heals on the unaffected assignment read and this assertion trips.
+	require.Never(t, anyStable, 8*time.Second, 200*time.Millisecond,
+		"the reachability guard must HOLD terminal Degraded — no flap back to Stable")
+
+	require.True(t, nc.IsConnected(),
+		"the NATS connection must be CONNECTED throughout (this is a missing-bucket, not a connectivity, loss)")
+}

--- a/test/integration/manager/np1_live_recreate_returns_stable_test.go
+++ b/test/integration/manager/np1_live_recreate_returns_stable_test.go
@@ -3,7 +3,6 @@ package manager_test
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -130,10 +129,6 @@ func np1HasBucketRecreatedReason(p *np1Probe) bool {
 func TestNP1_LiveBucketRecreate_MustNotReturnToStable(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	if os.Getenv("PARTI_RUN_NP1_LIVE_RECREATE_PROOF") == "" {
-		t.Skip("opt-in KNOWN-FAILING proof (NP-1 live wipe+recreate fleet-wide flap, workers rest Stable on empty buckets); " +
-			"set PARTI_RUN_NP1_LIVE_RECREATE_PROOF=1 to run")
 	}
 
 	t.Parallel()

--- a/test/integration/manager/np3_kv_unavailable_recovery_test.go
+++ b/test/integration/manager/np3_kv_unavailable_recovery_test.go
@@ -2,7 +2,6 @@ package manager_test
 
 import (
 	"context"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -224,10 +223,6 @@ func TestNP3_KVUnavailable_HeldArmed_DoesNotFalselyExitToStable(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	if os.Getenv("PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF") == "" {
-		t.Skip("opt-in KNOWN-FAILING proof (NP-3 / deferred Finding A recover-on-wrong-signal flap); " +
-			"set PARTI_RUN_NP3_KVUNAVAIL_FLAP_PROOF=1 to run")
-	}
 
 	t.Parallel()
 
@@ -259,13 +254,16 @@ func TestNP3_KVUnavailable_HeldArmed_DoesNotFalselyExitToStable(t *testing.T) {
 	require.Greater(t, injectedEnd, injectedMid,
 		"faulting ops must keep being exercised in the second half of the window")
 
-	// CORROBORATION (assert, non-halting): a 2nd+ "kv-unavailable" OnDegraded
-	// REQUIRES a prior false exit-to-Stable, so on main this corroborates the
-	// flap. It is correlated with the hard gate (same flap), so it is an assert
-	// — on an unlucky-but-still-buggy run (one false exit, no re-entry yet
-	// within the window) the gate below still fails with a legible message.
-	assert.GreaterOrEqual(t, h.recorder.kvUnavailable(), 2,
-		"a re-entry into kv-unavailable Degraded proves a prior false exit (the flap)")
+	// REGRESSION INVARIANT (assert, non-halting): with the reason-scoped gate in
+	// place there is no false exit, hence no re-entry — so EXACTLY ONE
+	// "kv-unavailable" OnDegraded fires across the whole armed window (the single
+	// setup entry). A count of 2+ would mean the flap returned (a false
+	// exit-to-Stable then re-entry, the reopened gap). Complements the hard gate
+	// below (zero exits); both encode "no flap". (Pre-fix this asserted >=2 as the
+	// proof-of-bug; closing the gap flips it to exactly-one.)
+	assert.Equal(t, 1, h.recorder.kvUnavailable(),
+		"exactly one kv-unavailable Degraded entry: the reason-scoped gate prevents "+
+			"the false exit, so there is no re-entry/flap")
 
 	// HARD GATE (sole load-bearing assertion, LAST): while the fault is armed
 	// the manager must NOT exit Degraded -> Stable. On current main it does


### PR DESCRIPTION
## Summary

- Closes three degraded→Stable recovery-exit gaps where a worker healed on a healthy *assignment* read while a *different* fault still persisted. Each fix is an **additive** guard ANDed onto the existing `currentAssignmentApplied` commitment guard (none replaces it):
  - **Bucket wipe-and-recreate** → refuse the exit while a Parti-owned control-plane bucket's stream `Created` differs from the value captured at `Start` (live per-tick re-probe); the worker stays terminally Degraded for restart/rotation.
  - **Connected-but-KV-unavailable stall** → require a heartbeat `Put` success stamped *after* the degrade before leaving a `kv-unavailable` degrade (reason-scoped, so a `startup-timeout` degrade still recovers on the commitment guard alone).
  - **Missing/unreachable heartbeat bucket** → refuse the exit while the heartbeat stream is gone, holding an un-migrated `MemoryStorage` cluster terminally Degraded instead of flapping.
- **Heartbeat KV bucket now defaults to `FileStorage`** so new clusters survive a single-node NATS restart. Existing `MemoryStorage` buckets are migrated manually (`EnsureKVBucketWithRetry` is get-first) — runbook in `docs/OPERATIONS.md`; the reachability guard above keeps the un-migrated interim safe (loud, rotatable) and a rotation re-creates the bucket as `FileStorage`.
- Documents the `WorkerIDTTL` claim-loss self-stop boundary. A separate leader-enumeration-stall scenario (NP-10) is investigated and planned but **intentionally deferred** (recovery-precondition pre-verified; one design addition recorded).

## Test plan

- [x] `make pre-pr` green: lint (0 issues) + unit `-race` (all packages) + integration `-race` (all suites)
- [x] Verify-first: each gap's reproducer fails on the parent and passes with the fix (live-recreate, epoch fence, kv-unavailable hold, un-migrated heartbeat hold)
- [x] codex post-implementation review on both phases: **Merge** (0 P0/P1)
- [ ] Reviewer: confirm the additive guards never replace the commitment guard, and that the non-reason-scoped reachability guard holds for any degrade reason