### PR TITLE
test(failure): wait for async OnDegraded hook in full-NATS-outage test

### DIFF
--- a/test/integration/failure/full_nats_outage_test.go
+++ b/test/integration/failure/full_nats_outage_test.go
@@ -49,7 +49,8 @@ func TestFullNATSOutage_UnlimitedReconnects_RecoversFleet(t *testing.T) {
 	require.Eventually(t, func() bool { return nc.Status() != nats.CONNECTED },
 		5*time.Second, 50*time.Millisecond, "client did not observe NATS outage")
 	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 10*time.Second))
-	require.Positive(t, degradedCalls.Load(), "OnDegraded must report NATS connection down")
+	require.Eventually(t, func() bool { return degradedCalls.Load() > 0 },
+		5*time.Second, 20*time.Millisecond, "OnDegraded must report NATS connection down")
 	require.Len(t, stack.mgr.CurrentAssignment().Partitions, 1,
 		"manager must retain cached assignment while NATS is down")
 


### PR DESCRIPTION
## Problem

`TestFullNATSOutage_UnlimitedReconnects_RecoversFleet` flaked on CI under heavy few-core `-race` load with `"0" is not positive` ([failing run on #44](https://github.com/arloliu/parti/actions/runs/26995774921/job/79665115589?pr=44)). PR #44 only touches `test/iops-investigation/` + `docs/`, so this is a pre-existing flake on `main`, not a regression.

## Root cause

The test read `degradedCalls.Load()` **synchronously** right after `WaitState(StateDegraded)` returned:

```go
require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 10*time.Second))
require.Positive(t, degradedCalls.Load(), ...)   // racy
```

But `enterDegraded` commits the state CAS (which is what unblocks `WaitState`) **before** firing the `OnDegraded` hook, and that hook is dispatched **asynchronously** via `invokeHook → m.wg.Go`. So the `Degraded` state becomes observable before the counter is incremented. Under CI's heavy few-core `-race` load the hook goroutine is descheduled past the read → counter is 0.

This is **not a product bug**: `OnDegraded` still fires exactly once with reason `"NATS connection down"` (AGENTS.md contract #3). Across 55 local runs the connection-down path always won the degrade reason (the KV-error-threshold path never won). Only the test's timing assumption was wrong.

## Fix

Replace the synchronous `require.Positive` with `require.Eventually`, matching the shape the `OnDegraded`-hook contract test (`TestManager_LiveNATSBucketLoss_OnDegradedHook`) already uses to wait for the async hook:

```go
require.Eventually(t, func() bool { return degradedCalls.Load() > 0 },
    5*time.Second, 20*time.Millisecond, "OnDegraded must report NATS connection down")
```

## Verification

- **Deterministic reproducer**: injecting a `time.Sleep(400ms)` into the `OnDegraded` hook makes the original synchronous assert fail with the exact CI message (`"0" is not positive`, counter=0, reason still "NATS connection down"); the `Eventually` form passes with the same delay still injected.
- Clean test: 5× `-race` green; full `failure` package `-race` green (123s); `make lint` 0 issues.