### PR TITLE
fix(degraded): degrade a leader stalled on worker enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ switch** so a single-node NATS restart no longer flaps the fleet. No API breaks.
   degraded, no flap) — and claim-loss self-stop is now documented.
 - **Degrade on connected-but-KV-unavailable timeouts** — a heartbeat / election /
   stableID stall now escalates (reason `kv-unavailable`) instead of being swallowed.
+- **A leader stalled on worker enumeration now degrades instead of silently
+  freezing** — a heartbeat-`Keys` scan that sustains a non-connectivity deadline
+  (while single-key heartbeat `Put` and election renewal keep succeeding) is
+  classified as neither connectivity nor degrading, so it used to be swallowed and
+  the leader froze its assignment, never reassigning a departed worker's
+  partitions. It now degrades (reason `heartbeat-enumeration-stall`) once sustained
+  and exits only after enumeration recovers; losing leadership while in this state
+  is not a trap.
 - **Self-heal a stuck version-advance** — a leader that bumped the commit version
   but failed to persist every claim no longer reports `Stable` with uncommitted
   claims; per-version commitment drives recovery.

--- a/internal/assignment/calculator.go
+++ b/internal/assignment/calculator.go
@@ -159,6 +159,13 @@ type Calculator struct {
 	// widening either of the path-specific locks.
 	lastKnownWorkerCount     int
 	workerShrunkObservations int
+
+	// enumFailures is the running count of consecutive non-connectivity
+	// enumeration (heartbeat Keys scan) failures. Crossed against
+	// EnumerationFailureThreshold to fire OnEnumerationError; reset to zero on any
+	// successful enumeration (nil-error GetActiveWorkers, before F10-A handling).
+	// Guarded by c.mu (same as workerShrunkObservations).
+	enumFailures int
 }
 
 // cachedWorkerList bundles worker data with its timestamp for atomic operations.
@@ -1210,8 +1217,20 @@ func (c *Calculator) getActiveWorkers(ctx context.Context) ([]string, bool, erro
 			return nil, false, fmt.Errorf("%w: no cached workers available: %w", types.ErrDegraded, err)
 		}
 
+		// Sustained non-connectivity enumeration failure (NP-10): the poll loop
+		// only logs this and no caller routes it to the degraded circuit. Threshold
+		// locally and, once sustained, surface it via OnEnumerationError so the
+		// manager can degrade directly (the transient KV-error window would be
+		// cleared by the still-succeeding heartbeat Put — the F-D1 constraint).
+		c.recordEnumerationFailure(err)
+
 		return nil, false, err
 	}
+
+	// Enumeration succeeded: the Keys-scan stall (if any) has recovered. Reset the
+	// NP-10 counter and signal recovery HERE — before the F10-A suspicious-shrink
+	// handling below — so a recovered-but-suspicious scan still clears the stall.
+	c.resetEnumerationFailures()
 
 	// F10-A defense: a sharply-shrunk fresh observation is treated as
 	// suspicious until the confirmation window is satisfied. The first
@@ -1252,6 +1271,38 @@ func (c *Calculator) getActiveWorkers(ctx context.Context) ([]string, bool, erro
 	}
 
 	return workers, true, nil
+}
+
+// recordEnumerationFailure increments the consecutive enumeration-failure counter
+// and invokes OnEnumerationError once the threshold is reached/exceeded. Firing
+// while already over the threshold is intentional and harmless: the manager's
+// enterDegraded is idempotent (CAS short-circuits while degraded). Only the
+// swallowed non-connectivity branch of getActiveWorkers calls this; connectivity
+// errors stay owned by the existing circuit (heartbeat Put SetOnError).
+func (c *Calculator) recordEnumerationFailure(err error) {
+	if c.OnEnumerationError == nil {
+		return
+	}
+	c.mu.Lock()
+	c.enumFailures++
+	fire := c.enumFailures >= c.EnumerationFailureThreshold
+	c.mu.Unlock()
+	if fire {
+		c.OnEnumerationError(err)
+	}
+}
+
+// resetEnumerationFailures clears the consecutive-failure counter and signals
+// enumeration recovery. Called on every SUCCESSFUL enumeration — right after a
+// nil-error GetActiveWorkers, before F10-A suspicious-shrink handling — NOT only
+// on the fresh==true path (a recovered-but-suspicious scan must still clear).
+func (c *Calculator) resetEnumerationFailures() {
+	c.mu.Lock()
+	c.enumFailures = 0
+	c.mu.Unlock()
+	if c.OnEnumerationSuccess != nil {
+		c.OnEnumerationSuccess()
+	}
 }
 
 // recordWorkerObservation runs the F10-A counter under c.mu. It

