### PR TITLE
docs: sync operational guides with measurement findings (+ fix CI lint)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -187,14 +187,16 @@ cfg := &parti.Config{
 | Bucket             | Purpose                   | Recommended TTL                | Default Storage |
 |--------------------|---------------------------|--------------------------------|-----------------|
 | `StableIDBucket`   | Worker ID claims          | Auto (WorkerIDTTL)             | File            |
-| `ElectionBucket`   | Leader lease              | Lease-based                    | Memory          |
-| `HeartbeatBucket`  | Worker health signals     | Auto (HeartbeatTTL)            | Memory          |
+| `ElectionBucket`   | Leader lease              | Lease-based                    | File            |
+| `HeartbeatBucket`  | Worker health signals     | Auto (HeartbeatTTL)            | File            |
 | `AssignmentBucket` | Partition assignments     | 0 (no expiration) or very long | File            |
 | `HandoffBucket`    | Two-phase handoff claims  | 2-5 minutes                    | File            |
 
-Heartbeat and election buckets use `MemoryStorage` to minimize PVC IOPS on file-backed JetStream clusters. Their data is intrinsically ephemeral — workers re-publish heartbeats every `HeartbeatInterval`, and a lost leader key simply triggers re-election. Stable-ID, assignment, and handoff buckets use `FileStorage` for durability: stable IDs must survive NATS restart to preserve worker identity, assignments must remain visible to followers joining during an outage, and handoff claims protect two-phase ownership transfers.
+All five coordination buckets use `FileStorage`. The election and heartbeat buckets were switched from `MemoryStorage` to `FileStorage` (in v2.5.0 and v2.6.0 respectively) because a single-node JetStream restart lost the in-memory stream and flapped the fleet `Degraded`↔`Stable`; persisting them survives the restart. The added write IOPS is a flat, partition-count-independent term — moving these coordination buckets to memory was measured to save only ~1–2% of cluster write IOPS (they are not the cost driver), so the durability win dominates. See the "Election Bucket Storage Migration" and "Heartbeat Bucket Storage Migration" sections in [`OPERATIONS.md`](OPERATIONS.md) for migrating existing clusters.
 
-If a bucket with a different storage type already exists (e.g., from a prior parti version or pre-provisioned by ops), parti opens it as-is and logs a `Warn` pointing at the manual migration path: `nats kv del <bucket>` during a maintenance window, then restart pods.
+> **Note:** this is the storage type for parti's *coordination* KV buckets. It is unrelated to per-consumer state storage (`WithConsumerMemoryStorage`), which is a separate, conditional IOPS lever covered in [`CONSUMERS.md`](CONSUMERS.md).
+
+If a bucket with a different storage type already exists (e.g., from a prior parti version or pre-provisioned by ops), parti opens it as-is and logs a `Warn` pointing at the manual migration path: remove the bucket with `nats kv rm <bucket>` during a maintenance window, then restart pods so parti recreates it as `FileStorage`.
 
 ### Multi-Application Clusters
 

--- a/docs/CONSUMERS.md
+++ b/docs/CONSUMERS.md
@@ -19,12 +19,14 @@
    - [Static](#static)
    - [Dynamic](#dynamic)
    - [Broadcast](#broadcast)
-4. [Message Handler](#message-handler)
-5. [WIPHandler — Long-Running Processing](#wiphandler--long-running-processing)
-6. [Auto-Recovery](#auto-recovery)
-7. [Functional Options](#functional-options)
-8. [Migrating from Legacy Consumer APIs](#migrating-from-legacy-consumer-apis)
-9. [Legacy Consumer APIs](#legacy-consumer-apis)
+4. [Stream Retention Policy](#stream-retention-policy)
+5. [Message Handler](#message-handler)
+6. [WIPHandler — Long-Running Processing](#wiphandler--long-running-processing)
+7. [Auto-Recovery](#auto-recovery)
+8. [Functional Options](#functional-options)
+9. [Consumer Storage Tuning](#consumer-storage-tuning)
+10. [Migrating from Legacy Consumer APIs](#migrating-from-legacy-consumer-apis)
+11. [Legacy Consumer APIs](#legacy-consumer-apis)
 
 ---
 
@@ -269,6 +271,60 @@ if err := c.Start(ctx); err != nil {
 |--------------|--------------------------------------|
 | `Start(ctx)` | Begin consuming messages             |
 | `Stop(ctx)`  | Gracefully stop with context timeout |
+
+---
+
+## Stream Retention Policy
+
+The JetStream **retention policy** of the stream a consumer reads from is the
+single most consequential — and most error-prone — choice when wiring up a
+consumer. It controls *when a message is deleted*, and the wrong policy silently
+loses data. Pick it by answering two questions, then check the per-type table.
+
+**The two questions:**
+
+1. **Must messages survive after they are processed** — for replay, multiple
+   independent readers, or windows where no consumer covers the subject? →
+   **`LimitsPolicy`** (messages retained until age/size/count limits; acks never
+   delete).
+2. **Is this a dedicated, consume-once queue** with a single non-overlapping
+   consumer set, where restricted recovery is acceptable? → **`WorkQueuePolicy`**
+   (delivered once, deleted on ack; filters must be disjoint).
+
+`InterestPolicy` is a narrow third option: it retains a message only while a
+bound consumer still owes an ack, and **discards any message published when no
+consumer covers its subject**.
+
+**Per consumer type:**
+
+| Consumer | Recommended | Also valid (caveats) | Avoid / Forbidden |
+|----------|-------------|----------------------|-------------------|
+| `Queue`     | **`WorkQueuePolicy`** for a dedicated consume-once queue — one shared durable matches WorkQueue's delete-on-ack model and bounds storage automatically | **`LimitsPolicy`** when the stream is shared, you need replay/retention, or you need `RecoverFromNew` | `InterestPolicy` — messages published with no live consumer are dropped |
+| `Static`    | **`LimitsPolicy`** when retention/replay matters (e.g. event-sourced partitions); **`WorkQueuePolicy`** for fixed consume-once partitions (filters are non-overlapping by construction) | — | `InterestPolicy` unless every partition durable exists before publishing |
+| `Dynamic`   | **`LimitsPolicy`** — preserves all recovery strategies and replay, and tolerates the brief unassigned windows during handoff | **`WorkQueuePolicy`** is supported (proven lossless across graceful handoff *and* abrupt crash), but it limits recovery to `RecoverFromBeginning`/`RecoveryDisabled` and forgoes replay — pick it only for consume-once work | `InterestPolicy` — an unassigned/just-moved subject's messages can be discarded |
+| `Broadcast` | **`LimitsPolicy`** — every instance must receive every message; Limits retains independently of which instances are up | `InterestPolicy` *only* when instance identities are stable, all recipients are registered before publishing, churn is low (or `InactiveThreshold` is short), and dropping messages published while all instances are down is acceptable | **`WorkQueuePolicy`** — single delivery defeats fan-out (rejected) |
+
+**Three cross-cutting rules that bite regardless of type:**
+
+- **WorkQueue restricts recovery.** WorkQueue consumers may only use
+  `DeliverAllPolicy`, so `RecoverFromNew` and `RecoverFromLastProcessed` are
+  rejected — see [WorkQueuePolicy Restriction](#workqueuepolicy-restriction).
+  Only `RecoverFromBeginning`/`RecoveryDisabled` work (and on WorkQueue,
+  `RecoverFromBeginning` replays just the unacked backlog).
+- **Replicas cap depends on retention.** On any stream, consumer replicas may
+  not *exceed* the stream's. On `LimitsPolicy` (the default) any value
+  `1…stream.Replicas` is allowed — so `WithConsumerReplicas(1)` works on an RF=5
+  stream. On `InterestPolicy`/`WorkQueuePolicy`, a nonzero value must *equal* the
+  stream's replica count, so any mismatch (e.g. `WithConsumerReplicas(1)` or `3`
+  on an RF=5 stream) is rejected by NATS (`err_code=10134`). The single-replica
+  IOPS option in [Consumer Storage Tuning](#consumer-storage-tuning) is therefore
+  unavailable on Interest/WorkQueue; pair `WithConsumerMemoryStorage(true)` with
+  inherited replicas (the Balanced config) instead.
+- **Interest pins messages behind stopped consumers.** A consumer's durable is
+  not deleted on `Stop()` (it is garbage-collected only after
+  `InactiveThreshold`, default 24h). On `InterestPolicy`, that lingering durable
+  still holds interest, so a stopped/churned instance pins its unacked messages
+  until GC — the reason `Broadcast` defaults to `LimitsPolicy`, not Interest.
 
 ---
 
@@ -656,7 +712,10 @@ if err := cfg.Validate(); err != nil {
 
 ## Functional Options
 
-All consumers accept functional options for customization:
+All consumer constructors accept functional options. The tables below list the
+commonly-used options, not the complete set — see the
+[package reference](https://pkg.go.dev/github.com/arloliu/parti/v2/consumer) for
+every `With*` option.
 
 ```go
 c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
@@ -668,7 +727,7 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 )
 ```
 
-**Common Options:**
+**Common Options (selected):**
 
 | Option                            | Description                                   |
 |-----------------------------------|-----------------------------------------------|
@@ -682,6 +741,8 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 | `WithManualAck(bool)`             | Disable auto-acknowledgement                  |
 | `WithInactiveThreshold(duration)` | Consumer cleanup threshold                    |
 | `WithRecoveryStrategy(strategy)`  | Auto-recovery on unexpected consumer deletion |
+| `WithConsumerMemoryStorage(bool)` | Store per-consumer state in memory (IOPS lever; **not** live-editable; see [Consumer Storage Tuning](#consumer-storage-tuning)) |
+| `WithConsumerReplicas(n)`         | Replica count for consumer state (live-editable; `0` inherits the stream's) |
 
 **Broadcast-Specific Options:**
 
@@ -695,6 +756,54 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 |--------------------------------------|----------------------------------------------|
 | `WithProcessingGate(cfg)`            | Enable processing gate for ownership control |
 | `WithDrainOnRemove(enabled, timeout)`| Drain messages when partitions are removed   |
+
+---
+
+## Consumer Storage Tuning
+
+> **Scope:** this section is about **per-consumer JetStream state** (each
+> consumer's own ack/cursor store), tuned with `WithConsumerMemoryStorage` and
+> `WithConsumerReplicas`. It is **unrelated** to parti's coordination KV buckets
+> (heartbeat/election/etc.), which always use `FileStorage` — see
+> [`CONFIGURATION.md`](CONFIGURATION.md). Do not move the coordination buckets to
+> memory.
+
+Each consumer persists its delivery state (ack floor, redelivery counts) to a
+small per-consumer file. At scale this is the **dominant** NATS write-IOPS
+cost — measured at **72–81% of cluster write IOPS** with one consumer per
+partition. Moving that state to memory is the single largest IOPS lever.
+
+**It is conditional — the file-backed default is correct for most deployments.**
+Only reach for memory storage when one of these is true: ≳10k partitions per
+NATS node, provisioned-IOPS billing (e.g. AWS io2/gp3 above baseline),
+latency-tail sensitivity, or a tightly-constrained dev/test cluster. Otherwise,
+do nothing.
+
+When you *do* need it, choose by how much redelivery the workload tolerates:
+
+| Config | Set | IOPS reduction | Redelivery exposure |
+|--------|-----|----------------|---------------------|
+| **Default** | (nothing) | baseline | None beyond JetStream's own |
+| **Balanced** | `WithConsumerMemoryStorage(true)` + replicas inherited (R≥3) | ~90% at N=1000, ~72% at N=3000 | Redelivery only on a **coordinated cluster-wide restart**; keeps consumer HA |
+| **Aggressive** | `WithConsumerMemoryStorage(true)` + `WithConsumerReplicas(1)` | ~99%; per-partition cost goes flat in N | Redelivery on **single-node failure** too — correct only for idempotent handlers |
+
+```go
+// Balanced: recommended once the decision above reaches "yes".
+c, _ := consumer.NewDynamic(js, "ORDERS", "processor", "orders.{{.PartitionID}}", handler,
+    consumer.WithConsumerMemoryStorage(true),  // not live-editable — set before first start
+    consumer.WithConsumerReplicas(3),           // live-editable; on a 3-replica stream
+)
+```
+
+Notes:
+
+- `WithConsumerMemoryStorage` is **not** live-editable — changing it requires
+  recreating the consumer. `WithConsumerReplicas` **is** live-editable.
+- On `InterestPolicy`/`WorkQueuePolicy` streams, consumer replicas must equal the
+  stream's replicas, so the Aggressive (R=1) row is unavailable there — use the
+  Balanced row. See [Stream Retention Policy](#stream-retention-policy).
+- For capacity numbers (RSS per partition, latency) see the "NATS-Side Cost"
+  section in [`OPERATIONS.md`](OPERATIONS.md).
 
 ---
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -28,7 +28,7 @@
 | Component     | Requirement                          |
 |---------------|--------------------------------------|
 | Go            | 1.25 or later                        |
-| NATS Server   | 2.10.0+ with JetStream enabled       |
+| NATS Server   | 2.10.0+ (2.12+ recommended at scale) |
 | Memory        | 50-100 MB per worker (typical)       |
 | Network       | Low-latency connection to NATS       |
 
@@ -68,6 +68,26 @@ cluster {
     ]
 }
 ```
+
+**Cluster size and replicas.** Run **at least 3 nodes** and use **R=3** for the
+application stream and parti's KV buckets — this is the HA posture validated by
+the scaling study (3-node cluster, RF=3 stream, R=3 consumers). A single node
+has no failover; 5 nodes (RF=5) only buys extra message-stream durability and is
+not required.
+
+**Metacontroller snapshots at large fleets (NATS ≥ 2.12).** Each parti partition
+is one JetStream durable, so a large fleet (≈10k+ consumers) drives the JetStream
+metacontroller's Raft snapshot. On **NATS ≥ 2.12 snapshots are asynchronous** —
+at 10k consumers a snapshot is a ~30 ms background operation, ~20–40× below the
+pre-async blocking behavior. Guidance:
+
+- **Stay on NATS ≥ 2.12** for any fleet past a few thousand partitions.
+- **Do not lower `meta_compact_size`** — it is gated by an internal floor and has
+  no effect at this scale (it cannot make snapshots cheaper).
+- **Do not set `JetStreamMetaCompactSync`** — it forces blocking snapshots,
+  reintroducing the cost async removed.
+
+There is effectively no metacontroller knob to turn at ≤10k consumers on ≥2.12.
 
 ### NATS Client Connection
 
@@ -246,7 +266,7 @@ version: '3.8'
 
 services:
   nats:
-    image: nats:2.10-alpine
+    image: nats:2.14-alpine  # 2.10 is the documented minimum; 2.12+ recommended at scale
     command: ["--jetstream", "--store_dir=/data"]
     volumes:
       - nats-data:/data
@@ -924,13 +944,40 @@ grep "parti error" /var/log/app.log
 | 128        | 16-64               | Large production                 |
 | 256+       | 32-128              | Consider cluster sharding        |
 
-### Resource Estimates
+> This table sizes the **worker** count (how many pods share the load); it is a
+> different axis from the **partition** count. With `consumer.Dynamic` (one
+> consumer per partition), parti has been validated to **10,000 partitions** on a
+> 3-node cluster — see "NATS-Side Cost" below. Partition count is bounded by
+> NATS-side RSS, not by parti.
+
+### Resource Estimates (per worker pod)
 
 | Workers | NATS Memory | KV Storage | Network (steady) |
 |---------|-------------|------------|------------------|
 | 10      | 50 MB       | 1 MB       | 10 KB/s          |
 | 50      | 100 MB      | 5 MB       | 50 KB/s          |
 | 100     | 200 MB      | 10 MB      | 100 KB/s         |
+
+### NATS-Side Cost (partition scaling)
+
+The table above estimates the **worker pod** footprint. The NATS **server-side**
+cost scales with the number of partitions (one JetStream durable each). The
+scaling study measured the recommended config (`consumer.Dynamic` with memory
+consumer state + R=3) and fit an affine model, validated to **N = 10,000**
+partitions:
+
+| Resource | Scaling | Notes |
+|----------|---------|-------|
+| Cluster RSS | ~**0.793 MiB per partition** (+ ~90 MiB baseline) | The binding constraint — size NATS memory by partition count |
+| Latency | flat **~1.3 ms P95/P99**, independent of N | No per-partition fetch tax vs the JetStream floor |
+| Write IOPS / CPU | sub-linear in N | Never the wall on modern NVMe/gp3 |
+
+Worked point: at **N = 5,000** (memory consumer state + R=3) the cluster sits at
+~4 GiB RSS, ~1.3 ms P99. **RSS is the first ceiling you hit**, not IOPS or CPU —
+provision NATS memory accordingly. For consumer-state storage tuning (the IOPS
+lever behind this config), see [`CONSUMERS.md`](CONSUMERS.md); for pushing
+partition count far beyond 10k with a bounded consumer count, see
+[`SCALING.md`](SCALING.md).
 
 ### Performance Tuning
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,9 +47,10 @@ mgr.Start(context.Background())
 | Document                                      | Description                                                 |
 |-----------------------------------------------|-------------------------------------------------------------|
 | [Lifecycle](LIFECYCLE.md)                     | Worker states, stable IDs, two-phase handoff, degraded mode |
-| [Consumer Package](CONSUMERS.md)              | Queue, Static, Dynamic, Broadcast consumers                 |
+| [Consumer Package](CONSUMERS.md)              | Queue, Static, Dynamic, Broadcast consumers; stream retention policy; storage tuning |
 | [Strategies & Sources](STRATEGIES.md)         | Assignment strategies, partition sources                    |
 | [Static Partitioning](STATIC_PARTITIONING.md) | Key-based routing plus static partition publisher/subscriber helpers |
+| [Scaling](SCALING.md)                         | Bounded-cost partitioning: NATS `partition()` + `Dynamic` over a fixed K |
 
 ### Reference
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,0 +1,205 @@
+# Scaling: bounded-cost partitioning with NATS `partition()` + `consumer.Dynamic`
+
+> Serve a high-cardinality key space with a *fixed, small* number of JetStream
+> consumers (K), losslessly, **without writing any new parti code**.
+
+**Related Documentation:**
+- [Consumers Guide](CONSUMERS.md) — consumer types, retention policy, storage tuning
+- [Operations Guide](OPERATIONS.md) — capacity planning, NATS-side cost model
+- [Architecture](ARCHITECTURE.md) — system architecture and concepts
+
+---
+
+## Overview
+
+By default, parti runs one `consumer.Dynamic` per partition. The perf study shows
+that scales cleanly to **N = 10,000 partitions** on a 3-node cluster — so most
+deployments never need anything else.
+
+When you have far more logical keys than you want JetStream consumers for — and
+**per-key isolation is not required** — you can serve the whole key space with a
+*fixed* number of numbered partition-subjects (K) and let NATS deterministically
+hash keys into them. This is "be Kafka": choose a partition count K, hash keys
+into K, consume K. It reuses parti's existing `consumer.Dynamic` over a fixed set
+of K subjects — **no new consumer type**, and it is the only K-bounded pattern
+parti ships.
+
+Requires **NATS ≥ 2.10** (≥ 2.12 recommended at large fleets — see
+[OPERATIONS.md](OPERATIONS.md)).
+
+### When to use this
+
+✅ Use it when:
+- You have far more logical keys (entities) than you want JetStream consumers for,
+  and **per-key isolation is not required** — per-*partition* (per-slot) ordering
+  and ownership is enough (exactly Kafka's model).
+- You're approaching the per-consumer cost wall (≳10k consumers strains RSS or the
+  metacontroller snapshot), or you simply want a Kafka-style fixed partition count.
+
+❌ Don't use it when:
+- The workload needs **per-key cache locality or per-key isolation** (a stuck key
+  must not block its neighbours). Then keep one `Dynamic` consumer per entity
+  (K = N) — that scales cleanly to N = 10,000.
+
+---
+
+## How it works (one mapping + existing `Dynamic`)
+
+```
+producer ──publish ingest.<key>──▶  NATS partition() mapping  ──▶ stream WORK (work.0 … work.K-1)
+                                    work.{{partition(K,1)}}              │
+                                    (fnv32a(key) % K, ordering-preserving)│
+                                                                          ▼
+            parti Manager assigns the K partition-subjects across W workers
+            (ConsistentHash, >80% cache affinity), one Dynamic durable per work.<p>;
+            worker churn → lossless durable rebind (same single-filter durable).
+```
+
+A `work.<p>` partition-subject is a "slot". Each slot is **one single-filter
+durable** with its **own cursor**, so the filter never changes and reassignment is
+a lossless rebind — identical to today's `Dynamic` per-partition handoff. parti
+sees K partitions and reassigns them exactly as it reassigns any partition set.
+
+---
+
+## Step-by-step
+
+### 1. Choose K (pick once, over-provision)
+
+`W ≤ K`. K bounds consumer count and is the isolation/cost dial: larger K ⇒
+smaller per-slot head-of-line blast radius (fewer keys per slot) but more
+consumers. A typical choice is K = 256 (Kafka-like). **Changing K later is a
+disruptive reshuffle** (see [Operating notes](#operating-notes)).
+
+### 2. Partition source — K numbered partitions
+
+```go
+parts := make([]types.Partition, K)
+for i := range parts {
+    parts[i] = types.Partition{Keys: []string{strconv.Itoa(i)}, Weight: 1} // PartitionID "0".."K-1"
+}
+src := source.NewStatic(parts)
+```
+
+### 3. Stream — capture the K partition-subjects
+
+```go
+js.CreateStream(ctx, jetstream.StreamConfig{
+    Name:      "WORK",
+    Subjects:  []string{"work.*"},
+    Storage:   jetstream.FileStorage,        // durable messages
+    Replicas:  3,                            // on a cluster
+    Retention: jetstream.LimitsPolicy,       // recommended for Dynamic — see CONSUMERS.md
+})
+```
+
+`LimitsPolicy` is the recommended retention policy for `Dynamic`; see
+[Stream Retention Policy](CONSUMERS.md#stream-retention-policy) for why (and what
+`WorkQueuePolicy`/`InterestPolicy` cost here).
+
+### 4. Route keys → partition-subjects (producer side)
+
+The producer's subject **must equal** the consumer's filter subject (`work.<p>`).
+
+**Option A — NATS server-side mapping (zero producer code).** In the account scope
+of `nats.conf` (hot-reloadable). The destination `work.<p>` matches the consumer
+template; `partition(K,1)` hashes the first wildcard token (the key):
+
+```
+mappings = {
+  "ingest.*": "work.{{partition(256,1)}}"
+}
+```
+
+Producers just publish to `ingest.<key>`; NATS rewrites to `work.<fnv32a(key)%256>`
+*before* the stream stores it.
+
+**Option B — client-side hash (more control; enables graceful repartition later).**
+The producer computes `p` and publishes `work.<p>` directly. Use a consistent-hash
+partitioner if you want to grow K with minimal remapping.
+
+### 5. The consumer — existing `consumer.Dynamic`, numeric template
+
+```go
+c, err := consumer.NewDynamic(
+    js, "WORK", "worker",
+    "work.{{.PartitionID}}",                 // PartitionID "7" → filter subject "work.7"
+    handler,
+    consumer.WithMaxDeliver(maxDeliver),      // + a dead-letter handler: bounds per-slot HoL
+)
+```
+
+> **Consumer-state storage is a separate, conditional choice.** You may add
+> `WithConsumerMemoryStorage(true)` (+ `WithConsumerReplicas(3)`) here to cut
+> write IOPS — but only if your deployment meets the criteria in
+> [Consumer Storage Tuning](CONSUMERS.md#consumer-storage-tuning). The default
+> file-backed consumer state is correct for most deployments; this pattern does
+> not require memory storage.
+
+### 6. The Manager — unchanged wiring (one per worker instance)
+
+```go
+cfg := parti.DefaultConfig() // your existing config
+mgr, err := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(),
+    parti.WithWorkerConsumerUpdater(c),
+)
+_ = mgr.Start(ctx)
+_ = <-mgr.WaitState(parti.StateStable, 30*time.Second)
+```
+
+That's it — no new consumer type. The `Manager` assigns the K slots across the W
+workers; each worker's `Dynamic` creates a durable per assigned `work.<p>`; churn
+triggers lossless rebind.
+
+---
+
+## Operating notes
+
+- **`W ≤ K`.** Excess workers (W > K) sit idle (harmless standby). Size K ≥ your
+  max expected W.
+- **Per-slot, not per-key.** A slot's `(keyspace / K)` keys share **one cursor and
+  one `MaxAckPending`** → per-slot ordering, and a stuck key head-of-line-blocks
+  its slot-mates. Mitigate with a larger K and `WithMaxDeliver` + a dead-letter
+  path.
+- **Retention = `LimitsPolicy`** (recommended). On `InterestPolicy`, messages
+  published while no consumer covers a subject are discarded at publish time; on
+  `WorkQueuePolicy`, overlapping filters are rejected and cross-slot moves need
+  remove-before-add. See [Stream Retention Policy](CONSUMERS.md#stream-retention-policy).
+- **K is pick-once.** NATS `partition()` is `fnv32a(key) % K`, so changing K
+  reshuffles ~all keys (a disruptive repartition, Kafka-class). parti can
+  grow/shrink its *consume-set* (`source.NatsKV.AddPartitions` / `RemovePartitions`),
+  but the producer-side hash change is an ops/config action and needs a
+  drain-and-cutover. If you must grow K gracefully at runtime, use Option B with a
+  **consistent-hash** partitioner (remaps only ~Δ/K of keys).
+- **Rebalancing is cooperative, not stop-the-world.** Unlike a Kafka eager
+  consumer-group rebalance (revoke-all → re-join → re-assign barrier), worker churn
+  here moves only the ~Δ/K reassigned slots; **slots that stay put keep flowing at
+  baseline latency** (the `Dynamic` updater touches only added/removed subjects).
+  The producer never rebalances (the `partition()` hash is independent of worker
+  count). Cost is a brief per-*moved*-slot handoff blip (drain + rebind) and, for
+  an *abrupt crash*, a `HeartbeatTTL` detection gap for the crashed worker's slots
+  only. Retained slots keep flowing at baseline throughout.
+- **Cost (projected from the perf study, memory consumer state + R=3, K=256/N=5000):**
+  ~300 MiB cluster RSS, ~12 cluster IOPS, sub-ms metacontroller snapshot. Latency
+  is at the JetStream floor; this buys footprint, not speed. See the "NATS-Side
+  Cost" section in [OPERATIONS.md](OPERATIONS.md).
+
+---
+
+## Proof
+
+This pattern is backed by live-cluster integration tests in
+`test/integration/fixedpartitions/`:
+
+- **Lossless reassignment across churn** — worker join, graceful leave, and abrupt
+  crash, single-node and on a 3-node cluster (RF=3 stream + R=3 consumers), plus a
+  processing-gate variant; `-race` clean.
+- **Cooperative (no stop-the-world) rebalance** — per-message latency shows
+  retained slots keep flowing during churn while only moved slots blip
+  (`TestFixedPartitions_NoStopTheWorld`).
+- **Full server-side `partition()` path** — producers publish `ingest.<key>`, NATS
+  `{{partition(K,1)}}` routes to `work.<p>`, `Dynamic` consumes.
+
+For the full design analysis, the three-way isolation↔cost trade, and the cost
+model, see the feasibility assessment under
+[`docs/plans/partition-scaling/`](plans/partition-scaling/01-feasibility-assessment.md).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -92,7 +92,7 @@ See [Architecture Guide](ARCHITECTURE.md) for detailed documentation.
 ### Prerequisites
 
 - **Go**: Version 1.25 or later
-- **NATS Server**: Version 2.10.0+ with JetStream enabled
+- **NATS Server**: Version 2.10.0+ with JetStream enabled (2.12+ recommended for large fleets — async metacontroller snapshots keep snapshot cost off the critical path)
 
 ### Installation
 

--- a/docs/plans/docs-operational-sync/00-sync-plan.md
+++ b/docs/plans/docs-operational-sync/00-sync-plan.md
@@ -1,0 +1,314 @@
+# Operational Docs Sync Plan
+
+**Date:** 2026-06-07
+**Scope:** `docs/` operational guides — `CONFIGURATION.md`, `OPERATIONS.md`,
+`CONSUMERS.md`, `USER_GUIDE.md`, `ARCHITECTURE.md`, `KUBERNETES.md`.
+**Driver:** Reconcile the operational docs with the verified state of `main`
+and the three investigation campaigns:
+- `docs/plans/iops-investigation/` (IOPS attribution, KV-storage findings)
+- `docs/plans/perf-measurement/` (Dynamic-consumer cost + latency model, to N=10k)
+- `docs/plans/partition-scaling/` (NATS `partition()` + `Dynamic` over fixed K)
+
+This is a **plan only**. No edits applied yet. Each fix below cites the source
+of truth it was verified against.
+
+---
+
+## The one correctness trap (read first)
+
+The word **`MemoryStorage`** points in **two opposite directions**. The sync
+must keep them separate everywhere, loudly:
+
+| Subject | Correct storage | Why |
+|---|---|---|
+| **Parti coordination KV buckets** (stableid, election, heartbeat, assignment, handoff) | **`FileStorage`** | Memory-KV was *falsified* as an IOPS mitigation (M1.9: ~1–2% savings, within noise). Worse, a `MemoryStorage` heartbeat bucket is **lost on a single-node restart and flaps the fleet** `Degraded`↔`Stable` (v2.6.0 fix). All five buckets are `FileStorage` in code (`manager_setup.go:92,158,162,166,182`). |
+| **Per-consumer JetStream state** (the consumer's own ack/cursor store) | **`MemoryStorage` — but only when the decision tree says so** | Per-consumer state files are **72–81% of cluster write IOPS** (iops-investigation §4). Moving consumer state to memory is the real lever — but it is **conditional**, not a blanket default (see B2). |
+
+A reader must never come away thinking "memory for the buckets too." Every
+edit that mentions consumer `MemoryStorage` states "consumer state, *not* the
+parti KV buckets."
+
+**Second trap — do not flatten the recommendation.** The findings are a
+**decision tree**, not "always set `WithConsumerMemoryStorage(true)`." The
+default file-backed config is correct for most deployments. The plan's authored
+content (Part B) is anchored to the Q1→Q2→Q3 tree below, never to a flat directive.
+
+```
+Q1. Is disk-IOPS pressure actually high?
+    (≥10k partitions per NATS pod, or noisy-neighbour latency tail,
+     or provisioned-IOPS billing, or a constrained dev/test cluster)
+    NO  → stop. Default (file-backed consumer state, R=3) is fine.
+    YES → continue.
+Q2. Can the workload tolerate redelivery ONLY on a coordinated cluster-wide restart?
+    YES → WithConsumerMemoryStorage(true), Replicas inherited (R≥3).   [M2.A]
+          ~90% IOPS cut at N=1000, ~72% at N=3000. Keeps consumer HA. ← recommended when Q1=YES
+    NO  → continue.
+Q3. Idempotent handler that tolerates redelivery on single-node failure too?
+    YES → WithConsumerMemoryStorage(true) + WithConsumerReplicas(1).   [M2.B]
+          ~99% cut; per-partition cost collapses to flat-in-N.
+    NO  → keep file-backed state, or redesign (consumer.Queue / fixed-K).
+```
+
+---
+
+## Part A — STALE fixes (must-fix, low risk, source-verified)
+
+### A1. `CONFIGURATION.md` "Bucket Purposes and Storage Type" table — WRONG storage column
+- **Lines ~185–196.** Table lists `ElectionBucket` and `HeartbeatBucket` as
+  **`Memory`**. Source: all five buckets are `FileStorage`
+  (`manager_setup.go:92,158,162,166,182`); v2.6.0 CHANGELOG documents the election +
+  heartbeat switch.
+- **Fix:** set the `Default Storage` column to **`File`** for every bucket.
+
+### A2. `CONFIGURATION.md:195-197` rationale paragraph — encodes the *old* memory-KV reasoning + a wrong migration command
+- Current text (line 195): *"Heartbeat and election buckets use `MemoryStorage`
+  to minimize PVC IOPS … intrinsically ephemeral …"* — false on `main`.
+- Current text (line 197): the manual-migration hint says `nats kv del <bucket>`.
+  **Wrong command** — `nats kv del` deletes a *key*; bucket removal is
+  `nats kv rm` (the OPERATIONS runbook uses `nats kv rm` at `OPERATIONS.md:633,689`).
+  *[codex round-1 catch, verified]*
+- **Fix:** rewrite the rationale to: all five coordination buckets use
+  `FileStorage`; election/heartbeat were switched from Memory in v2.5.0/v2.6.0
+  because a single-node restart lost a memory stream and flapped the fleet; the
+  added write IOPS is a flat, partition-count-independent term (memory-KV was
+  measured to save only ~1–2%, so the durability win dominates). Point to the
+  OPERATIONS migration sections, and correct the command to `nats kv rm`.
+
+### A3. `CONFIGURATION.md:132` heartbeat-interval prose — OPTIONAL reword (NOT a contradiction)
+- *"Defaults are tuned for low IOPS on file-backed JetStream clusters."*
+  *[codex round-1: this is still TRUE — heartbeat writes hit file-backed KV, so
+  slower interval = less write load regardless of storage type. Downgraded from
+  must-fix STALE to optional clarity reword.]*
+- **Fix (optional):** keep the interval/TTL guidance as-is; only touch if a
+  reader could misread it as implying memory/ephemeral heartbeat storage.
+
+### A4. NATS version floor — `USER_GUIDE.md:95`, `OPERATIONS.md:31` (ADDITIVE, not a verified stale-fix)
+- Both say **"2.10.0+"**. *[codex round-1: do NOT claim this is source-verified.
+  go.mod pinning server `v2.14.1` is the embedded test-server version, not proof
+  CI validates 2.10.0. Leave the documented `2.10.0+` minimum untouched.]*
+- **Fix (additive only):** keep `2.10.0+` as the documented minimum, add
+  "**≥2.12 recommended** for large fleets — async metacontroller snapshots keep
+  snapshot cost off the critical path (≤~30 ms async at 10k consumers)." Do not
+  assert 2.10 is tested.
+
+### A6. `OPERATIONS.md:248` Docker Compose pins `nats:2.10-alpine` *[codex round-1 catch]*
+- If A4 adds "≥2.12 recommended," this example contradicts it.
+- **Fix:** bump to a current tag (e.g. `nats:2.14-alpine`) OR add a one-line
+  "minimum-version local example; see version guidance above" note.
+
+### A7. SOURCE follow-up — `manager_setup.go:457-470` `warnOnStorageMismatch` is inverted *[codex round-1 catch; NOT a docs edit]*
+- The comment and the operator-facing `Warn` log both say *"even after parti's
+  defaults switched to **memory** storage / IOPS reduction from the
+  memory-storage default is NOT active"* and emit `nats kv del <bucket>`. Both
+  are wrong on `main`: defaults are **FileStorage**, and the command should be
+  `nats kv rm`. Same defect as A2.
+- **Fix:** a small SOURCE change (comment + log string). **DECISION (user,
+  2026-06-07): include as a paired follow-up commit** after the docs land —
+  reword the comment + `Warn` string (memory→file framing) and correct
+  `nats kv del` → `nats kv rm`. Touches `manager/` surface → triggers the
+  `make pre-pr` gate (lint + `make test -race` + `make test-integration`).
+
+### A5 — DROPPED (user, 2026-06-07): leave `ARCHITECTURE.md` KV table as-is.
+
+---
+
+## Part B — MISSING additions (authoring; anchored to the decision tree)
+
+### B1. `CONSUMERS.md` option tables — add the two shipped options + fix the "all options" framing
+- **Lines ~672–697.** `WithConsumerMemoryStorage` and `WithConsumerReplicas`
+  exist on Dynamic/Queue/Static/Broadcast (`consumer/options.go:597,639`;
+  `consumer/common.go:102-144`) but appear in **no** options table.
+- **Fix:** add both to the common options table, with one-line descriptions
+  that flag `WithConsumerMemoryStorage` as **not live-editable** and
+  `WithConsumerReplicas` as **live-editable** (per the Godoc).
+- *[codex round-1 catch]* the tables are introduced at `CONSUMERS.md:660` as
+  "All consumers accept functional options" but are already **non-exhaustive**
+  (source also has common `WithMaxWaiting`, `WithAckPolicy` at
+  `consumer/options.go:371-403`, plus Static/Dynamic options at `:719-835`).
+  **Fix:** relabel the tables as "**Selected / commonly-used options**" and add
+  a pointer to `API_REFERENCE.md` / Godoc for the complete list — rather than
+  silently implying the storage options are the only addition. Full
+  option-table exhaustiveness is a larger doc-sync pass, out of scope here.
+
+### B2. `CONSUMERS.md` — new "Tuning consumer storage for scale" subsection
+- Author the **decision tree** (Q1→Q2→Q3 above) verbatim-in-spirit, with the
+  measured numbers (M2.A ~90%/72%, M2.B ~99% flat-in-N) and the redelivery
+  trade-offs per branch. **Open with the disambiguation callout** (consumer
+  state ≠ parti KV buckets). Do **not** write "recommended = always memory."
+- *[codex round-1]* **Wording guard:** do NOT carry the perf report's phrase
+  "production default" for memory+R3 (it's the report's internal label,
+  `03-findings-production-mem-r3.md:8-16`). Operator-facing text says
+  "**recommended once the decision tree reaches Q2**," never "default."
+
+### B7. `CONSUMERS.md` — new "Stream Retention Policy" section (consumer-type × policy)
+*[Added 2026-06-07 after a dedicated codex judgment pass — see consensus log
+Round 3. Stream retention policy is the hardest JetStream concept and the
+per-type guidance is currently scattered (Broadcast callout @245, WorkQueue
+recovery restriction @416). Consolidate into one matrix + a two-axis decision.]*
+
+- **Placement:** new `## Stream Retention Policy` section after Overview (or
+  after Consumer Types), plus a one-line "Recommended retention: …" in each
+  type's subsection linking to it. **Cross-link, do NOT duplicate** the existing
+  Broadcast callout (245) and WorkQueuePolicy Restriction (416) — a second
+  drifting copy is worse than none.
+- **The two-axis framing (lead with this, don't flatten to per-type rules):**
+  (1) must messages survive after processing — replay / multiple readers /
+  no-consumer windows? → `LimitsPolicy`. (2) dedicated consume-once queue,
+  single non-overlapping consumer set, restricted recovery acceptable? →
+  `WorkQueuePolicy`. Interest is a narrow third option.
+- **Reconciled matrix (codex-judged, source-verified):**
+
+  | Consumer | Recommended | Acceptable (caveats) | Avoid / Forbidden |
+  |---|---|---|---|
+  | `Queue` | **WorkQueuePolicy** — dedicated consume-once queue (shared durable ⇒ delete-on-ack, auto-trim) | **LimitsPolicy** — shared stream, replay, or `RecoverFromNew` needed | Interest (no-cover publishes lost) |
+  | `Static` | **LimitsPolicy** (retain/replay) **or WorkQueuePolicy** (non-overlapping consume-once) | Interest — only with full partition coverage pre-created | — |
+  | `Dynamic` | **LimitsPolicy** — recommended; preserves all recovery strategies and replay; the partition-scaling scaling guide assumes it | WorkQueue — **viable, now proven for BOTH paths**: graceful join+leave (`TestDynamic_OnWorkQueueStream`, 876/876, 0 overlap) and 3-node RF=3 abrupt crash (`TestDynamic_OnWorkQueueStream_ClusterCrash`, 1166/1166, 0 overlap), `-race` clean. The remaining trade is real but bounded: recovery limited to `Beginning`/`Disabled` (`RecoverFromNew`/`LastProcessed` banned) + delete-on-ack (no replay) + single consumer set. Choose it for auto-trim/bounded-storage; choose Limits for recovery flexibility | Interest — no-cover discard on unassigned/GC'd windows |
+  | `Broadcast` | **LimitsPolicy** — every instance gets every message; no churn-pinning | InterestPolicy — only if stable instance IDs, all recipients pre-created, low churn / short `InactiveThreshold`, no-recipient discard acceptable | **WorkQueuePolicy** — single delivery defeats fan-out (hard) |
+
+- **Cross-cutting notes that MUST accompany the table:**
+  1. **WorkQueue recovery cost:** consumers limited to `DeliverAllPolicy` ⇒ only
+     `RecoverFromBeginning`/`RecoveryDisabled`; `RecoverFromNew`/`LastProcessed`
+     rejected (already in the WorkQueuePolicy Restriction section — link it).
+  2. **Replicas on Interest/WorkQueue:** nonzero consumer replicas must **equal**
+     stream replicas (NATS rule, `consumer/options.go:621-629`). So on a typical
+     RF3 stream `WithConsumerReplicas(1)` is rejected — the M2.B IOPS lever (B2)
+     is unavailable; use M2.A (`WithConsumerMemoryStorage(true)` + inherited
+     replicas) on those policies.
+  3. **Interest ghost-durable pinning (source-verified in nats-server):** a
+     stopped consumer's durable keeps interest until the durable is *deleted*;
+     parti's `Stop()` doesn't delete it (GC after `InactiveThreshold`, 24h
+     default), so Interest pins un-acked messages behind churned instances —
+     the decisive reason Broadcast defaults to Limits, not Interest.
+- **Overstatement guard:** Dynamic recommendation is firm `LimitsPolicy` but
+  NOT "forbidden" for WorkQueue. WorkQueue is empirically VIABLE for Dynamic
+  (both graceful + crash proven); the recommendation rests on the recovery
+  trade-off, not impossibility. The doc must say "Limits recommended (keeps
+  recovery + replay); WorkQueue is a valid consume-once alternative if you
+  accept Beginning/Disabled-only recovery" — NOT "WorkQueue may not work." Only
+  Broadcast gets a hard "WorkQueue forbidden."
+- **Empirical proof artifact:** `test/integration/fixedpartitions/workqueue_dynamic_test.go`
+  — two tests, both `WorkQueuePolicy`, both capturing `OnError` to assert no
+  `10100`: `TestDynamic_OnWorkQueueStream` (Exp11 scenario 1, single-node
+  join+leave → 876/876, 0 overlap) and `TestDynamic_OnWorkQueueStream_ClusterCrash`
+  (Exp11 scenario 2, 3-node RF=3 + R=3 consumers, abrupt crash → 1166/1166, 0
+  overlap). `go vet` clean; both `-race` clean together (45.8s). Keep in-tree as
+  the WorkQueue-viability record. NOTE: consumer `Replicas` must equal stream
+  replicas on WorkQueue (R=3 here), so the crash test uses
+  `WithConsumerMemoryStorage(true)`+`WithConsumerReplicas(3)` — corroborates
+  cross-cutting note #2.
+
+### B3. Recommended pattern for partitioning at scale — NATS `partition()` + `Dynamic` over fixed K
+- **DECISION (user, 2026-06-07): promote into a real docs page** — proposed
+  `docs/SCALING.md` (name to confirm at review). Lift
+  `docs/plans/partition-scaling/02-guide-nats-partition-dynamic.md` into `docs/`
+  as a first-class page.
+- The recommended posture to carry over: `consumer.Dynamic` + memory consumer
+  state + R=3 scales cleanly to **N=10,000**; reach for the fixed-K
+  `partition()` pattern only when ≥10k partitions/cluster strain per-consumer
+  RSS or the metacontroller snapshot.
+- **Trim on promotion (do not imply shipped features):** the source guide and
+  feasibility doc discuss speculative `consumer.Grouped` / `consumer.Pooled`
+  types that **do not ship** (assessment-only). The promoted page documents
+  only what ships today — NATS `partition()` (or a client hash) + the existing
+  `consumer.Dynamic` over a fixed K of numbered subjects — and explicitly notes
+  the fixed-K *types* are not built and should not be built speculatively.
+- Cross-link the new page from `CONSUMERS.md` and `OPERATIONS.md` (B4).
+- Carry the verified delivery contract: at-least-once + per-partition order, but
+  only if a partition never changes slots after first delivery; one stuck key
+  HoL-blocks its whole slot; `Retention: LimitsPolicy` (not Interest/WorkQueue);
+  K is pick-once (over-provision, e.g. K=256). Proven by `poc/` Exp1–10 +
+  `test/integration/fixedpartitions/` Exp11/12.
+- *[codex round-1]* **Overstatement guard on promotion:** the source guide's
+  examples set `WithConsumerMemoryStorage(true)` and call it the perf study's
+  recommended config (`02-guide-…:101-110,144-147`). On promotion, add a
+  sentence near the first example: *this assumes the deployment already
+  satisfies the IOPS/scale decision tree (B2); default file-backed consumer
+  state remains fine otherwise.* Do not present memory state as unconditional.
+
+### B4. `OPERATIONS.md` — new NATS-side capacity/cost model (separate axis)
+- The existing "Resource Estimates" table (~929–933, per-**worker-pod** RSS
+  50–200 MB) answers a *different* question than the perf model (NATS-**server**
+  cost per partition). **Add, do not overwrite.**
+- New content (perf-measurement, production config = memory consumer state + R=3,
+  validated to N=10,000):
+  - **RSS is the binding constraint:** ~**0.793 MiB cluster RSS per partition**
+    (+ ~90 MiB baseline). IOPS and CPU never wall on modern NVMe/gp3.
+  - **Latency is flat ~1.3 ms P95/P99, independent of N** to 5000+ (no
+    per-partition fetch tax vs the JetStream floor).
+  - Worked point: K=256 / N=5000 fixed-K ≈ ~300 MiB cluster RSS, ~12 IOPS,
+    sub-ms metacontroller snapshot.
+  - **Cluster sizing:** ≥**3 nodes, R=3** for consumer/KV HA (the validated
+    production posture). RF=5 only if message-stream durability needs 5-way.
+    (The perf rig's 5-node/RF=5 was a test-isolation artifact, not a
+    recommendation.)
+
+### B5. `OPERATIONS.md` worker-count guidelines table (~915–925) — caps at "256+"
+- Reads as if 256 partitions is "large." The library is validated to **10,000**.
+- **Fix:** add a row/note distinguishing **worker count** (the table's axis)
+  from **partition count** (validated to 10k; see B4). Don't conflate.
+
+### B6. `OPERATIONS.md` — metacontroller note for large fleets
+- New short note: on NATS **≥2.12** snapshots are async (~30 ms background at
+  10k consumers, 20–40× below the pre-async 1.286 s incident). **Do not lower
+  `meta_compact_size`** (inert below the 8 MB floor) and **do not set
+  `JetStreamMetaCompactSync`** (forces blocking snapshots). There is no knob to
+  turn at ≤10k on ≥2.12.
+
+---
+
+## Part C — Out of scope / already synced (do NOT touch)
+- `OPERATIONS.md` Election + Heartbeat **Bucket Storage Migration** sections
+  (@613, @661) — already correct and complete.
+- `PROVISION.md:748-751` — already references `WithConsumerMemoryStorage`.
+- `docs/plans/**` and `docs/design/**` — internal; not doc-sync targets.
+
+---
+
+## Execution order (once scope confirmed)
+1. **Part A** first (mechanical STALE fixes, lowest risk) — A1, A2, A3, A4 (A5 optional).
+2. **Part B** authored content — B1, B2 (CONSUMERS), B4, B5, B6 (OPERATIONS),
+   then B3 (the link/promote decision).
+3. Re-grep `docs/*.md` for `MemoryStorage`/`low.*IOPS`/`ephemeral` to confirm no
+   stale sibling survived (per global-grep discipline).
+4. `/post-impl-review` is overkill for docs; instead a final read-through +
+   `make lint` (no Go changed, but cheap) before commit.
+
+## Cross-model consensus log
+- **Round 1 (codex, read-only, 2026-06-07):** independently verified the core
+  findings from source with tighter cites — AGREE on all of: 5 buckets =
+  FileStorage (`CONFIGURATION.md:187-195` stale); both consumer options ship +
+  live-edit semantics; decision tree is conditional; Grouped/Pooled don't ship.
+  Refinements ACCEPTED into the plan: A2 command fix (`kv del`→`kv rm`), A3
+  downgraded (not a contradiction), A4 reframed as additive (2.10 not
+  source-verified), A6 (Docker tag), A7 (source `warnOnStorageMismatch` is
+  inverted), B1 table-framing, B2/B3 "production default" wording guards. No
+  evidence-backed disagreement remained → substance consensus reached round 1.
+  Round 2 = confirm the amended plan.
+- **Round 2 (codex, read-only, 2026-06-07):** CONFIRMED A2/A3/A4/A6/A7/B1/B2/B3
+  faithfully incorporated; both `MemoryStorage` directions preserved; **no
+  execution blockers — "ready to execute as-is."** One non-blocking cite nit
+  (five-buckets range) fixed. **Consensus reached — plan is execution-ready,
+  pending the user's final go-ahead.**
+- **Round 3 (codex retention-policy judgment, read-only, 2026-06-07):**
+  independent judge on consumer-type × retention-policy → produced B7. AGREE:
+  Queue→WorkQueue(dedicated), Static→WorkQueue(non-overlap), Broadcast→Limits
+  (ghost-durable pinning **confirmed in nats-server source**:
+  `stream.go:8771,8777`, `consumer.go:3822,6657,6666,6718`). CORRECTED 3 of my
+  claims, all accepted: (1) Dynamic WorkQueue is *not forbidden* (single-filter
+  rebind, no overlap) — softened to "firm Limits recommendation, WorkQueue
+  unproven+recovery-cost, not forbidden"; (2) `Replicas=1` rejection rule is
+  "must equal stream replicas" (RF3 rejects 1, RF1 accepts); (3) Queue
+  `DeliverAll` is JetStream's default, not parti-set. No unresolved disagreement
+  → consensus. B7 matrix is the reconciled output.
+
+## Resolved scope (user, 2026-06-07)
+- **Depth:** Part A + Part B (full sync).
+- **B3:** promote the fixed-K guide into a real `docs/` page (proposed
+  `docs/SCALING.md`, name to confirm), trimming the unshipped `Grouped`/`Pooled`
+  design.
+- **Status:** plan handed back for review — **no doc edits applied yet**, awaiting
+  go-ahead.
+
+## Still to confirm at review
+- Final name for the promoted scaling page (`docs/SCALING.md`?).
+- Whether `ARCHITECTURE.md` A5 (add a storage note to the KV table) is in or out.

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -447,9 +447,10 @@ func reconcileStableIDBucketMaxAge(
 }
 
 // warnOnStorageMismatch logs a warning if the existing bucket's storage type
-// differs from the type parti would have created. This catches the silent
-// non-upgrade path where a pre-existing file-backed bucket continues to
-// absorb IOPS even after parti's defaults switched to memory storage.
+// differs from the type parti would have created. parti opens a pre-existing
+// bucket as-is ("pre-creation wins"), so this surfaces the divergence — for
+// example a bucket still on MemoryStorage after parti's defaults moved to
+// FileStorage — and points at the manual migration path.
 func (m *Manager) warnOnStorageMismatch(
 	ctx context.Context,
 	kv jetstream.KeyValue,
@@ -465,9 +466,10 @@ func (m *Manager) warnOnStorageMismatch(
 		return
 	}
 	m.logger.Warn(
-		"KV bucket storage type differs from parti's default — "+
-			"IOPS reduction from the memory-storage default is NOT active on this bucket. "+
-			"To migrate during a maintenance window: `nats kv del "+bucket+"` then restart pods.",
+		"KV bucket storage type differs from parti's default; parti is using the "+
+			"existing bucket as-is. To align it, remove the bucket during a "+
+			"maintenance window (`nats kv rm "+bucket+"`) and restart pods so parti "+
+			"recreates it with the expected storage type.",
 		"bucket", bucket,
 		"existing_storage", storageTypeName(got),
 		"parti_default_storage", storageTypeName(want),

--- a/test/integration/fixedpartitions/fixedpartitions_test.go
+++ b/test/integration/fixedpartitions/fixedpartitions_test.go
@@ -24,7 +24,7 @@ package fixedpartitions_test
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -109,6 +109,7 @@ type vpProducer struct {
 	wg        sync.WaitGroup
 }
 
+//nolint:unparam // k is the partition count; constant across current tests by design.
 func startProducer(js jetstream.JetStream, k int, interval time.Duration) *vpProducer {
 	p := &vpProducer{stop: make(chan struct{})}
 	p.wg.Add(1)
@@ -266,7 +267,7 @@ func TestFixedPartitions_ClusterCrashRecovery(t *testing.T) {
 	// CRASH worker 1: kill its connection (no graceful relinquish). Survivors must
 	// detect via heartbeat TTL and rebind its slot durables from the cluster.
 	w[1].nc.Close()
-	t.Logf("Exp11/cluster-crash: killed worker[1] connection; waiting for TTL-driven reassignment")
+	t.Log("Exp11/cluster-crash: killed worker[1] connection; waiting for TTL-driven reassignment")
 	time.Sleep(10 * time.Second) // > HeartbeatTTL(5s) + reassignment + drain
 
 	// Survivors converge.
@@ -420,9 +421,7 @@ func TestFixedPartitions_ServerSidePartitionMapping(t *testing.T) {
 	published := make([]string, 0, 1024)
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		seq := 0
 		tk := time.NewTicker(8 * time.Millisecond)
 		defer tk.Stop()
@@ -440,7 +439,7 @@ func TestFixedPartitions_ServerSidePartitionMapping(t *testing.T) {
 				seq++
 			}
 		}
-	}()
+	})
 	time.Sleep(1 * time.Second)
 
 	m3 := newWorker() // JOIN
@@ -521,12 +520,12 @@ func newTimeLedger() *vpTimeLedger { return &vpTimeLedger{delivered: map[string]
 // delivery can be attributed to the worker that processed it.
 func (l *vpTimeLedger) handlerForWorker(worker string) consumer.MessageHandler {
 	return consumer.MessageHandlerFunc(func(_ context.Context, msg jetstream.Msg) error {
-		recv := time.Now().UnixNano()
+		recvNano := time.Now().UnixNano()
 		id, pubStr, _ := strings.Cut(string(msg.Data()), ":")
 		pubNano, _ := strconv.ParseInt(pubStr, 10, 64)
 		part, _ := strconv.Atoi(strings.TrimPrefix(msg.Subject(), "work."))
 		l.mu.Lock()
-		l.events = append(l.events, vpEvent{id: id, partition: part, worker: worker, pubNano: pubNano, recvNano: recv})
+		l.events = append(l.events, vpEvent{id: id, partition: part, worker: worker, pubNano: pubNano, recvNano: recvNano})
 		l.delivered[id]++
 		l.mu.Unlock()
 
@@ -664,11 +663,11 @@ func TestFixedPartitions_NoStopTheWorld(t *testing.T) {
 
 	prod := startTimedProducer(js, vpK, 20*time.Millisecond) // ~800 msg/s across 16 slots
 	time.Sleep(1500 * time.Millisecond)                      // warmup; exclude from baseline
-	tWarmupEnd := time.Now().UnixNano()
+	tWarmupEndNano := time.Now().UnixNano()
 
 	time.Sleep(2 * time.Second) // clean quiet baseline (steady 2-worker operation)
 
-	tJoin := time.Now().UnixNano()
+	tJoinNano := time.Now().UnixNano()
 	m3 := newWorker("w3") // JOIN 2->3: ConsistentHash moves ~1/3 of slots to w3
 	time.Sleep(3 * time.Second)
 	waitStable(m1)
@@ -678,7 +677,7 @@ func TestFixedPartitions_NoStopTheWorld(t *testing.T) {
 	time.Sleep(3 * time.Second)
 	waitStable(m1)
 	waitStable(m3)
-	tEnd := time.Now().UnixNano()
+	tEndNano := time.Now().UnixNano()
 
 	published := prod.stopAndWait()
 	t.Cleanup(func() { _ = m1.Stop(context.Background()); _ = m3.Stop(context.Background()) })
@@ -691,7 +690,7 @@ func TestFixedPartitions_NoStopTheWorld(t *testing.T) {
 	// 2) Analyze: classify slots, compute per-class latency distributions and the
 	// pause-sensitivity metrics. Extracted to keep this test under the cyclomatic
 	// budget; see analyzeNoStopTheWorld for the method.
-	s := analyzeNoStopTheWorld(ledger.snapshot(), tWarmupEnd, tJoin, tEnd)
+	s := analyzeNoStopTheWorld(ledger.snapshot(), tWarmupEndNano, tJoinNano, tEndNano)
 
 	t.Logf("Exp12/no-stop-the-world: slots retained=%d moved=%d (K=%d)", s.retained, s.moved, vpK)
 	t.Logf("  RETAINED latency ms: quiet p99=%.1f | churn p50=%.1f p99=%.1f max=%.1f (n_quiet=%d n_churn=%d)",
@@ -783,7 +782,7 @@ func classifyNoStwSlots(events []vpEvent) (moved, retained map[int]bool) {
 		for _, c := range m {
 			counts = append(counts, c)
 		}
-		sort.Sort(sort.Reverse(sort.IntSlice(counts)))
+		slices.SortFunc(counts, func(a, b int) int { return b - a })
 		if len(counts) >= 2 && counts[1] > overlapAllow {
 			moved[p] = true
 		} else {
@@ -860,8 +859,8 @@ func retainedDeadAir(events []vpEvent, moved map[int]bool, tJoin, tEnd int64) (d
 			pubTimes = append(pubTimes, e.pubNano)
 		}
 	}
-	sort.Slice(recvTimes, func(i, j int) bool { return recvTimes[i] < recvTimes[j] })
-	sort.Slice(pubTimes, func(i, j int) bool { return pubTimes[i] < pubTimes[j] })
+	slices.Sort(recvTimes)
+	slices.Sort(pubTimes)
 
 	return float64(maxGapNano(recvTimes)) / 1e6, float64(maxGapNano(pubTimes)) / 1e6
 }
@@ -928,9 +927,9 @@ func analyzeNoStopTheWorld(events []vpEvent, tWarmupEnd, tJoin, tEnd int64) noSt
 			}
 		}
 	}
-	sort.Slice(quietRetained, func(i, j int) bool { return quietRetained[i] < quietRetained[j] })
-	sort.Slice(churnRetained, func(i, j int) bool { return churnRetained[i] < churnRetained[j] })
-	sort.Slice(churnMoved, func(i, j int) bool { return churnMoved[i] < churnMoved[j] })
+	slices.Sort(quietRetained)
+	slices.Sort(churnRetained)
+	slices.Sort(churnMoved)
 
 	slow, epochsOver50, worstEpochMs := retainedPauseMetrics(events, moved, tJoin, tEnd)
 	deadAirMs, publishGapMs := retainedDeadAir(events, moved, tJoin, tEnd)

--- a/test/integration/fixedpartitions/workqueue_dynamic_test.go
+++ b/test/integration/fixedpartitions/workqueue_dynamic_test.go
@@ -1,0 +1,268 @@
+// This file is the empirical answer to an open question raised while drafting the
+// retention-policy guidance for docs/CONSUMERS.md (see
+// docs/plans/docs-operational-sync/00-sync-plan.md, item B7):
+//
+//	Is consumer.Dynamic actually usable over a WorkQueuePolicy stream?
+//
+// A codex judgment pass argued it is "mechanically possible (single-filter rebind,
+// no overlap)" — i.e. because Dynamic keeps ONE durable per partition-subject and
+// rebinds it on handoff, it never creates the transient OVERLAPPING filter that
+// WorkQueuePolicy rejects with err_code=10100. But the partition-scaling integration
+// proofs (Exp11/Exp12 in fixedpartitions_test.go) ALL ran on LimitsPolicy, so the
+// WorkQueue claim was UNPROVEN. This test settles it.
+//
+// It is Exp11 scenario 1 (single-node graceful join+leave) with exactly ONE change —
+// the stream is WorkQueuePolicy instead of LimitsPolicy — and it asserts three things:
+//
+//  1. Dynamic creates its per-subject durables on a WorkQueue stream at all
+//     (no DeliverPolicy / retention rejection at Update time).
+//  2. A worker join+leave handoff (which forces ~1/3 of slots to rebind to a
+//     different worker) does NOT trip err_code=10100 — captured via an OnError hook,
+//     not merely inferred from downstream loss.
+//  3. Delivery stays LOSSLESS across the churn (WorkQueue's delete-on-ack + same-durable
+//     rebind hands the unacked backlog to the gaining worker).
+//
+// A 10100 on handoff (assertion 2) or any lost message (assertion 3) would REFUTE the
+// "mechanically possible" claim and prove WorkQueue is unsafe for Dynamic.
+package fixedpartitions_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// errSink collects manager OnError callbacks so the test can assert on their
+// content (specifically: did any handoff produce an overlapping-filter / 10100
+// error?) rather than only observing the downstream delivery effect.
+type errSink struct {
+	mu   sync.Mutex
+	errs []string
+}
+
+func (s *errSink) hook() *parti.Hooks {
+	return &parti.Hooks{
+		OnError: func(_ context.Context, err error) error {
+			if err != nil {
+				s.mu.Lock()
+				s.errs = append(s.errs, err.Error())
+				s.mu.Unlock()
+			}
+			return nil
+		},
+	}
+}
+
+// overlapErrs returns the captured errors that look like a WorkQueuePolicy
+// overlapping-filter rejection (NATS err_code=10100 /
+// "filter subject already in use" / "overlap").
+func (s *errSink) overlapErrs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, e := range s.errs {
+		le := strings.ToLower(e)
+		if strings.Contains(e, "10100") ||
+			strings.Contains(le, "overlap") ||
+			strings.Contains(le, "filter subject already in use") ||
+			(strings.Contains(le, "work queue") && strings.Contains(le, "filter")) {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+func (s *errSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.errs)
+}
+
+func TestDynamic_OnWorkQueueStream(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: short mode")
+	}
+	ctx := context.Background()
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	// THE single difference vs Exp11 scenario 1: WorkQueuePolicy, not LimitsPolicy.
+	// File storage so delete-on-ack is exercised against a real store.
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name: vpStream, Subjects: []string{"work.*"},
+		Storage: jetstream.FileStorage, Retention: jetstream.WorkQueuePolicy,
+	})
+	require.NoError(t, err)
+
+	ledger := newLedger()
+	sink := &errSink{}
+	src := source.NewStatic(vpPartitions())
+	cfg := parti.TestConfig()
+
+	newWorker := func() *parti.Manager {
+		// Default recovery (disabled): WorkQueue restricts recovery to
+		// Beginning/Disabled, and recovery is not what this test probes.
+		c, err := consumer.NewDynamic(js, vpStream, "worker", "work.{{.PartitionID}}", ledger.handler())
+		require.NoError(t, err)
+		m, err := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(),
+			parti.WithWorkerConsumerUpdater(c),
+			parti.WithHooks(sink.hook()),
+		)
+		require.NoError(t, err)
+		require.NoError(t, m.Start(ctx))
+
+		return m
+	}
+	waitStable := func(m *parti.Manager) { require.NoError(t, <-m.WaitState(parti.StateStable, 30*time.Second)) }
+
+	m1 := newWorker()
+	m2 := newWorker()
+	waitStable(m1)
+	waitStable(m2)
+
+	prod := startProducer(js, vpK, 8*time.Millisecond)
+	time.Sleep(1 * time.Second)
+
+	m3 := newWorker() // JOIN 2->3: ConsistentHash rebinds ~1/3 of the slots onto a new worker.
+	time.Sleep(2 * time.Second)
+	waitStable(m1)
+	waitStable(m3)
+	time.Sleep(1 * time.Second)
+
+	require.NoError(t, m2.Stop(context.Background())) // LEAVE (graceful handoff back onto m1/m3).
+	time.Sleep(2 * time.Second)
+	waitStable(m1)
+	waitStable(m3)
+	time.Sleep(1 * time.Second)
+
+	published := prod.stopAndWait()
+	t.Cleanup(func() { _ = m1.Stop(context.Background()); _ = m3.Stop(context.Background()) })
+
+	// Assertion 2: no overlapping-filter / 10100 rejection occurred on any handoff.
+	overlaps := sink.overlapErrs()
+	require.Empty(t, overlaps,
+		"WorkQueue+Dynamic handoff produced an overlapping-filter/10100 rejection — REFUTES 'single-filter rebind, no overlap': %v", overlaps)
+
+	// Assertions 1 & 3: durables were created and every message was delivered at
+	// least once across the churn (delete-on-ack + rebind handed off cleanly).
+	assertLossless(t, ledger, published)
+	distinct, dups := ledger.stats()
+	t.Logf("WorkQueue+Dynamic (single-node join+leave): published=%d delivered=%d dups=%d | manager errors total=%d overlap/10100=%d",
+		len(published), distinct, dups, sink.count(), len(overlaps))
+}
+
+// TestDynamic_OnWorkQueueStream_ClusterCrash is the harder half of the WorkQueue
+// proof: Exp11 scenario 2 (3-node cluster, RF=3 stream + R=3 consumers, abrupt
+// worker CRASH) on a WorkQueuePolicy stream instead of LimitsPolicy.
+//
+// The crash path stresses what the graceful test cannot: a worker dies WITHOUT
+// relinquishing, survivors detect it via heartbeat TTL and rebind its slot
+// durables from the cluster, and — on WorkQueue specifically — the in-flight,
+// unacked messages on those durables must REDELIVER to the rebinding worker
+// (WorkQueue retains unacked, deletes only on ack) rather than being lost.
+// Consumer state is MemoryStorage + R=3 (the only replica value NATS accepts on a
+// WorkQueue RF=3 stream — consumer replicas must equal stream replicas), so the
+// durables survive the crashed client and the survivors rebind the same names
+// (no overlapping-filter create → no 10100).
+//
+// Asserts: no 10100 on the TTL-driven reassignment, and lossless delivery across
+// the crash (duplicates EXPECTED — a crash redelivers in-flight work).
+func TestDynamic_OnWorkQueueStream_ClusterCrash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: short mode")
+	}
+	ctx := context.Background()
+	clusterNC, servers, cleanup := testutil.StartEmbeddedNATSCluster(t)
+	defer cleanup()
+	require.GreaterOrEqual(t, len(servers), 3, "need a 3-node cluster")
+
+	jsMain, err := jetstream.New(clusterNC)
+	require.NoError(t, err)
+
+	// WorkQueuePolicy, RF=3 — the one difference vs Exp11 scenario 2.
+	_, err = jsMain.CreateStream(ctx, jetstream.StreamConfig{
+		Name: vpStream, Subjects: []string{"work.*"},
+		Storage: jetstream.FileStorage, Retention: jetstream.WorkQueuePolicy, Replicas: 3,
+	})
+	require.NoError(t, err)
+
+	ledger := newLedger()
+	sink := &errSink{}
+	src := source.NewStatic(vpPartitions())
+	cfg := testutil.IntegrationTestConfig() // WorkerIDMax=100, flake-tuned TTLs
+
+	type worker struct {
+		m  *parti.Manager
+		nc *nats.Conn
+	}
+	newWorker := func(i int) *worker {
+		wnc, err := nats.Connect(servers[i%len(servers)].ClientURL())
+		require.NoError(t, err)
+		wjs, err := jetstream.New(wnc)
+		require.NoError(t, err)
+		// Consumer R=3 (must equal stream replicas on WorkQueue) + memory state so the
+		// durable survives the crashed client and is rebindable by a survivor.
+		c, err := consumer.NewDynamic(wjs, vpStream, "worker", "work.{{.PartitionID}}", ledger.handler(),
+			consumer.WithConsumerMemoryStorage(true), consumer.WithConsumerReplicas(3))
+		require.NoError(t, err)
+		m, err := parti.NewManager(&cfg, wjs, src, strategy.NewConsistentHash(),
+			parti.WithWorkerConsumerUpdater(c),
+			parti.WithHooks(sink.hook()),
+		)
+		require.NoError(t, err)
+		require.NoError(t, m.Start(ctx))
+
+		return &worker{m: m, nc: wnc}
+	}
+
+	w := []*worker{newWorker(0), newWorker(1), newWorker(2)}
+	for _, x := range w {
+		require.NoError(t, <-x.m.WaitState(parti.StateStable, 40*time.Second))
+	}
+
+	prod := startProducer(jsMain, vpK, 12*time.Millisecond)
+	time.Sleep(2 * time.Second)
+
+	// CRASH worker 1: kill its connection (no graceful relinquish). Survivors must
+	// detect via heartbeat TTL and rebind its slot durables from the cluster.
+	w[1].nc.Close()
+	t.Log("WorkQueue+Dynamic/cluster-crash: killed worker[1] connection; waiting for TTL-driven reassignment")
+	time.Sleep(10 * time.Second) // > HeartbeatTTL(5s) + reassignment + drain
+
+	require.NoError(t, <-w[0].m.WaitState(parti.StateStable, 40*time.Second))
+	require.NoError(t, <-w[2].m.WaitState(parti.StateStable, 40*time.Second))
+	time.Sleep(2 * time.Second)
+
+	published := prod.stopAndWait()
+	t.Cleanup(func() {
+		_ = w[0].m.Stop(context.Background())
+		_ = w[2].m.Stop(context.Background())
+		w[0].nc.Close()
+		w[2].nc.Close()
+	})
+
+	// No overlapping-filter / 10100 rejection on the TTL-driven rebind.
+	overlaps := sink.overlapErrs()
+	require.Empty(t, overlaps,
+		"WorkQueue+Dynamic crash-reassignment produced an overlapping-filter/10100 rejection: %v", overlaps)
+
+	// Lossless across the crash (dups expected — crash redelivers in-flight work).
+	assertLossless(t, ledger, published)
+	distinct, dups := ledger.stats()
+	t.Logf("WorkQueue+Dynamic (cluster-crash, RF=3, R=3 consumers): published=%d delivered=%d dups=%d (dups expected) | manager errors total=%d overlap/10100=%d",
+		len(published), distinct, dups, sink.count(), len(overlaps))
+}


### PR DESCRIPTION
## Summary

Syncs the operator-facing docs with the current code and the perf / IOPS /
partition-scaling measurement campaigns, and clears the `golangci-lint`
findings that currently have **main's CI red**.

## Changes

- **Unblock CI lint** (`test/integration/fixedpartitions/fixedpartitions_test.go`):
  clears 13 revive findings from the last change (`sort.*`→`slices.*`,
  `wg.Add/go/Done`→`wg.Go`, nanosecond-epoch naming, static `t.Logf`→`t.Log`).
  Behavior unchanged. *This is its own commit so it can stand alone.*
- **Docs sync**:
  - `CONFIGURATION.md` — correct the KV bucket storage table: all five
    coordination buckets use `FileStorage` (election + heartbeat were switched
    from memory); fix the migration command to `nats kv rm`; disambiguate
    coordination-bucket storage from per-consumer storage.
  - `CONSUMERS.md` — new **Stream Retention Policy** section (which retention
    policy fits each consumer type and why) and **Consumer Storage Tuning**
    section (the conditional memory-storage IOPS lever); document the two
    shipped consumer-storage options.
  - `OPERATIONS.md` — NATS-side cost model (RSS per partition, flat latency,
    validated to 10k partitions), cluster-sizing and metacontroller guidance,
    version-floor note.
  - `USER_GUIDE.md`, `README.md` — version note + docs map.
  - New `SCALING.md` — bounded-cost partitioning with NATS `partition()` +
    `Dynamic` over a fixed K.
- **Prove `Dynamic` over `WorkQueuePolicy`** (`workqueue_dynamic_test.go`):
  two live-cluster tests showing single-filter durables rebind on handoff
  without the `10100` overlapping-filter rejection — single-node graceful
  (876/876) and 3-node RF=3 abrupt crash (1166/1166), both `-race` clean.
- **Source fix**: `warnOnStorageMismatch` claimed the opposite of reality
  (said defaults are memory; they are `FileStorage`) and pointed at
  `nats kv del` (deletes a key, not a bucket) — corrected.

## Verification

- `make lint` → **0 issues** (was 13 on main)
- `make test-unit` (`-race`) → all packages pass, exit 0
- `fixedpartitions` integration package (`-race`) → all 7 tests pass

The retention-policy guidance was cross-checked against NATS server source and
two empirical proofs (WorkQueue+Dynamic handoff/crash; the Interest/WorkQueue
consumer-replica match rule on a 5-node RF=5 cluster, `err_code=10134`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
