### PR TITLE
fix(degraded): exit degraded only on a confirmed Degraded->Stable transition

### DIFF
--- a/docs/plans/auto-healing-consolidation/03-exit-on-confirmed-degraded-plan.md
+++ b/docs/plans/auto-healing-consolidation/03-exit-on-confirmed-degraded-plan.md
@@ -1,0 +1,180 @@
+# 03 — exit-on-confirmed-degraded (consolidation Phase 4.7)
+
+**Status:** IMPLEMENTED + full gate GREEN (lint 0, unit -race, integration -race); codex plan-review
+and post-impl review both clean (0 P0/P1).
+**Branch / worktree:** `exit-on-confirmed-degraded` off `main` (`760f351`).
+**Parent plan:** `02-degraded-record-pointer-plan.md` §5 documented this as a PRE-EXISTING race left
+out of scope ("4.7 exit-on-confirmed-degraded"). This is that follow-up.
+
+## 1. Goal and framing
+
+`exitDegraded` must clear the degraded record ONLY on a genuine `Degraded → Stable` transition. Today
+it calls `transitionState(StateStable)`, which returns `true` **vacuously** when the state is already
+`StateStable` (`manager_state.go:106`, `from == to`), and then unconditionally `Store(nil)`s the
+record. That vacuous-success path lets a recovery tick clear a record that a *concurrent* enterer is
+mid-publishing — stranding the worker in `Degraded` with a `nil` record.
+
+**This is a behaviour change, narrowly scoped:** it removes one reachable stuck-Degraded outcome. It
+is NOT a pure refactor (unlike 4.6). The only externally-observable delta is that an `exitDegraded`
+call which today vacuously "succeeds" against an already-`Stable` state will instead become a no-op
+(record preserved), so the in-flight degrade episode completes and recovers normally on the next tick.
+
+## 2. The race (pre-existing; widened 7 lines by 4.6, not introduced by it)
+
+`enterDegraded` ordering: publish record (CAS) **then** `transitionState(StateDegraded)`.
+`exitDegraded` ordering: `transitionState(StateStable)` **then** `Store(nil)`.
+
+Stranding sequence (clean start: `record==nil`, `state==Stable`):
+
+1. Goroutine **A** (NOT the connection monitor — e.g. startup watchdog, `onEnumerationStall`, the
+   assignment watcher, or `recordKVError` off the election/assignment path) calls
+   `enterDegraded(reason)`: `CompareAndSwap(nil, rec)` publishes the record, but A has not yet reached
+   `transitionState(StateDegraded)`. State is still `Stable`.
+2. The connection-monitor goroutine **B** runs `attemptRecoveryFromDegraded` on its 1 s tick, loads
+   A's record (non-nil), passes the gates, and calls `exitDegraded`:
+   `transitionState(StateStable)` is **vacuous** (state is `Stable`) → returns `true` →
+   `Store(nil)` wipes A's record.
+3. A resumes: `transitionState(StateDegraded)` → **final state = `Degraded` + record `nil`**.
+
+That stuck state defeats recovery (`attemptRecoveryFromDegraded` returns early on a nil record) and
+alerting (`monitorDegradedAlerts` returns on a nil record). It self-heals only when some *independent*
+`enterDegraded` re-arms the record (CAS succeeds on nil → vacuous `Degraded→Degraded` → record set
+again) — which, if A's degrade condition cleared immediately, may not happen until the next unrelated
+degrade event.
+
+**Scope of the trigger:** ANY degrade reason can reach the strand — including the reason-scoped ones.
+The reason-scoped gates (Family B kv-unavailable, NP-10 enumeration-stall) are immune only to
+*stale / pre-degrade* signals: `recoverySignalStalled` blocks when `signalAt == 0 || signalAt <= since`
+(`manager_degraded.go:415`). But `recordKVHealthyOp` and `recordEnumerationSuccess` stamp their signals
+**unconditionally — even while degraded** (`manager_degraded.go:239`, `:392`), so a success landing in
+the post-record / pre-transition window has `signalAt > rec.since` and **opens** the gate, letting B
+reach `exitDegraded`. This is exactly the "reason-scoped self-protection is only partial" caveat the
+02 plan already documented (`02-degraded-record-pointer-plan.md:133`). Non-reason-scoped reasons
+(startup-timeout / NP-5 / generic) reach the strand the most directly (commitment guard alone), but the
+fix closes the window for **all** reasons uniformly. The realistic regime is startup churn / many
+goroutines entering degraded under CPU pressure.
+
+**Pre-existing-on-parent:** the two-atomic design reached the identical outcome (`Degraded` +
+`since==0`). 4.6 only widened the record-visible point from reason-store→transition to CAS→transition
+(~7 lines). `manager_degraded_window_race_test.go` is deliberately parent-relative for this reason and
+explicitly documents this strand as out-of-scope-there / in-scope-here.
+
+## 3. The fix
+
+Replace the vacuous-tolerant transition in `exitDegraded` with a **confirmed-Degraded CAS**, mirroring
+the existing `casToStableFromWaitingAssignment` lock-free idiom (referenced at `manager_state.go:140`):
+commit the state with a from-specific CAS, then fire `emitTransitionEffects` so observers see an
+identical transition regardless of path.
+
+```go
+func (m *Manager) exitDegraded() {
+    rec := m.degraded.Load()
+    if rec == nil {
+        return
+    }
+
+    duration := time.Since(time.Unix(0, rec.since))
+
+    // Only a genuine Degraded->Stable transition may clear the record. A vacuous
+    // Stable->Stable "success" (the state a concurrent enterDegraded is in after it
+    // published the record but before it transitioned to Degraded) must NOT clear
+    // it — doing so strands that episode in Degraded with a nil record.
+    if !m.state.CompareAndSwap(int32(StateDegraded), int32(StateStable)) {
+        return
+    }
+    m.emitTransitionEffects(StateDegraded, StateStable)
+
+    m.degraded.Store(nil)
+    // ... unchanged: log, metrics, leader recovery-grace ...
+}
+```
+
+`emitTransitionEffects(from, to)` is the shared side-effect emitter (`manager_state.go:145`): the
+structured log line, the `OnStateChanged` hook (via `invokeHook`, so `Stop`'s WaitGroup waits), and
+`RecordStateTransition`. Calling it with `(StateDegraded, StateStable)` reproduces exactly what
+`transitionState(StateStable)` emitted on the real-transition path, so observers see no difference.
+
+**Shutdown handling preserved:** today, if the state is `Shutdown`, `transitionState(StateStable)`
+returns false (invalid transition) and `exitDegraded` skips cleanup. Under the CAS, a `Shutdown` state
+also fails `CompareAndSwap(Degraded, Stable)` and skips cleanup — same behaviour. **Observability delta
+(intentional):** on that skipped path the old `transitionState` logged an "invalid state transition
+attempted" error on its first attempt (`manager_state.go:109`); the bare CAS does not. This is by
+design — a recovery tick racing a concurrent Shutdown (or a pre-transition enter) is a benign,
+expected non-event, not an operator-actionable error, so suppressing that log removes noise rather than
+hiding a fault. The genuine-exit log ("exiting degraded mode") is unchanged.
+
+## 4. Tightness argument (no legitimate exit is newly blocked)
+
+A non-nil record is set ONLY by `enterDegraded` (the single CAS publish). `isValidTransition`
+(`manager_state.go:180`) forbids `StateDegraded → {anything but Stable, Shutdown}`. Therefore, whenever
+`exitDegraded` runs against a *real* degrade episode, the state is genuinely `Degraded` (A's enter has
+completed its own `transitionState(StateDegraded)`), so `CompareAndSwap(Degraded, Stable)` succeeds and
+behaviour is unchanged. The ONLY case the CAS newly refuses is `state != Degraded` while a record is
+present — i.e. exactly the racy transient (record published, transition not yet run) or a `Shutdown`
+that already skipped cleanup. So the fix cannot regress a real recovery; it removes precisely the
+strand.
+
+## 5. Verify-first / proof obligation
+
+The fix's *contract* is deterministically testable without any production seam or scheduler stress —
+this is what makes the change cheap and the proof non-vacuous. Confirmed empirically during
+investigation (RED on `main` `760f351`, GREEN with the fix):
+
+1. **Strand reproducer (deterministic, white-box, table-driven):** arm `{state = <S>, record != nil}`
+   for **every** state an enterer can be in during the pre-transition window — `StateStable`,
+   `StateWaitingAssignment`, `StateScaling`, `StateRebalancing`, `StateEmergency` (all valid
+   `*→Degraded` sources, and all today valid `*→Stable` so the old vacuous/real `transitionState`
+   would clear the record from any of them) — then call `exitDegraded()` directly and assert the record
+   **survives** (`m.degraded.Load() != nil`), the state is **unchanged** (no spurious transition out of
+   `<S>`), and **no `OnStateChanged` fired** (no spurious effect emission). On the parent this is RED
+   (the record is cleared, and for the non-Stable states the state is also dragged to Stable); with the
+   fix it is GREEN. Uses the existing `markDegraded` test helper + `m.state.Store(int32(<S>))` (the
+   field-poke pattern `manager_epoch_fence_test.go` already uses). This is the load-bearing proof:
+   "exitDegraded won't clear unless it genuinely transitioned from Degraded" IS the mechanism that
+   prevents stranding.
+2. **Positive path unchanged:** arm `{state = StateDegraded, record != nil}`, call `exitDegraded()`,
+   assert the record is cleared, state is `StateStable`, and the `OnStateChanged` hook fired with
+   `(Degraded, Stable)` — i.e. the genuine exit still works and still emits its effects.
+3. **Behaviour-preservation gate (must stay green, unchanged):** the existing degraded/recovery
+   suite — `manager_recovery_conjuncts_test.go`, `manager_kv_read_unavailable_test.go`,
+   `manager_enumeration_stall_recovery_test.go`, `manager_degraded_recovery_selfheal_test.go`,
+   `manager_degraded_test.go`, `manager_alert_level_test.go`, `manager_np5_blocked_apply_recovery_test.go`,
+   `manager_epoch_fence_test.go`, `manager_stream_missing_observer_test.go`,
+   `manager_degraded_window_race_test.go`, and the np2 integration test.
+4. **Window stress, now strengthened (optional but cheap):** `manager_degraded_window_race_test.go` is
+   currently parent-relative (asserts record atomicity + liveness, NOT state-vs-record consistency).
+   With the fix the strand is closed, so this test MAY be tightened to also assert "never ends in
+   `Degraded` + nil record" after the storm drains. Decide during impl whether to tighten it here or
+   keep it parent-relative and rely on proofs 1–2 (leaning: add a post-drain assertion, since the
+   stronger invariant now holds).
+
+## 6. Blast radius and concrete edits
+
+**Production — `manager_degraded.go` only:** the `exitDegraded` transition block (§3). No signature
+changes, no new fields, no other call sites (`exitDegraded` is called only from
+`attemptRecoveryFromDegraded`). `emitTransitionEffects` is already exported within the package and
+already used by both transition paths, so no new surface.
+
+**Tests:** add the two deterministic proofs (§5.1, §5.2) — likely one new file
+`manager_exit_confirmed_test.go`. Optionally tighten `manager_degraded_window_race_test.go` (§5.4).
+
+## 7. Sequencing and gate
+
+`plan → codex plan-review until clean → write §5.1 reproducer + confirm RED on parent → implement →
+confirm §5.1/§5.2 GREEN → make lint (0) → go test -race ./... (unit) → go test -race
+./test/integration/... → /simplify → /post-impl-review (codex ≠ implementer) to MERGE → squash by
+scope → PR → CI`. Keep ≤1 step unverified.
+
+## 8. Invariants ledger
+
+- **NEW (the change's purpose):** `exitDegraded` clears the record iff it performed a genuine
+  `Degraded → Stable` transition. Consequence: a worker can no longer end in `Degraded` + nil record
+  via the pre-transition exit window.
+- **T1** (recovery-gate dual nature) — unchanged: the gates in `attemptRecoveryFromDegraded` are
+  untouched; only the final `exitDegraded`'s transition mechanism changes.
+- **T4** (record pair-atomicity, from 4.6) — unchanged: still one atomic swap.
+- **Transition effects parity** — `emitTransitionEffects(Degraded, Stable)` reproduces exactly the
+  log/hook/metric the prior `transitionState(StateStable)` emitted on its real-transition path, so
+  no observer sees a difference on the genuine-exit path.
+- **Shutdown** — a `Shutdown` state fails the CAS and skips cleanup, identical to today's
+  `transitionState` returning false from `Shutdown`.

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -340,6 +340,36 @@ func (m *Manager) enterDegraded(reason string) {
 	m.wg.Go(m.monitorDegradedAlerts)
 }
 
+// casToStableFromDegraded performs a guarded Degraded → Stable transition and
+// reports whether it fired; exitDegraded gates its record cleanup on the result.
+//
+// Generic transitionState(StateStable) is unsafe here. It returns true vacuously
+// when state is already Stable (manager_state.go:106), and CAS-walks a real but
+// wrong transition from any other active state (Scaling/Rebalancing/Emergency/
+// WaitingAssignment → Stable are all valid). A recovery tick that hit the
+// enterDegraded window — record published by a concurrent enter but its
+// transitionState(StateDegraded) not yet run — would then succeed and let
+// exitDegraded clear that in-flight record, stranding the worker in Degraded with
+// a nil record (recovery and alerting both early-return on a nil record). The
+// direct from-Degraded CAS only succeeds when state really is Degraded, so it
+// refuses that window and leaves the in-flight enter to complete and recover on
+// the next tick.
+//
+// On a successful CAS it calls emitTransitionEffects — the same shared emitter
+// transitionState uses for the OnStateChanged hook and RecordStateTransition
+// metric — so observers see no difference from a normal transition. A Shutdown
+// (or the racy non-Degraded state) fails the CAS and the caller skips cleanup,
+// matching the prior transitionState-returns-false behaviour (minus its
+// now-suppressed invalid-transition warn, benign noise on this path).
+func (m *Manager) casToStableFromDegraded() bool {
+	if !m.state.CompareAndSwap(int32(StateDegraded), int32(StateStable)) {
+		return false
+	}
+	m.emitTransitionEffects(StateDegraded, StateStable)
+
+	return true
+}
+
 // exitDegraded transitions the manager out of degraded mode.
 func (m *Manager) exitDegraded() {
 	rec := m.degraded.Load()
@@ -349,9 +379,10 @@ func (m *Manager) exitDegraded() {
 
 	duration := time.Since(time.Unix(0, rec.since))
 
-	// Transition out of degraded mode via validated CAS.
-	// If already Shutdown, transitionState returns false and we skip cleanup.
-	if !m.transitionState(StateStable) {
+	// Exit ONLY on a genuine Degraded->Stable transition (see casToStableFromDegraded):
+	// a vacuous transitionState(StateStable) success would clear a record a concurrent
+	// enterDegraded is mid-publishing, stranding the worker in Degraded+nil-record.
+	if !m.casToStableFromDegraded() {
 		return
 	}
 
@@ -365,7 +396,7 @@ func (m *Manager) exitDegraded() {
 		"next_state", StateStable,
 	)
 
-	// Record metrics (state transition already recorded by transitionState)
+	// Record metrics (state transition already recorded by emitTransitionEffects)
 	m.metrics.RecordDegradedDuration(duration.Seconds())
 	m.metrics.SetDegradedMode(0.0)
 	m.metrics.SetCacheAge(0.0)

--- a/manager_degraded_window_race_test.go
+++ b/manager_degraded_window_race_test.go
@@ -17,15 +17,17 @@ import (
 // commitment guard is satisfied and the reason is non-reason-scoped) concurrently
 // with re-entry (enterDegraded) and a heartbeat-success stamp that advances the
 // recovery signal inside the window, under -race, and asserts:
-//   - a loaded record is always nil or fully populated (never a torn since/reason), and
-//   - the storm completes without panic or deadlock.
+//   - a loaded record is always nil or fully populated (never a torn since/reason),
+//   - the storm completes without panic or deadlock, and
+//   - the storm never strands in Degraded with a nil record.
 //
-// Out of scope (documented; pre-existing on BOTH the two-atomic parent and this
-// pointer design): a recovery tick can vacuously transition Stable->Stable in the
-// window and clear a record an enterer is mid-publishing, ending Degraded with a
-// nil record. Closing that needs an exit-on-confirmed-Degraded guard — a separate
-// behaviour change. So this asserts record atomicity + liveness, NOT absolute
-// state-vs-record consistency.
+// That last assertion is the end-to-end guard for the exit-on-confirmed-Degraded
+// fix: a recovery tick that hits the window (record published, transition not yet
+// run) used to vacuously transition Stable->Stable and clear the in-flight record,
+// stranding the worker in Degraded+nil-record. exitDegraded now clears only on a
+// genuine Degraded->Stable CAS, so that strand can no longer occur regardless of
+// interleaving (the storm may legitimately end Degraded+record or Stable+nil, but
+// never Degraded+nil). On the pre-fix parent this assertion is reachable-RED.
 func TestDegradedRecord_EnterRecoverRace_NoTornRecord(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping embedded-NATS concurrency stress in short mode")
@@ -85,4 +87,11 @@ func TestDegradedRecord_EnterRecoverRace_NoTornRecord(t *testing.T) {
 	})
 	require.False(t, t.Failed(),
 		"the widened enter/transition window must not produce a torn record or a hang")
+
+	// End-to-end exit-on-confirmed-Degraded guard: after the storm drains, the
+	// worker must never sit in Degraded with a nil record — the strand the
+	// from-Degraded exit CAS closes. Degraded+record (last op was an enter) and
+	// Stable+nil (last op was a genuine exit) are both fine.
+	require.False(t, m.State() == StateDegraded && m.degraded.Load() == nil,
+		"enter/recover storm stranded the worker in Degraded with a nil record")
 }

--- a/manager_exit_confirmed_test.go
+++ b/manager_exit_confirmed_test.go
@@ -1,0 +1,108 @@
+package parti
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExitDegraded_OnlyClearsOnConfirmedDegradedTransition pins the
+// exit-on-confirmed-Degraded contract: exitDegraded clears the degraded record
+// ONLY when it performs a genuine Degraded->Stable transition. It must NOT clear
+// the record when the state is not (yet) Degraded — the transient an enterDegraded
+// caller is in after it published the record (single-swap CAS) but before it ran
+// transitionState(StateDegraded).
+//
+// Without the fix, exitDegraded calls transitionState(StateStable), which returns
+// true vacuously when the state is already Stable (and performs a REAL but wrong
+// transition from any other active state, e.g. Scaling->Stable), then unconditionally
+// Store(nil)s the record. A concurrent enterer's transitionState(StateDegraded)
+// then lands last, stranding the worker in Degraded with a nil record — recovery
+// and alerting both early-return on a nil record, so it cannot self-heal until an
+// unrelated degrade re-arms it.
+//
+// enterDegraded is reachable from every active state (isValidTransition allows
+// *->Degraded from Stable/Scaling/Rebalancing/Emergency/WaitingAssignment), so the
+// pre-transition window can be entered from any of them — hence the table.
+func TestExitDegraded_OnlyClearsOnConfirmedDegradedTransition(t *testing.T) {
+	t.Parallel()
+
+	// Every state an enterDegraded caller can be in during the pre-transition
+	// window (record published, transitionState(StateDegraded) not yet run).
+	preTransitionStates := []State{
+		StateStable,
+		StateScaling,
+		StateRebalancing,
+		StateEmergency,
+		StateWaitingAssignment,
+	}
+
+	for _, start := range preTransitionStates {
+		t.Run(start.String(), func(t *testing.T) {
+			t.Parallel()
+
+			var hookFired atomic.Bool
+			m := newHookTestManager(&types.Hooks{
+				OnStateChanged: func(_ context.Context, _, _ types.State) error {
+					hookFired.Store(true)
+					return nil
+				},
+			})
+			defer m.cancel()
+
+			// Arm the racy transient: a degraded record is live, but the state is
+			// NOT Degraded (the enterer has not transitioned yet).
+			m.markDegraded(time.Now().UnixNano(), "startup-timeout")
+			m.state.Store(int32(start))
+
+			m.exitDegraded()
+			m.wg.Wait()
+
+			require.NotNil(t, m.degraded.Load(),
+				"exitDegraded must NOT clear the record when state is %s (not Degraded); "+
+					"clearing it strands a concurrent enterer in Degraded+nil-record", start)
+			require.Equal(t, start, m.State(),
+				"exitDegraded must not perform a spurious transition out of %s when not Degraded", start)
+			require.False(t, hookFired.Load(),
+				"exitDegraded must not emit OnStateChanged when it did not transition out of %s", start)
+		})
+	}
+}
+
+// TestExitDegraded_GenuineExitStillWorks is the positive-path guard: a real
+// Degraded->Stable exit still clears the record, transitions to Stable, and emits
+// the OnStateChanged(Degraded, Stable) effect — i.e. the fix does not weaken the
+// legitimate recovery path.
+func TestExitDegraded_GenuineExitStillWorks(t *testing.T) {
+	t.Parallel()
+
+	var gotFrom, gotTo atomic.Int32
+	var fired atomic.Bool
+	hooks := &types.Hooks{
+		OnStateChanged: func(_ context.Context, from, to types.State) error {
+			gotFrom.Store(int32(from))
+			gotTo.Store(int32(to))
+			fired.Store(true)
+			return nil
+		},
+	}
+
+	m := newHookTestManager(hooks)
+	defer m.cancel()
+
+	m.markDegraded(time.Now().UnixNano(), DegradeReasonNATSConnectionDown)
+	m.state.Store(int32(StateDegraded))
+
+	m.exitDegraded()
+	m.wg.Wait()
+
+	require.Nil(t, m.degraded.Load(), "genuine exit must clear the degraded record")
+	require.Equal(t, StateStable, m.State(), "genuine exit must transition to Stable")
+	require.True(t, fired.Load(), "genuine exit must emit OnStateChanged")
+	require.Equal(t, StateDegraded, State(gotFrom.Load()), "OnStateChanged.from must be Degraded")
+	require.Equal(t, StateStable, State(gotTo.Load()), "OnStateChanged.to must be Stable")
+}

--- a/manager_state.go
+++ b/manager_state.go
@@ -137,9 +137,10 @@ func (m *Manager) transitionState(to State) bool {
 // emitTransitionEffects fires the observable side effects of a state transition
 // that has just been committed: the structured log line, the OnStateChanged hook
 // (dispatched through invokeHook so Stop's WaitGroup waits for it), and the
-// RecordStateTransition metric. Both transition paths — the CAS-retry
-// transitionState and the lock-free casToStableFromWaitingAssignment — commit the
-// state themselves and then call this, so observers see an identical transition
+// RecordStateTransition metric. The transition paths — the CAS-retry
+// transitionState and the lock-free casToStableFrom* helpers
+// (casToStableFromWaitingAssignment, casToStableFromDegraded) — commit the state
+// themselves and then call this, so observers see an identical transition
 // regardless of which path ran. from is taken by value, so the hook closure
 // captures the committed transition without the caller needing a manual copy.
 func (m *Manager) emitTransitionEffects(from, to State) {


### PR DESCRIPTION
## Summary

`exitDegraded` cleared the degraded record after `transitionState(StateStable)`, which returns `true` **vacuously** when the state is already Stable (and performs a real-but-wrong transition from any other active state, e.g. `Scaling->Stable`). A recovery tick that hit the `enterDegraded` window — the record published by a concurrent `enterDegraded` (single CAS) but its `transitionState(StateDegraded)` not yet run — could thereby clear that in-flight record, **stranding the worker in `Degraded` with a `nil` record**. In that state both recovery and alerting early-return on the nil record, so it cannot self-heal until an unrelated degrade re-arms it.

This is the follow-up the degraded-record-pointer change explicitly scoped out (its plan §5 flagged the pre-transition exit-window race). The race is pre-existing on the two-atomic parent too; it is **not** introduced by the pointer collapse.

## Fix

Extract `casToStableFromDegraded() bool` — the bool-returning twin of the existing `casToStableFromWaitingAssignment` — which clears the record only on a genuine `Degraded->Stable` CAS, then emits the same transition effects. `exitDegraded` gates its cleanup (record clear, log, metrics, leader recovery-grace) on that result. The CAS refuses the racy window (state is not yet `Degraded`), leaving the in-flight enter to complete and recover on the next tick.

- **Genuine-exit path: behaviour unchanged** — same transition-then-clear ordering, log line, metrics, leader recovery-grace, and `OnStateChanged(Degraded, Stable)` via the shared `emitTransitionEffects`.
- **Shutdown**: fails the CAS and skips cleanup, as before (minus a now-suppressed invalid-transition warn — benign noise on this path).
- The only states where a live record coexists with `state != Degraded` are the racy pre-transition window and `Shutdown` (`Degraded` exits only to `Stable`/`Shutdown`), so the from-Degraded CAS cannot strand a worker a new way.

## Tests

- Table-driven reproducer over every pre-transition entry state (`Stable`/`Scaling`/`Rebalancing`/`Emergency`/`WaitingAssignment`): record survives, state unchanged, no `OnStateChanged`. Confirmed RED on the parent before the fix.
- Positive path: a genuine `Degraded->Stable` exit still clears the record, transitions to Stable, and emits the hook.
- End-to-end no-strand assertion added to the enter/recover race stress test (`never Degraded+nil-record` after the storm drains).

## Verification

`make lint` = 0 · `make test` (unit `-race`, all dirs) = green · `make test-integration` (`-race`) = green (incl. the failure suite that exercises degraded/recovery).