--- a/internal/assignment/calculator_enumeration_stall_test.go
+++ b/internal/assignment/calculator_enumeration_stall_test.go
@@ -1,0 +1,132 @@
+package assignment
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// keysTimeoutKV wraps a real jetstream.KeyValue and, when armed, makes Keys()
+// return context.DeadlineExceeded while every other operation — notably the
+// single-key Put/Get a worker uses for its own heartbeat — passes through to
+// the real bucket unchanged. This is NP-10's defining asymmetry: the
+// stream-wide heartbeat-enumeration scan times out, single-key ops do not.
+//
+// The wrapper returns the deadline directly rather than blocking on ctx so the
+// calculator-level proof is deterministic and timing-free; the resulting error
+// value is identical to what a real Keys scan returns when WorkerMonitor's
+// bounded op-context (hbTTL/2) expires mid-scan.
+type keysTimeoutKV struct {
+	jetstream.KeyValue
+	armed atomic.Bool
+}
+
+func (k *keysTimeoutKV) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	if k.armed.Load() {
+		return nil, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Keys(ctx, opts...)
+}
+
+// TestNP10_EnumerationDeadline_EvadesClassifiers is the empirical linchpin of
+// NP-10. It confirms — by running the real classifiers, not by reading them —
+// that a heartbeat Keys-scan context.DeadlineExceeded is classified as NEITHER
+// a connectivity error NOR a degrading-JetStream error, both bare AND wrapped
+// (worker_monitor wraps it as "failed to list heartbeat keys: %w"). That dual
+// miss is precisely why getActiveWorkers returns the deadline raw and no caller
+// routes it to the manager's degraded circuit.
+//
+// PASSES on the parent: it characterizes the current classification gap.
+func TestNP10_EnumerationDeadline_EvadesClassifiers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"bare", context.DeadlineExceeded},
+		{"wrapped", fmt.Errorf("failed to list heartbeat keys: %w", context.DeadlineExceeded)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.False(t, natsutil.IsConnectivityError(tc.err),
+				"%s context.DeadlineExceeded must NOT be a connectivity error; if it were, getActiveWorkers would take the cache-fallback/ErrDegraded branch and NP-10 would not exist", tc.name)
+			require.False(t, natsutil.IsDegradingJetStreamError(tc.err),
+				"%s context.DeadlineExceeded must NOT be a degrading-JetStream error", tc.name)
+		})
+	}
+
+	// The fix will need to classify the WRAPPED deadline, so confirm the
+	// errors.Is chain that a fix would key on is intact today.
+	require.ErrorIs(t, cases[1].err, context.DeadlineExceeded)
+}
+
+// TestNP10_GetActiveWorkers_EnumerationDeadline_IsSwallowed proves the NP-10
+// gap at the calculator level: a sustained heartbeat Keys-scan deadline is
+// surfaced RAW by getActiveWorkers — it does NOT take the connectivity
+// cache-fallback branch and is NOT wrapped in types.ErrDegraded, so nothing in
+// the assignment layer routes it to a degrade signal. The worker's own
+// single-key heartbeat Put is untouched (the wrapper faults Keys only), modeling
+// "own heartbeat healthy, enumeration blind".
+//
+// PASSES on the parent: it characterizes the swallow. It does NOT — and cannot —
+// assert the manager stays falsely StateStable; that is a different state
+// machine and is proven end-to-end in the integration proof
+// (test/integration/failure/np10_enumeration_stall_test.go).
+func TestNP10_GetActiveWorkers_EnumerationDeadline_IsSwallowed(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	assignmentKV := partitest.CreateJetStreamKV(t, nc, "np10-calc-assign")
+	heartbeatKV := partitest.CreateJetStreamKV(t, nc, "np10-calc-hb")
+
+	// Seed a live worker heartbeat so a non-faulted scan succeeds and sees it.
+	_, err := heartbeatKV.Put(ctx, "worker-hb.worker-1", []byte(time.Now().Format(time.RFC3339Nano)))
+	require.NoError(t, err)
+
+	fault := &keysTimeoutKV{KeyValue: heartbeatKV}
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:     assignmentKV,
+		HeartbeatKV:      fault,
+		AssignmentPrefix: "assignment",
+		Source:           &mockSource{partitions: []types.Partition{{Keys: []string{"p1"}}}},
+		Strategy:         &mockStrategy{},
+		HeartbeatPrefix:  "worker-hb",
+		HeartbeatTTL:     6 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Baseline (fault disarmed): enumeration succeeds and observes the worker.
+	workers, fresh, err := calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.True(t, fresh)
+	require.Contains(t, workers, "worker-1")
+
+	// Arm the Keys-only stall. The scan now times out; single-key Puts (the
+	// worker's own heartbeat) would still succeed against the real bucket.
+	fault.armed.Store(true)
+
+	workers, fresh, err = calc.getActiveWorkers(ctx)
+
+	// THE GAP: the deadline surfaces raw. Not a connectivity error (so no cache
+	// fallback and no types.ErrDegraded wrap), not classified as degrading —
+	// nothing routes it to the degraded circuit.
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, types.ErrDegraded,
+		"parent gap: a sustained enumeration deadline is swallowed (returned raw), NOT surfaced as ErrDegraded")
+	require.False(t, fresh)
+	require.Nil(t, workers)
+}

--- a/internal/assignment/calculator_enumeration_stall_test.go
+++ b/internal/assignment/calculator_enumeration_stall_test.go
@@ -130,3 +130,57 @@ func TestNP10_GetActiveWorkers_EnumerationDeadline_IsSwallowed(t *testing.T) {
 	require.False(t, fresh)
 	require.Nil(t, workers)
 }
+
+// TestNP10_GetActiveWorkers_SustainedEnumerationDeadline_FiresCallback drives the
+// fix: a SINGLE enumeration deadline must NOT fire OnEnumerationError (debounce —
+// a transient blip is not a sustained stall), EnumerationFailureThreshold
+// consecutive deadlines MUST fire it, and a subsequent healthy scan must fire
+// OnEnumerationSuccess and reset the counter.
+func TestNP10_GetActiveWorkers_SustainedEnumerationDeadline_FiresCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	assignmentKV := partitest.CreateJetStreamKV(t, nc, "np10-fire-assign")
+	heartbeatKV := partitest.CreateJetStreamKV(t, nc, "np10-fire-hb")
+
+	_, err := heartbeatKV.Put(ctx, "worker-hb.worker-1", []byte(time.Now().Format(time.RFC3339Nano)))
+	require.NoError(t, err)
+
+	fault := &keysTimeoutKV{KeyValue: heartbeatKV}
+	var enumErr, enumOK atomic.Int64
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:                assignmentKV,
+		HeartbeatKV:                 fault,
+		AssignmentPrefix:            "assignment",
+		Source:                      &mockSource{partitions: []types.Partition{{Keys: []string{"p1"}}}},
+		Strategy:                    &mockStrategy{},
+		HeartbeatPrefix:             "worker-hb",
+		HeartbeatTTL:                6 * time.Second,
+		EnumerationFailureThreshold: 3,
+		OnEnumerationError:          func(error) { enumErr.Add(1) },
+		OnEnumerationSuccess:        func() { enumOK.Add(1) },
+	})
+	require.NoError(t, err)
+
+	// NEGATIVE SPACE: a single failure must NOT fire (below the threshold). This
+	// distinguishes a correct consecutive-counter from a broken one that fires on
+	// the first failure.
+	fault.armed.Store(true)
+	_, _, err = calc.getActiveWorkers(ctx)
+	require.Error(t, err)
+	require.Zero(t, enumErr.Load(), "one enumeration failure must not fire OnEnumerationError (below threshold)")
+
+	// Sustained: two more consecutive failures cross the threshold of 3.
+	for range 2 {
+		_, _, _ = calc.getActiveWorkers(ctx)
+	}
+	require.GreaterOrEqual(t, enumErr.Load(), int64(1),
+		"a sustained enumeration deadline must fire OnEnumerationError once the threshold is crossed")
+
+	// Recovery: a healthy scan resets the counter and signals success.
+	fault.armed.Store(false)
+	_, _, err = calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.Positive(t, enumOK.Load(), "a healthy enumeration must signal recovery via OnEnumerationSuccess")
+}

--- a/internal/assignment/config.go
+++ b/internal/assignment/config.go
@@ -150,6 +150,30 @@ type Config struct {
 	// method so a former leader cannot pass the fence after another worker has
 	// taken over.
 	LeaderCheck func(ctx context.Context, claimed uint64) error
+
+	// OnEnumerationError, if set, is invoked when worker enumeration (the
+	// heartbeat Keys scan in WorkerMonitor.GetActiveWorkers) has failed
+	// EnumerationFailureThreshold times in a row with a non-connectivity error —
+	// notably a context.DeadlineExceeded on the stream-wide scan while single-key
+	// heartbeat Puts still succeed (NP-10). The manager wires this to a DIRECT
+	// degrade (NOT the transient KV-error window, which a succeeding heartbeat Put
+	// would clear). When nil, sustained enumeration failure remains logged-only
+	// (back-compat / test default). Must be safe for concurrent use.
+	OnEnumerationError func(err error)
+
+	// OnEnumerationSuccess, if set, is invoked on every SUCCESSFUL worker
+	// enumeration — i.e. whenever the heartbeat Keys scan (GetActiveWorkers)
+	// returns a nil error — REGARDLESS of the F10-A worker-credibility decision
+	// (it fires even when a sharply-shrunk result is treated as suspicious). The
+	// manager stamps it as the "enumeration recovered" signal its recovery exit
+	// gate keys on. Must be safe for concurrent use.
+	OnEnumerationSuccess func()
+
+	// EnumerationFailureThreshold is the number of consecutive non-connectivity
+	// enumeration failures before OnEnumerationError fires. Default: 3 (also
+	// applied to any value < 1, so a zero/negative config cannot fire on the
+	// first failure). Set explicitly to 1 to fire on the first failure.
+	EnumerationFailureThreshold int
 }
 
 // Validate checks configuration validity.
@@ -233,5 +257,8 @@ func (c *Config) SetDefaults() {
 	}
 	if c.WorkerShrinkConfirmationThresholdPct == 0 {
 		c.WorkerShrinkConfirmationThresholdPct = 50
+	}
+	if c.EnumerationFailureThreshold < 1 {
+		c.EnumerationFailureThreshold = 3
 	}
 }

--- a/manager.go
+++ b/manager.go
@@ -219,6 +219,11 @@ type Manager struct {
 	// degraded). The reason-scoped gate uses it to confirm the failing
 	// connected-but-KV-unavailable op recovered AFTER we degraded. 0 = never.
 	lastHeartbeatSuccessAt atomic.Int64
+	// lastEnumerationSuccessAt is the UnixNano of the most recent healthy worker
+	// enumeration (stamped via the calculator's OnEnumerationSuccess). The
+	// reason-scoped recovery gate keys on it to confirm a heartbeat-enumeration
+	// stall (NP-10) recovered before exiting Degraded. 0 = never.
+	lastEnumerationSuccessAt atomic.Int64
 
 	// Lifecycle management
 	ctx    context.Context

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -148,6 +148,8 @@ func (m *Manager) startCalculator(assignmentKV, heartbeatKV jetstream.KeyValue) 
 		StateProvider:         m, // Pass manager as state provider for degraded mode checks
 		LeaderRevision:        m.electionRevision,
 		LeaderCheck:           m.checkElectionLeadership,
+		OnEnumerationError:    m.onEnumerationStall,
+		OnEnumerationSuccess:  m.recordEnumerationSuccess,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create calculator: %w", err)

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -20,6 +20,13 @@ import (
 // reason is preserved.
 const degradedReasonKVUnavailable = "kv-unavailable"
 
+// degradedReasonEnumerationStall is the distinct enterDegraded reason for a
+// sustained leader-side worker-enumeration (heartbeat Keys scan) stall that the
+// connectivity / degrading classifiers miss (NP-10). Kept separate so the
+// recovery exit can require an enumeration success before exiting, and so the
+// operator surface distinguishes it from a kv-unavailable op stall.
+const degradedReasonEnumerationStall = "heartbeat-enumeration-stall"
+
 // kvErrorEvent is one entry in the degraded-circuit error window.
 //
 // transient marks an F-D1 connected-but-KV-unavailable timeout (an
@@ -392,6 +399,25 @@ func (m *Manager) exitDegraded() {
 	}
 }
 
+// onEnumerationStall is wired to the calculator's OnEnumerationError. The
+// calculator fires it only after EnumerationFailureThreshold consecutive
+// non-connectivity enumeration failures, so the stall is already sustained:
+// degrade directly, bypassing the transient kvErrorWindow (a still-succeeding
+// heartbeat Put would clear a transient entry before it accumulated — the F-D1
+// constraint). enterDegraded is idempotent (CAS), so repeated calls while
+// degraded are no-ops.
+func (m *Manager) onEnumerationStall(err error) {
+	m.logger.Warn("sustained heartbeat-enumeration stall; entering degraded", "error", err)
+	m.enterDegraded(degradedReasonEnumerationStall)
+}
+
+// recordEnumerationSuccess is wired to the calculator's OnEnumerationSuccess. It
+// stamps the recovery signal the reason-scoped exit gate keys on. Stamped on
+// every successful enumeration (even while degraded), mirroring recordKVHealthyOp.
+func (m *Manager) recordEnumerationSuccess() {
+	m.lastEnumerationSuccessAt.Store(time.Now().UnixNano())
+}
+
 // attemptRecoveryFromDegraded checks if recovery conditions are met and exits degraded mode.
 func (m *Manager) attemptRecoveryFromDegraded() {
 	// Check if in degraded mode
@@ -477,6 +503,25 @@ func (m *Manager) attemptRecoveryFromDegraded() {
 	if m.heartbeatBucketUnavailable(m.ctx) {
 		m.logger.Warn("recovery: heartbeat bucket unavailable; staying Degraded for restart/rotation")
 		return
+	}
+
+	// NP-10 — reason-scoped enumeration-recovery gate. A heartbeat-enumeration
+	// stall degrade must not exit on the (unaffected) assignment read while the
+	// Keys scan is still timing out — the leader would resume serving stale
+	// membership. Require an enumeration success stamped AFTER we degraded.
+	// Leadership-loss escape: enumeration is leader-only (startCalculator), so a
+	// non-leader can never stamp a success — treat "not currently leader" as
+	// enumeration-N/A and do NOT block, else a leader that lost leadership while in
+	// this degrade would be stuck forever (a gate on a capability that cannot
+	// fire). Reason-scoped, so other degrade reasons are unaffected.
+	if reason == degradedReasonEnumerationStall && m.isLeader.Load() {
+		ensAt := m.lastEnumerationSuccessAt.Load()
+		since := m.degradedSince.Load()
+		if ensAt == 0 || ensAt <= since {
+			m.logger.Debug("recovery: worker enumeration not recovered since stall degrade; staying Degraded",
+				"last_enumeration_success_unixnano", ensAt, "degraded_since_unixnano", since)
+			return
+		}
 	}
 
 	// Success - exit degraded mode

--- a/manager_enumeration_stall_recovery_test.go
+++ b/manager_enumeration_stall_recovery_test.go
@@ -1,0 +1,69 @@
+package parti
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttemptRecovery_EnumerationStall_LeaderStaysUntilEnumerationRecovers proves
+// the NP-10 reason-scoped exit gate: a leader degraded with
+// degradedReasonEnumerationStall must NOT exit on the (unaffected) assignment
+// commitment read while its Keys scan is still timing out — it would resume
+// serving stale membership while blind. It exits only once an enumeration success
+// is stamped AFTER the degrade.
+func TestAttemptRecovery_EnumerationStall_LeaderStaysUntilEnumerationRecovers(t *testing.T) {
+	t.Parallel()
+
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	committed := snap
+	m, _ := armDegraded(t, &committed, snap) // current assignment applied+acked
+	plantAssignment(t, m, snap)
+	m.isLeader.Store(true)
+	m.lastDegradedReason.Store(degradedReasonEnumerationStall)
+
+	// No enumeration success since the degrade: the commitment guard is satisfied,
+	// but the leader must STAY Degraded — exiting would resume serving stale
+	// membership while the enumeration scan is still stalling.
+	m.attemptRecoveryFromDegraded()
+	require.NotZero(t, m.degradedSince.Load(),
+		"a leader whose worker enumeration has not recovered must stay Degraded")
+	require.Equal(t, StateDegraded, m.State())
+
+	// Stamp an enumeration success AFTER degradedSince: the gate opens and the
+	// applied leader exits. (Assert synchronously; exitDegraded transitions before
+	// the recovery-grace goroutine it spawns matters.)
+	m.lastEnumerationSuccessAt.Store(m.degradedSince.Load() + 1)
+	m.attemptRecoveryFromDegraded()
+	require.Zero(t, m.degradedSince.Load(),
+		"a stamped enumeration success must let the leader exit Degraded")
+	require.Equal(t, StateStable, m.State())
+}
+
+// TestAttemptRecovery_EnumerationStall_NonLeaderEscapesStuckDegrade is the
+// load-bearing leadership-loss-escape test. A leader that degraded with
+// degradedReasonEnumerationStall and then LOST leadership runs no enumeration
+// (startCalculator is leader-only via stopCalculator), so it can never stamp an
+// enumeration success. Without the "&& m.isLeader.Load()" escape in the exit
+// conjunct, such a worker would be trapped in Degraded forever — a gate on a
+// capability that can no longer fire. With the escape, the gate is N/A for a
+// non-leader and the worker exits normally.
+func TestAttemptRecovery_EnumerationStall_NonLeaderEscapesStuckDegrade(t *testing.T) {
+	t.Parallel()
+
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	committed := snap
+	m, _ := armDegraded(t, &committed, snap)
+	plantAssignment(t, m, snap)
+	m.isLeader.Store(false) // lost leadership while enumeration-stall-degraded
+	m.lastDegradedReason.Store(degradedReasonEnumerationStall)
+	// lastEnumerationSuccessAt stays 0 — a non-leader runs no enumeration and can
+	// never stamp a success. The escape must let it exit anyway.
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait() // safe: a non-leader exit skips the recovery-grace goroutine
+
+	require.Zero(t, m.degradedSince.Load(),
+		"a non-leader must not be trapped in an enumeration-stall degrade it can never clear")
+	require.Equal(t, StateStable, m.State())
+}

--- a/test/integration/failure/np10_enumeration_stall_test.go
+++ b/test/integration/failure/np10_enumeration_stall_test.go
@@ -2,7 +2,6 @@ package failure_test
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -111,34 +110,28 @@ func (k *np10FaultKeyValue) Keys(ctx context.Context, opts ...jetstream.WatchOpt
 	return k.KeyValue.Keys(ctx, opts...)
 }
 
-// TestNP10_LeaderEnumerationStall_FrozenMembership is the end-to-end NP-10 proof
-// (the verify-first load-bearing gate). It stands up a leader + 2 followers with
-// full partition coverage, arms a Keys-only stall on the heartbeat bucket (the
-// connection stays UP and every single-key op keeps succeeding), removes a
-// follower, and observes whether the leader reacts.
+// TestNP10_LeaderEnumerationStall_FrozenMembership is the end-to-end NP-10
+// regression guard. It stands up a leader + 2 followers with full partition
+// coverage, arms a Keys-only stall on the heartbeat bucket (the connection stays
+// UP and every single-key op keeps succeeding), removes a follower, and asserts
+// the leader surfaces the stall instead of silently freezing.
 //
-// Oracle (verify-first against the parent — 06 landed, 07 absent):
-//   - GAP (this assertion FAILS on the parent): while the leader's enumeration
-//     scan stalls, the removed follower's partitions stay orphaned and the leader
-//     sits silently in StateStable with no degrade. A correct leader must surface
-//     the stall (enter Degraded) or re-cover.
-//   - CONTROL (PASSES on the parent, no fix): disarming the stall lets the leader
-//     re-enumerate, see the departed follower, and re-cover — proving the freeze
-//     is specifically the enumeration blind spot, not a broken leader.
+// This is a verify-first test: it FAILED on the parent (the leader sat in
+// StateStable with the removed follower's partitions orphaned and 0 degrades) and
+// PASSES with the fix (the leader degrades with reason "heartbeat-enumeration-
+// stall", then recovers on disarm). The three checks:
+//   - GAP (the gate): within the armed window the leader must surface the stall —
+//     degrade with the enumeration-stall reason, or re-cover. Pre-fix it did
+//     neither; the fix degrades it.
+//   - CONTROL: disarming the stall lets the leader re-enumerate, see the departed
+//     follower, and re-cover — this held even on the parent with no fix, proving
+//     the freeze is specifically the enumeration blind spot, not a broken leader.
 //   - NON-VACUITY (guards both directions): the Keys fault actually fired
-//     (injected > 0) and the connection stayed CONNECTED throughout.
-//
-// If on the parent the leader reacts on its own WHILE injected > 0 and the
-// connection held, NP-10 is NOT real — STOP, do not implement the fix.
+//     (injected > 0), the removal orphaned a partition, and the connection stayed
+//     CONNECTED throughout.
 func TestNP10_LeaderEnumerationStall_FrozenMembership(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-	}
-	// Env-gated: this is a verify-first reproducer that FAILS on the parent until
-	// the NP-10 fix lands, so it stays out of the default `make test`/`make pre-pr`
-	// baseline. Remove this gate when the fix flips it green.
-	if os.Getenv("PARTI_RUN_NP10_ENUM_STALL_PROOF") == "" {
-		t.Skip("set PARTI_RUN_NP10_ENUM_STALL_PROOF=1 to run the NP-10 verify-first proof")
 	}
 
 	t.Parallel()
@@ -146,7 +139,7 @@ func TestNP10_LeaderEnumerationStall_FrozenMembership(t *testing.T) {
 	const (
 		numPartitions    = 6
 		numWorkers       = 3
-		armedObservation = 12 * time.Second
+		armedObservation = 15 * time.Second
 	)
 
 	nc, cleanup := testutil.StartEmbeddedNATS(t)
@@ -180,14 +173,16 @@ func TestNP10_LeaderEnumerationStall_FrozenMembership(t *testing.T) {
 
 	// Per-worker observers. WithHooks here replaces the cluster's tracker hooks,
 	// which is fine: every wait/coverage helper reads live manager state, not the
-	// trackers. Shared, thread-safe sinks captured by all workers.
-	degradedReasons := make(chan string, 16)
+	// trackers. Shared, thread-safe sinks captured by all workers. The gate keys on
+	// the SPECIFIC enumeration-stall reason (not "any degrade") so a wrong-reason
+	// degrade — e.g. from the leadership path — cannot pass the proof spuriously.
+	const enumStallReason = "heartbeat-enumeration-stall"
+	var sawEnumStallDegrade atomic.Bool
 	var degradedEntries atomic.Int64
 	observerHooks := &parti.Hooks{
 		OnDegraded: func(_ context.Context, reason string) error {
-			select {
-			case degradedReasons <- reason:
-			default:
+			if reason == enumStallReason {
+				sawEnumStallDegrade.Store(true)
 			}
 
 			return nil
@@ -266,7 +261,7 @@ func TestNP10_LeaderEnumerationStall_FrozenMembership(t *testing.T) {
 	reactedWhileArmed := false
 	deadline := time.Now().Add(armedObservation)
 	for time.Now().Before(deadline) {
-		if liveCoverage() == numPartitions || leader.State() == parti.StateDegraded {
+		if liveCoverage() == numPartitions || sawEnumStallDegrade.Load() {
 			reactedWhileArmed = true
 			break
 		}
@@ -288,12 +283,14 @@ func TestNP10_LeaderEnumerationStall_FrozenMembership(t *testing.T) {
 	require.True(t, nc.IsConnected(),
 		"the NATS connection stayed CONNECTED throughout — this is an enumeration stall, not a disconnect")
 
-	// THE GAP — post-fix invariant. FAILS on the parent, proving NP-10 is real.
+	// THE GAP — post-fix invariant. FAILS on the parent, proving NP-10 is real;
+	// flips green once the fix degrades the leader with the enumeration-stall reason.
 	require.True(t, reactedWhileArmed,
 		"NP-10 silent false-healthy leader: with the heartbeat Keys scan stalling, the removed follower's "+
-			"partitions stayed orphaned (live coverage %d/%d) and the leader sat in %s without degrading "+
-			"(cluster degraded-entries=%d) for %s while the connection stayed up and the fault fired %d times. "+
-			"A correct leader must surface the stall (enter Degraded) or re-cover. This assertion FAILS on the "+
-			"parent commit, proving the gap is real.",
-		observedCoverage, numPartitions, observedLeaderState, degradedEntries.Load(), armedObservation, fc.injected.Load())
+			"partitions stayed orphaned (live coverage %d/%d) and the leader sat in %s without surfacing a %q "+
+			"degrade (cluster degraded-entries=%d) for %s while the connection stayed up and the fault fired %d "+
+			"times. A correct leader must surface the stall (Degraded reason %q) or re-cover. This assertion "+
+			"FAILS on the parent commit, proving the gap is real.",
+		observedCoverage, numPartitions, observedLeaderState, enumStallReason, degradedEntries.Load(),
+		armedObservation, fc.injected.Load(), enumStallReason)
 }

--- a/test/integration/failure/np10_enumeration_stall_test.go
+++ b/test/integration/failure/np10_enumeration_stall_test.go
@@ -1,0 +1,299 @@
+package failure_test
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// --- NP-10 leader enumeration-stall fault seam -------------------------------
+//
+// NP-10 reproduces a SILENT FALSE-HEALTHY LEADER: the leader's worker
+// enumeration (the heartbeat-bucket Keys scan in WorkerMonitor.GetActiveWorkers,
+// which runs leader-only) sustains a context.DeadlineExceeded, while every
+// single-key op stays healthy — each worker's own heartbeat Put on the SAME
+// bucket, and the leader's election renewal on a SEPARATE bucket. A
+// Keys()-scan DeadlineExceeded is classified as neither a connectivity error nor
+// a degrading-JetStream error (see calculator_enumeration_stall_test.go), so
+// getActiveWorkers returns it raw, the poll loop only logs it, and nothing routes
+// it to the manager's degraded circuit. The leader therefore stays StateStable,
+// FREEZES its last-computed assignment, and stops reacting to real membership
+// changes — a departed worker's partitions are never reassigned, with no
+// degraded signal.
+//
+// The seam is modeled on NP-9's np9Fault* seam but INVERTED: NP-9 faults
+// Put/Update/Create/Get/Watch and lets Keys pass through; NP-10 faults ONLY
+// Keys() (the enumeration scan) and lets every other op pass through, scoped to
+// the heartbeat bucket. That isolation is essential — faulting the whole bucket
+// would fail the heartbeat Put and degrade the leader via the kv-unavailable
+// circuit (the WRONG reason), masking NP-10.
+
+type np10FaultController struct {
+	armed    atomic.Bool
+	injected atomic.Int64
+}
+
+func (fc *np10FaultController) arm()    { fc.injected.Store(0); fc.armed.Store(true) }
+func (fc *np10FaultController) disarm() { fc.armed.Store(false) }
+func (fc *np10FaultController) fault() bool {
+	if !fc.armed.Load() {
+		return false
+	}
+	fc.injected.Add(1)
+
+	return true
+}
+
+type np10FaultJetStream struct {
+	jetstream.JetStream
+	buckets map[string]struct{}
+	fc      *np10FaultController
+}
+
+func (f *np10FaultJetStream) wrap(kv jetstream.KeyValue, bucket string) jetstream.KeyValue {
+	if _, ok := f.buckets[bucket]; ok {
+		return &np10FaultKeyValue{KeyValue: kv, fc: f.fc}
+	}
+
+	return kv
+}
+
+func (f *np10FaultJetStream) KeyValue(ctx context.Context, bucket string) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.KeyValue(ctx, bucket)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, bucket), nil
+}
+
+func (f *np10FaultJetStream) CreateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+func (f *np10FaultJetStream) CreateOrUpdateKeyValue(ctx context.Context, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	kv, err := f.JetStream.CreateOrUpdateKeyValue(ctx, cfg)
+	if err != nil {
+		return kv, err
+	}
+
+	return f.wrap(kv, cfg.Bucket), nil
+}
+
+// np10FaultKeyValue faults ONLY Keys() — the leader's worker-enumeration scan —
+// while Put/Get/Update/Delete/Watch pass through unchanged. This is NP-10's
+// defining asymmetry: the stream-wide enumeration times out while every worker's
+// single-key heartbeat Put (and the leader's election renewal on a separate
+// bucket) keep succeeding.
+type np10FaultKeyValue struct {
+	jetstream.KeyValue
+	fc *np10FaultController
+}
+
+func (k *np10FaultKeyValue) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	if k.fc.fault() {
+		return nil, context.DeadlineExceeded
+	}
+
+	return k.KeyValue.Keys(ctx, opts...)
+}
+
+// TestNP10_LeaderEnumerationStall_FrozenMembership is the end-to-end NP-10 proof
+// (the verify-first load-bearing gate). It stands up a leader + 2 followers with
+// full partition coverage, arms a Keys-only stall on the heartbeat bucket (the
+// connection stays UP and every single-key op keeps succeeding), removes a
+// follower, and observes whether the leader reacts.
+//
+// Oracle (verify-first against the parent — 06 landed, 07 absent):
+//   - GAP (this assertion FAILS on the parent): while the leader's enumeration
+//     scan stalls, the removed follower's partitions stay orphaned and the leader
+//     sits silently in StateStable with no degrade. A correct leader must surface
+//     the stall (enter Degraded) or re-cover.
+//   - CONTROL (PASSES on the parent, no fix): disarming the stall lets the leader
+//     re-enumerate, see the departed follower, and re-cover — proving the freeze
+//     is specifically the enumeration blind spot, not a broken leader.
+//   - NON-VACUITY (guards both directions): the Keys fault actually fired
+//     (injected > 0) and the connection stayed CONNECTED throughout.
+//
+// If on the parent the leader reacts on its own WHILE injected > 0 and the
+// connection held, NP-10 is NOT real — STOP, do not implement the fix.
+func TestNP10_LeaderEnumerationStall_FrozenMembership(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	// Env-gated: this is a verify-first reproducer that FAILS on the parent until
+	// the NP-10 fix lands, so it stays out of the default `make test`/`make pre-pr`
+	// baseline. Remove this gate when the fix flips it green.
+	if os.Getenv("PARTI_RUN_NP10_ENUM_STALL_PROOF") == "" {
+		t.Skip("set PARTI_RUN_NP10_ENUM_STALL_PROOF=1 to run the NP-10 verify-first proof")
+	}
+
+	t.Parallel()
+
+	const (
+		numPartitions    = 6
+		numWorkers       = 3
+		armedObservation = 12 * time.Second
+	)
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	realJS, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	cfg := testutil.IntegrationTestConfig()
+
+	fc := &np10FaultController{}
+	faultJS := &np10FaultJetStream{
+		JetStream: realJS,
+		fc:        fc,
+		// Scope strictly to the heartbeat bucket: faulting any other bucket
+		// (election / assignment) would trigger a DIFFERENT real degrade or a
+		// leadership loss and mask NP-10.
+		buckets: map[string]struct{}{
+			cfg.KVBuckets.HeartbeatBucket: {},
+		},
+	}
+
+	src := source.NewStatic(testutil.CreateTestPartitions(numPartitions))
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	// Inject the fault wrapper. AddWorkerWithOptions reads cluster.JS at worker
+	// creation time, so every manager receives the heartbeat-Keys-faulting JS.
+	// The injected>0 precondition below makes any propagation failure loud rather
+	// than vacuous.
+	cluster.JS = faultJS
+
+	// Per-worker observers. WithHooks here replaces the cluster's tracker hooks,
+	// which is fine: every wait/coverage helper reads live manager state, not the
+	// trackers. Shared, thread-safe sinks captured by all workers.
+	degradedReasons := make(chan string, 16)
+	var degradedEntries atomic.Int64
+	observerHooks := &parti.Hooks{
+		OnDegraded: func(_ context.Context, reason string) error {
+			select {
+			case degradedReasons <- reason:
+			default:
+			}
+
+			return nil
+		},
+		OnStateChanged: func(_ context.Context, _, to parti.State) error {
+			if to == parti.StateDegraded {
+				degradedEntries.Add(1)
+			}
+
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 150*time.Second)
+	defer cancel()
+
+	for range numWorkers {
+		cluster.AddWorkerWithOptions(ctx, parti.WithHooks(observerHooks))
+	}
+	cluster.StartWorkers(ctx)
+	t.Cleanup(cluster.StopWorkers)
+
+	leader := cluster.WaitForLeader(20 * time.Second)
+	require.NotNil(t, leader, "a single leader must be elected")
+	cluster.WaitForPartitionCoverage(numPartitions, 20*time.Second)
+
+	// liveCoverage = unique partition IDs across the still-running workers (a
+	// removed worker is excluded). Frozen membership shows as coverage < N.
+	liveCoverage := func() int {
+		uniq := make(map[string]struct{})
+		for _, mgr := range cluster.GetActiveWorkers() {
+			for _, p := range mgr.CurrentAssignment().Partitions {
+				if id := p.ID(); id != "" {
+					uniq[id] = struct{}{}
+				}
+			}
+		}
+
+		return len(uniq)
+	}
+
+	// Pick a FOLLOWER to remove (never the leader — removing the leader would
+	// trigger a real re-election and confound the proof).
+	followerIdx := -1
+	for i, mgr := range cluster.GetWorkers() {
+		if mgr.State() != parti.StateShutdown && mgr.WorkerID() != leader.WorkerID() {
+			followerIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, followerIdx, 0, "must have at least one follower to remove")
+
+	// Arm the Keys-only enumeration stall.
+	fc.arm()
+
+	// HARD PRECONDITION (vacuity killer): the fault must actually reach the
+	// leader's enumeration scan (leader-only WorkerMonitor poll, every hbTTL/2).
+	require.Eventually(t, func() bool { return fc.injected.Load() > 0 }, 15*time.Second, 250*time.Millisecond,
+		"the heartbeat Keys-only fault must actually fire against the leader's enumeration before we assert anything")
+	require.True(t, nc.IsConnected(), "the NATS connection must be up when the stall is armed (this is not a disconnect)")
+
+	// Remove the follower. Its heartbeat key is deleted on Stop (Delete passes
+	// through the Keys-only fault), so a NON-stalled leader would see the reduced
+	// set on its next scan. Under the stall, the leader's scan times out instead.
+	cluster.RemoveWorker(followerIdx)
+
+	// Vacuity guard: the removal must actually orphan ≥1 partition (the leader is
+	// frozen, so the departed follower's share is now uncovered). If it held no
+	// partitions, coverage would stay full and the gate would pass spuriously.
+	require.Less(t, liveCoverage(), numPartitions,
+		"removing the follower must orphan at least one partition, else the scenario is vacuous")
+
+	// Observe the armed window WITHOUT failing: does the leader react to the
+	// follower's departure — re-cover the orphaned partitions, or surface the
+	// stall by degrading?
+	reactedWhileArmed := false
+	deadline := time.Now().Add(armedObservation)
+	for time.Now().Before(deadline) {
+		if liveCoverage() == numPartitions || leader.State() == parti.StateDegraded {
+			reactedWhileArmed = true
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	observedCoverage := liveCoverage()
+	observedLeaderState := leader.State()
+
+	// CONTROL (recovery) — PASSES on the parent with no fix. Clearing the stall
+	// lets the leader re-enumerate, see the departed follower, and re-cover. This
+	// is the causal proof: the freeze is the enumeration blind spot, not a broken
+	// leader.
+	fc.disarm()
+	cluster.WaitForPartitionCoverage(numPartitions, 30*time.Second)
+
+	// NON-VACUITY (guards both directions of the STOP gate).
+	require.Positive(t, fc.injected.Load(),
+		"the Keys-only heartbeat-enumeration fault must have actually fired against the leader")
+	require.True(t, nc.IsConnected(),
+		"the NATS connection stayed CONNECTED throughout — this is an enumeration stall, not a disconnect")
+
+	// THE GAP — post-fix invariant. FAILS on the parent, proving NP-10 is real.
+	require.True(t, reactedWhileArmed,
+		"NP-10 silent false-healthy leader: with the heartbeat Keys scan stalling, the removed follower's "+
+			"partitions stayed orphaned (live coverage %d/%d) and the leader sat in %s without degrading "+
+			"(cluster degraded-entries=%d) for %s while the connection stayed up and the fault fired %d times. "+
+			"A correct leader must surface the stall (enter Degraded) or re-cover. This assertion FAILS on the "+
+			"parent commit, proving the gap is real.",
+		observedCoverage, numPartitions, observedLeaderState, degradedEntries.Load(), armedObservation, fc.injected.Load())
+}


### PR DESCRIPTION
## Summary

A cluster leader runs the only worker-enumeration scan (the heartbeat-bucket `Keys` listing; this scan runs only on the leader). When that scan sustains a non-connectivity `context.DeadlineExceeded` — while its single-key heartbeat write and election renewal (a separate bucket) keep succeeding — the deadline is classified as **neither** a connectivity **nor** a degrading error, so it was returned raw, only logged, and never reached the degraded circuit. The leader stayed `Stable` and **froze its assignment**: a departed worker's partitions were never reassigned, with no degraded signal.

## Approach

Two commits — first the reproducers, then the fix that turns them green:

1. **Reproducers** (`cd5bc7f`) — failing against the parent:
   - unit: pins the classifier behaviour (both the connectivity and the degrading classifier reject `context.DeadlineExceeded`, bare and wrapped) and characterises the swallow;
   - integration: a leader and two followers reach full coverage, a scan-only stall is armed on the heartbeat bucket (the connection stays up, every single-key op keeps succeeding), a follower is removed → the leader stayed `Stable` with live coverage `4/6` and **0 degrades** (the gap). The disarm-recovery control and the non-vacuity guards (the stall fired, the removal orphaned a partition, the connection stayed up) all passed, attributing the freeze specifically to the enumeration blindness.
2. **Fix** (`b3afa54`) — turns the integration test green; it now runs in CI as a regression guard.

## The fix

- The calculator config gains `OnEnumerationError` / `OnEnumerationSuccess` / `EnumerationFailureThreshold` — plain function callbacks (the assignment package must not import the manager; the seam is import-cycle-free and matches the existing optional-callback fields).
- The calculator counts **consecutive** non-connectivity enumeration failures and fires `OnEnumerationError` once the stall is sustained; every successful enumeration fires `OnEnumerationSuccess` (placed before the suspicious-shrink handling so a recovered-but-suspicious scan still clears the counter).
- The manager degrades **directly** with a distinct reason `heartbeat-enumeration-stall`, kept off the transient KV-error window — a still-succeeding heartbeat write would otherwise clear a transient entry before it accumulated — and gates the recovery exit on an enumeration success recorded after the degrade.
- **Leadership-loss handling**: enumeration runs only on the leader, so a non-leader can never record a success; the exit gate treats a non-leader as not-applicable instead of waiting for a success it can never produce, so a leader that loses leadership while in this state is not trapped.

Primarily an **observability** fix: degrading surfaces the blindness so failover/an operator can act; recovery itself still requires enumeration to succeed.

## Tests

- Unit: the threshold fires on three consecutive failures and **not** on a single one; the recovery gate holds a leader until enumeration recovers and lets a non-leader exit the otherwise-stuck degrade.
- Integration: the end-to-end test runs by default (short-mode-gated) as a regression guard.

## Verification (local)

- `make lint` → `0 issues`
- `go test -race ./internal/assignment .` → green (assignment 14.6s, root 75.6s)
- `go test -race ./test/integration/...` → all 11 packages green, **0 data races**
- Independent second-model review (read-only) → no findings.

Please **squash on merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
