### PR TITLE
fix: consumer healing and correctness sweep — terminal holds, silent-stall signals, ordering and lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,138 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.7.0] - 2026-06-11
+
+Dynamic-consumer healing release. It closes a family of silent-stall paths
+where a worker reported `Stable` while its consumer was dead or stranded, runs
+a correctness sweep across all four consumer types, and fixes an assignment-retry
+coalescing bug that could leave partition ownership silently divergent. Three
+themes: **stream-missing healing** — a deleted stream or exhausted recovery now
+drives the manager to a terminal `Degraded` hold so readiness-driven rotation
+can act, instead of flapping back to `Stable` with a dead consumer;
+**consumer-wide correctness** — `Stop`/`Close` is now terminal, retry backoff
+grows as configured, `Queue` validates compatibility before creating durables,
+a key-dispatch idle-exit race is closed, and disabled-recovery stalls become
+visible; and **assignment-retry coalescing** — retries now coalesce by the full
+applied identity the apply gate trusts. Two new exported symbols
+(`consumer.ErrConsumerStopped`, `consumer.WithSuppressManagerDegradeOnStreamMissing`)
+make this a minor rather than a patch. One behavior change at defaults:
+`WithOnPermanentFailure` no longer suppresses the manager's stream-missing
+auto-degraded route.
+
+### Added
+
+- **`consumer.ErrConsumerStopped`** — sentinel returned by `Start`/`Update`
+  after a consumer has been stopped or closed. Re-exported from
+  `types.ErrConsumerStopped`. Match with `errors.Is`.
+- **`consumer.WithSuppressManagerDegradeOnStreamMissing()`** — opt-out option
+  that restores the pre-v2.7.0 behavior where registering
+  `WithOnPermanentFailure` suppressed the manager's stream-missing
+  auto-degraded route (see _Changed_ below).
+
+### Fixed
+
+- **Deleted stream now exhausts recovery instead of stalling silently.** With
+  `RecoveryStrategy` enabled and an active iterator, deleting the underlying
+  stream surfaces `ErrNoHeartbeat`, and the burst confirmation probe treated
+  the stream-scoped `ErrStreamNotFound` answer as "consumer still exists" —
+  classifying the permanent loss as transient-forever. The consumer ping-ponged
+  between heartbeat failures and backoff indefinitely, stream-missing
+  exhaustion never fired, and the worker reported `Stable` with a stalled
+  consumer. The probe now routes stream-not-found to the bounded stream-missing
+  detour, so exhaustion reaches `OnPermanentFailure` and the manager's terminal
+  `Degraded` hold within the configured `RecoveryRetry.MaxAttempts` budget.
+  (`Queue`, `Broadcast`, and internal partition consumers now log this case as
+  stream-missing instead of an unlabeled transient backoff.)
+- **Terminal `Degraded` hold on stream-missing exhaustion.** Manager now stays
+  `Degraded` permanently after a dynamic consumer's stream-missing recovery
+  exhausts, so readiness-driven rotation can occur; previously it returned to
+  `Stable` within seconds while dead partition consumers were still assigned and
+  silently not consuming.
+- **Assignment retries coalesce by full applied identity.** The apply-retry
+  stash and the commit coalesce/drain compared candidates by `Version` alone,
+  while the core apply gate orders by `(Version, LeaderRevision)` and the
+  applied-ack identity also spans the partition-set digest and source
+  revision. A same-version pair — produced by a lost commit CAS racing its own
+  pre-published alias — under two consecutive apply failures dropped the
+  commit-authority assignment from the stash: the retry applied the stale
+  alias digest and nothing in direct mode converged the worker until the next
+  rebalance, leaving silent partition-ownership divergence behind a `Stable`
+  status. Stash and coalesce comparisons now use the same full identity
+  ordering the apply gate trusts. The leader audit additionally logs a
+  warning for workers stuck behind in direct mode, where automatic repair is
+  deliberately unavailable.
+- **`Dynamic.Update` rejects over-cap assignments before any mutation.** Returns
+  `ErrMaxSubjectsExceeded` (as documented) when an assignment exceeds
+  `MaxConcurrentSubjects`, instead of silently skipping excess partitions — which
+  could strand a partition unowned after a committed handoff. The rejection error
+  names the stream and fires the
+  `parti_worker_consumer_guardrail_violations_total{kind="max_subjects"}` metric.
+- **`Dynamic.Update` surfaces remove-timeout failures.** Returns an error when
+  removed partition loops fail to stop within `DrainOnRemoveTimeout`, instead of
+  reporting success while a handler could still be processing; the manager retries
+  the apply and converges.
+- **`Stop`/`Close` is terminal for `Static`, `Broadcast`, and the Dynamic worker
+  consumer.** Restarting after stop previously half-worked (channels and loop
+  state were not rebuilt) and, for `Dynamic`, `Close` nils the gate resolver, so
+  a post-Close `Update` restarted pull loops WITHOUT the configured processing
+  gate — a silent safety downgrade. `Start`/`Update` after `Stop`/`Close` now
+  returns the new `ErrConsumerStopped` sentinel; construct a new consumer to
+  restart.
+- **Disabled-recovery iterator stalls are now visible.** With `RecoveryStrategy`
+  disabled (the default), persistent iterator failures in `Queue`, `Static`, and
+  `Broadcast` consumers — e.g. a durable deleted via `InactiveThreshold` expiry —
+  retried silently at Debug level forever. Each restart now logs a Warn and fires
+  the iterator-restart metric with reason `recovery_disabled`.
+- **Broadcast and Dynamic retry backoff actually grows.** The consume-loop
+  backoff re-slept a constant base delay, ignoring the configured `Multiplier`,
+  `Max`, and `Seed`; it now grows via decorrelated jitter as documented (matching
+  `Queue`).
+- **Key-worker idle-exit ordering race.** A per-key dispatch worker's idle exit
+  now decides under the dispatcher's write lock, closing a window where a
+  concurrently dispatched message could land on a worker that was exiting and
+  never be processed.
+- **Queue validates WorkQueue compatibility before creating the durable.**
+  `Queue.Start` previously created the durable consumer first and then failed
+  the WorkQueue/recovery compatibility check, orphaning a just-created durable
+  on the WorkQueuePolicy stream.
+- **Queue closed-iterator hot loop.** An iterator that reports closed while the
+  consumer is still running now takes the backoff path instead of respinning
+  iterator creation at full speed.
+- **All constructor validation failures wrap `ErrInvalidConfig`.**
+  `errors.Is(err, consumer.ErrInvalidConfig)` now matches every
+  construction-time validation failure across the four consumer constructors;
+  struct-tag (range/required) failures were previously returned unwrapped.
+
+### Changed
+
+- **`WithOnPermanentFailure` no longer suppresses the manager observer.**
+  Registering `WithOnPermanentFailure` no longer disables the manager's
+  auto-degraded route for stream-missing exhaustion: both the application callback
+  and the manager observer now fire (callback first). Use the new
+  `WithSuppressManagerDegradeOnStreamMissing()` option to restore the previous
+  opt-out behavior explicitly.
+- **Over-cap assignments surface as visible apply failures.** An assignment that
+  keeps a worker over `MaxConcurrentSubjects` indefinitely now surfaces as
+  repeating "handoff apply failed" logs with an un-acked assignment version
+  (leader-visible), rather than a silent gap — raise the cap or rebalance to
+  resolve.
+- **`FetchTimeout` below 1s now fails construction.** NATS pull consumers
+  enforce a 1s minimum request expiry; configs in `(0, 1s)` previously passed
+  validation and stalled at runtime. All consumer constructors now reject them
+  with `ErrInvalidConfig`.
+
+### Documentation
+
+- **Zero-overlap claims corrected to the per-tier overlap contract.** Two-phase
+  handoff orders the release of a partition (no unowned gap); it does not gate
+  consumption. The processing gate is per-message admission control and cannot
+  revoke an in-flight handler, so the irreducible window is one in-flight
+  invocation plus AckWait-expiry redelivery of that message via the shared
+  per-partition durable (mitigation: `consumer.NewWIPHandler`). The fictional
+  leader-driven prepare/commit ACK exchange in `docs/LIFECYCLE.md` is replaced
+  with the actual worker-driven KV CAS protocol, with a per-configuration-tier
+  guarantee table; delivery is at-least-once at every tier.
 
 ## [v2.6.1] - 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Use it for stream processors, job queues, sharded caches, or any system where a 
 - **Stable Worker IDs**: Workers claim stable IDs (e.g., `worker-0`, `worker-1`) that persist across restarts, minimizing assignment churn during rolling updates.
 - **Leader-Based Assignment**: A single leader worker calculates assignments, ensuring consistency and preventing split-brain scenarios.
 - **Dynamic Partition Discovery**: Supports dynamic partition updates via NATS KV without restarting workers.
-- **Two-Phase Handoff**: Implements a Prepare/Commit protocol for partition reassignment, ensuring no partition is processed by two workers simultaneously.
+- **Two-Phase Handoff**: Orders partition release during reassignment via a worker-driven prepare/commit claim protocol so a partition is never left unowned; combined with the processing gate it minimizes overlapping processing (see `docs/LIFECYCLE.md` for the per-tier overlap contract).
 - **Degraded Mode**: Continues operation using cached assignments when NATS connectivity is lost, prioritizing availability over strict consistency during outages.
-- **Processing Gate**: Controls message processing flow based on assignment status, preventing processing of revoked partitions.
+- **Processing Gate**: Per-message admission control based on assignment status, NAKing deliveries for revoked partitions.
 - **Cache Affinity**: Preserves >80% partition locality during rebalancing using consistent hashing.
 - **Weighted Assignment**: Supports partition weights for uneven workload distribution.
 

--- a/consumer/broadcast.go
+++ b/consumer/broadcast.go
@@ -72,8 +72,12 @@ type BroadcastConfig struct {
 	// This ensures that each instance gets a unique durable name, achieving fan-out.
 	ConsumerPrefix string `validate:"required"`
 
-	// Retry configures the backoff behavior for control-plane operations
-	// (e.g., initial connection, creating the consumer).
+	// Retry configures the backoff behavior for the consume loop.
+	//
+	// On each iterator failure the loop sleeps for a jittered delay that grows via
+	// decorrelated jitter from Base toward Max using the Multiplier factor. Seed
+	// makes the sequence deterministic (useful in tests); zero uses the package-level
+	// PRNG. The delay resets to zero after every successful iteration cycle.
 	Retry RetryConfig
 
 	// IteratorFactory optionally overrides the internal iterator creation logic.
@@ -196,11 +200,15 @@ func NewBroadcast(
 // Start may only be called once. Calling Start on an already-started consumer
 // is a no-op.
 //
+// Stop is terminal: after [Broadcast.Stop] is called, Start returns
+// [ErrConsumerStopped]. Create a new instance to consume again.
+//
 // Parameters:
 //   - ctx: Context for the start operation. Used for JetStream API calls.
 //
 // Returns:
-//   - error: Non-nil if JetStream consumer creation fails.
+//   - error: Non-nil if JetStream consumer creation fails, or [ErrConsumerStopped]
+//     if the consumer has been stopped.
 func (b *Broadcast) Start(ctx context.Context) error {
 	// BroadcastConsumer uses UpdateWorkerConsumer to start; we wrap it as Start
 	// for a more intuitive API. The workerID and partitions are ignored internally.
@@ -225,6 +233,14 @@ func (b *Broadcast) UpdateWorkerConsumer(ctx context.Context, workerID string, p
 // to complete (up to the context deadline). The underlying JetStream consumer
 // is NOT deleted; it will be garbage-collected by the server after InactiveThreshold.
 //
+// Stop is terminal: after Stop returns, any subsequent call to [Broadcast.Start] or
+// [Broadcast.UpdateWorkerConsumer] returns [ErrConsumerStopped]. Create a new
+// instance to consume again.
+//
+// If the consumer is stopped while still registered with a running manager, the
+// manager will retry the failed update indefinitely (by design). Stop the manager
+// first, or deregister this consumer before calling Stop.
+//
 // Stop is idempotent; calling it multiple times is safe.
 //
 // Parameters:
@@ -248,11 +264,15 @@ func (c *BroadcastConfig) Validate() error {
 		return err
 	}
 	if err := fuda.Validate(c); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
 		return err
 	}
 
 	if !jsutil.IsValidConsumerName(c.ConsumerPrefix) {
-		return fmt.Errorf("consumer prefix %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", c.ConsumerPrefix)
+		return fmt.Errorf("%w: consumer prefix %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", ErrInvalidConfig, c.ConsumerPrefix)
 	}
 
 	return nil

--- a/consumer/broadcast_test.go
+++ b/consumer/broadcast_test.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,72 @@ import (
 
 	"github.com/arloliu/parti/v2/partitest"
 )
+
+// TestBroadcastConfig_Validate_WrapsErrInvalidConfig verifies that every
+// validation failure in NewBroadcast / BroadcastConfig.Validate is reachable
+// via errors.Is(err, ErrInvalidConfig).
+func TestBroadcastConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "nil js",
+			fn: func() error {
+				_, err := NewBroadcast(nil, "S", "pfx", "s.>", handler)
+
+				return err
+			},
+		},
+		{
+			name: "fuda required field (missing StreamName)",
+			fn: func() error {
+				cfg := BroadcastConfig{ConsumerPrefix: "pfx", FilterSubject: "s.>"}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "FetchTimeout below 1s floor",
+			fn: func() error {
+				cfg := BroadcastConfig{
+					StreamName:     "S",
+					ConsumerPrefix: "pfx",
+					FilterSubject:  "s.>",
+					CommonConfig:   CommonConfig{FetchTimeout: 100 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "invalid consumer prefix",
+			fn: func() error {
+				cfg := BroadcastConfig{
+					StreamName:     "S",
+					ConsumerPrefix: "bad prefix!",
+					FilterSubject:  "s.>",
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrInvalidConfig),
+				"expected errors.Is(err, ErrInvalidConfig), got: %v", err)
+		})
+	}
+}
 
 // TestBroadcast_ConsumerOptions_AppliedToLiveConsumer verifies that
 // WithConsumerMemoryStorage and WithConsumerReplicas reach the live

--- a/consumer/common.go
+++ b/consumer/common.go
@@ -34,7 +34,8 @@ type CommonConfig struct {
 	//
 	// When true:
 	//  - The handler MUST explicitly call msg.Ack(), msg.Nak(), or msg.Term().
-	//  - Returning an error from the handler is still logged but does not trigger Action.
+	//  - A returned handler error is discarded (neither logged nor acted on);
+	//    surface failures from inside the handler itself.
 	ManualAck bool
 
 	// AckWait is the time allowed for processing a message before it is considered lost
@@ -66,6 +67,11 @@ type CommonConfig struct {
 	//
 	// If no messages are available within this timeout, the pull request expires.
 	// The consumer loop manages this automatically.
+	//
+	// Minimum: 1s. NATS rejects a PullExpiry below 1s at iterator-creation
+	// time; a sub-second value previously caused Start to return success and
+	// then fail every iterator creation forever — a permanently dead consumer
+	// with no terminal signal. Construction now fails fast instead.
 	//
 	// Default: 5s.
 	FetchTimeout time.Duration `default:"5s" validate:"gt=0"`
@@ -165,7 +171,24 @@ func (c *CommonConfig) Validate() error {
 		return err
 	}
 
-	return fuda.Validate(c)
+	if err := fuda.Validate(c); err != nil {
+		return err
+	}
+
+	return validateFetchTimeoutFloor(c.FetchTimeout)
+}
+
+// validateFetchTimeoutFloor enforces NATS's 1s PullExpiry minimum. Each
+// consumer config's Validate calls this directly (they run fuda on their own
+// struct rather than delegating to CommonConfig.Validate), so the floor lives
+// in one place. A sub-second value previously passed validation and produced
+// a consumer whose Start succeeded and then failed every iterator creation.
+func validateFetchTimeoutFloor(ft time.Duration) error {
+	if ft < time.Second {
+		return fmt.Errorf("%w: FetchTimeout must be at least 1s (NATS PullExpiry floor), got %v", ErrInvalidConfig, ft)
+	}
+
+	return nil
 }
 
 // CheckWorkQueueRecoveryCompat returns ErrInvalidConfig when the stream uses
@@ -178,6 +201,11 @@ func (c *CommonConfig) Validate() error {
 // so callers are not blocked by transient connectivity issues. This means
 // transient JetStream API failures during the pre-flight do not block consumer
 // updates; the runtime continues as if the check passed.
+//
+// For [Dynamic], the per-consumer outcome is cached: a pass recorded during a
+// transient fetch failure is not re-evaluated until a stream-recreate resets
+// the check, so a genuinely incompatible configuration may go undetected
+// until recovery first misbehaves.
 //
 // This function is exported so the provision SDK can reuse the exact same
 // implementation in its dynamic-consumer alignment check

--- a/consumer/common_test.go
+++ b/consumer/common_test.go
@@ -156,3 +156,17 @@ func TestBroadcastConfig_SetDefaults_PreservesExistingValues(t *testing.T) {
 	require.Equal(t, -1, cfg.MaxDeliver)
 	require.Equal(t, 100*time.Millisecond, cfg.Retry.Backoff)
 }
+
+// TestCommonConfig_FetchTimeout_FloorIsOneSecond pins the validation floor:
+// nats.go rejects PullExpiry below 1s at iterator-creation time, so a
+// sub-second FetchTimeout produced a consumer whose Start succeeded and then
+// failed every iterator creation forever — a permanently dead consumer with
+// a success return. Construction must reject it instead.
+func TestCommonConfig_FetchTimeout_FloorIsOneSecond(t *testing.T) {
+	cfg := CommonConfig{FetchTimeout: 500 * time.Millisecond}
+	err := cfg.Validate()
+	require.Error(t, err, "FetchTimeout below the 1s NATS PullExpiry floor must fail validation")
+
+	cfg = CommonConfig{FetchTimeout: time.Second}
+	require.NoError(t, cfg.Validate(), "FetchTimeout == 1s is the boundary and must pass")
+}

--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -62,11 +62,17 @@ type Dynamic struct {
 	workQueueMu sync.Mutex
 
 	// userOnPermanentFailure is the application-supplied callback
-	// captured from WithOnPermanentFailure. When non-nil it wins over
-	// the manager-installed observer at fire time, preserving the
-	// existing OnPermanentFailure contract (see [WithOnPermanentFailure]).
+	// captured from WithOnPermanentFailure. When non-nil it fires
+	// first in the dispatcher, before the manager-installed observer
+	// is consulted (see [WithOnPermanentFailure]).
 	// Nil if the application did not supply one.
 	userOnPermanentFailure func(subject string, err error)
+
+	// suppressManagerDegrade, when true, prevents the dispatcher from
+	// notifying the manager-installed stream-missing observer. Set via
+	// WithSuppressManagerDegradeOnStreamMissing for applications that
+	// deliberately own rotation/degrade signaling themselves.
+	suppressManagerDegrade bool
 
 	// managerOnStreamMissing holds the closure registered via
 	// SetOnStreamMissingError. The atomic.Pointer indirection lets
@@ -115,11 +121,17 @@ type DynamicConfig struct {
 	// This ensures unique, stable durability for each partition assignment.
 	ConsumerPrefix string `validate:"required"`
 
-	// ProcessingGate configures optional exclusive processing enforcement.
+	// ProcessingGate configures optional per-message admission control.
 	//
-	// When enabled, the WorkerConsumer uses a distributed lock (via KV) to ensure
-	// that it is the *only* active processor for its assigned partitions.
-	// This prevents split-brain processing during rebalances.
+	// When enabled, the consumer checks KV-backed ownership claims before each
+	// handler invocation and NAKs deliveries for partitions it does not own.
+	// This bounds — but does not eliminate — cross-worker overlap during
+	// rebalances: an already-in-flight handler invocation cannot be revoked,
+	// and AckWait-expiry redelivery through the shared per-partition durable
+	// can hand the same message to the new owner while the old owner's handler
+	// is still running. Wrap long-running handlers with [NewWIPHandler] to
+	// prevent that expiry. See docs/LIFECYCLE.md "Two-Phase Handoff" for the
+	// per-tier overlap contract.
 	ProcessingGate *ProcessingGateConfig
 
 	// Resolver configures the ownership resolver used when ProcessingGate is enabled.
@@ -136,20 +148,29 @@ type DynamicConfig struct {
 
 	// DrainOnRemove enables graceful draining when a partition assignment is revoked.
 	//
-	// When true, the consumer will stop pulling new messages but finish processing
-	// buffered messages before shutting down the partition consumer.
+	// When true, removal first polls the partition's durable until the server
+	// reports no pending acknowledgements — the pull loop keeps running during
+	// this wait — and only then stops the loop. Both the drain wait and the
+	// loop-stop wait are bounded by DrainOnRemoveTimeout.
 	DrainOnRemove bool
 
-	// DrainOnRemoveTimeout caps the time spent draining a revoked partition.
+	// DrainOnRemoveTimeout caps the time spent draining a revoked partition
+	// and bounds the wait for its pull loop to stop.
 	//
-	// If draining takes longer than this timeout, the consumer is forcibly closed.
-	// Default: 10s.
+	// The wait is best-effort: if loops have not stopped within this bound,
+	// [Dynamic.Update] returns an error (the manager retries the apply with
+	// backoff) while an already-in-flight handler invocation may still run
+	// to completion. Default: 10s.
 	DrainOnRemoveTimeout time.Duration `default:"10s" validate:"gte=0"`
 
 	// MaxConcurrentSubjects limits the number of partitions (subjects) processed concurrently.
 	//
-	// If the manager assigns more partitions than this limit, excess partitions
-	// will be ignored (and logged/warned).
+	// If an assignment's deduped subject count exceeds this limit,
+	// [Dynamic.Update] rejects the whole update with [ErrMaxSubjectsExceeded]
+	// before making any changes; the manager retries the apply with backoff
+	// and the previous owners keep consuming. Size this above the worst-case
+	// per-worker partition count (e.g. after scale-down) or leave it 0
+	// (unlimited).
 	MaxConcurrentSubjects int `validate:"gte=0"`
 
 	// AllowWorkerIDChange controls whether the worker's identity can change during runtime.
@@ -157,8 +178,12 @@ type DynamicConfig struct {
 	// Default: false (immutable once set). Changing WorkerID usually requires a restart.
 	AllowWorkerIDChange bool
 
-	// Retry configures the backoff behavior for control-plane operations
-	// (e.g., initial connection, creating consumers).
+	// Retry configures the backoff behavior for the consume loop.
+	//
+	// On each iterator failure the loop sleeps for a jittered delay that grows via
+	// decorrelated jitter from Base toward Max using the Multiplier factor. Seed
+	// makes the sequence deterministic (useful in tests); zero uses the package-level
+	// PRNG. The delay resets to zero after every successful iteration cycle.
 	Retry RetryConfig
 
 	// IteratorEscalationWindow defines the sliding time window used to aggregate
@@ -240,11 +265,20 @@ type DynamicConfig struct {
 	// exhaustion drove the failure, so applications can route those
 	// distinctly from generic envelope exhaustion.
 	//
-	// Setting this disables the Parti manager's auto-degraded route for
-	// stream-missing exhaustion (the manager-installed observer is only
-	// consulted when this field is nil). See [WithOnPermanentFailure]
-	// for the option form and the full trade-off discussion.
+	// Registering this callback does NOT disable the Parti manager's
+	// auto-degraded route: for stream-missing exhaustion the manager
+	// observer is notified after this callback returns. Use
+	// [DynamicConfig.SuppressManagerDegradeOnStreamMissing] (option form:
+	// [WithSuppressManagerDegradeOnStreamMissing]) to opt out explicitly.
+	// See [WithOnPermanentFailure] for the full contract.
 	OnPermanentFailure func(subject string, err error)
+
+	// SuppressManagerDegradeOnStreamMissing disables the Parti manager's
+	// auto-degraded route for stream-missing recovery exhaustion. By default
+	// the manager observer is notified even when OnPermanentFailure is set
+	// (both fire; application callback first). Set this only when the
+	// application deliberately owns degrade/rotation signaling itself.
+	SuppressManagerDegradeOnStreamMissing bool
 
 	// RecoveryRetry tunes the bounded-retry envelope wrapped around
 	// the iterator-creation path and the stream-missing Site B
@@ -334,25 +368,26 @@ func NewDynamic(
 			ConsumerMemoryStorage: o.consumerMemoryStorage,
 			ConsumerReplicas:      o.consumerReplicas,
 		},
-		StreamName:                  streamName,
-		ConsumerPrefix:              consumerPrefix,
-		SubjectTemplate:             subjectTemplate,
-		ProcessingGate:              o.processingGate,
-		Resolver:                    o.resolver,
-		PullGatingEnabled:           o.pullGatingEnabled,
-		DrainOnRemove:               o.drainOnRemove,
-		DrainOnRemoveTimeout:        o.drainOnRemoveTimeout,
-		MaxConcurrentSubjects:       o.maxConcurrentSubjects,
-		AllowWorkerIDChange:         o.allowWorkerIDChange,
-		Retry:                       o.retry,
-		IteratorEscalationWindow:    o.iteratorEscalationWindow,
-		IteratorEscalationThreshold: o.iteratorEscalationThreshold,
-		PartitionRefreshMinInterval: o.partitionRefreshMinInterval,
-		IteratorFactory:             o.iteratorFactory,
-		RecoveryStrategy:            o.recoveryStrategy,
-		StreamMissingHook:           o.streamMissingHook,
-		OnPermanentFailure:          o.onPermanentFailure,
-		RecoveryRetry:               o.recoveryRetry,
+		StreamName:                            streamName,
+		ConsumerPrefix:                        consumerPrefix,
+		SubjectTemplate:                       subjectTemplate,
+		ProcessingGate:                        o.processingGate,
+		Resolver:                              o.resolver,
+		PullGatingEnabled:                     o.pullGatingEnabled,
+		DrainOnRemove:                         o.drainOnRemove,
+		DrainOnRemoveTimeout:                  o.drainOnRemoveTimeout,
+		MaxConcurrentSubjects:                 o.maxConcurrentSubjects,
+		AllowWorkerIDChange:                   o.allowWorkerIDChange,
+		Retry:                                 o.retry,
+		IteratorEscalationWindow:              o.iteratorEscalationWindow,
+		IteratorEscalationThreshold:           o.iteratorEscalationThreshold,
+		PartitionRefreshMinInterval:           o.partitionRefreshMinInterval,
+		IteratorFactory:                       o.iteratorFactory,
+		RecoveryStrategy:                      o.recoveryStrategy,
+		StreamMissingHook:                     o.streamMissingHook,
+		OnPermanentFailure:                    o.onPermanentFailure,
+		SuppressManagerDegradeOnStreamMissing: o.suppressManagerDegradeOnStreamMissing,
+		RecoveryRetry:                         o.recoveryRetry,
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -369,6 +404,7 @@ func NewDynamic(
 		streamName:             streamName,
 		recoveryStrategy:       o.recoveryStrategy,
 		userOnPermanentFailure: cfg.OnPermanentFailure,
+		suppressManagerDegrade: cfg.SuppressManagerDegradeOnStreamMissing,
 	}
 
 	// Build worker consumer config from unified DynamicConfig.
@@ -433,19 +469,23 @@ func NewDynamic(
 // the partition consumer's goroutine when iterator-creation envelope
 // or Site B detour exhaustion fires.
 //
-// Dispatch precedence:
-//  1. An application-supplied OnPermanentFailure callback (captured
-//     from WithOnPermanentFailure) wins — applications opt out of the
-//     manager observer route by registering their own callback.
-//  2. Otherwise a manager-installed observer (set via
-//     SetOnStreamMissingError) receives only stream-missing
-//     exhaustion. Generic exhaustion is left to the durable layer's
-//     existing WARN log + metric (see
-//     internal/durable/partition_consumer.go OnPermanent), which is the
-//     operator-visible signal for non-stream-missing failures.
+// Dispatch rules:
+//  1. An application-supplied OnPermanentFailure callback (captured from
+//     WithOnPermanentFailure) fires first when registered.
+//  2. The manager-installed observer (set via SetOnStreamMissingError) is
+//     then ALSO notified for stream-missing exhaustion, so platform
+//     self-healing (enterDegraded -> rotation) does not silently turn off
+//     when an application adds its own observability callback. Applications
+//     that own degrade signaling themselves opt out explicitly via
+//     WithSuppressManagerDegradeOnStreamMissing.
+//  3. Generic (non-stream-missing) exhaustion never reaches the manager
+//     observer; the durable layer's WARN log + metric remain the
+//     operator-visible signal for those.
 func (d *Dynamic) onPermanentFailure(subject string, err error) {
 	if d.userOnPermanentFailure != nil {
 		d.userOnPermanentFailure(subject, err)
+	}
+	if d.suppressManagerDegrade {
 		return
 	}
 	if fn := d.managerOnStreamMissing.Load(); fn != nil && errors.Is(err, types.ErrStreamMissing) {
@@ -463,9 +503,11 @@ func (d *Dynamic) onPermanentFailure(subject string, err error) {
 // types.ErrStreamMissing error chain. Calling with fn == nil clears
 // any previously-installed observer.
 //
-// Application-supplied callbacks registered via
-// [WithOnPermanentFailure] take precedence over the manager observer
-// (see [Dynamic.onPermanentFailure] for the dispatch rules).
+// Application-supplied callbacks registered via [WithOnPermanentFailure]
+// do not suppress this observer: both fire for stream-missing exhaustion
+// (application callback first, then this observer), unless the application
+// explicitly opts out via [WithSuppressManagerDegradeOnStreamMissing].
+// See [Dynamic.onPermanentFailure] for the full dispatch rules.
 //
 // Safe for concurrent use; calls before, during, or after NewDynamic
 // are equivalent — the durable layer reads the slot at fire time.
@@ -503,7 +545,14 @@ func (d *Dynamic) SetOnStreamMissingError(fn func(streamName string, err error))
 //     AllowWorkerIDChange is false.
 //   - [ErrMaxSubjectsExceeded]: Returned when partition count
 //     exceeds MaxConcurrentSubjects.
+//   - Non-sentinel error: Returned when one or more removed partition loops
+//     fail to stop within DrainOnRemoveTimeout; the stop wait is bounded by
+//     that timeout even when DrainOnRemove is false. Tracking entries are
+//     cleared so the manager's retry converges.
 func (d *Dynamic) Update(ctx context.Context, workerID string, partitions []types.Partition) error {
+	if d.inner.Closed() {
+		return fmt.Errorf("dynamic consumer: %w", ErrConsumerStopped)
+	}
 	if err := d.ensureCompatChecked(ctx); err != nil {
 		return err
 	}
@@ -521,6 +570,9 @@ func (d *Dynamic) UpdateWorkerConsumer(ctx context.Context, workerID string, par
 	// bypassed the check entirely, so a stale Dynamic registered with
 	// the manager could silently accept an incompatible
 	// WorkQueuePolicy/recovery combination on a recreated stream.
+	if d.inner.Closed() {
+		return fmt.Errorf("dynamic consumer: %w", ErrConsumerStopped)
+	}
 	if err := d.ensureCompatChecked(ctx); err != nil {
 		return err
 	}
@@ -573,8 +625,6 @@ func (d *Dynamic) Capabilities() uint32 {
 	return d.inner.Capabilities()
 }
 
-// Close stops all partition consumers.
-//
 // Stop gracefully stops all partition consumers.
 //
 // Stop cancels all internal pull loops and waits for pending message processing
@@ -584,6 +634,11 @@ func (d *Dynamic) Capabilities() uint32 {
 //
 // If DrainOnRemove is enabled, Stop will first drain pending messages
 // (up to DrainOnRemoveTimeout) before stopping.
+//
+// Stop is terminal: subsequent manager updates (via [Dynamic.Update] or
+// [Dynamic.UpdateWorkerConsumer]) will fail with [ErrConsumerStopped]. Create a
+// new [Dynamic] to consume again. To avoid a loud retry loop in the manager,
+// stop the manager first or deregister this consumer before calling Stop.
 //
 // Stop is idempotent; calling it multiple times is safe.
 //
@@ -616,11 +671,15 @@ func (c *DynamicConfig) Validate() error {
 		return err
 	}
 	if err := fuda.Validate(c); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
 		return err
 	}
 
 	if !jsutil.IsValidConsumerName(c.ConsumerPrefix) {
-		return fmt.Errorf("consumer prefix %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", c.ConsumerPrefix)
+		return fmt.Errorf("%w: consumer prefix %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", ErrInvalidConfig, c.ConsumerPrefix)
 	}
 
 	return validateStreamMissingHookStrategy(c.StreamMissingHook != nil, c.RecoveryStrategy)

--- a/consumer/dynamic_compat_rearm_test.go
+++ b/consumer/dynamic_compat_rearm_test.go
@@ -7,7 +7,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/arloliu/parti/v2/partitest"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
@@ -216,4 +218,55 @@ func TestDynamic_CompatRearm_ConcurrentStress_NoRace(t *testing.T) {
 
 	// We don't assert a particular outcome — any (cached err) or nil
 	// is acceptable. The point is -race not triggering.
+}
+
+// TestDynamic_UpdateAfterStop_SentinelPrecedence verifies that calling Update
+// or UpdateWorkerConsumer on a stopped Dynamic returns ErrConsumerStopped
+// rather than ErrInvalidConfig, even when the compat check is injected to
+// return an ErrInvalidConfig-wrapped error. The terminal-stopped sentinel must
+// take precedence over the compat preflight.
+func TestDynamic_UpdateAfterStop_SentinelPrecedence(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	d, err := NewDynamic(
+		js,
+		"DYNSENTINEL_STREAM",
+		"dynsentinel_worker",
+		"dynsentinel.{{.PartitionID}}",
+		handler,
+	)
+	require.NoError(t, err)
+
+	// Inject a compat check that always returns ErrInvalidConfig.
+	failErr := fmt.Errorf("%w: injected WorkQueuePolicy mismatch", ErrInvalidConfig)
+	swapCompatCheckFn(t, func(_ context.Context, _ jetstream.JetStream, _ string, _ RecoveryStrategy) error {
+		return failErr
+	})
+
+	// Stop before ever calling Update — marks the inner closed flag.
+	require.NoError(t, d.Stop(ctx))
+
+	// Update must return ErrConsumerStopped, NOT ErrInvalidConfig.
+	err = d.Update(ctx, "worker-0", nil)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrConsumerStopped),
+		"Update: expected ErrConsumerStopped, got: %v", err)
+	require.False(t, errors.Is(err, ErrInvalidConfig),
+		"Update: ErrConsumerStopped must take precedence over ErrInvalidConfig, got: %v", err)
+
+	// UpdateWorkerConsumer must return ErrConsumerStopped as well.
+	err = d.UpdateWorkerConsumer(ctx, "worker-0", nil)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrConsumerStopped),
+		"UpdateWorkerConsumer: expected ErrConsumerStopped, got: %v", err)
+	require.False(t, errors.Is(err, ErrInvalidConfig),
+		"UpdateWorkerConsumer: ErrConsumerStopped must take precedence over ErrInvalidConfig, got: %v", err)
 }

--- a/consumer/dynamic_on_permanent_failure_test.go
+++ b/consumer/dynamic_on_permanent_failure_test.go
@@ -93,79 +93,81 @@ func TestNewDynamic_OnPermanentFailure_ThreadedToDynamicConfig(t *testing.T) {
 // threaded through.
 type fakeJSPF struct{ jetstream.JetStream }
 
-// TestNewDynamic_WithOnPermanentFailure_Constructs verifies the option
-// composes with the existing NewDynamic constructor surface: validation
-// must accept WithOnPermanentFailure, and NewDynamic must proceed past
-// cfg.Validate into the durable layer (where the embedded nil interface
-// triggers a panic on the first JS method call).
-//
-// The test discriminates three outcomes explicitly:
-//   - NewDynamic returns an error (validation rejected the option) → FAIL.
-//   - NewDynamic returns successfully (impossible with the stub JS) → FAIL.
-//   - NewDynamic panics inside the durable layer (validation passed,
-//     option threaded through, fake JS reached) → PASS.
-//
-// (v3 P2 fix: the prior version of this test used a deferred recover()
-// that swallowed every outcome including validation rejection, making
-// it a vacuous smoke test.)
-// TestDynamic_onPermanentFailure_UserCallbackWinsOverManagerObserver
-// pins the dispatch precedence contract documented on
-// [Dynamic.onPermanentFailure]: when an application has registered
-// its own OnPermanentFailure via [WithOnPermanentFailure], the
-// manager-installed observer must NOT also fire — even for
-// stream-missing exhaustion. This is the row in the dispatch matrix
-// that is most likely to bite operators if a regression accidentally
-// chained the dispatch (both fire), because the cross-feature
-// contract enforcement (manager.enterDegraded with the named reason)
-// would silently double-fire alongside the application's own
-// degraded-routing logic.
-//
-// Tested by constructing a Dynamic directly (bypassing NewDynamic so
-// no JetStream context is required), pre-populating both the
-// userOnPermanentFailure slot and the managerOnStreamMissing slot,
-// then invoking the private dispatcher with a wrapped
-// types.ErrStreamMissing. Assert: user runs, manager does not.
-func TestDynamic_onPermanentFailure_UserCallbackWinsOverManagerObserver(t *testing.T) {
+// TestDynamic_onPermanentFailure_UserCallbackAndManagerObserverBothFire
+// pins the dual-dispatch contract: when an application has registered its
+// own OnPermanentFailure via WithOnPermanentFailure, the manager-installed
+// observer ALSO fires for stream-missing exhaustion (user callback first,
+// then manager observer), so platform self-healing (Degraded -> rotation)
+// is not silently coupled to an app-level observability hook. Applications
+// that deliberately manage rotation themselves opt out explicitly via
+// WithSuppressManagerDegradeOnStreamMissing.
+func TestDynamic_onPermanentFailure_UserCallbackAndManagerObserverBothFire(t *testing.T) {
 	var (
-		userCalls      atomic.Int32
-		userArgSubject atomic.Pointer[string]
-		userArgErr     atomic.Pointer[error]
-		managerCalls   atomic.Int32
-		managerArgErr  atomic.Pointer[error]
-		managerArgName atomic.Pointer[string]
+		userCalls    atomic.Int32
+		managerCalls atomic.Int32
+		order        []string // single-goroutine test; no sync needed
 	)
 
 	d := &Dynamic{
 		streamName: "TEST_STREAM",
-		userOnPermanentFailure: func(subject string, err error) {
+		userOnPermanentFailure: func(_ string, _ error) {
 			userCalls.Add(1)
-			s := subject
-			userArgSubject.Store(&s)
-			e := err
-			userArgErr.Store(&e)
+			order = append(order, "user")
 		},
 	}
-	// Manager observer slot via the public method that NewDynamic-less
-	// callers use; this is the same path Manager.Start drives.
-	d.SetOnStreamMissingError(func(streamName string, err error) {
+	d.SetOnStreamMissingError(func(_ string, err error) {
 		managerCalls.Add(1)
-		n := streamName
-		managerArgName.Store(&n)
-		e := err
-		managerArgErr.Store(&e)
+		order = append(order, "manager")
+		require.ErrorIs(t, err, types.ErrStreamMissing,
+			"manager observer must receive the wrapped types.ErrStreamMissing chain")
+	})
+
+	wrapped := fmt.Errorf("stream %q: %w", "TEST_STREAM", types.ErrStreamMissing)
+	d.onPermanentFailure("test.subject.p1", wrapped)
+
+	require.Equal(t, []string{"user", "manager"}, order,
+		"documented order: application callback first, then manager observer")
+	require.Equal(t, int32(1), userCalls.Load(),
+		"user callback must fire exactly once")
+	require.Equal(t, int32(1), managerCalls.Load(),
+		"manager observer must ALSO fire for stream-missing exhaustion when a user callback is registered")
+
+	// Generic (non-stream-missing) exhaustion still reaches ONLY the user
+	// callback — the manager observer remains scoped to stream-missing.
+	d.onPermanentFailure("test.subject.p1", errors.New("generic exhaustion"))
+	require.Equal(t, int32(2), userCalls.Load())
+	require.Equal(t, int32(1), managerCalls.Load(),
+		"manager observer must NOT fire for non-stream-missing exhaustion")
+}
+
+// TestDynamic_onPermanentFailure_SuppressOptionDisablesManagerObserver pins
+// the explicit opt-out: with suppressManagerDegrade set, the manager
+// observer never fires (stream-missing or otherwise) while the user
+// callback still does.
+func TestDynamic_onPermanentFailure_SuppressOptionDisablesManagerObserver(t *testing.T) {
+	var (
+		userCalls    atomic.Int32
+		managerCalls atomic.Int32
+	)
+
+	d := &Dynamic{
+		streamName:             "TEST_STREAM",
+		suppressManagerDegrade: true,
+		userOnPermanentFailure: func(_ string, _ error) {
+			userCalls.Add(1)
+		},
+	}
+	d.SetOnStreamMissingError(func(_ string, _ error) {
+		managerCalls.Add(1)
 	})
 
 	wrapped := fmt.Errorf("stream %q: %w", "TEST_STREAM", types.ErrStreamMissing)
 	d.onPermanentFailure("test.subject.p1", wrapped)
 
 	require.Equal(t, int32(1), userCalls.Load(),
-		"user callback must fire exactly once when registered via WithOnPermanentFailure")
+		"user callback must still fire when suppression is enabled")
 	require.Equal(t, int32(0), managerCalls.Load(),
-		"manager observer must NOT fire when a user callback is registered — application callback wins per the documented dispatch precedence")
-	require.Equal(t, "test.subject.p1", *userArgSubject.Load(),
-		"user callback must receive the partition subject from the durable layer")
-	require.ErrorIs(t, *userArgErr.Load(), types.ErrStreamMissing,
-		"user callback must receive the wrapped types.ErrStreamMissing chain so apps can branch on the sentinel")
+		"manager observer must NOT fire when the application explicitly suppressed the degrade route")
 }
 
 // TestDynamic_onPermanentFailure_ManagerObserverOnlyOnStreamMissing
@@ -243,6 +245,21 @@ func TestDynamic_SetOnStreamMissingError_NilClearsAfterFire(t *testing.T) {
 			"a regression that left the slot populated would re-enter the (potentially stale) closure")
 }
 
+// TestNewDynamic_WithOnPermanentFailure_Constructs verifies the option
+// composes with the existing NewDynamic constructor surface: validation
+// must accept WithOnPermanentFailure, and NewDynamic must proceed past
+// cfg.Validate into the durable layer (where the embedded nil interface
+// triggers a panic on the first JS method call).
+//
+// The test discriminates three outcomes explicitly:
+//   - NewDynamic returns an error (validation rejected the option) → FAIL.
+//   - NewDynamic returns successfully (impossible with the stub JS) → FAIL.
+//   - NewDynamic panics inside the durable layer (validation passed,
+//     option threaded through, fake JS reached) → PASS.
+//
+// (v3 P2 fix: the prior version of this test used a deferred recover()
+// that swallowed every outcome including validation rejection, making
+// it a vacuous smoke test.)
 func TestNewDynamic_WithOnPermanentFailure_Constructs(t *testing.T) {
 	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
 

--- a/consumer/dynamic_test.go
+++ b/consumer/dynamic_test.go
@@ -2,6 +2,7 @@ package consumer_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -121,4 +122,70 @@ func TestDynamic_ConsumerOptions_AppliedToLiveConsumer(t *testing.T) {
 	}
 	require.NoError(t, lister.Err(), "ListConsumers iteration failed")
 	require.True(t, found, "no per-partition consumer was created under the dynopt_worker prefix")
+}
+
+// TestDynamicConfig_Validate_WrapsErrInvalidConfig verifies that every
+// validation failure in NewDynamic / DynamicConfig.Validate is reachable
+// via errors.Is(err, consumer.ErrInvalidConfig).
+func TestDynamicConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "nil js",
+			fn: func() error {
+				_, err := consumer.NewDynamic(nil, "S", "pfx", "s.{{partition}}", handler)
+
+				return err
+			},
+		},
+		{
+			name: "fuda required field (missing StreamName via Validate)",
+			fn: func() error {
+				cfg := consumer.DynamicConfig{ConsumerPrefix: "pfx", SubjectTemplate: "s.{{partition}}"}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "FetchTimeout below 1s floor",
+			fn: func() error {
+				cfg := consumer.DynamicConfig{
+					StreamName:      "S",
+					ConsumerPrefix:  "pfx",
+					SubjectTemplate: "s.{{partition}}",
+					CommonConfig:    consumer.CommonConfig{FetchTimeout: 100 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "invalid consumer prefix",
+			fn: func() error {
+				cfg := consumer.DynamicConfig{
+					StreamName:      "S",
+					ConsumerPrefix:  "bad prefix!",
+					SubjectTemplate: "s.{{partition}}",
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, consumer.ErrInvalidConfig),
+				"expected errors.Is(err, consumer.ErrInvalidConfig), got: %v", err)
+		})
+	}
 }

--- a/consumer/errors.go
+++ b/consumer/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/types"
 )
 
 // ErrInvalidConfig is returned by constructors ([NewQueue], [NewStatic], [NewDynamic],
@@ -30,4 +31,11 @@ var (
 	// ErrMaxSubjectsExceeded is returned by [Dynamic.Update] when the
 	// partition count exceeds MaxConcurrentSubjects.
 	ErrMaxSubjectsExceeded = durable.ErrMaxSubjectsExceeded
+
+	// ErrConsumerStopped is returned by [Static.Start], [Broadcast.Start],
+	// [Broadcast.UpdateWorkerConsumer], [Dynamic.Update], and
+	// [Dynamic.UpdateWorkerConsumer] when the consumer has already been stopped
+	// or closed. Stop is terminal for Static, Broadcast, and Dynamic consumers:
+	// create a new instance to consume again.
+	ErrConsumerStopped = types.ErrConsumerStopped
 )

--- a/consumer/gate_config.go
+++ b/consumer/gate_config.go
@@ -6,14 +6,15 @@ import (
 	"github.com/arloliu/parti/v2/types"
 )
 
-// ProcessingGateConfig configures the optional exclusive processing gate.
+// ProcessingGateConfig configures the optional processing gate.
 //
-// When enabled, a Dynamic consumer uses a distributed lock (via KV) to ensure
-// that it is the *only* active processor for its assigned partitions. This
-// prevents split-brain processing during rebalances.
-//
-// The gate NAKs messages when the worker is not the owner or when the handoff
-// state is not in the allowed set.
+// When enabled, a Dynamic consumer checks KV-backed ownership claims before
+// each handler invocation (per-message admission control) and NAKs messages
+// when the worker is not the owner or when the handoff state is not in the
+// allowed set. This bounds, but does not eliminate, split-brain processing
+// during rebalances: a handler invocation that has already started cannot be
+// revoked. See docs/LIFECYCLE.md "Two-Phase Handoff" for the per-tier
+// overlap contract.
 type ProcessingGateConfig struct {
 	// Enabled toggles the gate.
 	// Default: false (gate disabled).

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -186,17 +186,18 @@ type options struct {
 	keyExtractor     func(msg jetstream.Msg) string
 
 	// Dynamic specific
-	processingGate              *ProcessingGateConfig
-	resolver                    ResolverConfig
-	pullGatingEnabled           bool
-	drainOnRemove               bool
-	drainOnRemoveTimeout        time.Duration
-	maxConcurrentSubjects       int
-	allowWorkerIDChange         bool
-	partitionRefreshMinInterval time.Duration
-	streamMissingHook           types.StreamMissingHook
-	onPermanentFailure          func(subject string, err error)
-	recoveryRetry               RecoveryRetryConfig
+	processingGate                        *ProcessingGateConfig
+	resolver                              ResolverConfig
+	pullGatingEnabled                     bool
+	drainOnRemove                         bool
+	drainOnRemoveTimeout                  time.Duration
+	maxConcurrentSubjects                 int
+	allowWorkerIDChange                   bool
+	partitionRefreshMinInterval           time.Duration
+	streamMissingHook                     types.StreamMissingHook
+	onPermanentFailure                    func(subject string, err error)
+	suppressManagerDegradeOnStreamMissing bool
+	recoveryRetry                         RecoveryRetryConfig
 }
 
 // defaultOptions returns sensible defaults.
@@ -488,28 +489,19 @@ func WithStreamMissingHook(hook types.StreamMissingHook) DynamicOption {
 //
 // # Interaction with the Parti manager's auto-degraded route
 //
-// IMPORTANT: registering this callback disables the Parti manager's
-// auto-degraded route for stream-missing exhaustion. When a [Dynamic]
-// is wired into a [parti.Manager] (directly or via a
-// [parti.CompositeConsumerUpdater]), the manager installs an observer
-// that — for stream-missing exhaustion only — calls Hooks.OnError with
-// the wrapped error and transitions to Degraded mode with reason
-// "stream-missing-recovery-exhausted" so the readiness probe rotates
-// the pod.
+// Registering this callback does NOT disable the Parti manager's
+// auto-degraded route. When a [Dynamic] is wired into a [parti.Manager]
+// (directly or via a [parti.CompositeConsumerUpdater]), the manager
+// installs an observer that — for stream-missing exhaustion only — calls
+// [parti.Hooks.OnError] with the wrapped error and then transitions to
+// Degraded mode with reason "stream-missing-recovery-exhausted" so the
+// readiness probe rotates the pod. Both this callback and the manager
+// observer fire (application callback first) for stream-missing exhaustion.
 //
-// That manager-side observer fires ONLY when no application callback
-// is registered here. If WithOnPermanentFailure is set, the dispatcher
-// hands every permanent failure to the application and STOPS — the
-// manager observer never sees the stream-missing event. Applications
-// that want both per-subject observability AND the manager's
-// auto-degraded behavior must either:
-//
-//   - Forgo WithOnPermanentFailure and rely on
-//     [parti.Hooks.OnError] (which receives the wrapped error from the
-//     manager observer route), or
-//   - Within the supplied callback, branch on
-//     errors.Is(err, [parti.ErrStreamMissing]) and forward the event
-//     to their own degraded-mode signaling path.
+// Applications that deliberately own degrade/rotation signaling themselves
+// (e.g. they forward stream-missing events to their own readiness wiring
+// inside this callback) can suppress the manager observer explicitly via
+// [WithSuppressManagerDegradeOnStreamMissing].
 //
 // Applies only to [Dynamic]. Optional; if unset, exhaustion is logged at
 // WARN with metric `iterator_restart{reason="recovery_exhausted"}` or
@@ -519,6 +511,27 @@ func WithStreamMissingHook(hook types.StreamMissingHook) DynamicOption {
 func WithOnPermanentFailure(fn func(subject string, err error)) DynamicOption {
 	return dynamicOpt(func(o *options) {
 		o.onPermanentFailure = fn
+	})
+}
+
+// WithSuppressManagerDegradeOnStreamMissing disables the Parti manager's
+// auto-degraded route for stream-missing recovery exhaustion on this
+// Dynamic consumer.
+//
+// By default, when a [Dynamic] is wired into a [parti.Manager], stream-missing
+// exhaustion notifies the manager observer (calling [parti.Hooks.OnError] with
+// the wrapped error and entering Degraded with reason
+// "stream-missing-recovery-exhausted" so the readiness probe rotates the
+// pod) IN ADDITION to any application callback registered via
+// [WithOnPermanentFailure]. Suppress this only when the application
+// deliberately owns degrade/rotation signaling itself — e.g. it forwards
+// stream-missing events to its own readiness wiring inside its
+// OnPermanentFailure callback.
+//
+// Applies only to [Dynamic].
+func WithSuppressManagerDegradeOnStreamMissing() DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.suppressManagerDegradeOnStreamMissing = true
 	})
 }
 
@@ -794,8 +807,11 @@ func WithPullGating(enabled bool) DynamicOption {
 
 // WithDrainOnRemove configures drain behavior on subject removal.
 //
-// When enabled, revoked partitions will finish processing buffered messages
-// before shutting down. The timeout caps the drain duration.
+// When enabled, removed partition loops drain buffered messages before
+// shutting down. Draining is bounded by DrainOnRemoveTimeout; if the loops
+// fail to stop within that bound, [Dynamic.Update] returns an error and the
+// manager retries the apply. An already-in-flight handler invocation may still
+// run to completion (best-effort, not a zero-overlap guarantee).
 //
 // Parameters:
 //   - enabled: Whether to enable graceful draining

--- a/consumer/queue.go
+++ b/consumer/queue.go
@@ -18,6 +18,13 @@ import (
 	"github.com/arloliu/parti/v2/types"
 )
 
+// errIteratorClosedUnexpectedly is returned by processIterator when the iterator
+// reports ErrMsgIteratorClosed while the loop context is still alive (i.e., not a
+// graceful shutdown). The sentinel is unexported so callers inside runLoop handle
+// it via the normal backoff path rather than forwarding to the recovery classifier
+// (which would return ActionExit for ErrMsgIteratorClosed).
+var errIteratorClosedUnexpectedly = errors.New("iterator closed unexpectedly")
+
 // Queue is a load-balanced consumer where multiple instances share one durable.
 // Each message is delivered to exactly one instance (queue group semantics).
 //
@@ -102,7 +109,10 @@ type QueueConfig struct {
 	//
 	// NATS only permits [jetstream.DeliverAllPolicy] on WorkQueuePolicy streams.
 	// [RecoverFromNew] maps to [jetstream.DeliverNewPolicy] and is therefore incompatible:
-	// [Queue.Start] will return [ErrInvalidConfig] when both are combined.
+	// [Queue.Start] rejects the combination with [ErrInvalidConfig]. The pre-flight
+	// check is best-effort — transient failures to fetch stream info are ignored
+	// (see [CheckWorkQueueRecoveryCompat]) — so an incompatible combination can
+	// slip past Start and only surface when recovery first misbehaves.
 	// Use [RecoverFromBeginning] or [RecoveryDisabled] for WorkQueuePolicy streams.
 	RecoveryStrategy RecoveryStrategy
 }
@@ -152,14 +162,18 @@ func (c *QueueConfig) Validate() error {
 		return err
 	}
 	if err := fuda.Validate(c); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
 		return err
 	}
 
 	if !jsutil.IsValidConsumerName(c.ConsumerName) {
-		return fmt.Errorf("consumer name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", c.ConsumerName)
+		return fmt.Errorf("%w: consumer name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", ErrInvalidConfig, c.ConsumerName)
 	}
 	if err := validateSubjectTokens(c.FilterSubject, true); err != nil {
-		return fmt.Errorf("filter subject is invalid: %w", err)
+		return fmt.Errorf("%w: filter subject is invalid: %w", ErrInvalidConfig, err)
 	}
 	if c.RecoveryStrategy == RecoverFromLastProcessed {
 		return fmt.Errorf("%w: RecoverFromLastProcessed is not supported for Queue consumers"+
@@ -270,16 +284,16 @@ func (q *Queue) Start(ctx context.Context) error {
 		return errors.New("queue consumer already started")
 	}
 
+	if err := CheckWorkQueueRecoveryCompat(ctx, q.js, q.config.StreamName, q.config.RecoveryStrategy); err != nil {
+		return err
+	}
+
 	// Create or get existing consumer
 	cons, err := q.ensureConsumer(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create consumer: %w", err)
 	}
 	q.consumer = cons
-
-	if err := CheckWorkQueueRecoveryCompat(ctx, q.js, q.config.StreamName, q.config.RecoveryStrategy); err != nil {
-		return err
-	}
 
 	// Start the pull loop
 	loopCtx, cancel := context.WithCancel(context.Background())
@@ -299,6 +313,11 @@ func (q *Queue) Start(ctx context.Context) error {
 }
 
 // Stop gracefully stops the consumer.
+//
+// If ctx expires before the pull loop exits, Stop returns the context error
+// and the consumer still counts as started: a subsequent [Queue.Start] fails,
+// and a second Stop call (which waits for the loop again) is required before
+// the consumer can be restarted.
 func (q *Queue) Stop(ctx context.Context) error {
 	q.mu.Lock()
 	if !q.loopStarted {
@@ -376,6 +395,13 @@ func (q *Queue) runLoop(ctx context.Context) {
 		q.mu.RUnlock()
 
 		if cons == nil {
+			// Defensive: Start always sets q.consumer before launching the loop,
+			// so this exit indicates internal state was cleared unexpectedly.
+			q.logger.Warn("queue consumer loop exiting: consumer reference is nil",
+				"stream", q.config.StreamName,
+				"consumer", q.config.ConsumerName,
+			)
+
 			return
 		}
 
@@ -393,6 +419,29 @@ func (q *Queue) runLoop(ctx context.Context) {
 		iterErr := q.processIterator(ctx, iter)
 		if iterErr == nil {
 			continue
+		}
+
+		// Iterator closed while loop context is alive (not a graceful shutdown).
+		// Back off and retry without forwarding to the recovery classifier, which
+		// would return ActionExit for ErrMsgIteratorClosed.
+		if errors.Is(iterErr, errIteratorClosedUnexpectedly) {
+			if q.delayWithBackoffOrExit(ctx, &backoff) {
+				return
+			}
+			continue
+		}
+
+		if q.recovery == nil {
+			// RecoveryDisabled (the default): the recovery controller is nil and
+			// classification short-circuits before any metric. A deleted durable
+			// causes a permanent stall with no operator signal at production log
+			// levels without this explicit path.
+			q.logger.Warn("iterator error with recovery disabled; consumer will retry but cannot recreate a deleted durable",
+				"error", iterErr,
+				"stream", q.config.StreamName,
+				"filter", q.config.FilterSubject,
+			)
+			q.metrics.IncrementWorkerConsumerIteratorRestart("recovery_disabled")
 		}
 
 		action, newCons, classifyErr := q.recovery.Classify(ctx, iterErr, q.consumerInfoFn(), consumerConfig, q.recreateFn())
@@ -466,9 +515,17 @@ func (q *Queue) processIterator(ctx context.Context, iter jetstream.MessagesCont
 		msg, err := iter.Next()
 		if err != nil {
 			if errors.Is(err, jetstream.ErrMsgIteratorClosed) || errors.Is(err, context.Canceled) {
-				return nil // graceful shutdown
+				if ctx.Err() != nil {
+					return nil // graceful shutdown: loop context cancelled
+				}
+				// Iterator closed while the loop context is still alive — the
+				// underlying pull consumer may have been server-side closed.
+				// Return the sentinel so runLoop takes the backoff path instead
+				// of spinning (a nil return resets backoff to 0).
+				return errIteratorClosedUnexpectedly
 			}
 			q.logger.Debug("iterator error", "error", err)
+
 			return err // caller classifies for recovery or backoff
 		}
 

--- a/consumer/queue_test.go
+++ b/consumer/queue_test.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -101,6 +102,83 @@ func TestQueueConfig_Validate_InvalidConsumerName(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "invalid characters"))
 }
 
+// TestQueueConfig_Validate_WrapsErrInvalidConfig verifies that every validation
+// failure in QueueConfig.Validate is reachable via errors.Is(err, ErrInvalidConfig).
+func TestQueueConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "fuda required field (missing StreamName)",
+			fn: func() error {
+				_, err := NewQueue(nil, "", "c", "s.>", handler)
+
+				return err
+			},
+		},
+		{
+			name: "fuda required field (missing ConsumerName)",
+			fn: func() error {
+				_, err := NewQueue(nil, "S", "", "s.>", handler)
+
+				return err
+			},
+		},
+		{
+			name: "invalid consumer name",
+			fn: func() error {
+				cfg := QueueConfig{
+					StreamName:    "TEST",
+					ConsumerName:  "bad name!",
+					FilterSubject: "events.>",
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "invalid filter subject",
+			fn: func() error {
+				cfg := QueueConfig{
+					StreamName:    "TEST",
+					ConsumerName:  "ok",
+					FilterSubject: "events..>",
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "FetchTimeout below 1s floor",
+			fn: func() error {
+				cfg := QueueConfig{
+					StreamName:    "TEST",
+					ConsumerName:  "ok",
+					FilterSubject: "events.>",
+					CommonConfig:  CommonConfig{FetchTimeout: 100 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrInvalidConfig),
+				"expected errors.Is(err, ErrInvalidConfig), got: %v", err)
+		})
+	}
+}
+
 func TestQueueConfig_SetDefaults(t *testing.T) {
 	cfg := QueueConfig{
 		CommonConfig:  CommonConfig{},
@@ -168,7 +246,7 @@ func TestQueue_StartStop(t *testing.T) {
 	handler := MessageHandlerFunc(func(ctx context.Context, msg jetstream.Msg) error { return nil })
 
 	q, err := NewQueue(js, "QUEUE_TEST", "queue-workers", "queue.>", handler,
-		WithFetchTimeout(500*time.Millisecond),
+		WithFetchTimeout(time.Second),
 	)
 	require.NoError(t, err)
 
@@ -465,6 +543,116 @@ func TestQueue_RunLoop_FailedRecoveryUsesBackoff(t *testing.T) {
 	require.Less(t, iterFactoryCalls.Load(), int32(5), "failed recovery should back off instead of hot-looping")
 	require.NotEmpty(t, m.attemptReasons)
 	require.Equal(t, []string{"failure"}, m.results[:1])
+}
+
+// queueSignalMetrics extends queueRecoveryMetrics to record iterator-restart reasons.
+type queueSignalMetrics struct {
+	queueRecoveryMetrics
+	restartReasons []string
+}
+
+func (m *queueSignalMetrics) IncrementWorkerConsumerIteratorRestart(reason string) {
+	m.restartReasons = append(m.restartReasons, reason)
+}
+
+// TestQueue_RecoveryDisabled_IteratorErrorIsSignaled pins the operator signal for
+// the default configuration: with RecoveryDisabled (nil controller), a non-graceful
+// iterator error (e.g. the durable was deleted) must emit a Warn log and the
+// iterator-restart metric with reason "recovery_disabled". Pre-fix the only artifact
+// was a Debug log — at production log levels a deleted durable was a zero-signal
+// permanent stall.
+func TestQueue_RecoveryDisabled_IteratorErrorIsSignaled(t *testing.T) {
+	m := &queueSignalMetrics{}
+
+	q := &Queue{
+		config: QueueConfig{
+			CommonConfig: CommonConfig{
+				BatchSize:    1,
+				FetchTimeout: time.Second,
+			},
+			StreamName:   "Q_RECOVERY_DISABLED",
+			ConsumerName: "q-worker",
+			Retry: RetryConfig{
+				Base:       20 * time.Millisecond,
+				Backoff:    20 * time.Millisecond,
+				Multiplier: 1.0,
+				Max:        20 * time.Millisecond,
+			},
+		},
+		logger:   logging.NewNop(),
+		metrics:  m,
+		consumer: &stubConsumer{},
+		loopDone: make(chan struct{}),
+		iterFactory: func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+			return &queueErrorIter{err: jetstream.ErrNoHeartbeat}, nil
+		},
+		consumerConfig: jetstream.ConsumerConfig{Durable: "q-worker"},
+		recovery:       nil, // RecoveryDisabled: NewController returns nil for Disabled strategy
+		retryRNG:       newRetryRNG(1),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go q.runLoop(ctx)
+
+	// One backoff cycle (20ms) is enough to observe the metric; wait two.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-q.loopDone
+
+	require.NotEmpty(t, m.restartReasons,
+		"expected IncrementWorkerConsumerIteratorRestart to be called on the nil-recovery path")
+	require.Contains(t, m.restartReasons, "recovery_disabled",
+		"expected reason=recovery_disabled on the nil-recovery path")
+}
+
+// TestQueue_ClosedIteratorWithLiveContext_BacksOff pins that a persistently
+// closing iterator (Next always returns ErrMsgIteratorClosed) with a live
+// context is bounded in factory call count over 200ms. Pre-fix processIterator
+// returned nil for ErrMsgIteratorClosed regardless of ctx state, causing
+// runLoop to reset backoff to 0 and recreate the iterator in a tight loop
+// (hundreds of calls in 200ms).
+func TestQueue_ClosedIteratorWithLiveContext_BacksOff(t *testing.T) {
+	var factoryCalls atomic.Int32
+
+	q := &Queue{
+		config: QueueConfig{
+			CommonConfig: CommonConfig{
+				BatchSize:    1,
+				FetchTimeout: time.Second,
+			},
+			StreamName:   "QUEUE",
+			ConsumerName: "queue-workers",
+			Retry: RetryConfig{
+				Base:       20 * time.Millisecond,
+				Backoff:    20 * time.Millisecond,
+				Multiplier: 1.0,
+				Max:        50 * time.Millisecond,
+			},
+		},
+		logger:   logging.NewNop(),
+		metrics:  &queueRecoveryMetrics{},
+		consumer: &stubConsumer{},
+		loopDone: make(chan struct{}),
+		iterFactory: func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
+			factoryCalls.Add(1)
+			return &queueErrorIter{err: jetstream.ErrMsgIteratorClosed}, nil
+		},
+		consumerConfig: jetstream.ConsumerConfig{Durable: "queue-workers"},
+		recovery:       nil, // RecoveryDisabled
+		retryRNG:       newRetryRNG(1),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go q.runLoop(ctx)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-q.loopDone
+
+	calls := factoryCalls.Load()
+	t.Logf("factory call count over 200ms: %d", calls)
+	require.Less(t, calls, int32(20),
+		"ErrMsgIteratorClosed with live context must back off; got %d factory calls in 200ms", calls)
 }
 
 // TestQueue_ConsumerOptions_AppliedToLiveConsumer verifies that

--- a/consumer/static.go
+++ b/consumer/static.go
@@ -207,7 +207,7 @@ func NewStatic(
 
 	inner, err := ipartition.NewJSConsumer(js, partitionCfg, handler.Handle)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidConfig, err)
 	}
 
 	return &Static{
@@ -224,15 +224,19 @@ func NewStatic(
 // a pull loop. Messages are delivered to the handler configured at creation.
 //
 // Start may only be called once. Calling Start on an already-started consumer
-// returns an error.
+// returns an error. After [Static.Stop] is called, Start returns
+// [ErrConsumerStopped]; create a new instance to consume again.
 //
 // Parameters:
 //   - ctx: Context for lifecycle control. Cancellation stops the consumer.
 //
 // Returns:
-//   - error: Non-nil if the consumer is already started or if JetStream
-//     consumer creation fails.
+//   - error: Non-nil if the consumer is already started, [ErrConsumerStopped]
+//     if the consumer has been stopped, or a JetStream consumer creation error.
 func (s *Static) Start(ctx context.Context) error {
+	if s.inner.Stopped() {
+		return fmt.Errorf("static consumer: %w", ErrConsumerStopped)
+	}
 	if err := CheckWorkQueueRecoveryCompat(ctx, s.js, s.streamName, s.recoveryStrategy); err != nil {
 		return err
 	}
@@ -244,6 +248,13 @@ func (s *Static) Start(ctx context.Context) error {
 // Stop cancels the internal pull loop and waits for pending message processing
 // to complete (up to the context deadline). The underlying JetStream consumer
 // is NOT deleted; it will be garbage-collected by the server after InactiveThreshold.
+//
+// Stop is terminal: after Stop returns, any subsequent call to [Static.Start]
+// returns [ErrConsumerStopped]. Create a new instance to consume again.
+//
+// If the consumer is stopped while still registered with a running manager, the
+// manager will retry the failed update indefinitely (by design). Stop the manager
+// first, or deregister this consumer before calling Stop.
 //
 // Stop is idempotent; calling it multiple times is safe.
 //
@@ -288,16 +299,20 @@ func (c *StaticConfig) Validate() error {
 		return err
 	}
 	if err := fuda.Validate(c); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidConfig, err)
+	}
+
+	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
 		return err
 	}
 
 	if !jsutil.IsValidConsumerName(c.ConsumerName) {
-		return fmt.Errorf("consumer name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", c.ConsumerName)
+		return fmt.Errorf("%w: consumer name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", ErrInvalidConfig, c.ConsumerName)
 	}
 
 	// Cross-field validation: partition must be within range
 	if c.Partition >= c.NumPartitions {
-		return fmt.Errorf("partition index %d out of range [0, %d)", c.Partition, c.NumPartitions)
+		return fmt.Errorf("%w: partition index %d out of range [0, %d)", ErrInvalidConfig, c.Partition, c.NumPartitions)
 	}
 
 	return nil

--- a/consumer/static_test.go
+++ b/consumer/static_test.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -77,6 +78,142 @@ func TestGetPartitionFromEnv(t *testing.T) {
 		_, err := GetPartitionFromEnv()
 		require.Error(t, err)
 	})
+}
+
+// TestStaticConfig_Validate_WrapsErrInvalidConfig verifies that every validation
+// failure in NewStatic / StaticConfig.Validate is reachable via
+// errors.Is(err, ErrInvalidConfig).
+func TestStaticConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "nil js",
+			fn: func() error {
+				_, err := NewStatic(nil, "S", "c", "s.{{partition}}", 2, 0, handler)
+
+				return err
+			},
+		},
+		{
+			name: "fuda required field (missing StreamName)",
+			fn: func() error {
+				cfg := StaticConfig{ConsumerName: "c", SubjectPattern: "s.{{partition}}", NumPartitions: 2}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "FetchTimeout below 1s floor",
+			fn: func() error {
+				cfg := StaticConfig{
+					StreamName:     "S",
+					ConsumerName:   "c",
+					SubjectPattern: "s.{{partition}}",
+					NumPartitions:  2,
+					CommonConfig:   CommonConfig{FetchTimeout: 100 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "invalid consumer name",
+			fn: func() error {
+				cfg := StaticConfig{
+					StreamName:     "S",
+					ConsumerName:   "bad name!",
+					SubjectPattern: "s.{{partition}}",
+					NumPartitions:  2,
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "invalid subject pattern (crosses ipartition boundary)",
+			fn: func() error {
+				// Pattern with an unrecognized placeholder: the error originates in
+				// partutil.ParsePattern inside ipartition.NewJSConsumer and must be
+				// wrapped at the NewStatic boundary. Use a non-nil js so the guard
+				// checks pass and the pattern parser is reached.
+				_, nc := partitest.StartEmbeddedNATS(t)
+				js, _ := jetstream.New(nc)
+				// "{{foo}}" is not a recognised placeholder; ParsePattern returns an error.
+				_, err := NewStatic(js, "S", "c", "s.{{foo}}", 2, 0, handler)
+
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrInvalidConfig),
+				"expected errors.Is(err, ErrInvalidConfig), got: %v", err)
+		})
+	}
+}
+
+// TestStatic_StartAfterStop_SentinelPrecedence verifies that calling Start on a
+// stopped Static consumer returns ErrConsumerStopped rather than ErrInvalidConfig,
+// even when the compat check would fail (WorkQueuePolicy stream + RecoverFromNew).
+// The terminal-stopped sentinel must take precedence over the compat preflight.
+func TestStatic_StartAfterStop_SentinelPrecedence(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create a WorkQueuePolicy stream — this is the stream type that makes the
+	// compat check fail when RecoverFromNew is configured.
+	streamName := "STATIC_SENTINEL_PREC"
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{"sentprec.>"},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	// Build a Static with RecoverFromNew — this combination is incompatible with
+	// WorkQueuePolicy, so CheckWorkQueueRecoveryCompat will return ErrInvalidConfig
+	// if reached.
+	s, err := NewStatic(
+		js,
+		streamName,
+		"sentprec-p0",
+		"sentprec.{{partition}}",
+		2,
+		0,
+		handler,
+		WithRecoveryStrategy(RecoverFromNew),
+	)
+	require.NoError(t, err)
+
+	// Stop before ever calling Start — marks the inner stopped flag.
+	require.NoError(t, s.Stop(ctx))
+
+	// Start must return ErrConsumerStopped, NOT ErrInvalidConfig.
+	err = s.Start(ctx)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrConsumerStopped),
+		"expected ErrConsumerStopped, got: %v", err)
+	require.False(t, errors.Is(err, ErrInvalidConfig),
+		"ErrConsumerStopped must take precedence over ErrInvalidConfig, got: %v", err)
 }
 
 // TestStatic_ConsumerOptions_AppliedToLiveConsumer verifies that

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -895,7 +895,7 @@ Known reasons and operator intent:
 | `startup-timeout` | startup apply/wait did not reach Stable in budget | Readiness rotation unless the runner recovers before the pod is replaced. |
 | `startup-background-panic` | a background startup goroutine panicked | Rotate the worker; inspect logs for the panic. Monitors are still started so the worker may self-recover. |
 | `assignment-watcher-exhausted` | assignment watcher retry envelope exhausted | Restart or rotate the worker; inspect the assignment bucket and NATS logs. |
-| `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | Recover the stream or rotate workers according to application ownership. |
+| `stream-missing-recovery-exhausted` | **terminal** — dynamic consumer stream missing, recovery exhausted | The worker stays `Degraded` permanently until restarted or rotated; stream recreation alone does not revive the dead partition-consumer loop. Recreate the stream, then rotate the worker. |
 | `source-unavailable:<bucket>` | caller-owned source bucket unavailable | Caller/operator recovers the source bucket; Parti does not recreate it. |
 
 **Returns**:
@@ -1933,9 +1933,12 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 
 | Option                           | Consumer Types | Description                          |
 |----------------------------------|----------------|--------------------------------------|
-| `WithInstanceID(id)`                        | Broadcast      | Set unique instance identifier       |
-| `WithProcessingGate(cfg)`                   | Dynamic        | Enable processing gate               |
-| `WithDrainOnRemove(enabled, timeout)`       | Dynamic        | Drain messages on partition removal  |
+| `WithInstanceID(id)`                              | Broadcast      | Set unique instance identifier                                                                                                      |
+| `WithProcessingGate(cfg)`                         | Dynamic        | Enable processing gate for ownership control                                                                                        |
+| `WithDrainOnRemove(enabled, timeout)`             | Dynamic        | Drain messages on partition removal (bounded by `DrainOnRemoveTimeout`; `Update` returns an error if loops fail to stop in time)    |
+| `WithMaxConcurrentSubjects(n)`                    | Dynamic        | Cap concurrent partitions; `Update` rejects over-cap assignments with `ErrMaxSubjectsExceeded`                                      |
+| `WithOnPermanentFailure(fn)`                      | Dynamic        | Application callback fired once per partition consumer on recovery exhaustion; manager stream-missing observer also fires            |
+| `WithSuppressManagerDegradeOnStreamMissing()`     | Dynamic        | Opt out of the manager's auto-degraded route for stream-missing exhaustion                                                          |
 
 ---
 
@@ -2023,6 +2026,11 @@ var (
     ErrNotStarted     = errors.New("manager not started")
 )
 ```
+
+`types.ErrConsumerStopped` (re-exported as `consumer.ErrConsumerStopped`) is
+returned by consumer `Start`/`Update` after `Stop`/`Close` — Stop is terminal
+for the `Static`, `Broadcast`, and `Dynamic` consumers; construct a new
+instance to resume consuming.
 
 ### Operational Errors
 

--- a/docs/CONSUMERS.md
+++ b/docs/CONSUMERS.md
@@ -644,13 +644,17 @@ strategies.
 
 **No-hook escalation route.** When the hook is omitted, or when the
 operator hook keeps returning an error, the F2 bounded-retry envelope
-eventually exhausts. The library then fires `OnPermanentFailure` with
-the cause wrapped in `parti.ErrStreamMissing`. The Parti `Manager`
-catches this via its built-in observer bridge: the worker enters
-degraded mode with reason `"stream-missing-recovery-exhausted"`, the
-configured `Hooks.OnError` fires with the wrapped error, and the
-readiness probe can rotate the pod. Branch on the typed sentinel
-inside `OnError`:
+eventually exhausts. The library fires the `OnPermanentFailure`
+dispatcher with the cause wrapped in `parti.ErrStreamMissing`. The
+Parti `Manager` observer is **also** notified (application callback
+first, then manager observer), so both app observability and
+platform self-healing fire regardless of whether an app callback is
+registered. The worker enters **terminal** degraded mode with reason
+`"stream-missing-recovery-exhausted"` — it stays `Degraded`
+permanently until restarted or rotated; stream recreation alone does
+not revive the dead partition-consumer loop. The configured
+`Hooks.OnError` fires with the wrapped error, and the readiness probe
+can rotate the pod. Branch on the typed sentinel inside `OnError`:
 
 ```go
 mgr, _ := parti.NewManager(&cfg, js, src, strategy,
@@ -667,10 +671,26 @@ mgr, _ := parti.NewManager(&cfg, js, src, strategy,
 )
 ```
 
+If your application owns degrade and rotation signaling itself and
+wants to suppress the manager's auto-degraded route, pass
+`consumer.WithSuppressManagerDegradeOnStreamMissing()` when
+constructing the `Dynamic` consumer.
+
 This route is distinct from the generic KV-error degraded-mode
 circuit — the named reason `"stream-missing-recovery-exhausted"`
 keeps the cross-feature contract that whole-bucket KV loss is the
 sole driver of `"KV error threshold exceeded"`.
+
+**Stream deletion / recovery behavior by consumer type.** The
+escalation tier above (bounded retries → `OnPermanentFailure` →
+terminal `Degraded`) is Dynamic-only. `Queue`, `Static`, and
+`Broadcast` do not own stream lifecycle: when the underlying stream
+is gone they log a warning and back off indefinitely, and they
+self-heal only if the stream returns AND a `RecoveryStrategy` is
+enabled — there is no exhaustion or degrade tier for them. When
+`RecoveryStrategy` is disabled, these consumers surface each iterator
+restart with a Warn log and the iterator-restart metric label
+`recovery_disabled` instead of cycling silently.
 
 ### Validation
 
@@ -752,10 +772,13 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 
 **Dynamic-Specific Options:**
 
-| Option                               | Description                                  |
-|--------------------------------------|----------------------------------------------|
-| `WithProcessingGate(cfg)`            | Enable processing gate for ownership control |
-| `WithDrainOnRemove(enabled, timeout)`| Drain messages when partitions are removed   |
+| Option                                         | Description                                                                 |
+|------------------------------------------------|-----------------------------------------------------------------------------|
+| `WithProcessingGate(cfg)`                      | Enable processing gate for ownership control                                |
+| `WithDrainOnRemove(enabled, timeout)`          | Drain messages when partitions are removed; bounded by `DrainOnRemoveTimeout` — if loops fail to stop within the bound, `Update` returns an error and the manager retries; tracking entries are cleared so retries converge; an in-flight handler invocation may still run to completion (best-effort, not a zero-overlap guarantee) |
+| `WithMaxConcurrentSubjects(n)`                 | Cap concurrent partitions; excess rejects the whole `Update` with `ErrMaxSubjectsExceeded` |
+| `WithOnPermanentFailure(fn)`                   | Application callback for permanent partition failure (fires before manager observer) |
+| `WithSuppressManagerDegradeOnStreamMissing()`  | Suppress the manager's auto-degraded route for stream-missing exhaustion    |
 
 ---
 
@@ -991,4 +1014,5 @@ All consumer types are thread-safe. Lifecycle methods (`Start`, `Stop`, `Update`
 **Runtime Errors:**
 - `context.DeadlineExceeded` - Stop timed out
 - `consumer.ErrWorkerIDMutation` - Dynamic consumer workerID changed unexpectedly
-- `consumer.ErrMaxSubjectsExceeded` - Partition count exceeds limit
+- `consumer.ErrMaxSubjectsExceeded` - Assignment's deduped subject count exceeds `MaxConcurrentSubjects`; the whole `Update` is rejected before any mutation; the manager retries with backoff and previous owners keep consuming
+- `consumer.ErrConsumerStopped` - `Start`/`Update` called after `Stop`/`Close`. Stop is terminal for `Static`, `Broadcast`, and `Dynamic`: construct a new consumer to resume consuming. Deregister the consumer (or stop the manager first) before stopping it, or manager-driven updates will retry loudly against the stopped consumer

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -216,45 +216,36 @@ cfg := &parti.Config{
 
 ## Two-Phase Handoff
 
-When `EnableTwoPhaseHandoff` is true, the manager uses a Prepare/Commit protocol for partition reassignment to ensure zero overlap in processing.
+When `EnableTwoPhaseHandoff` is true, workers coordinate partition reassignment through KV-backed ownership claims so that the old owner releases a partition only after the new owner has durably claimed it. This orders the **release** side of a handoff (no unowned gap) and minimizes processing overlap — it does not by itself gate message consumption (see the per-tier table below).
 
 ### The Protocol
 
+There is no leader→worker message exchange. Each worker independently drives its own side of the handoff against a shared KV bucket of per-partition claims, using CAS (revision-checked) writes:
+
 ```
-                        LEADER                           WORKERS
-                          │                                 │
-   1. Calculate new       │                                 │
-      assignment          │                                 │
-                          │    ┌───────────────────────┐    │
-                          │────│ Prepare: "P1 → W2"    │───▶│
-                          │    └───────────────────────┘    │
-                          │                                 │ W1: Stop processing P1
-                          │                                 │ W2: (wait)
-                          │    ┌───────────────────────┐    │
-                          │◀───│ Prepare ACK           │────│
-                          │    └───────────────────────┘    │
-                          │                                 │
-   2. All ACKs received   │                                 │
-                          │    ┌───────────────────────┐    │
-                          │────│ Commit: "P1 → W2"     │───▶│
-                          │    └───────────────────────┘    │
-                          │                                 │ W1: (released)
-                          │                                 │ W2: Start processing P1
-                          │    ┌───────────────────────┐    │
-                          │◀───│ Commit ACK            │────│
-                          │    └───────────────────────┘    │
-                          │                                 │
-   3. Finalize stable     │                                 │
-                          ▼                                 ▼
+   NEW OWNER (W2, gaining P1)            OLD OWNER (W1, losing P1)
+        │                                     │
+   1. Prepare: CAS-write claim                │
+      {P1: owner=W2, state=prepare}           │
+        │                                1. Removal guard: read P1's claim;
+   2. Apply: update consumer,               keep consuming P1 until the claim
+      start consuming P1's subject          shows a DIFFERENT owner in
+        │                                   commit or stable state
+   3. Commit: CAS claim → commit            │
+   4. Stabilize: CAS claim → stable     2. Claim shows W2 commit/stable →
+        │                                   remove P1's subject locally
+        ▼                                     ▼
 ```
+
+A background sweeper reconciles stale or interrupted claims toward `stable` on `SweepInterval`, so a worker crashing mid-handoff does not strand a claim.
 
 ### Handoff States
 
-| State     | Description                            |
-|-----------|----------------------------------------|
-| `Stable`  | Partition ownership is finalized       |
-| `Prepare` | Old owner stopping, new owner waiting  |
-| `Commit`  | New owner starting, old owner released |
+| State     | Description                                                        |
+|-----------|--------------------------------------------------------------------|
+| `Stable`  | Partition ownership is finalized                                   |
+| `Prepare` | New owner has claimed the partition; old owner may still be consuming |
+| `Commit`  | New owner is consuming; old owner may now remove the subject       |
 
 ### Configuration
 
@@ -271,18 +262,29 @@ cfg := &parti.Config{
 }
 ```
 
-### Benefits
+### What Each Tier Guarantees
 
-- **Consistency**: Guarantees that a partition is never processed by two workers simultaneously
-- **Safety**: Prevents race conditions during rebalancing
-- **Crash Recovery**: Stale claims are swept and resumed by new leaders
+Per-partition durables are **shared by name** across workers (`<prefix>_<partitionID>_<hash>` — no worker ID), so delivery is at-least-once at every tier and overlap is bounded, never zero:
+
+| Configuration | What it adds |
+|---------------|--------------|
+| No two-phase (default) | Assignments switch directly; old and new owner may briefly consume concurrently during the switch. |
+| `EnableTwoPhaseHandoff` only | Orders the release: the old owner keeps a partition until the new owner's claim reaches commit/stable, so no unowned gap. Claims are written but **never consulted on the consume path** — the manager logs a warning when the consumer reports no processing gate. Does not reduce overlap by itself. |
+| + Processing gate (`ProcessingGate`) | Per-message, pre-handler admission control: the non-owner NAKs deliveries instead of invoking the handler. Bounds overlap to already-in-flight handler invocations; it cannot revoke a handler that has started. |
+| + Pull gating (`PullGatingEnabled`) | Checks ownership before issuing new pull requests, suppressing new iterator episodes on a revoked partition. Narrows, but does not close, the window. |
+
+### The Irreducible Window
+
+At the strongest tier one overlap window remains: a handler invocation already in flight on the old owner, plus AckWait-expiry redelivery of that **same message** through the shared per-partition durable to the new owner — whose gate correctly admits it. Mitigation: wrap long-running handlers with `consumer.NewWIPHandler`, which sends periodic in-progress signals so AckWait does not expire mid-handler.
+
+The gate's ownership answer comes from a cached resolver. If the KV claim watcher stalls, a stale "I am the owner, state stable" answer can be served for up to `ReconcileInterval` (default 30s) before the periodic reconcile corrects it — a bounded, self-correcting window.
 
 ### When to Enable
 
-Enable two-phase handoff when:
-- Processing duplicates is unacceptable
+Enable two-phase handoff (with a processing gate) when:
+- Cross-worker duplicate processing must be minimized — it cannot be eliminated, so handlers should remain idempotent
 - Partitions have stateful resources (connections, caches)
-- Strict ordering guarantees are required
+- Ordering disruption during rebalancing must be kept short
 
 Keep disabled (default) when:
 - Brief duplicate processing is acceptable
@@ -356,6 +358,14 @@ When NATS connectivity is restored for `ExitThreshold`:
 2. **Recovery Grace Period** starts (default: 15s)
 3. During grace period, leader won't trigger emergency rebalance
 4. Resumes normal election and assignment participation
+
+**Terminal degraded reasons.** Some degraded entries cannot self-heal and the
+worker stays `Degraded` permanently regardless of connectivity recovery.
+`stream-missing-recovery-exhausted` is terminal: the dead partition-consumer
+loop cannot restart in-process, so stream recreation alone does not exit
+`Degraded`. The expected resolution is worker rotation (recreate the stream,
+then rotate the pod). See the [Degraded Reason Taxonomy](OPERATIONS.md#degraded-reason-taxonomy) for
+per-reason operator actions.
 
 ### Configuration
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -146,7 +146,7 @@ recovery, rotation, or caller-owned recovery.
 | `bucket-recreated:<bucket>` | ambiguous Parti-owned data loss | Restart or rotate workers; inspect JetStream storage before trusting the recreated bucket. |
 | `startup-timeout` | startup apply/wait did not reach Stable in budget | Readiness rotation unless the runner recovers before the pod is replaced. |
 | `assignment-watcher-exhausted` | assignment watcher retry envelope exhausted | Restart or rotate the worker; inspect the assignment bucket and NATS logs. |
-| `stream-missing-recovery-exhausted` | dynamic consumer stream missing and no app hook recovered it | Recover the stream or rotate workers according to application ownership. |
+| `stream-missing-recovery-exhausted` | **terminal** — dynamic consumer stream missing, recovery exhausted | The worker stays `Degraded` permanently until restarted or rotated; the dead partition-consumer loop cannot restart in-process and stream recreation alone does not revive it. Recreate the stream, then rotate the worker. |
 | `source-unavailable:<bucket>` | caller-owned source bucket unavailable | Caller/operator recovers the source bucket; Parti does not recreate it. |
 
 **Recovery bound — worker-ID lease (`WorkerIDTTL`).** M5 recover-to-Stable across

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -353,14 +353,14 @@ func TestPartitionProcessing(t *testing.T) {
 | **Partition**           | Logical division of work; has ID, optional weight, and metadata                                     |
 | **Partition Source**    | Provider of partition definitions (Static, NatsKV, custom)                                          |
 | **Partitioner**         | Application-level component mapping keys to partition IDs                                            |
-| **Prepare Phase**       | First phase of two-phase handoff; old owner stops processing                                        |
-| **Processing Gate**     | Component preventing message processing during handoff                                               |
+| **Prepare Phase**       | First phase of two-phase handoff; new owner durably claims the partition (KV CAS); old owner may keep processing until commit/stable |
+| **Processing Gate**     | Per-message admission control that NAKs deliveries to non-owners during handoff                      |
 | **Rebalancing**         | Redistributing partitions after worker or partition-source changes                                   |
 | **Recovery Grace**      | Period after degraded mode exit before emergency rebalancing is triggered                            |
 | **Scaling Window**      | Stabilization delay after worker joins/leaves established cluster (default: 10s)                   |
 | **Stable ID**           | Persistent worker identifier claimed from a pool; survives restarts within TTL                      |
 | **State**               | Current phase in worker lifecycle (Init, Stable, Scaling, Degraded, etc.)                           |
-| **Two-Phase Handoff**   | Prepare/Commit protocol ensuring zero overlap in partition processing                                |
+| **Two-Phase Handoff**   | KV-claim Prepare/Commit protocol ordering partition release; minimizes (does not eliminate) overlap |
 | **Virtual Nodes**       | Multiple hash ring positions per worker for better distribution                                      |
 | **Weight**              | Partition attribute influencing assignment distribution                                              |
 | **Worker**              | Instance running Parti Manager; processes assigned partitions                                        |

--- a/docs/plans/dynamic-consumer-healing-fixes/01-implementation-plan.md
+++ b/docs/plans/dynamic-consumer-healing-fixes/01-implementation-plan.md
@@ -1,0 +1,918 @@
+# Dynamic-Consumer Healing Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close four consensus-reviewed defects in the Dynamic consumer's
+auto-healing / handoff interplay: (1) the manager exits Degraded while
+partition consumers are permanently dead after stream-missing recovery
+exhaustion; (2) `ErrMaxSubjectsExceeded` is documented but never returned —
+the silent cap-skip can strand a partition unowned through a committed
+handoff; (3) the subject-loop remove-timeout path returns success while loops
+may still be processing; (4) an application `WithOnPermanentFailure` callback
+silently disables the manager's stream-missing degraded route.
+
+**Architecture:** All four fixes are small, local changes to existing
+mechanisms — a new reason-scoped terminal gate in
+`attemptRecoveryFromDegraded`, a pre-mutation cap check in
+`WorkerConsumer.UpdateWorkerConsumer`, an error return on the remove-timeout
+branch, and a dual-dispatch (user callback + manager observer) in
+`Dynamic.onPermanentFailure` with an explicit suppress option. No new types,
+no interface changes.
+
+**Tech Stack:** Go, NATS JetStream, testify, embedded-NATS integration
+harness (`partitest`).
+
+**Provenance:** QA findings + 2-round codex consensus:
+`tmp/dynamic-consumer-qa-findings-v2.md`, `tmp/codex-review-r1-verdict.md`,
+`tmp/codex-review-r2-verdict.md`. Task order follows the consensus sequencing
+constraint: the dispatcher change (Task 1) lands before the terminal-hold
+tests (Task 2) because they share the stream-missing observer route.
+
+**Repo discipline (applies to every task):**
+- Verify-first: run each new test BEFORE the fix and confirm it fails for the
+  expected reason.
+- Run `make lint` before every commit; fix findings.
+- Commit messages: no plan jargon (no "F1", "Task 2", review-round refs), no
+  attribution trailers.
+- This series touches `manager_degraded.go` (degraded routing) and
+  `internal/durable/` — the AGENTS.md pre-PR gate (`make pre-pr`) is
+  mandatory before opening the PR (Task 6).
+
+---
+
+### Task 1: Dual-dispatch stream-missing observer + explicit suppress option
+
+The application callback currently suppresses the manager observer entirely
+(`consumer/dynamic.go:446-454`). New contract: user callback fires first
+(when set), THEN the manager observer is notified for stream-missing
+exhaustion — unless the application explicitly opts out via the new
+`WithSuppressManagerDegradeOnStreamMissing()` option.
+
+**Files:**
+- Modify: `consumer/dynamic.go` (struct field, dispatcher, `NewDynamic`
+  wiring, `DynamicConfig` field + godoc on `OnPermanentFailure`)
+- Modify: `consumer/options.go` (new option; rewrite `WithOnPermanentFailure`
+  godoc "Interaction with the Parti manager's auto-degraded route" section)
+- Modify: `consumer/options.go` — the `options` struct at line 150 (add the
+  new bool field next to `onPermanentFailure` at line 198)
+- Test: `consumer/dynamic_on_permanent_failure_test.go`
+
+- [ ] **Step 1: Rewrite the dispatch-precedence test to pin the NEW contract**
+
+In `consumer/dynamic_on_permanent_failure_test.go`, replace
+`TestDynamic_onPermanentFailure_UserCallbackWinsOverManagerObserver` with:
+
+```go
+// TestDynamic_onPermanentFailure_UserCallbackAndManagerObserverBothFire
+// pins the dual-dispatch contract: when an application has registered its
+// own OnPermanentFailure via WithOnPermanentFailure, the manager-installed
+// observer ALSO fires for stream-missing exhaustion (user callback first,
+// then manager observer), so platform self-healing (Degraded -> rotation)
+// is not silently coupled to an app-level observability hook. Applications
+// that deliberately manage rotation themselves opt out explicitly via
+// WithSuppressManagerDegradeOnStreamMissing.
+func TestDynamic_onPermanentFailure_UserCallbackAndManagerObserverBothFire(t *testing.T) {
+	var (
+		userCalls    atomic.Int32
+		managerCalls atomic.Int32
+	)
+
+	d := &Dynamic{
+		streamName: "TEST_STREAM",
+		userOnPermanentFailure: func(_ string, _ error) {
+			userCalls.Add(1)
+		},
+	}
+	d.SetOnStreamMissingError(func(_ string, err error) {
+		managerCalls.Add(1)
+		require.ErrorIs(t, err, types.ErrStreamMissing,
+			"manager observer must receive the wrapped types.ErrStreamMissing chain")
+	})
+
+	wrapped := fmt.Errorf("stream %q: %w", "TEST_STREAM", types.ErrStreamMissing)
+	d.onPermanentFailure("test.subject.p1", wrapped)
+
+	require.Equal(t, int32(1), userCalls.Load(),
+		"user callback must fire exactly once")
+	require.Equal(t, int32(1), managerCalls.Load(),
+		"manager observer must ALSO fire for stream-missing exhaustion when a user callback is registered")
+
+	// Generic (non-stream-missing) exhaustion still reaches ONLY the user
+	// callback — the manager observer remains scoped to stream-missing.
+	d.onPermanentFailure("test.subject.p1", errors.New("generic exhaustion"))
+	require.Equal(t, int32(2), userCalls.Load())
+	require.Equal(t, int32(1), managerCalls.Load(),
+		"manager observer must NOT fire for non-stream-missing exhaustion")
+}
+
+// TestDynamic_onPermanentFailure_SuppressOptionDisablesManagerObserver pins
+// the explicit opt-out: with suppressManagerDegrade set, the manager
+// observer never fires (stream-missing or otherwise) while the user
+// callback still does.
+func TestDynamic_onPermanentFailure_SuppressOptionDisablesManagerObserver(t *testing.T) {
+	var (
+		userCalls    atomic.Int32
+		managerCalls atomic.Int32
+	)
+
+	d := &Dynamic{
+		streamName:             "TEST_STREAM",
+		suppressManagerDegrade: true,
+		userOnPermanentFailure: func(_ string, _ error) {
+			userCalls.Add(1)
+		},
+	}
+	d.SetOnStreamMissingError(func(_ string, _ error) {
+		managerCalls.Add(1)
+	})
+
+	wrapped := fmt.Errorf("stream %q: %w", "TEST_STREAM", types.ErrStreamMissing)
+	d.onPermanentFailure("test.subject.p1", wrapped)
+
+	require.Equal(t, int32(1), userCalls.Load(),
+		"user callback must still fire when suppression is enabled")
+	require.Equal(t, int32(0), managerCalls.Load(),
+		"manager observer must NOT fire when the application explicitly suppressed the degrade route")
+}
+```
+
+Keep `TestDynamic_onPermanentFailure_ManagerObserverOnlyOnStreamMissing`,
+`..._NoUserNoManager`, and `..._NilClearsAfterFire` unchanged — they pin
+rows of the matrix that do not change.
+
+- [ ] **Step 2: Run the new tests to verify they fail on the current code**
+
+Run: `go test ./consumer/ -run 'TestDynamic_onPermanentFailure' -v`
+Expected: `UserCallbackAndManagerObserverBothFire` FAILS (managerCalls == 0 —
+old precedence suppresses the observer); `SuppressOption...` FAILS to compile
+or fails (no `suppressManagerDegrade` field yet). Compile error counts as the
+failing-reproducer evidence for the suppress test.
+
+- [ ] **Step 3: Implement the dual dispatcher**
+
+In `consumer/dynamic.go`, add the struct field (next to
+`userOnPermanentFailure`):
+
+```go
+	// suppressManagerDegrade, when true, prevents the dispatcher from
+	// notifying the manager-installed stream-missing observer. Set via
+	// WithSuppressManagerDegradeOnStreamMissing for applications that
+	// deliberately own rotation/degrade signaling themselves.
+	suppressManagerDegrade bool
+```
+
+Replace `onPermanentFailure` (currently `dynamic.go:446-454`) and update its
+doc comment:
+
+```go
+// onPermanentFailure is the indirection dispatcher installed as
+// WorkerConsumerConfig.OnPermanentFailure for every Dynamic. It runs on
+// the partition consumer's goroutine when iterator-creation envelope
+// or Site B detour exhaustion fires.
+//
+// Dispatch rules:
+//  1. An application-supplied OnPermanentFailure callback (captured from
+//     WithOnPermanentFailure) fires first when registered.
+//  2. The manager-installed observer (set via SetOnStreamMissingError) is
+//     then ALSO notified for stream-missing exhaustion, so platform
+//     self-healing (enterDegraded -> rotation) does not silently turn off
+//     when an application adds its own observability callback. Applications
+//     that own degrade signaling themselves opt out explicitly via
+//     WithSuppressManagerDegradeOnStreamMissing.
+//  3. Generic (non-stream-missing) exhaustion never reaches the manager
+//     observer; the durable layer's WARN log + metric remain the
+//     operator-visible signal for those.
+func (d *Dynamic) onPermanentFailure(subject string, err error) {
+	if d.userOnPermanentFailure != nil {
+		d.userOnPermanentFailure(subject, err)
+	}
+	if d.suppressManagerDegrade {
+		return
+	}
+	if fn := d.managerOnStreamMissing.Load(); fn != nil && errors.Is(err, types.ErrStreamMissing) {
+		(*fn)(d.streamName, err)
+	}
+}
+```
+
+Add to `DynamicConfig` (after `OnPermanentFailure`):
+
+```go
+	// SuppressManagerDegradeOnStreamMissing disables the Parti manager's
+	// auto-degraded route for stream-missing recovery exhaustion. By default
+	// the manager observer is notified even when OnPermanentFailure is set
+	// (both fire; application callback first). Set this only when the
+	// application deliberately owns degrade/rotation signaling itself.
+	SuppressManagerDegradeOnStreamMissing bool
+```
+
+Wire it in `NewDynamic`: set `SuppressManagerDegradeOnStreamMissing: o.suppressManagerDegradeOnStreamMissing`
+in the `cfg := DynamicConfig{...}` literal, and
+`suppressManagerDegrade: o.suppressManagerDegradeOnStreamMissing` in the
+`d := &Dynamic{...}` literal. Update the `OnPermanentFailure` field godoc in
+`DynamicConfig` (currently `dynamic.go:231-247`): replace the sentence
+"Setting this disables the Parti manager's auto-degraded route ..." with:
+
+```go
+	// Registering this callback does NOT disable the Parti manager's
+	// auto-degraded route: for stream-missing exhaustion the manager
+	// observer is notified after this callback returns. Use
+	// [DynamicConfig.SuppressManagerDegradeOnStreamMissing] (option form:
+	// [WithSuppressManagerDegradeOnStreamMissing]) to opt out explicitly.
+```
+
+- [ ] **Step 4: Add the option and update option godoc**
+
+In the `options` struct (`consumer/options.go:150`, field block around line
+198), add `suppressManagerDegradeOnStreamMissing bool`. In
+`consumer/options.go`, next to `WithOnPermanentFailure`:
+
+```go
+// WithSuppressManagerDegradeOnStreamMissing disables the Parti manager's
+// auto-degraded route for stream-missing recovery exhaustion on this
+// Dynamic consumer.
+//
+// By default, when a [Dynamic] is wired into a [parti.Manager], stream-missing
+// exhaustion notifies the manager observer (entering Degraded with reason
+// "stream-missing-recovery-exhausted" so the readiness probe rotates the
+// pod) IN ADDITION to any application callback registered via
+// [WithOnPermanentFailure]. Suppress this only when the application
+// deliberately owns degrade/rotation signaling itself — e.g. it forwards
+// stream-missing events to its own readiness wiring inside its
+// OnPermanentFailure callback.
+//
+// Applies only to [Dynamic].
+func WithSuppressManagerDegradeOnStreamMissing() DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.suppressManagerDegradeOnStreamMissing = true
+	})
+}
+```
+
+Rewrite the "# Interaction with the Parti manager's auto-degraded route"
+section of the `WithOnPermanentFailure` godoc (`options.go` around line 489)
+to describe the new both-fire contract and point at the suppress option
+(delete the "fires ONLY when no application callback is registered" text and
+the two-bullet workaround list; state: callback first, manager observer
+second for stream-missing, opt out via WithSuppressManagerDegradeOnStreamMissing).
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `go test ./consumer/ -run 'TestDynamic_onPermanentFailure|TestDynamic_SetOnStreamMissingError' -v`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add consumer/
+git commit -m "feat(consumer): notify manager stream-missing observer alongside user callback
+
+The application OnPermanentFailure callback previously suppressed the
+manager's stream-missing observer entirely, so adding a logging callback
+silently disabled the Degraded-entry route that drives pod rotation.
+Now both fire (application callback first); applications that own
+rotation signaling themselves opt out explicitly via the new
+WithSuppressManagerDegradeOnStreamMissing option."
+```
+
+---
+
+### Task 2: Terminal Degraded hold for stream-missing recovery exhaustion
+
+`attemptRecoveryFromDegraded` has no exit gate for
+`DegradeReasonStreamMissingRecoveryExhausted`; the connection never dropped,
+so the worker exits back to Stable within ~one monitor tick while its
+partition-consumer loop is permanently dead (the dead subject stays in the
+worker-consumer subject map; re-applies compute an empty diff). Hold
+terminally Degraded for restart/rotation.
+
+**Files:**
+- Modify: `manager_degraded.go` (gate in `attemptRecoveryFromDegraded`,
+  placed immediately after `reason := rec.reason` — i.e. after the refresh +
+  commitment guard so `scheduleApplyRetry` still re-arms an unapplied
+  assignment, and before the Family B gate)
+- Test: `manager_recovery_conjuncts_test.go`
+- Test: `test/integration/failure/stream_missing_no_hook_test.go`
+
+- [ ] **Step 1: Write the failing unit test (both directions)**
+
+Append to `manager_recovery_conjuncts_test.go`:
+
+```go
+// TestAttemptRecovery_StreamMissingExhausted_StaysDegraded pins the terminal
+// hold for the dynamic-consumer stream-missing route: once a partition
+// consumer's recovery envelope has exhausted, its loop has exited and cannot
+// restart in-process (the dead subject remains in the worker-consumer's
+// subject map, so a re-apply computes an empty diff), and operator stream
+// recreation cannot revive it either. Recovery must therefore never exit
+// this reason — rotation is the only recovery, matching the
+// heartbeat-bucket backstop's terminal contract. Without the gate, the
+// connection monitor exits back to Stable within ~one tick (the NATS
+// connection never dropped) and the worker reports Stable while assigned
+// partitions are silently not consumed.
+func TestAttemptRecovery_StreamMissingExhausted_StaysDegraded(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, &snap, snap)
+	plantAssignment(t, m, snap)
+	m.markDegraded(time.Now().UnixNano(), DegradeReasonStreamMissingRecoveryExhausted)
+
+	// Even with every recovery signal healthy (commitment guard satisfied by
+	// armDegraded, fresh heartbeat far in the future), the hold is terminal.
+	m.lastHeartbeatSuccessAt.Store(time.Now().UnixNano() + int64(time.Hour))
+
+	m.attemptRecoveryFromDegraded()
+
+	require.Equal(t, StateDegraded, m.State(),
+		"stream-missing-recovery-exhausted must hold the worker terminally Degraded for rotation")
+}
+
+// TestAttemptRecovery_StreamMissingHold_IsReasonScoped proves the new gate
+// is NOT accidentally global: a reason with no blocking gate (startup
+// timeout) still exits to Stable through the same pipeline. This is the
+// negative-space direction the boundary-test discipline requires.
+func TestAttemptRecovery_StreamMissingHold_IsReasonScoped(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, &snap, snap)
+	plantAssignment(t, m, snap)
+	m.markDegraded(time.Now().UnixNano(), DegradeReasonStartupTimeout)
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Equal(t, StateStable, m.State(),
+		"a non-stream-missing reason with healthy signals must still exit; the terminal hold must be reason-scoped")
+}
+```
+
+- [ ] **Step 2: Run the unit tests to verify direction**
+
+Run: `go test . -run 'TestAttemptRecovery_StreamMissing' -v`
+Expected: `StaysDegraded` FAILS (state is Stable — recovery exited);
+`IsReasonScoped` PASSES (it pins existing behavior; it exists to catch an
+over-broad gate after Step 4).
+
+- [ ] **Step 3: Write the failing integration assertion**
+
+In `test/integration/failure/stream_missing_no_hook_test.go`, immediately
+after the `firstDegradedReason` assertions (after the
+`degradedMu.Unlock()` that closes the reason-sequence check), insert:
+
+```go
+	// Terminal hold: the worker must STAY Degraded — recovery must not exit
+	// this reason. Pre-fix, the connection monitor (connection up the whole
+	// time) exited back to Stable within ~one tick, defeating the
+	// rotate-on-Degraded operator contract. 5s spans multiple ExitThreshold
+	// windows at this test's cadence.
+	require.Never(t, func() bool {
+		return mgr.State() != types.StateDegraded
+	}, 5*time.Second, 100*time.Millisecond,
+		"stream-missing-recovery-exhausted must hold the worker terminally Degraded for rotation; "+
+			"an exit back to Stable leaves dead partition consumers reported as healthy")
+```
+
+(Adjust the 5s window down only if the test's configured
+`DegradedBehavior.ExitThreshold` makes a shorter window conclusive — the
+window must comfortably exceed one ExitThreshold plus one monitor tick.)
+
+- [ ] **Step 4: Run the integration test to verify it fails on the unfixed code**
+
+Run: `go test ./test/integration/failure/ -run TestStreamMissingNoHook -race -v -timeout 300s`
+(confirm the exact test name with `grep -n "func Test" test/integration/failure/stream_missing_no_hook_test.go`)
+Expected: FAIL at the new `require.Never` — state flips back to `Stable`
+within the window. This is the verify-first evidence for the bug.
+
+- [ ] **Step 5: Implement the terminal hold**
+
+In `manager_degraded.go`, `attemptRecoveryFromDegraded`, immediately after
+`reason := rec.reason` (currently line ~504) and BEFORE the Family B gate:
+
+```go
+	// Terminal hold — stream-missing recovery exhaustion means at least one
+	// partition-consumer loop in this process has exited permanently. The
+	// loop cannot restart in-process (the dead subject remains in the
+	// worker-consumer's subject map, so a re-apply computes an empty diff),
+	// and operator stream recreation cannot revive it either. No recovery
+	// signal exists that could stamp this reason healthy; hold the worker
+	// terminally Degraded for restart/rotation, matching the
+	// heartbeat-bucket backstop's terminal contract. Placed after the
+	// commitment guard so an unapplied refreshed assignment still re-arms
+	// scheduleApplyRetry above.
+	if reason == DegradeReasonStreamMissingRecoveryExhausted {
+		m.logger.Warn("recovery: stream-missing recovery exhausted is terminal; staying Degraded for restart/rotation")
+		return
+	}
+```
+
+- [ ] **Step 6: Run unit + integration tests to verify they pass**
+
+Run: `go test . -run 'TestAttemptRecovery' -v`
+Expected: ALL PASS (including the pre-existing kv-unavailable /
+heartbeat-backstop gate tests — the new gate must not disturb them).
+
+Run: `go test ./test/integration/failure/ -run TestStreamMissingNoHook -race -v -timeout 300s`
+Expected: PASS, including the new `require.Never`.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+make lint
+git add manager_degraded.go manager_recovery_conjuncts_test.go test/integration/failure/stream_missing_no_hook_test.go
+git commit -m "fix: hold Degraded terminally after stream-missing recovery exhaustion
+
+A dynamic consumer's exhausted stream-missing recovery permanently kills
+its partition-consumer loop, but the recovery monitor had no exit gate
+for this reason: the NATS connection never dropped, so the worker exited
+back to Stable within one tick while its dead partitions were still
+assigned, heartbeated as applied, and silently not consumed. Readiness
+probes never saw a lasting Degraded state, so the documented
+rotate-on-Degraded recovery could not trigger. Hold the worker
+terminally Degraded (like the heartbeat-bucket backstop) so rotation
+happens."
+```
+
+---
+
+### Task 3: Return `ErrMaxSubjectsExceeded` before any mutation
+
+The sentinel is exported and documented on `Dynamic.Update` but never
+returned; `addSubjectLoop` silently skips subjects over the cap
+(`internal/durable/worker_consumer.go:356-373`), which lets a two-phase
+handoff commit ownership of a partition no loop was started for. Move the
+check to `UpdateWorkerConsumer`, before any mutation, on the deduped subject
+count.
+
+**Files:**
+- Modify: `internal/durable/worker_consumer.go`
+- Modify: `internal/durable/config.go:257-259` (godoc)
+- Modify: `consumer/dynamic.go:149-153` (`MaxConcurrentSubjects` godoc)
+- Test: `internal/durable/worker_consumer_test.go`
+
+- [ ] **Step 1: Write the failing tests (both directions of the boundary)**
+
+Append to `internal/durable/worker_consumer_test.go`:
+
+```go
+// TestUpdateWorkerConsumer_OverCap_ErrorsBeforeMutation pins the
+// MaxConcurrentSubjects contract: a deduped subject set larger than the cap
+// must return ErrMaxSubjectsExceeded BEFORE any mutation — no workerID
+// store, no removals, no new loops. The pre-fix behavior (silently skipping
+// excess subjects inside the add loop and returning nil) let the two-phase
+// handoff commit ownership of a partition no loop was started for,
+// stranding it unowned while the worker reported the assignment applied.
+func TestUpdateWorkerConsumer_OverCap_ErrorsBeforeMutation(t *testing.T) {
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate:       "orders.{{.PartitionID}}.events",
+			MaxConcurrentSubjects: 2,
+		},
+		subjects: map[string]*partitionConsumer{
+			// Pre-existing subject NOT in the new set: over-cap must not remove it.
+			"orders.p9.events": nil,
+		},
+	}
+
+	// types.Partition is keyed by Keys; PartitionID in the subject template
+	// is the dot-joined HashID, so a single key "p0" yields "orders.p0.events".
+	parts := []types.Partition{
+		{Keys: []string{"p0"}}, {Keys: []string{"p1"}}, {Keys: []string{"p2"}},
+	}
+	err := wc.UpdateWorkerConsumer(context.Background(), "worker-1", parts)
+
+	require.ErrorIs(t, err, ErrMaxSubjectsExceeded,
+		"3 deduped subjects over cap 2 must surface the documented sentinel")
+	require.Contains(t, wc.subjects, "orders.p9.events",
+		"over-cap update must not perform removals — error must precede all mutation")
+	require.Len(t, wc.subjects, 1,
+		"over-cap update must not start any new subject loops")
+	wc.mu.RLock()
+	gotWorkerID := wc.workerID
+	wc.mu.RUnlock()
+	require.Empty(t, gotWorkerID,
+		"over-cap update must not store the workerID — the check runs before setWorkerIDAndSnapshot")
+}
+
+// TestUpdateWorkerConsumer_AtCap_Succeeds pins the positive direction of the
+// boundary: a deduped subject count EQUAL to the cap passes the check. The
+// target subjects are pre-populated so the update is a no-op diff and no
+// JetStream client is needed.
+func TestUpdateWorkerConsumer_AtCap_Succeeds(t *testing.T) {
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate:       "orders.{{.PartitionID}}.events",
+			MaxConcurrentSubjects: 2,
+		},
+		subjects: map[string]*partitionConsumer{
+			"orders.p0.events": nil,
+			"orders.p1.events": nil,
+		},
+	}
+
+	parts := []types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}
+	err := wc.UpdateWorkerConsumer(context.Background(), "worker-1", parts)
+
+	require.NoError(t, err, "subject count == cap must pass; the boundary is len(subjects) > cap")
+	require.Len(t, wc.subjects, 2)
+}
+```
+
+Notes for the implementer: `logging.NewNop()` is the no-op logger already
+used by `internal/durable/partition_consumer_test.go:18` — copy its import.
+The `Partition{Keys: ...}` literal shape matches
+`internal/dynamicbuild/builder_test.go` usage (`{{.PartitionID}}` renders
+the dot-joined keys).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/durable/ -run 'TestUpdateWorkerConsumer_OverCap|TestUpdateWorkerConsumer_AtCap' -v`
+Expected: `OverCap` FAILS — current code returns nil and stores the workerID
+(and would remove `orders.p9.events`). `AtCap` PASSES (pins existing
+behavior; it exists to catch an off-by-one `>=` in Step 3).
+
+- [ ] **Step 3: Implement the pre-mutation check; delete the silent skip**
+
+In `internal/durable/worker_consumer.go`, `UpdateWorkerConsumer`, insert
+between `subjects, err := wc.buildSubjects(partitions)` and
+`existing := wc.setWorkerIDAndSnapshot(workerID)`:
+
+```go
+	// Enforce the subject cap BEFORE any mutation (workerID store, removals,
+	// adds). Failing the whole update keeps the manager's apply pipeline
+	// honest: the apply fails pre-commit and retries with backoff, the
+	// two-phase removal guard keeps the previous owner consuming, and the
+	// un-acked heartbeat makes the over-capped worker visible to the leader.
+	// The pre-fix per-add silent skip returned success while ownership of
+	// the skipped partition could commit with no loop started — a silently
+	// unowned partition.
+	if maxSubjects := wc.config.MaxConcurrentSubjects; maxSubjects > 0 && len(subjects) > maxSubjects {
+		if wc.config.Metrics != nil {
+			wc.config.Metrics.IncrementWorkerConsumerSubjectThresholdWarning()
+		}
+		return fmt.Errorf("%d subjects exceed MaxConcurrentSubjects %d: %w",
+			len(subjects), maxSubjects, ErrMaxSubjectsExceeded)
+	}
+```
+
+Delete the cap block at the top of `addSubjectLoop` (the
+`if wc.config.MaxConcurrentSubjects > 0 { ... return nil }` block,
+currently lines 357-373). `addSubjectLoop` is reached only from
+`UpdateWorkerConsumer`'s add loop (verified: broadcast has its own
+`UpdateWorkerConsumer`), so the new check fully covers it.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/durable/ -run 'TestUpdateWorkerConsumer_OverCap|TestUpdateWorkerConsumer_AtCap' -v`
+Expected: BOTH PASS.
+
+Run: `go test ./internal/durable/ ./consumer/`
+Expected: PASS — no existing test depended on the silent-skip behavior (if
+one did, it pinned the bug; update it to expect the error and note that in
+the commit message).
+
+- [ ] **Step 5: Fix the contradicting godoc**
+
+`consumer/dynamic.go:149-153` — replace:
+
+```go
+	// MaxConcurrentSubjects limits the number of partitions (subjects) processed concurrently.
+	//
+	// If the manager assigns more partitions than this limit, excess partitions
+	// will be ignored (and logged/warned).
+	MaxConcurrentSubjects int `validate:"gte=0"`
+```
+
+with:
+
+```go
+	// MaxConcurrentSubjects limits the number of partitions (subjects) processed concurrently.
+	//
+	// If an assignment's deduped subject count exceeds this limit,
+	// [Dynamic.Update] rejects the whole update with [ErrMaxSubjectsExceeded]
+	// before making any changes; the manager retries the apply with backoff
+	// and the previous owners keep consuming. Size this above the worst-case
+	// per-worker partition count (e.g. after scale-down) or leave it 0
+	// (unlimited).
+	MaxConcurrentSubjects int `validate:"gte=0"`
+```
+
+Update `internal/durable/config.go:257-259` similarly (cap rejects the whole
+update with `ErrMaxSubjectsExceeded` pre-mutation).
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add internal/durable/ consumer/dynamic.go
+git commit -m "fix(consumer): reject over-cap assignments instead of silently skipping subjects
+
+ErrMaxSubjectsExceeded was documented on Dynamic.Update but never
+returned: the cap was enforced per-subject inside the add loop as a
+silent skip that still reported success. A committed handoff could then
+release the previous owner while no loop was started for the skipped
+partition, leaving it silently unowned. The cap is now enforced on the
+deduped subject count before any mutation, failing the apply so the
+manager retries and the previous owner keeps consuming. Behavior
+change: operators relying on the silent skip must raise the cap."
+```
+
+---
+
+### Task 4: Surface the remove-timeout instead of silent success
+
+`removeSubjectLoops`' `<-time.After(waitTimeout)` branch logs a warning but
+returns nil and deletes the map entries, so a handoff commits while an old
+loop's in-flight handler may still be processing. Return an error so the
+apply fails and the commit is deferred to the retry cycle. (Per consensus:
+this delays and surfaces the overlap risk — it does not prove handler
+quiescence. Entries must still be deleted: keeping a stopped entry would
+make a later re-add of the same subject a silent no-op.)
+
+**Files:**
+- Modify: `internal/durable/worker_consumer.go:332-353`
+- Modify: `consumer/dynamic.go:143-147` (`DrainOnRemoveTimeout` godoc)
+- Test: `internal/durable/worker_consumer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/durable/worker_consumer_test.go`:
+
+```go
+// TestUpdateWorkerConsumer_RemoveTimeout_SurfacesError pins the
+// remove-timeout contract: when subject loops fail to stop within
+// DrainOnRemoveTimeout, UpdateWorkerConsumer must return an error (so the
+// manager's apply fails pre-commit and retries) instead of reporting silent
+// success while a loop may still be processing. Map entries are still
+// deleted — a retained-but-stopped entry would make a later re-add of the
+// same subject a silent no-op (the dead-subject hazard) — so the follow-up
+// update converges.
+//
+// The never-stopping loop is simulated by a partitionConsumer whose done
+// channel never closes: Stop() tolerates a never-started consumer (cancel
+// is nil-checked) and Wait() blocks forever.
+func TestUpdateWorkerConsumer_RemoveTimeout_SurfacesError(t *testing.T) {
+	stuck := &partitionConsumer{done: make(chan struct{})}
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate:      "orders.{{.PartitionID}}.events",
+			DrainOnRemoveTimeout: 50 * time.Millisecond,
+		},
+		subjects: map[string]*partitionConsumer{
+			"orders.p0.events": stuck,
+		},
+	}
+
+	// Empty set removes everything; the stuck loop forces the wait to time out.
+	err := wc.UpdateWorkerConsumer(context.Background(), "worker-1", nil)
+	require.Error(t, err,
+		"a remove that times out waiting for loops to stop must fail the update, not report success")
+	require.NotErrorIs(t, err, context.DeadlineExceeded,
+		"the timeout is the internal wait bound, not the caller context")
+	require.Empty(t, wc.subjects,
+		"entries must still be deleted on timeout so the retry converges and re-adds are not silent no-ops")
+
+	// Convergence: the retry (same target set) finds nothing to remove.
+	err = wc.UpdateWorkerConsumer(context.Background(), "worker-1", nil)
+	require.NoError(t, err, "the follow-up update must converge once entries are gone")
+}
+```
+
+(`logging.NewNop()` import as in Task 3. `stuck` needs only the `done`
+channel — `Stop()` nil-checks `cancel` (`partition_consumer.go:406-414`),
+and `Drain` is skipped because `DrainOnRemove` is false.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/durable/ -run TestUpdateWorkerConsumer_RemoveTimeout -v`
+Expected: FAIL on `require.Error` — current code returns nil from the
+timeout branch.
+
+- [ ] **Step 3: Implement the error return**
+
+In `internal/durable/worker_consumer.go`, `removeSubjectLoops`, change the
+timeout case:
+
+```go
+	case <-time.After(waitTimeout):
+		// Surface the timeout so the caller's apply fails pre-commit and is
+		// retried with backoff. This delays the handoff commit by at least
+		// one retry cycle and makes the stall observable; it does NOT
+		// guarantee the old handler has finished — Stop only cancels the
+		// loop context, and an in-flight handler invocation runs to
+		// completion. Entries are still deleted below: a retained-but-
+		// stopped entry would make a later re-add a silent no-op.
+		wc.logger.Warn("timeout waiting for subject loops to stop",
+			"count", len(loops),
+			"timeout", waitTimeout,
+		)
+		err = fmt.Errorf("timed out after %v waiting for %d subject loops to stop", waitTimeout, len(loops))
+	}
+```
+
+(The existing Warn moves inside the case body unchanged; only the `err`
+assignment is new. The entry deletion below the select stays as-is.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/durable/ -run TestUpdateWorkerConsumer -v`
+Expected: ALL PASS (including Task 3's tests).
+
+- [ ] **Step 5: Sharpen the `DrainOnRemoveTimeout` godoc**
+
+`consumer/dynamic.go:143-147` — replace:
+
+```go
+	// DrainOnRemoveTimeout caps the time spent draining a revoked partition.
+	//
+	// If draining takes longer than this timeout, the consumer is forcibly closed.
+	// Default: 10s.
+	DrainOnRemoveTimeout time.Duration `default:"10s" validate:"gte=0"`
+```
+
+with:
+
+```go
+	// DrainOnRemoveTimeout caps the time spent draining a revoked partition
+	// and bounds the wait for its pull loop to stop.
+	//
+	// The wait is best-effort: if loops have not stopped within this bound,
+	// [Dynamic.Update] returns an error (the manager retries the apply with
+	// backoff) while an already-in-flight handler invocation may still run
+	// to completion. Default: 10s.
+	DrainOnRemoveTimeout time.Duration `default:"10s" validate:"gte=0"`
+```
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+make lint
+git add internal/durable/ consumer/dynamic.go
+git commit -m "fix(consumer): surface timeout when removed subject loops fail to stop
+
+The remove path's bounded wait logged a warning on timeout but returned
+success, letting a handoff commit while an old loop's in-flight handler
+could still be processing the partition. The timeout now fails the
+update so the manager's apply retries and the commit is deferred; map
+entries are still cleared so the retry converges."
+```
+
+---
+
+### Task 5: Docs, changelog, and informational godoc
+
+**Files:**
+- Modify: `consumer/common.go` (`CheckWorkQueueRecoveryCompat` godoc)
+- Modify: `docs/CONSUMERS.md`, `docs/OPERATIONS.md`, `docs/LIFECYCLE.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the cached-pass caveat to `CheckWorkQueueRecoveryCompat`**
+
+In `consumer/common.go`, append to the "best-effort" godoc paragraph
+(currently ending "...continues as if the check passed."):
+
+```go
+// For [Dynamic], the per-consumer outcome is cached: a pass recorded during a
+// transient fetch failure is not re-evaluated until a stream-recreate resets
+// the check, so a genuinely incompatible configuration may go undetected
+// until recovery first misbehaves.
+```
+
+- [ ] **Step 2: Sync the operator docs**
+
+Search-and-update (use grep to find every instance — fix all parallel
+occurrences, not just the first):
+
+- `docs/OPERATIONS.md`, degraded-reason taxonomy: mark
+  `stream-missing-recovery-exhausted` as **terminal** — the worker stays
+  Degraded until restarted/rotated; recovery never exits this reason because
+  the dead partition-consumer loop cannot restart in-process. Operator
+  action: recreate the stream, then rotate the worker.
+- `docs/CONSUMERS.md` (Dynamic sections): `MaxConcurrentSubjects` — excess
+  partitions now reject the whole `Update` with `ErrMaxSubjectsExceeded`
+  (was: "ignored"); `OnPermanentFailure` — manager observer now also fires
+  for stream-missing unless `WithSuppressManagerDegradeOnStreamMissing` is
+  set.
+- `docs/LIFECYCLE.md` (degraded-mode section): note the terminal reason in
+  whatever list/table enumerates recovery behavior, if one exists. Grep for
+  `stream-missing` across `docs/` to catch every mention.
+
+- [ ] **Step 3: Add changelog entries**
+
+In `CHANGELOG.md`, under a new Unreleased (or next-version) heading, follow
+the existing entry style:
+
+```markdown
+### Fixed
+- Manager now stays Degraded permanently after a dynamic consumer's
+  stream-missing recovery exhausts, so readiness-driven rotation can
+  occur; previously it returned to Stable within seconds while dead
+  partition consumers were still assigned and silently not consuming.
+- `Dynamic.Update` now returns `ErrMaxSubjectsExceeded` (as documented)
+  when an assignment exceeds `MaxConcurrentSubjects`, instead of
+  silently skipping excess partitions — which could strand a partition
+  unowned after a committed handoff.
+- `Dynamic.Update` now returns an error when removed partition loops
+  fail to stop within `DrainOnRemoveTimeout`, instead of reporting
+  success while a handler could still be processing.
+
+### Changed
+- Registering `WithOnPermanentFailure` no longer disables the manager's
+  auto-degraded route for stream-missing exhaustion: both the
+  application callback and the manager observer now fire. Use the new
+  `WithSuppressManagerDegradeOnStreamMissing()` option to restore the
+  previous opt-out behavior explicitly.
+```
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+make lint
+git add consumer/common.go docs/ CHANGELOG.md
+git commit -m "docs: sync consumer healing and subject-cap contracts
+
+Document the terminal stream-missing Degraded hold, the
+ErrMaxSubjectsExceeded rejection (replacing silent skip), the bounded
+best-effort remove wait, the dual-dispatch OnPermanentFailure contract,
+and the cached best-effort WorkQueue compatibility check."
+```
+
+---
+
+### Task 6: Full validation gate and review loop
+
+This series touches `manager_degraded.go` and `internal/durable/` — the
+pre-PR gate is mandatory, and the AGENTS.md cross-feature contracts (1)–(4)
+must be re-verified since this changes degraded-exit routing.
+
+- [ ] **Step 1: Run the full pre-PR gate**
+
+Run: `make pre-pr`
+Expected: lint clean, unit suite (`-race`) green, integration suite
+(`-race`) green. The integration suite covers the cross-feature contracts:
+`TestManager_LiveNATSBucketLoss*` (whole-bucket → Degraded; the new gate
+must not block kv-threshold recovery), `TestStableID_StaleKeyTakeover_Reclaim`
+(claim-lost routing), and the OnDegraded-once contract. Known load-flakes
+(`TestLeaderElection_ColdStart`, `TestHandoffConflictStress`,
+`TestFullNATSOutage_Unlimited`) pass in isolation if they trip under full
+suite load — rerun individually before concluding regression.
+
+- [ ] **Step 2: Quality pass**
+
+Run `/simplify` over the changed files; apply cleanups; re-run
+`make lint && make test`; commit any cleanup as
+`refactor: simplify consumer healing fixes` (or fold into the relevant fix
+commits if amending is cleaner pre-PR).
+
+- [ ] **Step 3: External post-implementation review loop**
+
+Run `/post-impl-review <this-plan-path> v1` (codex route). Iterate
+fix→review (v2, v3, …) until the verdict is merge-clean with 0 P0/P1.
+Re-run `make pre-pr` after any fix round that touches code.
+
+- [ ] **Step 4: Open the PR**
+
+Squash to one commit per fix (4 fix commits + 1 docs commit is fine;
+follow the repo's squash-on-merge-verdict practice). PR description: state
+the four user-visible behavior changes (terminal Degraded hold, over-cap
+rejection, remove-timeout error, dual-dispatch callback) and link the two
+behavior changes to the changelog. Base: `main`.
+
+---
+
+## Implementation addenda (review-found, accepted during execution)
+
+- **Task 2 addendum — exhaustion latch for reason overlap.** Code-quality
+  review found that the terminal condition carried only by the
+  degradedRecord reason string is lost when exhaustion fires while the
+  worker is ALREADY Degraded for another reason (enterDegraded CAS no-op);
+  the other reason's recovery could then exit to Stable with a dead loop.
+  Accepted fix: `Manager.streamMissingExhausted atomic.Bool`, set
+  unconditionally in `onStreamMissingError`, OR-ed into the terminal-hold
+  gate; never cleared in-process. Pinned by
+  `TestAttemptRecovery_StreamMissingExhausted_LatchSurvivesReasonOverlap`.
+- **Task 2 addendum — integration window 5s → 8s.** The plan's 5s
+  `require.Never` window cannot catch the pre-fix flip (default
+  ExitThreshold 5s + 1s monitor tick ⇒ flip at ~6.2s). Verified failing
+  pre-fix at 8s.
+- **Task 1 addendum — review fixes.** Dispatch-order assertion added to the
+  both-fire test; `Hooks.OnError` clause restored in the rewritten godoc;
+  orphaned comment block relocated.
+
+## Self-review notes
+
+- Spec coverage: F1→Task 2, F2→Task 3, F3→Task 4, F4→Task 1, F5→Task 5;
+  consensus sequencing (dispatcher before terminal-hold tests) honored by
+  task order; codex placement constraint (gate after commitment guard)
+  honored in Task 2 Step 5; codex wording constraint (no zero-overlap claim)
+  honored in Task 4's comment and godoc.
+- Out of scope (recorded, deliberate): reap/revive of dead subjects;
+  apply-retry age metric/escalation; version-only retry-stash coalescing.
+- Test-shape details verified against source: `types.Partition{Keys: ...}`
+  literals (no ID field; `{{.PartitionID}}` renders dot-joined keys),
+  `logging.NewNop()` logger (as in `partition_consumer_test.go:18`),
+  `options` struct at `consumer/options.go:150`,
+  `partitionConsumer.Stop()` nil-checks `cancel` so a never-Run stub is safe.

--- a/docs/plans/dynamic-consumer-healing-fixes/02-consumer-sweep-plan.md
+++ b/docs/plans/dynamic-consumer-healing-fixes/02-consumer-sweep-plan.md
@@ -1,0 +1,539 @@
+# Consumer Sweep Fixes Implementation Plan (Batch 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the consensus-confirmed defects from the pre-release
+Queue/Static/Broadcast QA sweep and the zero-overlap doc audit
+(tmp/consumer-sweep-findings-v1.md, ratified by codex in
+tmp/codex-sweep-r1-verdict.md), accumulating on PR #47 before release.
+
+**Architecture:** All fixes are local to the consumer layer (consumer/,
+internal/ipartition/, internal/durable/) plus a docs-truth batch. No manager
+core changes. One new exported sentinel (`ErrConsumerStopped`). Two behavior
+changes (FetchTimeout floor, reject-restart) — changelog entries.
+
+**Tech Stack:** Go, NATS JetStream, testify, embedded-NATS harness.
+
+**Repo discipline (every task):** verify-first (run each new test before the
+fix, record the failure), `make lint` before commit, no attribution trailers,
+no plan jargon in commit messages. Anchor on symbols, not line numbers.
+
+**Consensus decisions baked in:** validation floor (not clamp) for N1;
+reject-restart (not restart-support) for N3/N5 with a shared
+`types.ErrConsumerStopped` sentinel; mutual-exclusion (not drain-after-close)
+for N6; wire (not document) backoff growth for N7, INCLUDING Dynamic's
+`delayWithBackoffOrExit` (NF1); D1-D4 deferred.
+
+---
+
+### Task A: FetchTimeout 1s validation floor (N1, P1)
+
+**Files:**
+- Modify: `consumer/common.go` (CommonConfig.FetchTimeout tag + godoc)
+- Test: `consumer/common_test.go`
+- Modify: `CHANGELOG.md` (done in Task I)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestCommonConfig_FetchTimeout_FloorIsOneSecond pins the validation floor:
+// nats.go rejects PullExpiry below 1s at iterator-creation time, so a
+// sub-second FetchTimeout produced a consumer whose Start succeeded and then
+// failed every iterator creation forever — a permanently dead consumer with
+// a success return. Construction must reject it instead.
+func TestCommonConfig_FetchTimeout_FloorIsOneSecond(t *testing.T) {
+	cfg := CommonConfig{FetchTimeout: 500 * time.Millisecond}
+	err := cfg.Validate()
+	require.Error(t, err, "FetchTimeout below the 1s NATS PullExpiry floor must fail validation")
+
+	cfg = CommonConfig{FetchTimeout: time.Second}
+	require.NoError(t, cfg.Validate(), "FetchTimeout == 1s is the boundary and must pass")
+}
+```
+
+Mirror neighboring tests in `consumer/common_test.go` for construction style
+(Validate calls SetDefaults first — zero value gets the default and passes).
+
+- [ ] **Step 2: Run, expect FAIL** — `go test ./consumer/ -run TestCommonConfig_FetchTimeout -v`
+(sub-second currently passes validation).
+
+- [ ] **Step 3: Implement** — in `consumer/common.go`, change the FetchTimeout
+tag from `validate:"gt=0"` (find the exact current tag) to enforce >= 1s
+(fuda supports `gte=1s`-style duration tags — check how other duration floors
+in this repo express it, e.g. grep `validate:"gte=` for duration fields; if
+tag syntax can't express 1s, add an explicit check in
+`CommonConfig.Validate()` after fuda.Validate returning
+`fmt.Errorf("%w: FetchTimeout must be at least 1s (NATS PullExpiry floor), got %v", ErrInvalidConfig, c.FetchTimeout)`).
+Update the FetchTimeout godoc: document the 1s floor and why.
+
+- [ ] **Step 4: Run all consumer + durable + ipartition tests** — fix any test
+fixture using a sub-1s FetchTimeout (raise to 1s; do NOT weaken the check).
+Note each fixture change in the report.
+
+- [ ] **Step 5: Lint + commit** — `fix(consumer): reject FetchTimeout below the 1s NATS PullExpiry floor` (body: dead-consumer-with-successful-Start story; behavior change note).
+
+---
+
+### Task B: Signal the nil-recovery silent stall (N2, P1)
+
+**Files:**
+- Modify: `consumer/queue.go` (the runLoop iterator-error branch where
+  `q.recovery` is nil / Classify short-circuits — find the Debug "iterator
+  error" log)
+- Modify: `internal/ipartition/consumer.go` (same — Debug log ~`run` loop)
+- Modify: `internal/durable/broadcast_consumer.go` (same)
+- Test: `consumer/queue_test.go`, plus the equivalent test files for the other two
+
+- [ ] **Step 1: Write the failing tests (one per consumer)**
+
+Queue (adapt for the other two — each file has an injectable IteratorFactory
+and a recorded-metrics stub; mirror the file's existing recovery tests):
+
+```go
+// TestQueue_RecoveryDisabled_IteratorErrorIsSignaled pins the operator
+// signal for the default configuration: with RecoveryDisabled (nil
+// controller), a non-graceful iterator error (e.g. the durable was deleted)
+// must emit a Warn log and the iterator-restart metric. Pre-fix the only
+// artifact was a Debug log — at production log levels a deleted durable was
+// a zero-signal permanent stall.
+func TestQueue_RecoveryDisabled_IteratorErrorIsSignaled(t *testing.T) {
+	// Arrange a Queue with RecoveryDisabled (default), an IteratorFactory
+	// whose iterator returns jetstream.ErrNoHeartbeat from Next(), and the
+	// package's recording metrics stub. Run one loop cycle (or Start +
+	// brief settle + Stop, matching this file's loop-test pattern).
+	// Assert: metrics recorded IncrementWorkerConsumerIteratorRestart with
+	// a non-empty reason, and (if the file has a recording logger) a Warn
+	// was emitted. Mirror TestQueue_RunLoop_FailedRecoveryUsesBackoff for
+	// the harness shape.
+}
+```
+
+Write the full test bodies against the harness each file actually has (read
+the neighboring tests first); the assertion contract is fixed: Warn-level +
+iterator-restart metric on the nil-recovery path.
+
+- [ ] **Step 2: Run, expect FAIL** (no metric, Debug-only).
+
+- [ ] **Step 3: Implement** — in each consumer's iterator-error handling,
+when the recovery controller is nil (Queue: `q.recovery == nil`; Static/
+Broadcast: equivalent), before the backoff: log Warn (message:
+"iterator error with recovery disabled; consumer will retry but cannot
+recreate a deleted durable" + error + subject/stream fields) and emit
+`IncrementWorkerConsumerIteratorRestart("recovery_disabled")` when a metrics
+collector is configured. Do NOT change the retry semantics. Keep the Debug
+log if it carries extra fields, or fold into the Warn.
+
+- [ ] **Step 4: Run tests, expect PASS**; run the three packages fully.
+
+- [ ] **Step 5: Lint + commit** — `fix(consumer): surface iterator errors when recovery is disabled` (body: default-config deleted-durable = Debug-only zero-metric stall story).
+
+---
+
+### Task C: Terminal reject-restart for Broadcast and Static (N3+N5, P1/P2)
+
+**Files:**
+- Modify: `types/errors.go` (new sentinel), `consumer/errors.go` (re-export)
+- Modify: `internal/durable/broadcast_consumer.go`
+- Modify: `internal/ipartition/consumer.go`
+- Modify: `consumer/broadcast.go`, `consumer/static.go` (godoc)
+- Test: `internal/durable/broadcast_consumer_test.go`, `internal/ipartition/consumer_test.go` (or the files where lifecycle tests live — locate with grep)
+
+- [ ] **Step 1: Add the sentinel**
+
+`types/errors.go` (mirror the file's existing sentinel style):
+
+```go
+// ErrConsumerStopped is returned when an operation requires a running
+// consumer but the consumer has been stopped/closed. Stop is terminal for
+// Static and Broadcast consumers: create a new instance to consume again.
+// Pre-fix, a stopped Broadcast reported success ("active") on subsequent
+// Start/UpdateWorkerConsumer calls while its pull loop was permanently dead.
+var ErrConsumerStopped = errors.New("consumer is stopped")
+```
+
+Re-export in `consumer/errors.go` alongside the existing re-exports.
+
+- [ ] **Step 2: Write the failing tests**
+
+```go
+// TestBroadcastConsumer_UpdateAfterClose_ReturnsErrConsumerStopped pins the
+// terminal-Stop contract: Close cancels the pull loop permanently
+// (loopStarted was never reset; loopDone cannot be reused), so a subsequent
+// UpdateWorkerConsumer/Start must FAIL with the sentinel instead of logging
+// "active" and returning nil — which let a manager-driven apply report
+// success with a dead fan-out loop and the worker Stable.
+func TestBroadcastConsumer_UpdateAfterClose_ReturnsErrConsumerStopped(t *testing.T) {
+	// Construct via the file's existing harness (live embedded NATS or stub
+	// — mirror the existing Close test), Start/Update once, Close, then:
+	err := bc.UpdateWorkerConsumer(ctx, "w1", nil)
+	require.ErrorIs(t, err, types.ErrConsumerStopped)
+}
+```
+
+Static equivalent: Start → Stop → Start must return ErrConsumerStopped
+(pre-fix returns nil; godoc already promises Start-once). Also pin the
+DispatchByKey variant if cheap: restart returns the error BEFORE any
+fetch-never-process loop can exist.
+
+- [ ] **Step 3: Run, expect FAIL** (both currently return nil).
+
+- [ ] **Step 4: Implement**
+
+Broadcast (`internal/durable/broadcast_consumer.go`): add `closed bool` under
+the existing mutex; `Close` sets it (idempotent: repeated Close stays nil per
+current contract — verify current double-Close behavior and keep it);
+`UpdateWorkerConsumer` (and any Start entry) returns
+`fmt.Errorf("broadcast consumer: %w", types.ErrConsumerStopped)` when closed.
+
+Static (`internal/ipartition/consumer.go`): add `stopped bool` set in `Stop`
+(keep `cancel=nil` reset); `Start` returns
+`fmt.Errorf("js consumer: %w", types.ErrConsumerStopped)` when stopped.
+`Stop` stays idempotent.
+
+Godoc: `consumer/broadcast.go` Start/Stop and `consumer/static.go` Start/Stop
+— state Stop is terminal; create a new instance to consume again; name the
+sentinel.
+
+- [ ] **Step 5: Run tests + both packages; lint + commit** — `fix(consumer): make Stop terminal for Static and Broadcast` (body: dead-loop-reports-success story; behavior change note).
+
+---
+
+### Task D: keyDispatcher idle-exit/Dispatch mutual exclusion (N6, P2)
+
+**Files:**
+- Modify: `internal/ipartition/key_dispatcher.go`
+- Test: `internal/ipartition/key_dispatcher_test.go`
+
+**The race (confirmed):** worker idle path runs `len(worker.msgCh)==0` then
+`close(worker.closeCh); return` with NO synchronization against `Dispatch`'s
+send (`worker.msgCh <- km` in a select). A send can commit between the
+len-check and the close; the worker exits without draining; the message is
+stranded unacked until AckWait, and later same-key messages process first —
+breaking the documented per-key ordering. NOTE: a closeCh pre-check alone is
+insufficient — Go's select picks randomly when both the send and a closed
+closeCh are ready.
+
+**The fix (consensus: mutual exclusion):** serialize the send-commit and the
+exit-decision under `kd.mu`:
+
+1. `Dispatch` fast path: under `kd.mu.RLock()`, look up the worker AND
+   attempt a non-blocking send in the same critical section:
+
+```go
+	for {
+		kd.mu.RLock()
+		worker, exists := kd.workers[key]
+		if exists {
+			select {
+			case worker.msgCh <- keyMessage{ctx: ctx, msg: msg}:
+				kd.mu.RUnlock()
+				return true
+			default: // buffer full — fall through to the wait below
+			}
+		}
+		kd.mu.RUnlock()
+
+		if !exists {
+			if w := kd.getOrCreateWorker(key); w == nil {
+				return false // dispatcher closed
+			}
+			continue // retry the locked fast path against the fresh worker
+		}
+
+		// Backpressure: buffer full. Wait for drain progress, worker close,
+		// or dispatcher shutdown, then RETRY THE LOCKED FAST PATH — never
+		// commit a send outside the lock (an unlocked blocking send is the
+		// exact race this fix removes).
+		select {
+		case <-worker.closeCh:
+			select {
+			case <-worker.done:
+			case <-kd.ctx.Done():
+				return false
+			}
+		case <-kd.ctx.Done():
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+```
+
+2. Worker idle-exit: take the WRITE lock for the decision, remove from the
+   map inside it, close outside:
+
+```go
+		case <-timer.C:
+			kd.mu.Lock()
+			if len(worker.msgCh) == 0 {
+				// No send can commit concurrently (sends hold RLock) and no
+				// future sender can find this worker (removed under the same
+				// lock) — the stranded-message window is closed.
+				delete(kd.workers, worker.key)
+				kd.mu.Unlock()
+				close(worker.closeCh)
+				return
+			}
+			kd.mu.Unlock()
+			timer.Reset(kd.idleTimeout)
+```
+
+   Adjust the deferred `kd.removeWorker(worker.key)` so it cannot delete a
+   SUCCESSOR worker for the same key (delete only if the map still holds this
+   exact worker pointer; check removeWorker's current shape and make it
+   pointer-conditional).
+
+3. Audit the dispatcher-shutdown drain path (`<-kd.ctx.Done()` case in
+   runWorker) against the same invariant — it drains, so it is exempt, but
+   confirm its map removal also cannot clobber a successor.
+
+- [ ] **Step 1: Write the failing reproducer**
+
+```go
+// TestKeyDispatcher_IdleExitDoesNotStrandMessages hammers the idle-exit
+// window: a razor-thin idle timeout with paced single-key dispatches makes
+// the worker's exit decision race Dispatch's send. Every message Dispatch
+// accepted (returned true) must be processed exactly once and in dispatch
+// order — pre-fix, a send committing between the worker's len-check and its
+// close left the message stranded in a dead worker's channel (unprocessed
+// here; redelivered only after AckWait in production, breaking per-key
+// ordering).
+func TestKeyDispatcher_IdleExitDoesNotStrandMessages(t *testing.T) {
+	// Construct keyDispatcher directly (same package) with idleTimeout =
+	// 1*time.Millisecond, channelBuf >= 4, a handler that appends the
+	// message's sequence to a mutex-guarded []int.
+	// Loop i := 0; i < 2000; i++ { Dispatch(msg with key "k", seq i);
+	// time.Sleep(timing jittered around 1ms — alternate 0/1/2ms so dispatches
+	// straddle the idle boundary) }.
+	// After a final settle (Close or drain-wait), assert the recorded
+	// sequence equals exactly 0..1999 in order (no gaps = no stranding,
+	// no inversions = ordering preserved). Run with -race.
+}
+```
+
+Use the file's existing test scaffolding for constructing the dispatcher and
+fake messages (read it first; there are existing keyDispatcher tests —
+locate with `grep -n "func Test" internal/ipartition/key_dispatcher_test.go`).
+
+- [ ] **Step 2: Run with -race -count=5, expect FAIL** (gaps in the sequence).
+If 2000 iterations don't trip it, raise iterations / tighten pacing before
+concluding anything; record the failing output.
+
+- [ ] **Step 3: Implement the fix above.**
+
+- [ ] **Step 4: Run with -race -count=5, expect PASS; run the whole
+ipartition package -race** (the locked fast path touches every Dispatch).
+
+- [ ] **Step 5: Lint + commit** — `fix(consumer): serialize key-worker idle exit with dispatch sends` (body: stranded-message/ordering story).
+
+---
+
+### Task E: Wire real backoff growth in Broadcast and Dynamic loops (N7+NF1, P2)
+
+**Files:**
+- Modify: `internal/durable/broadcast_consumer.go` (`delayOrExit` + a
+  persistent prev-backoff field + seeded rng)
+- Modify: `internal/durable/partition_consumer.go` (`delayWithBackoffOrExit`
+  — same constant-Base bug: `jitterBackoff(0, ...)` with nil rng)
+- Test: `internal/durable/broadcast_consumer_test.go`, `internal/durable/partition_consumer_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+For each: a unit test that invokes the delay helper repeatedly and asserts
+the produced delays GROW toward Max (mirror how `consumer/queue.go` threads
+`prev` — `queue.go` around `delayWithBackoffOrExit(ctx, &backoff)` and its
+seeded rng at ~`:500-506`; and mirror whatever existing backoff tests exist —
+grep `jitterBackoff` in *_test.go). Test shape: with Base=10ms, Multiplier=2,
+Max=80ms, Seed fixed, call the helper N times capturing delays (inject a
+clock or assert monotonic non-decreasing until cap; if delays are slept, keep
+Base tiny and measure via the captured values not wall time — prefer
+refactoring the helper to RETURN the chosen delay so the test reads it).
+
+```go
+// TestBroadcastDelayOrExit_BackoffGrows pins that consecutive retry delays
+// grow per Multiplier up to Max. Pre-fix delayOrExit passed prev=0 on every
+// call, so jitterBackoff returned Base unconditionally: Multiplier, Max and
+// Seed in BroadcastConfig.Retry were dead config.
+```
+
+- [ ] **Step 2: Run, expect FAIL** (constant Base).
+
+- [ ] **Step 3: Implement** — give broadcastConsumer a `retryPrev
+time.Duration` (reset to 0 on successful iterate, mirroring Queue's
+`backoff=0` reset) and a seeded `*rand.Rand` built once from
+`config.Retry.Seed` (Queue's pattern); thread both through `delayOrExit` →
+`jitterBackoff(bc.retryPrev, ...)` and store the result back. Same for
+`partitionConsumer.delayWithBackoffOrExit`: add `retryPrev` field + seeded
+rng, reset on successful iterator episode (where the loop currently resets
+escalation counters / on ActionContinue), thread through. Check
+`startConsumerLoop`'s zero-delay 3-attempt loop: add the same jittered delay
+between attempts OR document it relies on jsutil.EnsureConsumer's internal
+retry — decide by reading EnsureConsumer; prefer wiring (consensus: wire).
+Update the `Retry` godoc in `consumer/broadcast.go` /
+`internal/durable/broadcast_config.go` to match what is now true.
+
+- [ ] **Step 4: Run both packages -race; lint + commit** — `fix(consumer): grow retry backoff in broadcast and dynamic consume loops` (body: constant-Base story, dead Multiplier/Max/Seed).
+
+---
+
+### Task F: Queue compat-check before durable creation (N4, P2)
+
+**Files:**
+- Modify: `consumer/queue.go` (Start: move `CheckWorkQueueRecoveryCompat`
+  BEFORE `ensureConsumer` — mirror `consumer/static.go`'s order)
+- Test: `consumer/queue_test.go` or the live test file used by queue tests
+
+- [ ] **Step 1: Failing test** — on a WorkQueuePolicy stream with
+RecoverFromNew, `Start` must fail AND leave no durable behind:
+
+```go
+// TestQueue_Start_IncompatibleConfig_LeavesNoDurable pins startup hygiene:
+// the WorkQueue/recovery compatibility check must run BEFORE the durable is
+// created. Pre-fix, a failed Start left an exclusive durable on the
+// WorkQueuePolicy stream that blocked every other consumer for
+// InactiveThreshold (default 24h).
+// Harness: embedded NATS (mirror this package's live tests), WorkQueuePolicy
+// stream, NewQueue(WithRecoveryStrategy(RecoverFromNew)), Start → require
+// ErrorIs ErrInvalidConfig → js.Consumer lookup for the durable name must
+// return not-found.
+```
+
+- [ ] **Step 2: Run, expect FAIL** (durable exists after the failed Start).
+
+- [ ] **Step 3: Implement the reorder (two statements); Step 4: PASS + package green; Step 5: lint + commit** — `fix(consumer): validate WorkQueue compatibility before creating the queue durable`.
+
+---
+
+### Task G: Queue closed-iterator hot loop (N9, P3)
+
+**Files:**
+- Modify: `consumer/queue.go` (runLoop / processIterator interplay)
+- Test: `consumer/queue_test.go` (reuse `queueErrorIter`)
+
+- [ ] **Step 1: Failing test** — IteratorFactory returning an iterator whose
+`Next` always returns `jetstream.ErrMsgIteratorClosed`, loop ctx alive:
+assert the iterator-factory call count stays bounded (e.g. < 20) over 200ms.
+Pre-fix it spins unboundedly (processIterator returns nil → continue with
+backoff reset to 0).
+
+- [ ] **Step 2: Run, expect FAIL** (hundreds+ of factory calls).
+
+- [ ] **Step 3: Implement** — distinguish "iterator closed but loop ctx
+alive": in `processIterator`, return a non-nil retryable signal (or a bool)
+when `ErrMsgIteratorClosed` arrives while `ctx.Err() == nil`, and take the
+existing backoff path in runLoop. Graceful shutdown (ctx done) keeps the
+current nil return. Keep the change minimal and inside queue.go.
+
+- [ ] **Step 4: PASS + package green; Step 5: lint + commit** — `fix(consumer): back off when the queue iterator closes without shutdown`.
+
+---
+
+### Task H: ErrInvalidConfig wrapping across constructors (N8, P2)
+
+**Files:**
+- Modify: `consumer/queue.go` (name `:158-160`, filter-subject `:161-163`),
+  `consumer/static.go` (name `~:294`), `consumer/broadcast.go` (prefix
+  `~:254`), `internal/ipartition/consumer.go` (subject parse errors `~:86-94`
+  — wrap at the consumer/static.go boundary, NOT inside internal, if internal
+  lacks the sentinel; decide by import direction: types owns no such sentinel,
+  consumer owns ErrInvalidConfig — so wrap where errors cross into the public
+  constructor), and the fuda validation returns in each `Validate()`
+  (`fmt.Errorf("%w: %w", ErrInvalidConfig, err)`).
+- Test: a table test per constructor asserting `errors.Is(err, ErrInvalidConfig)`
+  for: missing required field, out-of-range field, invalid name/prefix,
+  invalid subject/filter.
+
+- [ ] **Step 1: Write the failing table tests; Step 2: run, record which rows
+fail (expect: fuda rows + name/subject rows). Step 3: wrap consistently.
+Step 4: PASS + all four consumer constructors' packages green. Step 5: lint +
+commit** — `fix(consumer): wrap all constructor validation failures with ErrInvalidConfig`.
+
+---
+
+### Task I: Docs-truth batch (N10 + N11 + stale comment), changelog
+
+**Files:**
+- Modify: `docs/LIFECYCLE.md` (two-phase section rewrite), `docs/REFERENCE.md:363`,
+  `docs/CONSUMERS.md` (stream-missing per-type behavior; thread-safety notes),
+  `consumer/dynamic.go` (ProcessingGate field godoc + DrainOnRemove mechanism
+  wording), `consumer/common.go` (ManualAck godoc), `consumer/queue.go`
+  (Stop-timeout godoc, RecoveryStrategy guard wording, defensive-exit log line),
+  `test/integration/durable/processing_gate_exclusivity_test.go:88` (stale
+  comment: durables are shared, not per-worker), `CHANGELOG.md`.
+
+- [ ] **Step 1: LIFECYCLE rewrite** — replace the "zero overlap" claims
+(`:219`, `:276`, `:283`) and the fictional leader-ACK protocol diagram
+(`:224-249`) with: (a) an accurate worker-driven KV-CAS description; (b) a
+per-tier guarantee table (no two-phase / two-phase / +gate / +gate+pull-gating)
+stating two-phase orders RELEASE (no unowned gap) while the gate provides
+per-message admission control; (c) the irreducible window: an in-flight
+handler invocation plus AckWait-expiry redelivery of that message via the
+SHARED per-partition durable — mitigation `consumer.NewWIPHandler`
+(in-progress keepalive); (d) the resolver stale-positive bound
+(≤ ReconcileInterval, default 30s, self-correcting). Use "minimizes overlap";
+delivery is at-least-once at every tier. Align `docs/REFERENCE.md:363` to one
+honest line.
+- [ ] **Step 2: Godoc/docs sweep** — ProcessingGate "ensure ... *only* active
+processor" → "per-message admission control; bounds, does not eliminate,
+overlap" (consumer/dynamic.go + gate_config.go); DrainOnRemove mechanism
+wording (drain polls acks while pulls continue, then stop); ManualAck "still
+logged" → match reality (errors discarded — either add the missing log in
+recovery.Dispatch/keyDispatcher.processMessage [decide: doc-fix only this
+batch]; fix the doc); CONSUMERS.md stream-missing section: add the
+Queue/Static/Broadcast paragraph (Warn + backoff forever; self-heals only if
+the stream returns AND a recovery strategy is enabled; no exhaustion/degrade
+tier); Queue Stop-timeout note; queue.go defensive nil-consumer exit gets a
+Warn log line. Global-grep discipline: `grep -rn "zero overlap\|only active processor\|never processed" docs/ consumer/ internal/` and fix every parallel instance.
+- [ ] **Step 3: CHANGELOG** — Unreleased additions, matching house style:
+Fixed: N2 (silent stall signal), N3/N5 (terminal Stop), N4 (durable-before-
+compat), N6 (ordering race), N7/NF1 (backoff growth), N9 (hot loop), N8
+(sentinel wrapping). Changed: N1 (FetchTimeout floor — configs in (0,1s) now
+fail construction), reject-restart contract + new `ErrConsumerStopped`.
+Docs: zero-overlap claims corrected.
+- [ ] **Step 4: lint + commit** — `docs: replace zero-overlap claims with the per-tier overlap contract` (+ the changelog/godoc sweep).
+
+---
+
+### Task J: Validation gate + review loop + push
+
+- [ ] **Step 1:** `make pre-pr` (full: lint + unit -race + integration -race).
+- [ ] **Step 2:** `/simplify` over the batch range; apply; re-lint/test.
+- [ ] **Step 3:** post-impl review (codex) against THIS plan, v1 → iterate to
+merge-clean (0 P0/P1).
+- [ ] **Step 4:** push to PR #47 (history: keep one commit per task — they are
+already shaped that way; no squash needed beyond fix-round folding).
+
+---
+
+## Deferred (decided, do not implement in this batch)
+
+D1 retry-stash version-only family (next planned correctness item — needs own
+plan + reproducer via testHookHandleCommitValue/testHookHandleAssignment);
+D2 resolver stale-positive hardening (documented in Task I instead);
+D3 orphan stable-claim GC; D4 overlap chaos test (spec preserved in the
+zero-overlap audit transcript + findings doc).
+
+## Implementation addenda (review-found, accepted during execution)
+
+- **Task C addendum — terminal Close extended to Dynamic's WorkerConsumer.**
+  Review of Task C found the same hazard in internal/durable/worker_consumer.go,
+  aggravated: Close nils the gate resolver (constructor-only init), so a
+  post-Close UpdateWorkerConsumer restarted pull loops WITHOUT the configured
+  processing gate — a silent safety downgrade. Same reject-restart fix
+  (`closed` flag under updateMu, ErrConsumerStopped), pinned by
+  `TestUpdateWorkerConsumer_AfterClose_ReturnsErrConsumerStopped`. Manager
+  suite verified unaffected (no Update-after-Stop in shutdown paths).
+  Stop-before-Start is also terminal (pinned by never-started subtests).
+- **Task A addendum — floor duplicated into per-consumer Validates.** The
+  four consumer configs call fuda.Validate directly (no delegation to
+  CommonConfig.Validate), so the 1s floor lives in all five Validate methods.
+
+## Self-review notes
+
+- Consensus fidelity: N1 floor-not-clamp; N3/N5 reject-restart via shared
+  types.ErrConsumerStopped; N6 mutual-exclusion with the select-random-pick
+  hazard documented; N7 includes NF1 (Dynamic) per codex; D1-D4 deferred.
+- Tasks B, C, E Step-1 test bodies are contract-complete but harness-adaptive
+  (each file's existing scaffolding differs); the assertion contracts are
+  fixed and the implementer must record verify-first failures for each.
+- Behavior changes called out: Task A (validation floor), Task C (terminal
+  Stop). Both changelog'd in Task I.

--- a/docs/plans/self-healing/STATUS.md
+++ b/docs/plans/self-healing/STATUS.md
@@ -87,7 +87,10 @@ All six items below landed on the follow-up branch:
   `OnPermanentFailure` dispatcher, so a `Manager.Start` call after
   `NewDynamic` reaches the durable layer. Application-supplied
   `WithOnPermanentFailure` callbacks still win over the manager
-  observer per the documented contract.
+  observer per the documented contract. [Superseded 2026-06: both
+  now fire (application callback first, then manager observer);
+  use `WithSuppressManagerDegradeOnStreamMissing` to restore the
+  previous opt-out behavior explicitly — see consumer healing fixes.]
 - `manager_degraded.go:recordKVError`: short-circuits on
   `errors.Is(err, types.ErrStreamMissing)` so stream-missing does
   not double-count against the KV error threshold (cross-feature

--- a/internal/assignment/calculator_audit.go
+++ b/internal/assignment/calculator_audit.go
@@ -87,7 +87,7 @@ func (c *Calculator) auditApplied(ctx context.Context) {
 		return
 	}
 
-	c.maybeEscalateAudit(ctx, behind, fullyApplied, hbs)
+	c.maybeEscalateAudit(ctx, commit, behind, fullyApplied, hbs)
 }
 
 // classifyAuditWorkers partitions commit.Workers into three disjoint sets:
@@ -162,9 +162,43 @@ func (c *Calculator) classifyAuditWorkers(commit *types.AssignmentCommit, hbs ma
 // target gap exists).
 func (c *Calculator) maybeEscalateAudit(
 	ctx context.Context,
+	commit *types.AssignmentCommit,
 	behind, fullyApplied map[string]struct{},
 	hbs map[string]types.Heartbeat,
 ) {
+	// Direct-mode branch: log before capability filtering so the Warn reaches
+	// its target audience — homogeneous direct-mode fleets that never set
+	// CapTwoPhaseHandoff or CapProcessingGate and would otherwise be filtered
+	// out of behindReassignable before the Warn could fire.
+	if !c.EnableTwoPhaseHandoff {
+		c.Metrics.RecordAuditEscalationSkipped("direct_mode", "")
+		// Direct-mode fleets deliberately exclude audit_repair republish
+		// escalation, so a worker stuck behind on digest or leader revision
+		// would otherwise be visible only through the worker-behind metric.
+		// Warn once per audit tick per such worker (the loop runs once per
+		// tick) so the condition surfaces in logs; automatic repair requires
+		// two-phase handoff mode and worker-side capabilities.
+		// Sort for deterministic log ordering.
+		behindWorkers := make([]string, 0, len(behind))
+		for w := range behind {
+			behindWorkers = append(behindWorkers, w)
+		}
+		slices.Sort(behindWorkers)
+		for _, w := range behindWorkers {
+			hb := hbs[w]
+			c.Logger.Warn("audit: worker behind in direct mode; automatic repair requires two-phase handoff",
+				"worker", w,
+				"expected_version", commit.Version,
+				"expected_leader_revision", commit.LeaderRevision,
+				"acked_version", hb.AppliedVersion,
+				"acked_leader_revision", hb.LeaderRevision,
+				"acked_digest", hb.AppliedDigest,
+			)
+		}
+
+		return
+	}
+
 	// Filter behind workers whose caps allow safe reassignment.
 	behindReassignable := make([]string, 0, len(behind))
 	for w := range behind {
@@ -176,9 +210,9 @@ func (c *Calculator) maybeEscalateAudit(
 	}
 	if len(behindReassignable) == 0 {
 		// Nothing escalatable — cap_missing_behind metric(s) already covered
-		// the per-worker case. Skipping the targets/direct-mode signals
-		// avoids emitting noisy "no targets" / "direct mode" events when
-		// there was nothing to escalate to begin with.
+		// the per-worker case. Skipping the targets signal avoids emitting
+		// noisy "no targets" events when there was nothing to escalate to
+		// begin with.
 		return
 	}
 
@@ -191,11 +225,6 @@ func (c *Calculator) maybeEscalateAudit(
 	}
 	if len(targets) == 0 {
 		c.Metrics.RecordAuditEscalationSkipped("cap_missing_targets", "")
-		return
-	}
-
-	if !c.EnableTwoPhaseHandoff {
-		c.Metrics.RecordAuditEscalationSkipped("direct_mode", "")
 		return
 	}
 

--- a/internal/assignment/calculator_audit_test.go
+++ b/internal/assignment/calculator_audit_test.go
@@ -1,8 +1,10 @@
 package assignment
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -502,6 +504,117 @@ func TestCalculatorAudit_DirectMode_SkipsEscalation(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, hasDirect, "direct_mode must be emitted once when EnableTwoPhaseHandoff=false")
+}
+
+// TestCalculatorAudit_DirectMode_WarnsBehindWorker proves the direct-mode skip
+// also emits a per-worker Warn so a behind worker that cannot be auto-repaired
+// is visible in logs, not only in the worker-behind metric.
+func TestCalculatorAudit_DirectMode_WarnsBehindWorker(t *testing.T) {
+	t.Parallel()
+	digestA, digestB := uint64(0xAA), uint64(0xBB)
+	commit := &types.AssignmentCommit{
+		Version:        10,
+		LeaderRevision: 20,
+		PublishedAt:    time.Now().Add(-time.Hour),
+		Workers:        []string{"worker-A", "worker-B"},
+		Payloads: map[string]types.AssignmentPayloadRef{
+			"worker-A": auditPayloadRef("worker-A", digestA),
+			"worker-B": auditPayloadRef("worker-B", digestB),
+		},
+	}
+	hbs := map[string]types.Heartbeat{
+		"worker-A": {
+			SchemaVersion:  1,
+			Capabilities:   requiredAuditCaps,
+			LeaderRevision: 19, // behind on leader revision
+			AppliedVersion: 9,  // behind on version
+			AppliedDigest:  digestA,
+			Timestamp:      time.Now(),
+		},
+		"worker-B": fullCapsAck(20, 10, 0, false, digestB),
+	}
+	f := newAuditFixture(t, commit, hbs, false)
+
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	f.calc.Logger = logging.NewSlog(slog.New(handler))
+
+	f.calc.auditApplied(context.Background())
+
+	out := buf.String()
+	require.Contains(t, out, "audit: worker behind in direct mode")
+	require.Contains(t, out, `"worker":"worker-A"`)
+	require.Contains(t, out, `"expected_version":10`)
+	require.Contains(t, out, `"expected_leader_revision":20`)
+	require.Contains(t, out, `"acked_version":9`)
+	require.Contains(t, out, `"acked_leader_revision":19`)
+	// worker-B is fully applied; it must NOT appear in a behind Warn.
+	require.NotContains(t, out, `"worker":"worker-B"`)
+}
+
+// TestCalculatorAudit_DirectMode_WarnsBehindWorker_NoCaps proves the Warn fires
+// for a behind worker that carries NO capabilities — a homogeneous direct-mode
+// fleet that never sets CapTwoPhaseHandoff or CapProcessingGate. This is the
+// target audience: such workers are filtered out of behindReassignable by the
+// requiredAuditCaps gate and were therefore unreachable by the Warn before the
+// fix moved it before the filters.
+func TestCalculatorAudit_DirectMode_WarnsBehindWorker_NoCaps(t *testing.T) {
+	t.Parallel()
+	digestA, digestB := uint64(0xAA), uint64(0xBB)
+	commit := &types.AssignmentCommit{
+		Version:        10,
+		LeaderRevision: 20,
+		PublishedAt:    time.Now().Add(-time.Hour),
+		Workers:        []string{"worker-A", "worker-B"},
+		Payloads: map[string]types.AssignmentPayloadRef{
+			"worker-A": auditPayloadRef("worker-A", digestA),
+			"worker-B": auditPayloadRef("worker-B", digestB),
+		},
+	}
+	hbs := map[string]types.Heartbeat{
+		// worker-A is behind and carries only CapAckV1 — a direct-mode worker
+		// that never set CapTwoPhaseHandoff or CapProcessingGate. It is
+		// classified as "behind" (CapAckV1 is set, SchemaVersion>0) but is
+		// filtered out of behindReassignable by the requiredAuditCaps gate
+		// before the Warn could fire in the pre-fix code path.
+		"worker-A": {
+			SchemaVersion:  1,
+			Capabilities:   types.CapAckV1,
+			LeaderRevision: 19,
+			AppliedVersion: 9,
+			AppliedDigest:  digestA,
+			Timestamp:      time.Now(),
+		},
+		// worker-B is fully applied (also only CapAckV1 — pure direct-mode fleet).
+		"worker-B": {
+			SchemaVersion:  1,
+			Capabilities:   types.CapAckV1,
+			LeaderRevision: 20,
+			AppliedVersion: 10,
+			AppliedDigest:  digestB,
+			Timestamp:      time.Now(),
+		},
+	}
+	// EnableTwoPhaseHandoff=false — direct-mode calculator.
+	f := newAuditFixture(t, commit, hbs, false)
+
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	f.calc.Logger = logging.NewSlog(slog.New(handler))
+
+	f.calc.auditApplied(context.Background())
+
+	out := buf.String()
+	// The Warn must fire for worker-A even though it carries no caps.
+	require.Contains(t, out, "audit: worker behind in direct mode",
+		"Warn must fire for a no-caps behind worker in a direct-mode fleet")
+	require.Contains(t, out, `"worker":"worker-A"`)
+	require.Contains(t, out, `"expected_version":10`)
+	require.Contains(t, out, `"expected_leader_revision":20`)
+	require.Contains(t, out, `"acked_version":9`)
+	require.Contains(t, out, `"acked_leader_revision":19`)
+	// worker-B is fully applied; it must NOT appear in a behind Warn.
+	require.NotContains(t, out, `"worker":"worker-B"`)
 }
 
 func TestCalculatorAudit_BeforeGrace_NoMetricsForBehind(t *testing.T) {

--- a/internal/durable/broadcast_config.go
+++ b/internal/durable/broadcast_config.go
@@ -126,7 +126,13 @@ type BroadcastConsumerConfig struct {
 	// Default: RecoveryDisabled (no auto-recovery).
 	RecoveryStrategy RecoveryStrategy
 
-	// Retry configures backoff behavior for control-plane operations.
+	// Retry configures backoff behavior for the consume loop.
+	//
+	// On each iterator failure (transient error, stream missing, or ActionBackoff from the
+	// recovery controller) the loop sleeps for a jittered delay that grows via decorrelated
+	// jitter from Base toward Max using the Multiplier factor. Seed makes the sequence
+	// deterministic (useful in tests); zero uses the package-level PRNG.
+	// The delay is reset to zero after every successful iteration cycle.
 	Retry RetryConfig
 
 	// IteratorFactory optionally overrides the iterator creation logic for testing or

--- a/internal/durable/broadcast_consumer.go
+++ b/internal/durable/broadcast_consumer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	rand2 "math/rand/v2"
 	"os"
 	"strings"
 	"sync"
@@ -69,12 +70,17 @@ type BroadcastConsumer struct {
 	loopCancel  context.CancelFunc
 	loopDone    chan struct{}
 	loopStarted bool
+	closed      bool // set by Close; guards terminal state; same mutex as loopStarted
 
 	// Iterator factory
 	iterFactory func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error)
 
 	// Recovery
 	recovery *recovery.Controller
+
+	// Retry backoff state — guarded by: only accessed from the consume loop goroutine.
+	rng       *rand2.Rand   // seeded once from config.Retry.Seed; nil uses package PRNG
+	retryPrev time.Duration // previous jitter delay; threaded through to grow backoff
 }
 
 // NewBroadcastConsumer creates a new broadcast fan-out consumer.
@@ -120,6 +126,7 @@ func NewBroadcastConsumer(js jetstream.JetStream, cfg BroadcastConsumerConfig, f
 		consumerIDSource: consumerIDSource,
 		iterFactory:      defaultIterFactory,
 		loopDone:         make(chan struct{}),
+		rng:              newRetryRNG(cfg.Retry.Seed),
 		recovery: recovery.NewController(recovery.ControllerConfig{
 			Strategy:     cfg.RecoveryStrategy,
 			FetchTimeout: cfg.FetchTimeout,
@@ -141,13 +148,21 @@ func NewBroadcastConsumer(js jetstream.JetStream, cfg BroadcastConsumerConfig, f
 //
 // The partitions argument is IGNORED as this consumer receives all messages matching the wildcard.
 // Partition updates take effect strictly by ensuring the consumer is active.
+//
+// Returns [types.ErrConsumerStopped] when the consumer has been closed via [Close].
+// Stop is terminal: create a new instance to consume again.
 func (bc *BroadcastConsumer) UpdateWorkerConsumer(ctx context.Context, workerID string, partitions []types.Partition) error {
 	bc.updateMu.Lock()
 	defer bc.updateMu.Unlock()
 
 	bc.mu.Lock()
+	closed := bc.closed
 	started := bc.loopStarted
 	bc.mu.Unlock()
+
+	if closed {
+		return fmt.Errorf("broadcast consumer: %w", types.ErrConsumerStopped)
+	}
 
 	// First call: create consumer and start loop
 	if !started {
@@ -168,6 +183,15 @@ func (bc *BroadcastConsumer) UpdateWorkerConsumer(ctx context.Context, workerID 
 }
 
 // Close stops the consumer loop. Consumer is left for server GC via InactiveThreshold.
+//
+// Close is terminal. After Close returns, any subsequent call to [UpdateWorkerConsumer]
+// returns [types.ErrConsumerStopped]. Create a new instance to consume again.
+//
+// If the consumer is stopped while registered with a running manager, the manager
+// will retry the failed update indefinitely (by design). Stop the manager first, or
+// deregister this consumer before calling Close.
+//
+// Close is idempotent; calling it multiple times is safe.
 func (bc *BroadcastConsumer) Close(ctx context.Context) error {
 	bc.updateMu.Lock()
 	defer bc.updateMu.Unlock()
@@ -177,6 +201,7 @@ func (bc *BroadcastConsumer) Close(ctx context.Context) error {
 		bc.loopCancel()
 	}
 	started := bc.loopStarted
+	bc.closed = true
 	bc.mu.Unlock()
 
 	if !started {
@@ -202,6 +227,11 @@ func (bc *BroadcastConsumer) startConsumerLoop(ctx context.Context) error {
 		attempts = 3
 	)
 
+	// No explicit inter-attempt delay between collision retries: each attempt goes
+	// through bc.ensureConsumer → jsutil.EnsureConsumer which already applies a
+	// ~50–100ms jittered back-off for transient NATS errors (3 attempts, max 200ms).
+	// Collision retries only regenerate the consumer ID; the pacing from
+	// EnsureConsumer's internal retry is sufficient.
 	for range attempts {
 		durableName := bc.durableName()
 		cons, consCfg, err = bc.ensureConsumer(ctx, durableName)
@@ -321,12 +351,30 @@ func (bc *BroadcastConsumer) runLoop(ctx context.Context) {
 
 		iterErr := bc.processIterator(ctx, iter)
 		if iterErr == nil {
+			// Healthy iteration completed — reset backoff so the next failure
+			// episode starts from Base rather than inheriting a grown window.
+			bc.retryPrev = 0
 			continue
 		}
 
 		bc.consumerMu.RLock()
 		consumerConfig := bc.consumerConfig
 		bc.consumerMu.RUnlock()
+
+		if bc.recovery == nil {
+			// RecoveryDisabled (the default): the recovery controller is nil and
+			// classification short-circuits before any metric. A deleted durable
+			// causes a permanent stall with no operator signal at production log
+			// levels without this explicit path.
+			bc.logger.Warn("iterator error with recovery disabled; consumer will retry but cannot recreate a deleted durable",
+				"error", iterErr,
+				"stream", bc.config.StreamName,
+				"filter", bc.config.WildcardFilter,
+			)
+			if bc.config.Metrics != nil {
+				bc.config.Metrics.IncrementWorkerConsumerIteratorRestart("recovery_disabled")
+			}
+		}
 
 		action, newCons, classifyErr := bc.recovery.Classify(ctx, iterErr, bc.consumerInfoFn(), consumerConfig, bc.recreateFn())
 		switch action {
@@ -341,6 +389,9 @@ func (bc *BroadcastConsumer) runLoop(ctx context.Context) {
 			// advances, so it will not regress. Called here as a best-effort update
 			// in case the consumer was recreated over an existing durable.
 			bc.recovery.SeedCheckpoint(ctx, bc.consumerInfoFn())
+			// Successful recovery — reset backoff so the next failure episode
+			// starts from Base rather than the grown window from this episode.
+			bc.retryPrev = 0
 
 			continue
 		case recovery.ActionStreamMissing:
@@ -410,9 +461,14 @@ func (bc *BroadcastConsumer) processIterator(ctx context.Context, iter jetstream
 	}
 }
 
-// delayOrExit applies backoff delay or returns true if context is cancelled.
+// delayOrExit applies jittered exponential backoff delay or returns true if context is cancelled.
+// The previous delay (bc.retryPrev) is threaded through so the window grows toward Max on
+// consecutive failures; bc.retryPrev is updated in-place. Reset bc.retryPrev to 0 at every
+// successful iteration point (ActionContinue path in runLoop) so a recovered consumer starts
+// fresh. Guarded by: only called from the consume loop goroutine.
 func (bc *BroadcastConsumer) delayOrExit(ctx context.Context) bool {
-	delay := jitterBackoff(0, bc.config.Retry.Base, bc.config.Retry.Multiplier, bc.config.Retry.Max, nil)
+	delay := jitterBackoff(bc.retryPrev, bc.config.Retry.Base, bc.config.Retry.Multiplier, bc.config.Retry.Max, bc.rng)
+	bc.retryPrev = delay
 	bc.logger.Debug("backoff", "delay_ms", delay.Milliseconds())
 
 	select {

--- a/internal/durable/broadcast_consumer_test.go
+++ b/internal/durable/broadcast_consumer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 
+	"github.com/arloliu/parti/v2/internal/logging"
 	partitesting "github.com/arloliu/parti/v2/partitest"
 	"github.com/arloliu/parti/v2/types"
 )
@@ -593,4 +594,191 @@ func TestBroadcastConsumer_RecoverySnapshot_CarriesConsumerOptions(t *testing.T)
 	bcDefault.consumerMu.RUnlock()
 	require.False(t, storedDefault.MemoryStorage)
 	require.Equal(t, 0, storedDefault.Replicas)
+}
+
+// broadcastSignalMetrics extends captureEscalationMetrics to also record
+// IncrementWorkerConsumerIteratorRestart calls.
+type broadcastSignalMetrics struct {
+	captureEscalationMetrics
+	restartReasons []string
+}
+
+func (m *broadcastSignalMetrics) IncrementWorkerConsumerIteratorRestart(reason string) {
+	m.restartReasons = append(m.restartReasons, reason)
+}
+
+// TestBroadcastConsumer_RecoveryDisabled_IteratorErrorIsSignaled pins the operator
+// signal for the default configuration: with RecoveryDisabled (nil controller), a
+// non-graceful iterator error (e.g. the durable was deleted) must emit the
+// iterator-restart metric with reason "recovery_disabled". Pre-fix the only artifact
+// was a Debug log — at production log levels a deleted durable was a zero-signal
+// permanent stall.
+func TestBroadcastConsumer_RecoveryDisabled_IteratorErrorIsSignaled(t *testing.T) {
+	m := &broadcastSignalMetrics{}
+
+	bc := &BroadcastConsumer{
+		config: BroadcastConsumerConfig{
+			StreamName:     "BC_RECOVERY_DISABLED",
+			ConsumerPrefix: "bc",
+			WildcardFilter: "bc.>",
+			BatchSize:      1,
+			FetchTimeout:   time.Second,
+			Metrics:        m,
+			Retry: RetryConfig{
+				Base:       20 * time.Millisecond,
+				Backoff:    20 * time.Millisecond,
+				Multiplier: 1.0,
+				Max:        20 * time.Millisecond,
+			},
+		},
+		logger:   logging.NewNop(),
+		handler:  messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil }),
+		loopDone: make(chan struct{}),
+		iterFactory: func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+			return &errorOnNextIter{err: jetstream.ErrNoHeartbeat}, nil
+		},
+		recovery: nil, // RecoveryDisabled: NewController returns nil for Disabled strategy
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go bc.runLoop(ctx)
+
+	// One backoff cycle (20ms) is enough to observe the metric; wait two.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-bc.loopDone
+
+	require.NotEmpty(t, m.restartReasons,
+		"expected IncrementWorkerConsumerIteratorRestart to be called on the nil-recovery path")
+	require.Contains(t, m.restartReasons, "recovery_disabled",
+		"expected reason=recovery_disabled on the nil-recovery path")
+}
+
+// TestBroadcastConsumer_UpdateAfterClose_ReturnsErrConsumerStopped pins the
+// terminal-Stop contract: Close cancels the pull loop permanently
+// (loopStarted was never reset; loopDone cannot be reused), so a subsequent
+// UpdateWorkerConsumer/Start must FAIL with the sentinel instead of logging
+// "active" and returning nil — which let a manager-driven apply report
+// success with a dead fan-out loop and the worker Stable.
+//
+// Pre-fix: UpdateWorkerConsumer after Close saw loopStarted=true, skipped
+// startConsumerLoop, logged "active", and returned nil — a silent lie.
+// TestBroadcastDelayOrExit_BackoffGrows verifies that repeated calls to delayOrExit
+// produce growing delays (the previous delay is threaded through, not reset to 0 each call).
+//
+// Pre-fix: every call passed prev=0 into jitterBackoff, so the delay was always Base
+// regardless of how many times the helper was called.
+func TestBroadcastDelayOrExit_BackoffGrows(t *testing.T) {
+	const (
+		base     = 1 * time.Millisecond
+		mult     = 2.0
+		maxDelay = 8 * time.Millisecond
+		seed     = int64(42)
+		// Number of invocations — enough that the cap is reached with Seed=42.
+		calls = 6
+	)
+
+	bc := &BroadcastConsumer{
+		config: BroadcastConsumerConfig{
+			Retry: RetryConfig{
+				Base:       base,
+				Multiplier: mult,
+				Max:        maxDelay,
+				Seed:       seed,
+			},
+		},
+		logger:   logging.NewNop(),
+		loopDone: make(chan struct{}),
+	}
+	// Initialise the RNG exactly as NewBroadcastConsumer does.
+	bc.rng = newRetryRNG(bc.config.Retry.Seed)
+
+	ctx := context.Background()
+	delays := make([]time.Duration, 0, calls)
+	for range calls {
+		// We capture the delay value directly rather than sleeping.
+		// delayOrExit does sleep, so we cancel the context immediately after
+		// capturing the sleep value by using a cancelable ctx that fires after
+		// a generous deadline — the test runs with Base=1ms so actual wall time
+		// is negligible.
+		delayCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		bc.delayOrExit(delayCtx) //nolint:contextcheck // intentional: we want the sleep to complete
+		cancel()
+		delays = append(delays, bc.retryPrev)
+	}
+
+	require.Len(t, delays, calls)
+
+	// Every delay must be in [Base, Max].
+	for i, d := range delays {
+		require.GreaterOrEqual(t, d, base, "delay[%d] below Base", i)
+		require.LessOrEqual(t, d, maxDelay, "delay[%d] exceeds Max", i)
+	}
+
+	// Growth: last delay must exceed first (with a fixed seed this is deterministic).
+	require.Greater(t, delays[calls-1], delays[0],
+		"expected backoff to grow over %d calls; delays: %v", calls, delays)
+}
+
+func TestBroadcastConsumer_UpdateAfterClose_ReturnsErrConsumerStopped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "BCTERM",
+		Subjects:  []string{"bcterm.>"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	cfg := BroadcastConsumerConfig{
+		StreamName:     "BCTERM",
+		ConsumerPrefix: "bcterm",
+		ConsumerID:     "term-worker",
+		WildcardFilter: "bcterm.>",
+	}
+	require.NoError(t, cfg.SetDefaults())
+
+	handler := messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+	bc, err := NewBroadcastConsumer(js, cfg, handler)
+	require.NoError(t, err)
+
+	// Start the consumer
+	require.NoError(t, bc.UpdateWorkerConsumer(ctx, "term-worker", nil))
+
+	// Close the consumer (terminal)
+	closeCtx, closeCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer closeCancel()
+	require.NoError(t, bc.Close(closeCtx))
+
+	// A second Close must remain idempotent (same nil result as pre-fix)
+	require.NoError(t, bc.Close(closeCtx), "second Close must be idempotent")
+
+	// UpdateWorkerConsumer after Close must return ErrConsumerStopped, not nil
+	err = bc.UpdateWorkerConsumer(ctx, "term-worker", nil)
+	require.ErrorIs(t, err, types.ErrConsumerStopped,
+		"UpdateWorkerConsumer after Close must return ErrConsumerStopped, got: %v", err)
+
+	// Pin the never-started variant: New→Close→Update must also return
+	// ErrConsumerStopped even if UpdateWorkerConsumer was never called first.
+	// Use direct construction so no NATS call is needed.
+	t.Run("never-started", func(t *testing.T) {
+		bc2 := &BroadcastConsumer{
+			logger:   logging.NewNop(),
+			loopDone: make(chan struct{}),
+		}
+		require.NoError(t, bc2.Close(context.Background()), "Close on never-started must be nil")
+		err := bc2.UpdateWorkerConsumer(context.Background(), "", nil)
+		require.ErrorIs(t, err, types.ErrConsumerStopped,
+			"UpdateWorkerConsumer after Close on never-started must return ErrConsumerStopped")
+	})
 }

--- a/internal/durable/config.go
+++ b/internal/durable/config.go
@@ -184,15 +184,16 @@ type WorkerConsumerConfig struct {
 	// Keep false (default) for simple synchronous handlers to ensure safety.
 	ManualAck bool
 
-	// ProcessingGate configures optional exclusive processing enforcement.
+	// ProcessingGate configures optional per-message admission control.
 	// When enabled, WorkerConsumer automatically creates and manages a claim-based
 	// ownership resolver backed by the handoff KV bucket. The resolver lifecycle
 	// (start/stop) is handled internally - no manual management needed.
 	//
-	// Recommendation: Enable this for stateful workloads or when strict partition
-	// exclusivity is required. Without this, ownership transitions may be "loose",
-	// resulting in brief periods where a partition is processed by a worker that
-	// is no longer the assigned owner (though duplicates are rare).
+	// Recommendation: Enable this for stateful workloads or when cross-owner
+	// processing must be minimized (it cannot be eliminated: an in-flight
+	// handler invocation cannot be revoked). Without this, ownership
+	// transitions may be "loose", resulting in brief periods where a partition
+	// is processed by a worker that is no longer the assigned owner.
 	ProcessingGate *ProcessingGateConfig `validate:"omitempty"`
 
 	// Resolver configures the ownership resolver when ProcessingGate is enabled.
@@ -211,8 +212,11 @@ type WorkerConsumerConfig struct {
 	// Default: false (immediate cancellation as before).
 	DrainOnRemove bool
 
-	// DrainOnRemoveTimeout caps the drain wait per subject when DrainOnRemove is enabled.
-	// Default: 10s when zero.
+	// DrainOnRemoveTimeout caps the drain wait per subject when DrainOnRemove is
+	// enabled, and also bounds the wait for subject loops to stop after cancel.
+	// If loops have not stopped within this bound, UpdateWorkerConsumer returns
+	// an error so the caller retries; an in-flight handler may still run to
+	// completion. Default: 10s when zero.
 	DrainOnRemoveTimeout time.Duration `default:"10s" validate:"gte=0"`
 
 	// AckWait is the time allowed for processing before redelivery.
@@ -255,7 +259,8 @@ type WorkerConsumerConfig struct {
 	ConsumerReplicas int
 
 	// MaxConcurrentSubjects caps the total number of per-subject consumers/loops.
-	// When exceeded, additional subjects are skipped with a warning and metric increment.
+	// When the deduped subject count from an update exceeds this cap, the whole
+	// update is rejected with ErrMaxSubjectsExceeded before any mutation. 0 = unlimited.
 	MaxConcurrentSubjects int `validate:"gte=0"`
 
 	// AckPolicy controls JetStream ack policy. Defaults to AckExplicitPolicy.

--- a/internal/durable/errors.go
+++ b/internal/durable/errors.go
@@ -4,8 +4,8 @@ import "errors"
 
 // Guardrail errors for worker consumer updates.
 
-// ErrMaxSubjectsExceeded indicates the requested subjects exceed MaxSubjects.
-var ErrMaxSubjectsExceeded = errors.New("worker consumer subjects exceed MaxSubjects cap")
+// ErrMaxSubjectsExceeded indicates the requested subjects exceed MaxConcurrentSubjects.
+var ErrMaxSubjectsExceeded = errors.New("worker consumer subjects exceed MaxConcurrentSubjects cap")
 
 // ErrWorkerIDMutation indicates workerID changed while AllowWorkerIDChange=false.
 var ErrWorkerIDMutation = errors.New("workerID mutation is not allowed by configuration")

--- a/internal/durable/partition_consumer.go
+++ b/internal/durable/partition_consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	rand "math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -110,6 +111,10 @@ type partitionConsumer struct {
 
 	// Recovery
 	recovery *recovery.Controller
+
+	// Retry backoff state — guarded by: only accessed from the consume loop goroutine.
+	rng       *rand.Rand    // seeded once from config.Retry.Seed; nil uses package PRNG
+	retryPrev time.Duration // previous jitter delay; threaded through to grow backoff
 }
 
 // partitionConsumerOpts contains the identity and dependency options for a partition consumer.
@@ -157,6 +162,7 @@ func newPartitionConsumer(
 		iterFactory:          opts.iterFactory,
 		checkPullSuppression: opts.checkPullSuppression,
 		done:                 make(chan struct{}),
+		rng:                  newRetryRNG(config.Retry.Seed),
 		recovery: recovery.NewController(recovery.ControllerConfig{
 			Strategy:     config.RecoveryStrategy,
 			FetchTimeout: config.FetchTimeout,
@@ -229,6 +235,11 @@ func (pc *partitionConsumer) Run(ctx context.Context, handler messageHandler) {
 		}
 		if iterErr != nil && pc.handleIteratorFailure(ctx, iterErr) {
 			return
+		}
+		// Healthy iteration completed (no iterErr) — reset backoff so the next
+		// failure episode starts from Base rather than the grown window.
+		if iterErr == nil {
+			pc.retryPrev = 0
 		}
 		// loop continues to recreate iterator on next iteration
 	}
@@ -393,6 +404,9 @@ func (pc *partitionConsumer) handleIteratorFailure(ctx context.Context, iterErr 
 		// advances, so it will not regress. Called here as a best-effort update
 		// in case the consumer was recreated over an existing durable.
 		pc.recovery.SeedCheckpoint(ctx, pc.consumerInfoFn())
+		// Successful recovery — reset backoff so the next failure episode
+		// starts from Base rather than the grown window from this episode.
+		pc.retryPrev = 0
 
 		return false
 	case recovery.ActionBackoff:
@@ -661,8 +675,14 @@ func (pc *partitionConsumer) ensureConsumer(ctx context.Context) (jetstream.Cons
 }
 
 // delayWithBackoffOrExit applies jittered exponential backoff according to config.
+// The previous delay (pc.retryPrev) is threaded through so the window grows toward Max on
+// consecutive failures; pc.retryPrev is updated in-place. Reset pc.retryPrev to 0 at every
+// successful iteration point (ActionContinue in handleIteratorFailure, successful
+// processIterator call in Run) so a recovered consumer starts fresh from Base.
+// Guarded by: only called from the consume loop goroutine.
 func (pc *partitionConsumer) delayWithBackoffOrExit(ctx context.Context, purpose string) bool { //nolint:unparam // purpose is used for logging/metrics; all sites currently pass "iterate" but may diverge.
-	delay := jitterBackoff(0, pc.config.Retry.Base, pc.config.Retry.Multiplier, pc.config.Retry.Max, nil)
+	delay := jitterBackoff(pc.retryPrev, pc.config.Retry.Base, pc.config.Retry.Multiplier, pc.config.Retry.Max, pc.rng)
+	pc.retryPrev = delay
 	pc.logger.Debug("backoff", "purpose", purpose, "delay_ms", delay.Milliseconds())
 	emitControlRetry(pc.config.Metrics, purpose)
 	emitRetryBackoff(pc.config.Metrics, purpose, delay.Seconds())

--- a/internal/durable/partition_consumer_test.go
+++ b/internal/durable/partition_consumer_test.go
@@ -185,6 +185,66 @@ func TestPartitionConsumer_ProcessIterator_FiltersGracefulErrors(t *testing.T) {
 	}
 }
 
+// TestPartitionConsumerDelayWithBackoff_BackoffGrows verifies that repeated calls to
+// delayWithBackoffOrExit produce growing delays (the previous delay is threaded through,
+// not reset to 0 each call).
+//
+// Pre-fix: every call passed prev=0 into jitterBackoff, so the delay was always Base
+// regardless of how many times the helper was called.
+func TestPartitionConsumerDelayWithBackoff_BackoffGrows(t *testing.T) {
+	const (
+		base     = 1 * time.Millisecond
+		mult     = 2.0
+		maxDelay = 8 * time.Millisecond
+		seed     = int64(42)
+		calls    = 6
+	)
+
+	cfg := partitionConsumerConfig{
+		BatchSize:    1,
+		FetchTimeout: 100 * time.Millisecond,
+		Retry: RetryConfig{
+			Base:       base,
+			Multiplier: mult,
+			Max:        maxDelay,
+			Seed:       seed,
+		},
+	}
+
+	pc := newPartitionConsumer(
+		logging.NewNop(),
+		nil,
+		cfg,
+		partitionConsumerOpts{
+			streamName:  "stream",
+			durableName: "durable",
+			subject:     "subject",
+			partitionID: "pid",
+		},
+	)
+
+	ctx := context.Background()
+	delays := make([]time.Duration, 0, calls)
+	for range calls {
+		delayCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		pc.delayWithBackoffOrExit(delayCtx, "test")
+		cancel()
+		delays = append(delays, pc.retryPrev)
+	}
+
+	require.Len(t, delays, calls)
+
+	// Every delay must be in [Base, Max].
+	for i, d := range delays {
+		require.GreaterOrEqual(t, d, base, "delay[%d] below Base", i)
+		require.LessOrEqual(t, d, maxDelay, "delay[%d] exceeds Max", i)
+	}
+
+	// Growth: last delay must exceed first (with a fixed seed this is deterministic).
+	require.Greater(t, delays[calls-1], delays[0],
+		"expected backoff to grow over %d calls; delays: %v", calls, delays)
+}
+
 // --- mock helpers ---
 
 // errorOnNextIter returns an error immediately on Next().

--- a/internal/durable/processing_gate.go
+++ b/internal/durable/processing_gate.go
@@ -71,7 +71,8 @@ func (c *ProcessingGateConfig) applyDefaults() error {
 	return nil
 }
 
-// processingGate wraps a messageHandler and enforces exclusive processing based on ownership.
+// processingGate wraps a messageHandler and gates each invocation on ownership
+// (per-message admission control; an invocation that has started is not revoked).
 // Reads are O(1), relying on a resolver backed by a high-performance cache.
 type processingGate struct {
 	workerID   string

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -29,9 +29,22 @@ import (
 //   - All other public methods are safe for concurrent use
 //
 // Blocking Behavior:
-//   - UpdateWorkerConsumer may block up to DrainOnRemoveTimeout (default 10s) when
-//     removing subjects with DrainOnRemove enabled
+//   - UpdateWorkerConsumer may block up to ~2× DrainOnRemoveTimeout (default 10s)
+//     when removing subjects with DrainOnRemove enabled: one budget for draining
+//     buffered messages, then a separate equal wait for the pull loops to stop.
+//     If the loops have not stopped within the second bound, UpdateWorkerConsumer
+//     returns an error; map entries are still cleared so the caller (the manager)
+//     can retry and converge. An in-flight handler invocation may still run to
+//     completion — this is best-effort, not a zero-overlap guarantee.
 //   - Close may block up to the context deadline waiting for active pull loops to stop
+//
+// Lifecycle (Close semantics):
+//   - Close is terminal: after Close returns, UpdateWorkerConsumer returns
+//     [types.ErrConsumerStopped]. The gate resolver is permanently torn down
+//     by Close (it is not re-initialized on a subsequent call), so a post-Close
+//     update would resurrect loops without the configured processing gate — a
+//     silent safety downgrade. Create a new WorkerConsumer to consume again.
+//   - Close is idempotent; repeated calls return nil.
 type WorkerConsumer struct {
 	conn    *nats.Conn
 	js      jetstream.JetStream
@@ -46,6 +59,8 @@ type WorkerConsumer struct {
 
 	mu       sync.RWMutex
 	updateMu sync.Mutex // Serializes UpdateWorkerConsumer calls
+
+	closed bool // set by Close; terminal — UpdateWorkerConsumer returns ErrConsumerStopped after this
 
 	workerID string
 
@@ -132,6 +147,10 @@ func (wc *WorkerConsumer) UpdateWorkerConsumer(ctx context.Context, workerID str
 	wc.updateMu.Lock()
 	defer wc.updateMu.Unlock()
 
+	if wc.closed {
+		return fmt.Errorf("worker consumer: %w", types.ErrConsumerStopped)
+	}
+
 	if err := wc.validateUpdateParams(workerID); err != nil {
 		return err
 	}
@@ -139,6 +158,22 @@ func (wc *WorkerConsumer) UpdateWorkerConsumer(ctx context.Context, workerID str
 	subjects, err := wc.buildSubjects(partitions)
 	if err != nil {
 		return err
+	}
+
+	// Enforce the subject cap BEFORE any mutation (workerID store, removals,
+	// adds). Failing the whole update keeps the manager's apply pipeline
+	// honest: the apply fails pre-commit and retries with backoff, the
+	// two-phase removal guard keeps the previous owner consuming, and the
+	// un-acked heartbeat makes the over-capped worker visible to the leader.
+	// A partial apply (skipping excess subjects) must never report success —
+	// ownership of a skipped partition would commit with no loop started.
+	if maxSubjects := wc.config.MaxConcurrentSubjects; maxSubjects > 0 && len(subjects) > maxSubjects {
+		if wc.config.Metrics != nil {
+			wc.config.Metrics.IncrementWorkerConsumerSubjectThresholdWarning()
+			wc.config.Metrics.IncrementWorkerConsumerGuardrailViolation("max_subjects")
+		}
+		return fmt.Errorf("stream %s: %d subjects over cap %d: %w",
+			wc.config.StreamName, len(subjects), maxSubjects, ErrMaxSubjectsExceeded)
 	}
 
 	// Set workerID and snapshot existing subjects under lock
@@ -174,10 +209,19 @@ func (wc *WorkerConsumer) UpdateWorkerConsumer(ctx context.Context, workerID str
 }
 
 // Close cancels all subject loops. Consumers are left intact for server GC.
+//
+// Close is terminal. After Close returns, any subsequent call to [UpdateWorkerConsumer]
+// returns [types.ErrConsumerStopped]. Create a new [WorkerConsumer] to consume again.
+//
+// Close is idempotent; calling it multiple times is safe.
 func (wc *WorkerConsumer) Close(ctx context.Context) error {
 	// Serialize updates to prevent race conditions during shutdown
 	wc.updateMu.Lock()
 	defer wc.updateMu.Unlock()
+
+	// Mark closed before stopping loops so concurrent callers observe the
+	// terminal flag immediately. Idempotent: repeated Close returns nil.
+	wc.closed = true
 
 	wc.stopGateResolver()
 
@@ -336,11 +380,18 @@ func (wc *WorkerConsumer) removeSubjectLoops(ctx context.Context, toRemove []str
 		// caller's context canceled; stop waiting
 		err = ctx.Err()
 	case <-time.After(waitTimeout):
-		// give up waiting on this loop but continue cleanup for others
+		// Surface the timeout so the caller's apply fails pre-commit and is
+		// retried with backoff. This delays the handoff commit by at least
+		// one retry cycle and makes the stall observable; it does NOT
+		// guarantee the old handler has finished — Stop only cancels the
+		// loop context, and an in-flight handler invocation runs to
+		// completion. Entries are still deleted below: a retained-but-
+		// stopped entry would make a later re-add a silent no-op.
 		wc.logger.Warn("timeout waiting for subject loops to stop",
 			"count", len(loops),
 			"timeout", waitTimeout,
 		)
+		err = fmt.Errorf("timed out after %v waiting for %d subject loops to stop", waitTimeout, len(loops))
 	}
 
 	// Delete keys under lock regardless of wait outcome to prevent zombie entries
@@ -354,24 +405,6 @@ func (wc *WorkerConsumer) removeSubjectLoops(ctx context.Context, toRemove []str
 }
 
 func (wc *WorkerConsumer) addSubjectLoop(ctx context.Context, workerID string, subject string) error {
-	if wc.config.MaxConcurrentSubjects > 0 {
-		wc.mu.RLock()
-		current := len(wc.subjects)
-		wc.mu.RUnlock()
-
-		if current >= wc.config.MaxConcurrentSubjects {
-			wc.logger.Warn("per-subject consumer cap reached; skipping subject",
-				"subject", subject,
-				"cap", wc.config.MaxConcurrentSubjects,
-			)
-			if wc.config.Metrics != nil {
-				wc.config.Metrics.IncrementWorkerConsumerSubjectThresholdWarning()
-			}
-
-			return nil
-		}
-	}
-
 	durable := wc.perSubjectDurableName(wc.config.ConsumerPrefix, subject)
 	cons, err := wc.ensurePerSubjectConsumer(ctx, durable, subject)
 	if err != nil {
@@ -624,6 +657,16 @@ func (wc *WorkerConsumer) Capabilities() uint32 {
 		bits |= types.CapProcessingGate
 	}
 	return bits
+}
+
+// Closed reports whether this consumer has been closed.
+//
+// Used by the public Dynamic wrapper to give ErrConsumerStopped precedence
+// over the WorkQueue compatibility preflight.
+func (wc *WorkerConsumer) Closed() bool {
+	wc.updateMu.Lock()
+	defer wc.updateMu.Unlock()
+	return wc.closed
 }
 
 // extractPartitionID returns the partition id parsed from subject using the configured

--- a/internal/durable/worker_consumer_test.go
+++ b/internal/durable/worker_consumer_test.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
+	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
@@ -103,4 +105,147 @@ func TestWorkerConsumer_WorkerIDMutationGuard_EarlyReturn(t *testing.T) {
 	wc.handler = h
 	err = wc.UpdateWorkerConsumer(context.Background(), "w2", nil)
 	require.ErrorIs(t, err, ErrWorkerIDMutation)
+}
+
+// TestUpdateWorkerConsumer_OverCap_ErrorsBeforeMutation pins the
+// MaxConcurrentSubjects contract: a deduped subject set larger than the cap
+// must return ErrMaxSubjectsExceeded BEFORE any mutation — no workerID
+// store, no removals, no new loops. The pre-fix behavior (silently skipping
+// excess subjects inside the add loop and returning nil) let the two-phase
+// handoff commit ownership of a partition no loop was started for,
+// stranding it unowned while the worker reported the assignment applied.
+func TestUpdateWorkerConsumer_OverCap_ErrorsBeforeMutation(t *testing.T) {
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate:       "orders.{{.PartitionID}}.events",
+			MaxConcurrentSubjects: 2,
+		},
+		handler: messageHandlerFunc(func(context.Context, jetstream.Msg) error { return nil }),
+		subjects: map[string]*partitionConsumer{
+			// Pre-existing subject NOT in the new set: over-cap must not remove it.
+			"orders.p9.events": nil,
+		},
+	}
+
+	// types.Partition is keyed by Keys; PartitionID in the subject template
+	// is the dot-joined HashID, so a single key "p0" yields "orders.p0.events".
+	parts := []types.Partition{
+		{Keys: []string{"p0"}}, {Keys: []string{"p1"}}, {Keys: []string{"p2"}},
+	}
+	err := wc.UpdateWorkerConsumer(context.Background(), "worker-1", parts)
+
+	require.ErrorIs(t, err, ErrMaxSubjectsExceeded,
+		"3 deduped subjects over cap 2 must surface the documented sentinel")
+	require.Contains(t, wc.subjects, "orders.p9.events",
+		"over-cap update must not perform removals — error must precede all mutation")
+	require.Len(t, wc.subjects, 1,
+		"over-cap update must not start any new subject loops")
+	wc.mu.RLock()
+	gotWorkerID := wc.workerID
+	wc.mu.RUnlock()
+	require.Empty(t, gotWorkerID,
+		"over-cap update must not store the workerID — the check runs before setWorkerIDAndSnapshot")
+}
+
+// TestUpdateWorkerConsumer_AtCap_Succeeds pins the positive direction of the
+// boundary: a deduped subject count EQUAL to the cap passes the check. The
+// target subjects are pre-populated so the update is a no-op diff and no
+// JetStream client is needed.
+func TestUpdateWorkerConsumer_AtCap_Succeeds(t *testing.T) {
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate:       "orders.{{.PartitionID}}.events",
+			MaxConcurrentSubjects: 2,
+		},
+		handler: messageHandlerFunc(func(context.Context, jetstream.Msg) error { return nil }),
+		subjects: map[string]*partitionConsumer{
+			"orders.p0.events": nil,
+			"orders.p1.events": nil,
+		},
+	}
+
+	parts := []types.Partition{{Keys: []string{"p0"}}, {Keys: []string{"p1"}}}
+	err := wc.UpdateWorkerConsumer(context.Background(), "worker-1", parts)
+
+	require.NoError(t, err, "subject count == cap must pass; the boundary is len(subjects) > cap")
+	require.Len(t, wc.subjects, 2)
+}
+
+// TestUpdateWorkerConsumer_AfterClose_ReturnsErrConsumerStopped pins the
+// terminal-Close contract for the per-subject worker consumer. Pre-fix, a
+// post-Close UpdateWorkerConsumer recomputed every subject as an add and
+// restarted pull loops — and because Close nils the gate resolver (which is
+// only initialized in the constructor), the resurrected loops consumed
+// WITHOUT the configured processing gate: a silent safety downgrade, not
+// just a zombie restart.
+func TestUpdateWorkerConsumer_AfterClose_ReturnsErrConsumerStopped(t *testing.T) {
+	ctx := context.Background()
+
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate: "orders.{{.PartitionID}}.events",
+		},
+		handler:  messageHandlerFunc(func(context.Context, jetstream.Msg) error { return nil }),
+		subjects: make(map[string]*partitionConsumer),
+	}
+
+	// Close on a never-started consumer must be nil (idempotency baseline).
+	require.NoError(t, wc.Close(ctx), "first Close must be nil")
+
+	// Post-Close UpdateWorkerConsumer must return ErrConsumerStopped — not nil
+	// and not panic. Pre-fix the nil-js add path either panicked (js.CreateOrUpdateConsumer
+	// on nil) or returned nil after restarting loops without a gate resolver.
+	parts := []types.Partition{{Keys: []string{"p0"}}}
+	err := wc.UpdateWorkerConsumer(ctx, "worker-1", parts)
+	require.ErrorIs(t, err, types.ErrConsumerStopped,
+		"UpdateWorkerConsumer after Close must return ErrConsumerStopped, got: %v", err)
+
+	// subjects map must remain empty — no loops were (re)started.
+	require.Empty(t, wc.subjects, "no subject loops must be created after Close")
+
+	// Second Close must still be idempotent (nil).
+	require.NoError(t, wc.Close(ctx), "second Close must be idempotent")
+}
+
+// TestUpdateWorkerConsumer_RemoveTimeout_SurfacesError pins the
+// remove-timeout contract: when subject loops fail to stop within
+// DrainOnRemoveTimeout, UpdateWorkerConsumer must return an error (so the
+// manager's apply fails pre-commit and retries) instead of reporting silent
+// success while a loop may still be processing. Map entries are still
+// deleted — a retained-but-stopped entry would make a later re-add of the
+// same subject a silent no-op (the dead-subject hazard) — so the follow-up
+// update converges.
+//
+// The never-stopping loop is simulated by a partitionConsumer whose done
+// channel never closes: Stop() tolerates a never-started consumer (cancel
+// is nil-checked) and Wait() blocks forever.
+func TestUpdateWorkerConsumer_RemoveTimeout_SurfacesError(t *testing.T) {
+	stuck := &partitionConsumer{done: make(chan struct{})}
+	wc := &WorkerConsumer{
+		logger: logging.NewNop(),
+		config: WorkerConsumerConfig{
+			SubjectTemplate:      "orders.{{.PartitionID}}.events",
+			DrainOnRemoveTimeout: 50 * time.Millisecond,
+		},
+		handler: messageHandlerFunc(func(context.Context, jetstream.Msg) error { return nil }),
+		subjects: map[string]*partitionConsumer{
+			"orders.p0.events": stuck,
+		},
+	}
+
+	// Empty set removes everything; the stuck loop forces the wait to time out.
+	err := wc.UpdateWorkerConsumer(context.Background(), "worker-1", nil)
+	require.Error(t, err,
+		"a remove that times out waiting for loops to stop must fail the update, not report success")
+	require.NotErrorIs(t, err, context.DeadlineExceeded,
+		"the timeout is the internal wait bound, not the caller context")
+	require.Empty(t, wc.subjects,
+		"entries must still be deleted on timeout so the retry converges and re-adds are not silent no-ops")
+
+	// Convergence: the retry (same target set) finds nothing to remove.
+	err = wc.UpdateWorkerConsumer(context.Background(), "worker-1", nil)
+	require.NoError(t, err, "the follow-up update must converge once entries are gone")
 }

--- a/internal/ipartition/consumer.go
+++ b/internal/ipartition/consumer.go
@@ -3,12 +3,14 @@ package ipartition
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/partutil"
 	"github.com/arloliu/parti/v2/internal/recovery"
 	"github.com/arloliu/parti/v2/jsutil"
+	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -52,9 +54,10 @@ type JSConsumer struct {
 	// Recovery controller (nil when recovery is disabled)
 	rc *recovery.Controller
 
-	mu     sync.Mutex
-	cancel context.CancelFunc
-	done   chan struct{}
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	stopped bool // set by Stop; terminal — Start returns ErrConsumerStopped after this
 }
 
 // NewJSConsumer creates a JetStream consumer for a specific partition.
@@ -152,14 +155,20 @@ func NewJSConsumer(
 
 // Start begins consuming messages in a background goroutine.
 //
+// Start may only be called once. After [Stop] is called, Start returns
+// [types.ErrConsumerStopped]; create a new instance to consume again.
+//
 // Parameters:
 //   - ctx: Context for lifecycle control
 //
 // Returns:
-//   - error: Startup error
+//   - error: Startup error, or [types.ErrConsumerStopped] if already stopped.
 func (c *JSConsumer) Start(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.stopped {
+		return fmt.Errorf("js consumer: %w", types.ErrConsumerStopped)
+	}
 	if c.cancel != nil {
 		return errors.New("consumer already started")
 	}
@@ -183,6 +192,15 @@ func (c *JSConsumer) Start(ctx context.Context) error {
 
 // Stop gracefully stops the consumer and drains pending messages.
 //
+// Stop is terminal. After Stop returns, any subsequent call to [Start] returns
+// [types.ErrConsumerStopped]. Create a new instance to consume again.
+//
+// If the consumer is stopped while registered with a running manager, the manager
+// will retry the failed update indefinitely (by design). Stop the manager first, or
+// deregister this consumer before calling Stop.
+//
+// Stop is idempotent; calling it multiple times is safe.
+//
 // Parameters:
 //   - ctx: Context with shutdown deadline
 //
@@ -194,6 +212,7 @@ func (c *JSConsumer) Stop(ctx context.Context) error {
 	done := c.done
 	dispatcher := c.keyDispatcher
 	c.cancel = nil
+	c.stopped = true
 	c.mu.Unlock()
 
 	if cancel == nil {
@@ -215,6 +234,16 @@ func (c *JSConsumer) Stop(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Stopped reports whether this consumer has been stopped.
+//
+// Used by the public Static wrapper to give ErrConsumerStopped precedence
+// over the WorkQueue compatibility preflight.
+func (c *JSConsumer) Stopped() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.stopped
 }
 
 // Partition returns the partition index this consumer handles.
@@ -295,6 +324,18 @@ func (c *JSConsumer) run(ctx context.Context) {
 		c.consumerMu.RLock()
 		consumerConfig := c.consumerConfig
 		c.consumerMu.RUnlock()
+
+		if c.rc == nil {
+			// RecoveryDisabled (the default): the recovery controller is nil and
+			// classification short-circuits before any metric. A deleted durable
+			// causes a permanent stall with no operator signal at production log
+			// levels without this explicit path.
+			c.config.Logger.Warn("iterator error with recovery disabled; consumer will retry but cannot recreate a deleted durable",
+				"error", iterErr,
+				"subject", c.subject,
+			)
+			c.config.Metrics.IncrementWorkerConsumerIteratorRestart("recovery_disabled")
+		}
 
 		action, newCons, classifyErr := c.rc.Classify(ctx, iterErr, c.consumerInfoFn(), consumerConfig, c.recreateFn())
 		switch action {

--- a/internal/ipartition/consumer_test.go
+++ b/internal/ipartition/consumer_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/logging"
+	imetrics "github.com/arloliu/parti/v2/internal/metrics"
 	partitesting "github.com/arloliu/parti/v2/partitest"
 	"github.com/arloliu/parti/v2/partition"
+	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
@@ -297,4 +300,157 @@ func TestJSConsumer_RecoverySnapshot_CarriesConsumerOptions(t *testing.T) {
 
 	require.False(t, jcDefault.consumerConfig.MemoryStorage)
 	require.Equal(t, 0, jcDefault.consumerConfig.Replicas)
+}
+
+// --- stub types for nil-recovery unit test ---
+
+// consumerWithErrorIter is a jetstream.Consumer stub whose Messages() returns
+// an iterator that immediately returns a non-graceful error from Next().
+type consumerWithErrorIter struct {
+	jetstream.Consumer
+	iterErr error
+}
+
+func (c *consumerWithErrorIter) Messages(opts ...jetstream.PullMessagesOpt) (jetstream.MessagesContext, error) {
+	return &errorOnNextMsgsCtx{err: c.iterErr}, nil
+}
+
+func (c *consumerWithErrorIter) Info(_ context.Context) (*jetstream.ConsumerInfo, error) {
+	return nil, context.Canceled
+}
+
+type errorOnNextMsgsCtx struct {
+	err error
+}
+
+func (e *errorOnNextMsgsCtx) Next(opts ...jetstream.NextOpt) (jetstream.Msg, error) {
+	return nil, e.err
+}
+
+func (e *errorOnNextMsgsCtx) Stop()  {}
+func (e *errorOnNextMsgsCtx) Drain() {}
+
+// jsConsumerSignalMetrics records IncrementWorkerConsumerIteratorRestart calls.
+type jsConsumerSignalMetrics struct {
+	*imetrics.NopMetrics
+	restartReasons []string
+}
+
+func (m *jsConsumerSignalMetrics) IncrementWorkerConsumerIteratorRestart(reason string) {
+	m.restartReasons = append(m.restartReasons, reason)
+}
+
+// TestJSConsumer_StartAfterStop_ReturnsErrConsumerStopped pins the terminal-Stop
+// contract for JSConsumer: Stop resets cancel=nil, so pre-fix a second Start passed
+// the started guard (cancel==nil ≡ not-started) and returned nil — contradicting the
+// godoc "Start may only be called once". With DispatchByKey the keyDispatcher was
+// terminally closed (sync.Once) in Stop, so the restarted loop silently fetched
+// messages it could never process.
+func TestJSConsumer_StartAfterStop_ReturnsErrConsumerStopped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx := t.Context()
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "stopped",
+		Subjects: []string{"stopped.*"},
+	})
+	require.NoError(t, err)
+
+	consumer, err := NewJSConsumer(js, ConsumerConfig{
+		PartitionConfig: partition.PartitionConfig{
+			NumPartitions:  2,
+			SubjectPattern: "stopped.{{partition}}",
+		},
+		StreamName:   "stopped",
+		ConsumerName: "stopped-consumer-0",
+		Partition:    0,
+		FetchTimeout: time.Second,
+	}, messageHandlerFunc(func(context.Context, jetstream.Msg) error { return nil }))
+	require.NoError(t, err)
+
+	// Start successfully
+	require.NoError(t, consumer.Start(ctx))
+
+	// Stop the consumer (terminal)
+	stopCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	require.NoError(t, consumer.Stop(stopCtx))
+
+	// A second Stop must remain idempotent
+	require.NoError(t, consumer.Stop(stopCtx), "second Stop must be idempotent")
+
+	// Start after Stop must return ErrConsumerStopped, not nil
+	// Pre-fix: Stop reset cancel=nil, so Start saw cancel==nil (≡ not-started)
+	// and proceeded, returning nil while possibly operating a broken keyDispatcher.
+	err = consumer.Start(ctx)
+	require.ErrorIs(t, err, types.ErrConsumerStopped,
+		"Start after Stop must return ErrConsumerStopped, got: %v", err)
+
+	// Pin the never-started variant: New→Stop→Start must also return
+	// ErrConsumerStopped even if Start was never called first. The stopped
+	// flag is set by Stop regardless of whether the consumer was running.
+	t.Run("never-started", func(t *testing.T) {
+		c2, err2 := NewJSConsumer(js, ConsumerConfig{
+			PartitionConfig: partition.PartitionConfig{
+				NumPartitions:  2,
+				SubjectPattern: "stopped.{{partition}}",
+			},
+			StreamName:   "stopped",
+			ConsumerName: "never-started-consumer-0",
+			Partition:    0,
+			FetchTimeout: time.Second,
+		}, messageHandlerFunc(func(context.Context, jetstream.Msg) error { return nil }))
+		require.NoError(t, err2)
+
+		stopCtx, stopCancel := context.WithTimeout(ctx, 2*time.Second)
+		defer stopCancel()
+		require.NoError(t, c2.Stop(stopCtx), "Stop on never-started must be nil")
+
+		err2 = c2.Start(ctx)
+		require.ErrorIs(t, err2, types.ErrConsumerStopped,
+			"Start after Stop on never-started must return ErrConsumerStopped")
+	})
+}
+
+// TestJSConsumer_RecoveryDisabled_IteratorErrorIsSignaled pins the operator signal
+// for the default configuration: with RecoveryDisabled (nil controller), a non-graceful
+// iterator error (e.g. the durable was deleted) must emit the iterator-restart metric
+// with reason "recovery_disabled". Pre-fix the only artifact was a Debug log — at
+// production log levels a deleted durable was a zero-signal permanent stall.
+func TestJSConsumer_RecoveryDisabled_IteratorErrorIsSignaled(t *testing.T) {
+	m := &jsConsumerSignalMetrics{NopMetrics: imetrics.NewNop()}
+
+	c := &JSConsumer{
+		config: ConsumerConfig{
+			Logger:       logging.NewNop(),
+			Metrics:      m,
+			FetchTimeout: time.Second,
+			BatchSize:    1,
+		},
+		handler:   messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil }),
+		partition: 0,
+		subject:   "test.0",
+		done:      make(chan struct{}),
+		rc:        nil, // RecoveryDisabled: NewController returns nil for Disabled strategy
+		consumer:  &consumerWithErrorIter{iterErr: jetstream.ErrNoHeartbeat},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.run(ctx)
+
+	// iteratorRetryDelay is 200ms; wait for at least one cycle.
+	time.Sleep(250 * time.Millisecond)
+	cancel()
+	<-c.done
+
+	require.NotEmpty(t, m.restartReasons,
+		"expected IncrementWorkerConsumerIteratorRestart to be called on the nil-recovery path")
+	require.Contains(t, m.restartReasons, "recovery_disabled",
+		"expected reason=recovery_disabled on the nil-recovery path")
 }

--- a/internal/ipartition/key_dispatcher.go
+++ b/internal/ipartition/key_dispatcher.go
@@ -126,25 +126,40 @@ func (kd *keyDispatcher) Dispatch(ctx context.Context, msg jetstream.Msg) bool {
 	key := kd.keyExtractor(msg)
 
 	for {
-		// Fast path: check if worker exists
+		// Fast path: look up the worker AND attempt a non-blocking send in the
+		// SAME critical section. Holding the read lock across the send commit
+		// serializes it against the worker's idle-exit decision (which takes
+		// the write lock to re-check len(msgCh) and remove itself). A send can
+		// therefore never commit into a channel the worker is about to abandon.
 		kd.mu.RLock()
 		worker, exists := kd.workers[key]
+		if exists {
+			select {
+			case worker.msgCh <- keyMessage{ctx: ctx, msg: msg}:
+				kd.mu.RUnlock()
+				return true
+			default:
+				// Buffer full — fall through to the backpressure wait below.
+			}
+		}
 		kd.mu.RUnlock()
 
 		if !exists {
-			worker = kd.getOrCreateWorker(key)
-			if worker == nil {
+			if kd.getOrCreateWorker(key) == nil {
 				// Dispatcher is closed
 				return false
 			}
+			// Retry the locked fast path against the fresh worker.
+			continue
 		}
 
-		// Send message to worker (blocks if channel is full - backpressure)
+		// Backpressure: buffer full. Wait for drain progress, worker close, or
+		// dispatcher shutdown, then RETRY THE LOCKED FAST PATH — never commit a
+		// send outside the lock (an unlocked blocking send is the exact race
+		// this fix removes).
 		select {
-		case worker.msgCh <- keyMessage{ctx: ctx, msg: msg}:
-			return true
 		case <-worker.closeCh:
-			// Worker is closing, wait for cleanup and retry
+			// Worker is closing, wait for cleanup and retry.
 			select {
 			case <-worker.done:
 			case <-kd.ctx.Done():
@@ -152,6 +167,7 @@ func (kd *keyDispatcher) Dispatch(ctx context.Context, msg jetstream.Msg) bool {
 			}
 		case <-kd.ctx.Done():
 			return false
+		case <-time.After(time.Millisecond):
 		}
 	}
 }
@@ -193,7 +209,7 @@ func (kd *keyDispatcher) getOrCreateWorker(key string) *keyWorker {
 // runWorker is the main loop for a key worker goroutine.
 func (kd *keyDispatcher) runWorker(worker *keyWorker) {
 	defer func() {
-		kd.removeWorker(worker.key)
+		kd.removeWorker(worker)
 		close(worker.done)
 		kd.wg.Done()
 		kd.logger.Debug("key worker stopped", "key", worker.key)
@@ -223,11 +239,20 @@ func (kd *keyDispatcher) runWorker(worker *keyWorker) {
 			kd.processMessage(km.ctx, km.msg)
 
 		case <-timer.C:
-			// Idle timeout - check if channel is empty before exiting
+			// Idle timeout - decide whether to exit under the write lock so the
+			// decision is mutually exclusive with Dispatch's send (which holds
+			// the read lock across its non-blocking send).
+			kd.mu.Lock()
 			if len(worker.msgCh) == 0 {
+				// No send can commit concurrently (sends hold the read lock) and
+				// no future sender can find this worker (removed under the same
+				// lock) — the stranded-message window is closed.
+				delete(kd.workers, worker.key)
+				kd.mu.Unlock()
 				close(worker.closeCh)
 				return
 			}
+			kd.mu.Unlock()
 			// Channel has messages, reset timer and continue
 			timer.Reset(kd.idleTimeout)
 
@@ -273,11 +298,20 @@ func (kd *keyDispatcher) drainWorker(worker *keyWorker) {
 	}
 }
 
-// removeWorker removes a worker from the map.
-func (kd *keyDispatcher) removeWorker(key string) {
+// removeWorker removes a worker from the map, but ONLY if the map still holds
+// this exact worker pointer.
+//
+// The idle-exit path already removes the worker from the map under the write
+// lock before this deferred cleanup runs. If a successor worker for the same
+// key was created in the meantime (Dispatch → getOrCreateWorker), an
+// unconditional delete(key) here would clobber that live successor. The
+// pointer check makes the delete a no-op in that case.
+func (kd *keyDispatcher) removeWorker(worker *keyWorker) {
 	kd.mu.Lock()
 	defer kd.mu.Unlock()
-	delete(kd.workers, key)
+	if cur, ok := kd.workers[worker.key]; ok && cur == worker {
+		delete(kd.workers, worker.key)
+	}
 }
 
 // Close gracefully shuts down the dispatcher.

--- a/internal/ipartition/key_dispatcher_test.go
+++ b/internal/ipartition/key_dispatcher_test.go
@@ -2,6 +2,7 @@ package ipartition
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,12 +20,13 @@ import (
 // mockMsg implements jetstream.Msg for testing.
 type mockMsg struct {
 	subject string
+	data    []byte
 	acked   atomic.Bool
 	naked   atomic.Bool
 }
 
 func (m *mockMsg) Subject() string                           { return m.subject }
-func (m *mockMsg) Data() []byte                              { return nil }
+func (m *mockMsg) Data() []byte                              { return m.data }
 func (m *mockMsg) Headers() nats.Header                      { return nil }
 func (m *mockMsg) Reply() string                             { return "" }
 func (m *mockMsg) Metadata() (*jetstream.MsgMetadata, error) { return nil, nil } //nolint:nilnil // mock
@@ -378,4 +380,68 @@ func indexByte(s string, b byte) int {
 		}
 	}
 	return -1
+}
+
+// TestKeyDispatcher_IdleExitDoesNotStrandMessages hammers the idle-exit
+// window: a razor-thin idle timeout with paced single-key dispatches makes
+// the worker's exit decision race Dispatch's send. Every message Dispatch
+// accepted (returned true) must be processed exactly once and in dispatch
+// order — pre-fix, a send committing between the worker's len-check and its
+// close left the message stranded in a dead worker's channel (unprocessed
+// here; redelivered only after AckWait in production, breaking per-key
+// ordering).
+func TestKeyDispatcher_IdleExitDoesNotStrandMessages(t *testing.T) {
+	logger := logging.NewNop()
+
+	var mu sync.Mutex
+	var seqOrder []int
+
+	handler := messageHandlerFunc(func(ctx context.Context, msg jetstream.Msg) error {
+		seq, err := strconv.Atoi(string(msg.Data()))
+		if err != nil {
+			t.Errorf("bad seq payload %q: %v", msg.Data(), err)
+
+			return nil
+		}
+		mu.Lock()
+		seqOrder = append(seqOrder, seq)
+		mu.Unlock()
+
+		return nil
+	})
+
+	// 1ms idle timeout + buffer >= 4 so the worker idles between dispatches.
+	kd := newKeyDispatcher(logger, handler, testKeyExtractor, 8, 1*time.Millisecond, false, nil, nil)
+	defer func() {
+		_ = kd.Close(t.Context())
+	}()
+
+	ctx := t.Context()
+
+	const n = 2000
+	for i := range n {
+		msg := &mockMsg{subject: "events.0.same-key", data: []byte(strconv.Itoa(i))}
+		ok := kd.Dispatch(ctx, msg)
+		require.True(t, ok, "dispatch %d should be accepted", i)
+
+		// Jitter the pacing around the 1ms idle boundary so dispatches straddle
+		// the worker's idle-exit decision: alternate 0/1/2ms.
+		time.Sleep(time.Duration(i%3) * time.Millisecond)
+	}
+
+	// Settle: every accepted message must drain before we assert.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(seqOrder) == n
+	}, 5*time.Second, 2*time.Millisecond, "all dispatched messages should be processed")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, seqOrder, n, "no message should be stranded")
+	for i := range n {
+		require.Equalf(t, i, seqOrder[i],
+			"sequence inversion/gap at index %d: got %d", i, seqOrder[i])
+	}
 }

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -133,7 +133,7 @@ func (p *PrometheusCollector) ensureRegistered() {
 			Namespace: p.namespace,
 			Subsystem: "worker_consumer",
 			Name:      "subject_threshold_warnings_total",
-			Help:      "Warnings emitted when subjects near the MaxSubjects threshold.",
+			Help:      "Updates rejected because the deduped subject count exceeded MaxConcurrentSubjects (fires once per rejected update, including retries).",
 		})
 
 		p.wcUpdateResults = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -458,7 +458,7 @@ func (p *PrometheusCollector) IncrementWorkerConsumerGuardrailViolation(kind str
 	p.wcGuardrailViolations.WithLabelValues(kind).Inc()
 }
 
-// IncrementWorkerConsumerSubjectThresholdWarning increments threshold warnings.
+// IncrementWorkerConsumerSubjectThresholdWarning increments rejected-update counts for over-cap subject assignments.
 func (p *PrometheusCollector) IncrementWorkerConsumerSubjectThresholdWarning() {
 	p.ensureRegistered()
 	p.wcSubjectThresholdWarnings.Inc()

--- a/internal/recovery/classify_streammissing_test.go
+++ b/internal/recovery/classify_streammissing_test.go
@@ -1,0 +1,58 @@
+package recovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// streamGoneInfo simulates consumer.Info() against a DELETED STREAM: nats.go
+// surfaces jetstream.ErrStreamNotFound (server error 10059), not
+// ErrConsumerNotFound. This is the case the T4 integration test's
+// MaxAttempts=1 workaround documents (test/integration/failure/
+// stream_missing_no_hook_test.go): the whole stream is gone, so the
+// consumer-scoped probe answers with the stream-scoped error.
+func streamGoneInfo(_ context.Context) (*jetstream.ConsumerInfo, error) {
+	return nil, jetstream.ErrStreamNotFound
+}
+
+// TestClassify_NoHeartbeat_StreamDeleted_RoutesStreamMissing pins the
+// stream-deleted half of the ErrNoHeartbeat confirmation: when the burst
+// threshold is reached and the Info() probe surfaces stream-not-found, the
+// condition is PERMANENT (the stream is gone), so Classify must route it to
+// ActionStreamMissing — the bounded detour that ends in the operator hook or
+// OnPermanentFailure exhaustion.
+//
+// Pre-fix, confirmConsumerGone answered only IsConsumerNotFound, so
+// stream-not-found returned false and the branch fell through to
+// ActionBackoff: a permanent condition classified as transient-forever. The
+// outer consumption loop's backoff path is unbounded by design, so with
+// recovery enabled a deleted stream could leave the partition consumer
+// ping-ponging between ErrNoHeartbeat and backoff indefinitely — stream-
+// missing exhaustion never fires, the manager observer never sees it, and
+// the worker reports Stable with a stalled consumer (the silent-stall class
+// the terminal Degraded hold exists to prevent, defeated one layer up).
+func TestClassify_NoHeartbeat_StreamDeleted_RoutesStreamMissing(t *testing.T) {
+	c := NewController(ControllerConfig{
+		Strategy:       FromLastProcessed,
+		BurstThreshold: 2,
+		BurstWindow:    10 * time.Second,
+		Logger:         nopLog,
+	})
+
+	// 1st: below threshold — backoff without probing.
+	action, _, _ := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, streamGoneInfo, baseCfg, alwaysSucceedRecreate)
+	require.Equal(t, ActionBackoff, action)
+
+	// 2nd: threshold reached; the Info() probe surfaces stream-not-found.
+	action, newCons, classifyErr := c.Classify(context.Background(), jetstream.ErrNoHeartbeat, streamGoneInfo, baseCfg, alwaysSucceedRecreate)
+	require.Equal(t, ActionStreamMissing, action,
+		"a stream-not-found Info probe after a heartbeat burst is a permanent condition and must route to the bounded stream-missing detour, not unbounded backoff")
+	require.Nil(t, newCons)
+	require.ErrorIs(t, classifyErr, types.ErrStreamMissing,
+		"the companion error must wrap types.ErrStreamMissing so the detour and OnPermanentFailure chain can route on the sentinel")
+}

--- a/internal/recovery/controller.go
+++ b/internal/recovery/controller.go
@@ -186,7 +186,26 @@ func (c *Controller) Classify(
 			return ActionBackoff, nil, nil // not enough failures yet
 		}
 		// Burst threshold reached — confirm via consumer.Info().
-		if !c.confirmConsumerGone(ctx, infoFn) {
+		gone, infoErr := c.probeConsumerGone(ctx, infoFn)
+		if !gone {
+			if natsutil.IsStreamNotFound(infoErr) {
+				// The consumer-scoped probe answered with the stream-scoped
+				// error: the WHOLE stream is gone, which is a permanent
+				// condition. Route it to the bounded stream-missing detour
+				// (operator hook, then OnPermanentFailure exhaustion) —
+				// falling through to backoff would classify it as
+				// transient-forever and the consumption loop would ping-pong
+				// between heartbeat failures and backoff indefinitely, with
+				// no exhaustion signal ever reaching the manager observer.
+				// Same wrap shape as recover()'s stream-missing escalation.
+				c.logger.Warn("heartbeat-burst Info probe surfaced stream missing",
+					"op", "consumer_recovery",
+					"error", infoErr,
+				)
+
+				return ActionStreamMissing, nil, fmt.Errorf("%w: %w", types.ErrStreamMissing, infoErr)
+			}
+
 			return ActionBackoff, nil, nil // consumer still exists, transient issue
 		}
 		newCons, recErr := c.recover(ctx, "consumer_not_found_after_burst", baseCfg, recreate)
@@ -540,17 +559,20 @@ func (c *Controller) recover(
 	return newCons, nil
 }
 
-// confirmConsumerGone calls consumer.Info() and returns true if the consumer is confirmed gone.
-func (c *Controller) confirmConsumerGone(ctx context.Context, infoFn InfoFunc) bool {
+// probeConsumerGone calls consumer.Info() and reports whether the consumer is
+// confirmed gone (consumer-not-found), along with the raw probe error so the
+// caller can distinguish the stream-scoped answer (stream-not-found — the
+// whole stream is gone, a permanent condition) from a transient probe failure.
+func (c *Controller) probeConsumerGone(ctx context.Context, infoFn InfoFunc) (bool, error) {
 	if infoFn == nil {
-		return false
+		return false, nil
 	}
 
 	c.consInfoMu.Lock()
 	_, err := infoFn(ctx)
 	c.consInfoMu.Unlock()
 
-	return natsutil.IsConsumerNotFound(err)
+	return natsutil.IsConsumerNotFound(err), err
 }
 
 // callInfo calls consumer.Info() with serialization.

--- a/manager.go
+++ b/manager.go
@@ -195,7 +195,15 @@ type Manager struct {
 	// hand-maintained store ordering between two atomics. enterDegraded's
 	// CompareAndSwap(nil, rec) is the sole-winner entry gate; exitDegraded clears
 	// it with Store(nil) after a successful state transition. See degradedRecord.
-	degraded               atomic.Pointer[degradedRecord]
+	degraded atomic.Pointer[degradedRecord]
+	// streamMissingExhausted latches "a partition-consumer loop in this
+	// process has permanently exited after stream-missing recovery
+	// exhaustion". Unlike the degradedRecord reason — which is lost when
+	// enterDegraded's CAS no-ops because the worker was ALREADY Degraded
+	// for another reason — this latch survives reason overlap, keeping the
+	// recovery-exit hold terminal. Never cleared in-process: the dead loop
+	// cannot restart; rotation is the only recovery.
+	streamMissingExhausted atomic.Bool
 	connMonitorOnce        sync.Once      // ensures single connection monitor goroutine
 	postStableMonitorsOnce sync.Once      // ensures startPostStableMonitors fires exactly once
 	startedAt              time.Time      // absolute wall-clock anchor for StartupTimeout budget; set in prepareStart

--- a/manager_apply_retry_coalesce_test.go
+++ b/manager_apply_retry_coalesce_test.go
@@ -1,0 +1,108 @@
+package parti
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestAssignmentSupersedesForStash pins the full applied-identity ordering used
+// by the retry/coalesce stash. The ordering mirrors the applied-ack identity
+// the core apply gate trusts (isApplyResultStale / currentAssignmentApplied):
+// (Version, LeaderRevision) lex, then PartitionSetDigest, then source-revision
+// known/value. At identical full identity the candidate is an idempotent
+// duplicate and cur is kept.
+func TestAssignmentSupersedesForStash(t *testing.T) {
+	partsA := []types.Partition{{Keys: []string{"alpha"}}}
+	partsB := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+
+	base := func() Assignment {
+		return Assignment{Version: 7, LeaderRevision: 10, Partitions: partsA}
+	}
+
+	tests := []struct {
+		name      string
+		cur       Assignment
+		candidate Assignment
+		want      bool // candidate supersedes cur (replace)
+	}{
+		{
+			name:      "higher version replaces",
+			cur:       base(),
+			candidate: Assignment{Version: 8, LeaderRevision: 1, Partitions: partsA},
+			want:      true,
+		},
+		{
+			name:      "lower version is dropped",
+			cur:       base(),
+			candidate: Assignment{Version: 6, LeaderRevision: 99, Partitions: partsB},
+			want:      false,
+		},
+		{
+			name:      "same version higher leader revision replaces",
+			cur:       base(),
+			candidate: Assignment{Version: 7, LeaderRevision: 20, Partitions: partsA},
+			want:      true,
+		},
+		{
+			name:      "same version lower leader revision is dropped",
+			cur:       Assignment{Version: 7, LeaderRevision: 20, Partitions: partsA},
+			candidate: Assignment{Version: 7, LeaderRevision: 10, Partitions: partsB},
+			want:      false,
+		},
+		{
+			name:      "same (V,LR) different digest replaces (last arrival wins)",
+			cur:       base(),
+			candidate: Assignment{Version: 7, LeaderRevision: 10, Partitions: partsB},
+			want:      true,
+		},
+		{
+			name: "same (V,LR) same digest but candidate adds known source replaces",
+			cur:  base(),
+			candidate: Assignment{
+				Version: 7, LeaderRevision: 10, Partitions: partsA,
+				SourceRevisionKnown: true, SourceRevision: 5,
+			},
+			want: true,
+		},
+		{
+			name: "same (V,LR) same digest different known source value replaces",
+			cur: Assignment{
+				Version: 7, LeaderRevision: 10, Partitions: partsA,
+				SourceRevisionKnown: true, SourceRevision: 5,
+			},
+			candidate: Assignment{
+				Version: 7, LeaderRevision: 10, Partitions: partsA,
+				SourceRevisionKnown: true, SourceRevision: 6,
+			},
+			want: true,
+		},
+		{
+			name:      "identical full identity keeps cur (idempotent duplicate)",
+			cur:       base(),
+			candidate: base(),
+			want:      false,
+		},
+		{
+			name: "identical full identity with source keeps cur",
+			cur: Assignment{
+				Version: 7, LeaderRevision: 10, Partitions: partsA,
+				SourceRevisionKnown: true, SourceRevision: 5,
+			},
+			candidate: Assignment{
+				Version: 7, LeaderRevision: 10, Partitions: partsA,
+				SourceRevisionKnown: true, SourceRevision: 5,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := assignmentSupersedesForStash(tc.candidate, tc.cur)
+			if got != tc.want {
+				t.Fatalf("assignmentSupersedesForStash(candidate, cur) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/manager_apply_retry_digest_test.go
+++ b/manager_apply_retry_digest_test.go
@@ -1,0 +1,308 @@
+package parti
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/hooks"
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Reproducer: same-version / different-digest commit lost by the
+// scheduleApplyRetry version-only coalescing comparison.
+// ============================================================================
+//
+// THE DEFECT
+//
+// When two assignments share the same Version but carry different partition
+// digests — a real product of a CAS-race between the leader's legacy-alias
+// pre-publish and the commit CAS, acknowledged by manager_assignment.go's
+// committedAssignment/digest commentary (~:1216-1224) — and BOTH of their
+// initial applies fail, the second one is silently dropped by
+// scheduleApplyRetry's coalescing guard:
+//
+//	// scheduleApplyRetry (manager_assignment.go ~:1528-1530)
+//	cur := m.stashedApplyRetry.Load()
+//	if cur != nil && cur.Version >= newAssignment.Version {
+//	    break // <-- DROPS the newer (different-digest, higher-LR) target
+//	}
+//
+// The guard compares Version ONLY. It does not consider LeaderRevision or the
+// partition-set digest. So a stashed legacy-alias A (Version=n, LR=r1,
+// digest D1) shadows a later COMMIT authority B (Version=n, LR=r2 > r1,
+// digest D2): B.Version (n) is not > A.Version (n), so B is discarded.
+//
+// THE INTERLEAVING (each step verified against source)
+//
+//  1. Alias A arrives (handleAssignmentEntry): version gate n-1<n passes,
+//     LR fence passes, selectAuthority -> LegacyAlias -> applyAssignment(A).
+//  2. A's apply FAILS (updater returns error) -> scheduleApplyRetry(A):
+//     stash empty -> stash=A. Retry goroutine spawns, sleeps >=1s.
+//  3. Commit B arrives (handleCommitValue): case (a) passes (snapshot still
+//     n-1), LR fence passes, selectAuthority -> Commit -> applyAssignment(B).
+//  4. B's apply ALSO FAILS -> scheduleApplyRetry(B): cur.Version (n) >=
+//     B.Version (n) -> B DROPPED. <<< THE LOST UPDATE.
+//  5. Updater recovers. Retry pops A, applies successfully ->
+//     committedAssignment = (n, r1, D1). Heartbeat acks D1.
+//  6. Nothing re-delivers B in default (direct) mode: commit redelivery is
+//     version-gated (case (a): n <= n -> no-op); apply errors bypass the
+//     degraded circuit so the worker is never Degraded; the leader audit is
+//     dead without two-phase. The worker reports Stable on the WRONG digest.
+//
+// WHY IT MATTERS
+//
+// The partitions in D2 \ D1 are never served by this worker, yet the worker
+// reports Stable and acks D1. This is a silent partition-ownership divergence:
+// no error surfaces, no degraded transition fires, and the heartbeat audit
+// sees a self-consistent (but wrong) ack.
+//
+// THE REGRESSION GUARD
+//
+// After the retry drains, the worker's committedAssignment digest must be D2
+// (the commit authority). Pre-fix, the version-only coalescing guard dropped B
+// so the worker converged on the stale alias digest D1. This test pins the
+// fixed convergence: the coalescing guard now compares full
+// (Version, LeaderRevision) / identity, preserving B (D2).
+
+// failNCoordinator is a handoff.Coordinator stub whose Apply fails the first
+// failUntil calls (returning a synthetic error), then succeeds. It also
+// records the digest of every assignment it was asked to apply, in order, so
+// the test can prove which payload won the retry race.
+type failNCoordinator struct {
+	failUntil  int64
+	applyCount atomic.Int64
+
+	mu            atomicDigestLog
+	committedSeen atomic.Uint64 // digest of the last SUCCESSFUL apply's next set
+}
+
+type atomicDigestLog struct {
+	mu atomic.Pointer[[]digestEntry]
+}
+
+type digestEntry struct {
+	version int64
+	lr      uint64
+	digest  uint64
+	ok      bool // true if this apply succeeded
+}
+
+func (c *failNCoordinator) Start(_ context.Context) {}
+
+func (c *failNCoordinator) Apply(_ context.Context, _ string, _, next types.Assignment) error {
+	n := c.applyCount.Add(1)
+	digest := types.PartitionSetDigest(next.Partitions)
+	if n <= c.failUntil {
+		c.appendLog(digestEntry{version: next.Version, lr: next.LeaderRevision, digest: digest, ok: false})
+		return errors.New("synthetic apply failure")
+	}
+	c.committedSeen.Store(digest)
+	c.appendLog(digestEntry{version: next.Version, lr: next.LeaderRevision, digest: digest, ok: true})
+
+	return nil
+}
+
+func (c *failNCoordinator) appendLog(e digestEntry) {
+	for {
+		cur := c.mu.mu.Load()
+		var next []digestEntry
+		if cur != nil {
+			next = append(next, *cur...)
+		}
+		next = append(next, e)
+		if c.mu.mu.CompareAndSwap(cur, &next) {
+			return
+		}
+	}
+}
+
+func (c *failNCoordinator) log() []digestEntry {
+	if p := c.mu.mu.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// newAliasEntry builds the legacy `assignment.<W>` alias envelope: a
+// jetstream.KeyValueEntry whose Value() is the JSON encoding of a full
+// Assignment. Reuses the aliasEntry stub declared in
+// manager_commit_state_machine_test.go.
+func newAliasEntry(t *testing.T, a Assignment) aliasEntry {
+	t.Helper()
+	b, err := json.Marshal(a)
+	require.NoError(t, err)
+	return aliasEntry{value: b}
+}
+
+// publishCommitPayload stores a gzip-compressed, hash-addressed assignment
+// payload in the KV bucket and returns the ref the commit must carry. Mirrors
+// the leader's commit-payload publish so buildAssignmentFromCommit's
+// FetchAndVerifyCommitPayload succeeds.
+func publishCommitPayload(t *testing.T, kv jetstream.KeyValue, parts []types.Partition) types.AssignmentPayloadRef {
+	t.Helper()
+	payload := types.AssignmentPayload{
+		SchemaVersion: types.AssignmentSchemaVersion,
+		Partitions:    parts,
+	}
+	canonical, err := json.Marshal(payload)
+	require.NoError(t, err)
+	hash := sha256.Sum256(canonical)
+	hashHex := hex.EncodeToString(hash[:])
+	key := "assignment._payload." + hashHex
+
+	var gzBuf bytes.Buffer
+	gzw, _ := gzip.NewWriterLevel(&gzBuf, gzip.BestCompression)
+	_, err = gzw.Write(canonical)
+	require.NoError(t, err)
+	require.NoError(t, gzw.Close())
+	_, err = kv.Create(t.Context(), key, gzBuf.Bytes())
+	require.NoError(t, err)
+
+	return types.AssignmentPayloadRef{
+		Key:         key,
+		PayloadHash: hashHex,
+		SetDigest:   types.PartitionSetDigest(parts),
+	}
+}
+
+// newRetryDigestManager builds a Manager fixture wired with the failing
+// coordinator and a live KV bucket for commit-payload fetches.
+func newRetryDigestManager(t *testing.T, fc *failNCoordinator) *Manager {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	akv := partitest.CreateJetStreamKV(t, nc, "apply-retry-digest-asgn")
+
+	nopHooks := hooks.NewNop()
+	m := &Manager{
+		cfg:                TestConfig(),
+		hooks:              &nopHooks,
+		metrics:            newRecordingMetrics(),
+		logger:             logging.NewNop(),
+		heartbeat:          &recordingHeartbeat{},
+		handoffCoordinator: fc,
+		assignmentKV:       akv,
+	}
+	m.workerID.Store("worker-test")
+	m.assignment.Store(Assignment{})
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	m.ctx = ctx
+	m.cancel = cancel
+
+	return m
+}
+
+// TestApplyRetry_SameVersionDifferentDigest_CommitLost reproduces the lost
+// commit. See the file-level comment for the full interleaving and rationale.
+func TestApplyRetry_SameVersionDifferentDigest_CommitLost(t *testing.T) {
+	const (
+		version    = int64(7)
+		aliasLR    = uint64(10) // r1
+		commitLR   = uint64(20) // r2 > r1
+		applyDelay = 8 * time.Second
+	)
+
+	// Fail the first two applies (alias A, commit B); the third (retry of the
+	// surviving stash) succeeds.
+	fc := &failNCoordinator{failUntil: 2}
+	m := newRetryDigestManager(t, fc)
+	wid := m.WorkerID()
+
+	// Establish a prior applied snapshot at version-1 so the version gate
+	// (oldAssignment.Version >= newAssignment.Version) passes for version n.
+	prior := Assignment{Version: version - 1, LeaderRevision: aliasLR}
+	m.assignment.Store(prior)
+	committedPrior := prior
+	m.committedAssignment.Store(&committedPrior)
+	m.lastSeenLeaderRevision.Store(0)
+
+	// Partition sets: D1 (alias A) and D2 (commit B) are DIFFERENT and both
+	// non-empty so the digests differ and neither is the empty digest (0).
+	partsA := []types.Partition{{Keys: []string{"alpha"}}}
+	partsB := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+	digestD1 := types.PartitionSetDigest(partsA)
+	digestD2 := types.PartitionSetDigest(partsB)
+	require.NotEqual(t, digestD1, digestD2, "test precondition: D1 != D2")
+	require.NotZero(t, digestD1)
+	require.NotZero(t, digestD2)
+
+	// --- Step 1+2: alias A arrives and its apply fails, stashing A. ---
+	aliasA := Assignment{
+		Version:        version,
+		LeaderRevision: aliasLR,
+		Partitions:     partsA,
+	}
+	m.handleAssignmentEntry(wid, newAliasEntry(t, aliasA))
+
+	// A's apply must have failed and stashed A for retry.
+	require.Equal(t, int64(1), fc.applyCount.Load(), "step 2: alias A apply attempted once")
+	stashed := m.stashedApplyRetry.Load()
+	require.NotNil(t, stashed, "step 2: A must be stashed for retry")
+	require.Equal(t, version, stashed.Version)
+	require.Equal(t, digestD1, types.PartitionSetDigest(stashed.Partitions), "step 2: stash holds D1")
+	require.True(t, m.applyRetryActive.Load(), "step 2: retry goroutine active")
+
+	// --- Step 3+4: commit B arrives (same version, higher LR, digest D2),
+	//     its apply fails, and scheduleApplyRetry DROPS it. ---
+	ref := publishCommitPayload(t, m.assignmentKV, partsB)
+	commitB := &types.AssignmentCommit{
+		Version:        version,
+		LeaderRevision: commitLR,
+		Workers:        []string{wid},
+		Payloads:       map[string]types.AssignmentPayloadRef{wid: ref},
+	}
+	m.handleCommitValue(commitB)
+
+	require.Equal(t, int64(2), fc.applyCount.Load(), "step 4: commit B apply attempted once")
+	// With the full applied-identity coalesce, B (same version, higher LR,
+	// digest D2) supersedes the stashed alias A (D1): the stash now holds D2.
+	// Pre-fix the version-only guard kept D1 here, which is the lost update.
+	stashedAfterB := m.stashedApplyRetry.Load()
+	require.NotNil(t, stashedAfterB)
+	require.Equal(t, digestD2, types.PartitionSetDigest(stashedAfterB.Partitions),
+		"step 4: scheduleApplyRetry must coalesce by full identity and keep commit B (D2), not the stale alias D1")
+	require.Equal(t, commitLR, stashedAfterB.LeaderRevision,
+		"step 4: stash must carry the commit authority's LeaderRevision r2")
+
+	// --- Step 5: wait for the retry goroutine to drain the stash and apply
+	//     successfully. The retry initial backoff is ~1s (+/-20%). ---
+	deadline := time.Now().Add(applyDelay)
+	for time.Now().Before(deadline) {
+		if c := m.committedAssignment.Load(); c != nil && c.Version == version {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	committed := m.committedAssignment.Load()
+	require.NotNil(t, committed, "step 5: retry must have committed a version-n assignment")
+	require.Equal(t, version, committed.Version, "step 5: retry applied version n")
+
+	finalDigest := types.PartitionSetDigest(committed.Partitions)
+
+	t.Logf("apply log (digest, lr, ok per attempt): %+v", fc.log())
+	t.Logf("final committed: version=%d lr=%d digest=%d (D1=%d D2=%d)",
+		committed.Version, committed.LeaderRevision, finalDigest, digestD1, digestD2)
+
+	// Regression guard: the worker must converge on the COMMIT authority's
+	// digest (D2). Pre-fix, the version-only stash guard dropped B and the
+	// worker converged on the stale alias digest D1.
+	require.Equal(t, digestD2, finalDigest,
+		"regression: worker must commit the commit-authority digest D2; "+
+			"pre-fix the version-only coalescing guard silently dropped the same-version/higher-LR commit B (D2)")
+	require.Equal(t, commitLR, committed.LeaderRevision,
+		"committed assignment must carry the commit authority's LeaderRevision r2")
+}

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -1009,7 +1009,7 @@ func (m *Manager) handleCommitValueOnce(commit *types.AssignmentCommit) *types.A
 	if !m.pendingApplyInFlight.CompareAndSwap(false, true) {
 		for {
 			prev := m.stashedCommit.Load()
-			if prev != nil && prev.Version >= commit.Version {
+			if prev != nil && !commitSupersedesForStash(commit, prev) {
 				return nil
 			}
 			candidate := *commit
@@ -1047,11 +1047,40 @@ func (m *Manager) handleCommitValueOnce(commit *types.AssignmentCommit) *types.A
 	// deserves a fresh attempt rather than being orphaned.
 	m.pendingApplyInFlight.Store(false)
 
-	if pending := m.stashedCommit.Swap(nil); pending != nil && pending.Version > newAssignment.Version {
+	if pending := m.stashedCommit.Swap(nil); pending != nil && commitSupersedesAppliedForDrain(pending, newAssignment) {
 		return pending
 	}
 
 	return nil
+}
+
+// commitSupersedesAppliedForDrain reports whether a stashed pending commit
+// should be drained for a fresh apply after newAssignment (built from the
+// just-applied commit) was handed to applyAssignment. It applies the same
+// ordering definition as assignmentSupersedesForStash across the comparable
+// commit-vs-assignment identity coordinates: a strictly newer
+// (Version, LeaderRevision) pending commit drains; at equal coordinates it
+// drains only when the source-revision identity differs. Comparing by Version
+// alone here would orphan a same-version/higher-LR commit that arrived during
+// the failed apply.
+//
+// Note: the partition-set digest is intentionally NOT compared here. The
+// pending value is a whole-batch commit (BatchDigest spans every worker),
+// while applied is this worker's per-worker subset (its digest covers only the
+// worker's partitions) — the two digests are not the same quantity, so a
+// digest comparison would spuriously drain the same commit every time. The
+// commit's per-worker digest divergence is already resolved upstream by
+// commitSupersedesForStash on the commit-vs-commit stash, and a re-delivered
+// same-(V,LR) commit is harmlessly handled by case (a) on the next pass.
+func commitSupersedesAppliedForDrain(pending *types.AssignmentCommit, applied Assignment) bool {
+	if pending.Version != applied.Version {
+		return pending.Version > applied.Version
+	}
+	if pending.LeaderRevision != applied.LeaderRevision {
+		return pending.LeaderRevision > applied.LeaderRevision
+	}
+	return pending.SourceRevisionKnown != applied.SourceRevisionKnown ||
+		pending.SourceRevision != applied.SourceRevision
 }
 
 // buildAssignmentFromCommit constructs the Assignment this worker must
@@ -1194,6 +1223,83 @@ func isApplyResultStale(candidate, cur Assignment) bool {
 		return candidate.Version < cur.Version
 	}
 	return candidate.LeaderRevision < cur.LeaderRevision
+}
+
+// assignmentSupersedesForStash reports whether candidate should replace cur in
+// a retry/coalesce stash. The ordering mirrors the applied-ack identity the
+// core apply gate trusts (isApplyResultStale / currentAssignmentApplied) —
+// (Version, LeaderRevision) lex, then the full applied identity (partition-set
+// digest and source-revision known/value):
+//
+//   - strictly newer (Version, LeaderRevision) lex order replaces;
+//   - strictly older is dropped;
+//   - equal (Version, LeaderRevision) with a DIFFERENT full identity
+//     (PartitionSetDigest, or source-revision known/value) replaces — last
+//     arrival wins during the failure window only (bounded: once any
+//     same-version assignment applies, the watcher gates stop feeding the
+//     stash);
+//   - equal full identity keeps cur (idempotent duplicate).
+//
+// Rationale: a same-version pair with different digests is a real CAS-race
+// product (a legacy alias pre-published at the proposed version before the
+// commit CAS, or a CAS-lost batch re-commit). Comparing by Version alone — as
+// the stash guards did pre-fix — drops the commit-authority target, so the
+// retry applies the stale alias digest and nothing in direct mode ever
+// converges the worker (commit redelivery is version-gated; the leader audit's
+// repair is two-phase-gated). Ordering the stash by the same identity the apply
+// gate already trusts closes that lost update.
+func assignmentSupersedesForStash(candidate, cur Assignment) bool {
+	if candidate.Version != cur.Version {
+		return candidate.Version > cur.Version
+	}
+	if candidate.LeaderRevision != cur.LeaderRevision {
+		return candidate.LeaderRevision > cur.LeaderRevision
+	}
+	// Equal (Version, LeaderRevision): replace only when the full applied
+	// identity actually differs, otherwise keep cur (idempotent duplicate).
+	return !sameAppliedIdentity(candidate, cur)
+}
+
+// sameAppliedIdentity reports whether two assignments at the same
+// (Version, LeaderRevision) carry the same full applied identity — equal
+// partition-set digest and equal source-revision known/value. It is the
+// equal-coordinate tail of the applied-ack identity used by
+// currentAssignmentApplied.
+//
+// Unlike currentAssignmentApplied — which is deliberately asymmetric on
+// source-revision (a source-unknown current assignment always matches any
+// candidate, so degraded refreshes don't stall on a stale SourceRevisionKnown
+// bit) — this function is symmetric: both sides must agree on
+// SourceRevisionKnown and SourceRevision. The symmetric form is safe here
+// because the only equal-(Version, LeaderRevision) source-downgrade candidate
+// (a source-unknown alias vs a source-known commit) is dropped by
+// selectAuthority before any stash call is reached.
+func sameAppliedIdentity(a, b Assignment) bool {
+	return types.PartitionSetDigest(a.Partitions) == types.PartitionSetDigest(b.Partitions) &&
+		a.SourceRevisionKnown == b.SourceRevisionKnown &&
+		a.SourceRevision == b.SourceRevision
+}
+
+// commitSupersedesForStash reports whether candidate should replace cur in the
+// in-flight commit coalesce stash. It applies the same ordering definition as
+// assignmentSupersedesForStash, expressed over the commit's identity coordinates
+// — (Version, LeaderRevision) lex, then the commit's BatchDigest and
+// source-revision known/value. BatchDigest is the batch-level partition
+// identity the publisher writes alongside the commit (it matches the source
+// partition set's digest at publish time); using it keeps ONE conceptual
+// ordering definition across the Assignment and AssignmentCommit stashes.
+func commitSupersedesForStash(candidate, cur *types.AssignmentCommit) bool {
+	if candidate.Version != cur.Version {
+		return candidate.Version > cur.Version
+	}
+	if candidate.LeaderRevision != cur.LeaderRevision {
+		return candidate.LeaderRevision > cur.LeaderRevision
+	}
+	// Equal (Version, LeaderRevision): replace only when the full identity
+	// differs, otherwise keep cur (idempotent duplicate).
+	return candidate.BatchDigest != cur.BatchDigest ||
+		candidate.SourceRevisionKnown != cur.SourceRevisionKnown ||
+		candidate.SourceRevision != cur.SourceRevision
 }
 
 // committedAssignmentOrEmpty returns the last successfully applied+acked
@@ -1523,10 +1629,14 @@ func (m *Manager) invokeAssignmentChangedHooks(_ /* workerID */ string, oldAssig
 // The retry initial backoff is 1s, doubling up to 30s with ±20% jitter.
 // On retry success the goroutine self-terminates.
 func (m *Manager) scheduleApplyRetry(newAssignment Assignment) {
-	// Coalesce: keep the highest-Version pending.
+	// Coalesce by full applied identity (assignmentSupersedesForStash): keep
+	// cur unless newAssignment is strictly newer in (Version, LeaderRevision)
+	// or differs at equal coordinates on the full applied identity. Comparing
+	// by Version alone here would drop a same-version/higher-LR commit behind a
+	// stashed legacy alias and silently lose the commit-authority digest.
 	for {
 		cur := m.stashedApplyRetry.Load()
-		if cur != nil && cur.Version >= newAssignment.Version {
+		if cur != nil && !assignmentSupersedesForStash(newAssignment, *cur) {
 			break
 		}
 		candidate := newAssignment

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -503,6 +503,30 @@ func (m *Manager) attemptRecoveryFromDegraded() {
 	// design needed to close that window is no longer reachable and is gone.
 	reason := rec.reason
 
+	// Terminal hold — stream-missing recovery exhaustion means at least one
+	// partition-consumer loop in this process has exited permanently. The
+	// loop cannot restart in-process (the dead subject remains in the
+	// worker-consumer's subject map, so a re-apply computes an empty diff),
+	// and operator stream recreation cannot revive it either. No recovery
+	// signal exists that could stamp this reason healthy; hold the worker
+	// terminally Degraded for restart/rotation, matching the
+	// heartbeat-bucket backstop's terminal contract. Placed after the
+	// commitment guard so an unapplied refreshed assignment still re-arms
+	// scheduleApplyRetry above.
+	//
+	// The latch (streamMissingExhausted) widens this check beyond the reason
+	// string alone: if exhaustion fires while the worker is ALREADY Degraded
+	// for another reason, enterDegraded's CAS no-ops and the reason string
+	// never records the exhaustion. The latch survives that overlap, keeping
+	// the hold terminal regardless of which reason string is current. The
+	// reason-string branch is retained so white-box tests that arm the
+	// degradedRecord directly (without firing the observer) still pass.
+	if reason == DegradeReasonStreamMissingRecoveryExhausted || m.streamMissingExhausted.Load() {
+		m.logger.Warn("recovery: stream-missing recovery exhausted is terminal; staying Degraded for restart/rotation",
+			"degraded_for", time.Since(time.Unix(0, rec.since)).Round(time.Second))
+		return
+	}
+
 	// Family B — reason-scoped recover-on-wrong-signal gate. A kv-unavailable
 	// degrade is a connected-but-KV-unavailable op stall on the heartbeat /
 	// election / stableid buckets; the commitment guard above reads only the

--- a/manager_recovery_conjuncts_test.go
+++ b/manager_recovery_conjuncts_test.go
@@ -1,6 +1,7 @@
 package parti
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -165,4 +166,79 @@ func TestAttemptRecovery_HeartbeatBucketReachable_Exits(t *testing.T) {
 
 	require.Equal(t, StateStable, m.State(),
 		"a reachable heartbeat bucket must let recovery exit to Stable")
+}
+
+// TestAttemptRecovery_StreamMissingExhausted_StaysDegraded pins the terminal
+// hold for the dynamic-consumer stream-missing route: once a partition
+// consumer's recovery envelope has exhausted, its loop has exited and cannot
+// restart in-process (the dead subject remains in the worker-consumer's
+// subject map, so a re-apply computes an empty diff), and operator stream
+// recreation cannot revive it either. Recovery must therefore never exit
+// this reason — rotation is the only recovery, matching the
+// heartbeat-bucket backstop's terminal contract. Without the gate, the
+// connection monitor exits back to Stable within ~one tick (the NATS
+// connection never dropped) and the worker reports Stable while assigned
+// partitions are silently not consumed.
+func TestAttemptRecovery_StreamMissingExhausted_StaysDegraded(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, &snap, snap)
+	plantAssignment(t, m, snap)
+	m.markDegraded(time.Now().UnixNano(), DegradeReasonStreamMissingRecoveryExhausted)
+
+	// Even with every recovery signal healthy (commitment guard satisfied by
+	// armDegraded, fresh heartbeat far in the future), the hold is terminal.
+	m.lastHeartbeatSuccessAt.Store(time.Now().UnixNano() + int64(time.Hour))
+
+	m.attemptRecoveryFromDegraded()
+
+	require.Equal(t, StateDegraded, m.State(),
+		"stream-missing-recovery-exhausted must hold the worker terminally Degraded for rotation")
+}
+
+// TestAttemptRecovery_StreamMissingHold_IsReasonScoped proves the new gate
+// is NOT accidentally global: a reason with no blocking gate (startup
+// timeout) still exits to Stable through the same pipeline. This is the
+// negative-space direction the boundary-test discipline requires.
+func TestAttemptRecovery_StreamMissingHold_IsReasonScoped(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, &snap, snap)
+	plantAssignment(t, m, snap)
+	m.markDegraded(time.Now().UnixNano(), DegradeReasonStartupTimeout)
+
+	m.attemptRecoveryFromDegraded()
+	m.wg.Wait()
+
+	require.Equal(t, StateStable, m.State(),
+		"a non-stream-missing reason with healthy signals must still exit; the terminal hold must be reason-scoped")
+}
+
+// TestAttemptRecovery_StreamMissingExhausted_LatchSurvivesReasonOverlap pins
+// the overlap defense: when stream-missing exhaustion fires while the worker
+// is ALREADY Degraded for another reason, enterDegraded's CAS no-ops and the
+// reason string never records the exhaustion. The atomic latch must keep the
+// recovery exit terminal anyway — otherwise the other reason's recovery
+// signal (here: a fresh post-degrade heartbeat satisfying the kv-unavailable
+// gate) would exit to Stable with a permanently dead partition loop.
+func TestAttemptRecovery_StreamMissingExhausted_LatchSurvivesReasonOverlap(t *testing.T) {
+	t.Parallel()
+	snap := Assignment{Version: 1, LeaderRevision: 5, Partitions: []Partition{{Keys: []string{"p0"}}}}
+	m, _ := armDegraded(t, &snap, snap)
+	plantAssignment(t, m, snap)
+	sinceNano := time.Now().UnixNano()
+	m.markDegraded(sinceNano, DegradeReasonKVUnavailable)
+
+	// Exhaustion fires while already Degraded: enterDegraded CAS no-ops, only
+	// the latch records it.
+	m.onStreamMissingError("ORDERS", errors.New("recovery exhausted"))
+
+	// The kv-unavailable gate's own exit signal is satisfied (fresh heartbeat
+	// after the degrade) — without the latch, recovery would exit to Stable.
+	m.lastHeartbeatSuccessAt.Store(sinceNano + int64(time.Minute))
+
+	m.attemptRecoveryFromDegraded()
+
+	require.Equal(t, StateDegraded, m.State(),
+		"the exhaustion latch must hold the worker Degraded even when the degrade reason belongs to another (recovered) failure")
 }

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -80,6 +80,12 @@ func (m *Manager) onStreamMissingError(streamName string, cause error) {
 		"stream", streamName,
 		"error", cause,
 	)
+	// Set the latch BEFORE enterDegraded so it is visible even when the CAS
+	// no-ops because the worker is ALREADY Degraded for another reason. In
+	// that case the degradedRecord reason string never records the exhaustion,
+	// but the latch persists and keeps the terminal hold active on the next
+	// attemptRecoveryFromDegraded tick.
+	m.streamMissingExhausted.Store(true)
 	m.enterDegraded(DegradeReasonStreamMissingRecoveryExhausted)
 }
 

--- a/test/integration/consumer/queue_auto_recovery_test.go
+++ b/test/integration/consumer/queue_auto_recovery_test.go
@@ -82,6 +82,49 @@ func TestQueue_AutoRecovery_WorkQueuePolicy_RecoverFromNew_RejectsAtStart(t *tes
 	require.ErrorIs(t, err, consumer.ErrInvalidConfig)
 }
 
+// TestQueue_Start_IncompatibleConfig_LeavesNoDurable pins startup hygiene:
+// the WorkQueue/recovery compatibility check must run BEFORE the durable is
+// created. Pre-fix, a failed Start left an exclusive durable on the
+// WorkQueuePolicy stream that blocked every other consumer for
+// InactiveThreshold (default 24h).
+func TestQueue_Start_IncompatibleConfig_LeavesNoDurable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx := t.Context()
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "QWQ_NODUR",
+		Subjects:  []string{"qwq.nodur.>"},
+		Retention: jetstream.WorkQueuePolicy,
+		Storage:   jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error {
+		return nil
+	})
+
+	q, err := consumer.NewQueue(js, "QWQ_NODUR", "qwq-nodur", "qwq.nodur.>", handler,
+		consumer.WithRecoveryStrategy(consumer.RecoverFromNew),
+	)
+	require.NoError(t, err)
+
+	err = q.Start(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, consumer.ErrInvalidConfig)
+
+	// The durable must NOT have been created — a lingering exclusive durable
+	// on a WorkQueuePolicy stream blocks every other consumer for up to
+	// InactiveThreshold (default 24h), causing NATS err 10100.
+	_, consErr := js.Consumer(ctx, "QWQ_NODUR", "qwq-nodur")
+	require.Error(t, consErr, "durable must NOT exist after a failed Start (compat check must precede ensureConsumer)")
+}
+
 // TestQueue_AutoRecovery_RecoverFromNew_ExplicitDelete verifies that when the
 // durable consumer is explicitly deleted, the Queue consumer recovers using
 // RecoverFromNew and does NOT replay already-processed messages.

--- a/test/integration/durable/overlap_contract_test.go
+++ b/test/integration/durable/overlap_contract_test.go
@@ -1,0 +1,476 @@
+package durable_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestDynamicHandoff_AckWaitRedelivery_OverlapContract pins, in BOTH directions,
+// the irreducible per-partition overlap window that the lifecycle docs describe.
+//
+// # What the per-tier contract says
+//
+// docs/LIFECYCLE.md ("Two-Phase Handoff") and docs/CONSUMERS.md ("WIPHandler —
+// Long-Running Processing") together describe the strongest gating tier for a
+// dynamic per-partition consumer: two-phase handoff orders the RELEASE of a
+// partition, the processing gate is a per-message PRE-HANDLER admission check
+// (internal/durable.processingGate.Wrap evaluates ownership BEFORE calling the
+// underlying handler — "an invocation that has started is not revoked"), pull
+// gating suppresses pulls on the non-owner, and DrainOnRemove waits for the old
+// owner's pending acks before cancelling its loop.
+//
+// Even with all four engaged, ONE overlap window remains and cannot be closed
+// by ownership coordination alone:
+//
+//  1. The old owner (w1) PASSES the pre-handler gate for a message and enters
+//     its handler. The gate's verdict is taken once, at admission; it cannot
+//     retroactively abort an invocation already running.
+//  2. Ownership moves to the new stable owner (w2) while w1's handler is still
+//     mid-invocation. w1 cannot be interrupted: the pull loop is single
+//     threaded and only re-checks ctx after the handler returns, so a remove +
+//     drain cannot stop w1 until the handler finishes. removeSubjectLoops waits
+//     only up to DrainOnRemoveTimeout, then SURFACES a timeout error to the
+//     caller (UpdateWorkerConsumer returns non-nil) while the in-flight handler
+//     keeps running — pinned by the remove-error assertion below.
+//  3. AckWait expires before w1's handler acks. JetStream redelivers the SAME
+//     stream sequence. Because the durable is SHARED per partition — its name
+//     is prefix_partition_hash with NO workerID (internal/dynamicbuild.
+//     PerSubjectDurableName) — the redelivery is eligible for whichever worker
+//     pulls next. With pull gating, only the current owner (now w2) pulls, so
+//     w2 receives it. w2's gate correctly PASSES (w2 IS the stable owner) and
+//     w2 invokes the handler for that sequence while w1's invocation is still
+//     running.
+//
+// The net effect is at-least-once delivery with a temporally OVERLAPPING pair
+// of handler invocations for one sequence: w1 (old, draining) and w2 (new,
+// legitimately admitted). This is NOT a gate bug — at w2's admission ownership
+// is genuinely w2/stable. It is the documented residual window.
+//
+// # The documented mitigation
+//
+// consumer.NewWIPHandler wraps the handler and periodically calls
+// msg.InProgress(), extending AckWait so the redelivery in step 3 never fires
+// while the handler is still running. The negative subtest proves that with the
+// WIPHandler keepalive in place, no second invocation of the poison sequence
+// starts before the first ends.
+//
+// # Why this test exists
+//
+// If the POSITIVE subtest fails to reproduce the overlap, the docs OVERCLAIM
+// the window and that is a major finding (the test fails loudly, it does not
+// silently pass). If a future hardening narrows or closes the window, the
+// positive subtest will surface that as an intentional contract change.
+
+const (
+	overlapPoisonPayload = "POISON"
+	// overlapW1Sleep must outlast AckWait + the ownership flip + w2's redelivery
+	// so the two invocations genuinely overlap. AckWait is 2s; this gives a wide
+	// margin for CI load.
+	overlapW1Sleep = 8 * time.Second
+	// overlapW2Sleep only needs to be long enough for the collector poll to
+	// observe the overlap; it keeps total runtime bounded.
+	overlapW2Sleep = 300 * time.Millisecond
+)
+
+// invocationRecord captures one handler invocation of a stream sequence.
+type invocationRecord struct {
+	streamSeq uint64
+	workerID  string
+	start     time.Time
+	end       time.Time
+}
+
+// overlapCollector is a mutex-guarded sink for handler invocation records.
+type overlapCollector struct {
+	mu      sync.Mutex
+	records []invocationRecord
+}
+
+func (c *overlapCollector) begin(seq uint64, worker string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records = append(c.records, invocationRecord{streamSeq: seq, workerID: worker, start: time.Now()})
+
+	return len(c.records) - 1
+}
+
+func (c *overlapCollector) finish(idx int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records[idx].end = time.Now()
+}
+
+// poisonOverlap scans for a stream sequence processed by two distinct workers
+// whose invocations overlap in time (the second starts before the first ends).
+// It returns the two records and true when such an overlap exists.
+func (c *overlapCollector) poisonOverlap(seq uint64) (first, second invocationRecord, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var forSeq []invocationRecord
+	for _, r := range c.records {
+		if r.streamSeq == seq {
+			forSeq = append(forSeq, r)
+		}
+	}
+
+	for i := range forSeq {
+		for j := range forSeq {
+			if i == j || forSeq[i].workerID == forSeq[j].workerID {
+				continue
+			}
+			a, b := forSeq[i], forSeq[j]
+			// a started first; b started while a was still running (or a never ended).
+			if a.start.Before(b.start) {
+				aEnd := a.end
+				if aEnd.IsZero() || b.start.Before(aEnd) {
+					return a, b, true
+				}
+			}
+		}
+	}
+
+	return invocationRecord{}, invocationRecord{}, false
+}
+
+// distinctWorkersStarted reports how many distinct workers have started an
+// invocation of seq (regardless of overlap). Used by the negative control to
+// detect any redelivery to a second worker.
+func (c *overlapCollector) distinctWorkersStarted(seq uint64) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	seen := map[string]struct{}{}
+	for _, r := range c.records {
+		if r.streamSeq == seq {
+			seen[r.workerID] = struct{}{}
+		}
+	}
+
+	return len(seen)
+}
+
+// switchableResolver is a thread-safe OwnershipResolver whose owner/state can be
+// flipped at runtime to drive ownership deterministically (no KV watch latency).
+// It mirrors the switchingResolver pattern in processing_gate_exclusivity_test.go.
+// Both the processing gate and pull gating consult the same resolver instance.
+type switchableResolver struct {
+	owner atomic.Value // string
+	state atomic.Value // types.HandoffState
+}
+
+func newSwitchableResolver(owner string, st types.HandoffState) *switchableResolver {
+	r := &switchableResolver{}
+	r.owner.Store(owner)
+	r.state.Store(st)
+
+	return r
+}
+
+func (r *switchableResolver) GetOwner(string) (string, types.HandoffState, int64, bool) { //nolint:revive // interface requires 4 results
+	return r.owner.Load().(string), r.state.Load().(types.HandoffState), 1, true //nolint:errcheck,forcetypeassert
+}
+
+func (r *switchableResolver) ForceRefreshPartition(context.Context, string) error { return nil }
+
+func (r *switchableResolver) set(owner string, st types.HandoffState) {
+	r.owner.Store(owner)
+	r.state.Store(st)
+}
+
+// overlapHarness bundles the two worker consumers, the shared resolver, and the
+// instrumentation channels for one subtest.
+type overlapHarness struct {
+	w1, w2  *durable.WorkerConsumer
+	res     *switchableResolver
+	subject string
+	pid     string
+	js      jetstream.JetStream
+
+	collector *overlapCollector
+	// firstStarted fires once when the very first poison invocation begins (on
+	// w1) so the driver can flip ownership precisely mid-invocation.
+	firstStarted chan struct{}
+	firstOnce    sync.Once
+	// poisonSeq is set to the poison message's stream sequence on first delivery.
+	poisonSeq atomic.Uint64
+	// firstInvocation gates the long sleep to w1 only; redeliveries sleep briefly.
+	firstInvocation atomic.Bool
+}
+
+// makePoisonHandler builds the instrumented handler. The poison message (by
+// payload) records start/end into the collector; its FIRST invocation signals
+// firstStarted and sleeps overlapW1Sleep, later invocations sleep only
+// overlapW2Sleep so total runtime stays bounded. Non-poison messages return
+// immediately.
+func (h *overlapHarness) makePoisonHandler(workerID string) consumer.MessageHandlerFunc {
+	return func(_ context.Context, msg jetstream.Msg) error {
+		meta, err := msg.Metadata()
+		if err != nil {
+			return err
+		}
+		seq := meta.Sequence.Stream
+
+		if string(msg.Data()) != overlapPoisonPayload {
+			return nil
+		}
+
+		h.poisonSeq.CompareAndSwap(0, seq)
+
+		idx := h.collector.begin(seq, workerID)
+		defer h.collector.finish(idx)
+
+		if h.firstInvocation.CompareAndSwap(false, true) {
+			h.firstOnce.Do(func() { close(h.firstStarted) })
+			time.Sleep(overlapW1Sleep)
+		} else {
+			time.Sleep(overlapW2Sleep)
+		}
+
+		return nil
+	}
+}
+
+// newOverlapHarness builds embedded NATS, a LimitsPolicy stream with ONE
+// partition, and two Dynamic worker consumers (w1, w2) at the strongest gating
+// tier. The handler is wrapped by wrap (identity for the positive test,
+// WIPHandler for the negative control). Streams/subjects are uniquely suffixed
+// so the two subtests never share state.
+func newOverlapHarness(
+	t *testing.T,
+	tag string,
+	wrap func(consumer.MessageHandlerFunc) func(context.Context, jetstream.Msg) error,
+) *overlapHarness {
+	t.Helper()
+
+	ctx := context.Background()
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	suffix := fmt.Sprintf("%s_%d", tag, time.Now().UnixNano())
+	streamName := "OVERLAP_" + suffix
+	subjectRoot := "overlap" + tag
+
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{subjectRoot + ".*"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.MemoryStorage,
+		MaxMsgs:   -1,
+	})
+	require.NoError(t, err)
+
+	pid := "p1"
+	subject := subjectRoot + "." + pid
+
+	// Shared resolver: starts owner=w1/stable so w1 admits and processes; the
+	// driver flips it to w2/stable mid-invocation.
+	res := newSwitchableResolver("w1", types.HandoffStateStable)
+
+	h := &overlapHarness{
+		res:          res,
+		subject:      subject,
+		pid:          pid,
+		js:           js,
+		collector:    &overlapCollector{},
+		firstStarted: make(chan struct{}),
+	}
+
+	cfg := durable.WorkerConsumerConfig{
+		StreamName:      streamName,
+		ConsumerPrefix:  "worker",
+		SubjectTemplate: subjectRoot + ".{{.PartitionID}}",
+		ProcessingGate: &durable.ProcessingGateConfig{
+			Enabled:       true,
+			NakDelay:      50 * time.Millisecond,
+			AllowedStates: []types.HandoffState{types.HandoffStateStable},
+		},
+		Resolver:             durable.ResolverConfig{OwnershipResolver: res},
+		PullGatingEnabled:    true,
+		DrainOnRemove:        true,
+		DrainOnRemoveTimeout: 500 * time.Millisecond,
+		AckWait:              2 * time.Second,
+		MaxDeliver:           4,
+		BatchSize:            1,
+		FetchTimeout:         1 * time.Second,
+	}
+
+	w1, err := durable.NewWorkerConsumer(js, cfg, wrap(h.makePoisonHandler("w1")))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w1.Close(context.Background()) })
+
+	w2, err := durable.NewWorkerConsumer(js, cfg, wrap(h.makePoisonHandler("w2")))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w2.Close(context.Background()) })
+
+	h.w1, h.w2 = w1, w2
+
+	part := types.Partition{Keys: []string{pid}}
+	require.NoError(t, w1.UpdateWorkerConsumer(ctx, "w1", []types.Partition{part}))
+	require.NoError(t, w2.UpdateWorkerConsumer(ctx, "w2", []types.Partition{part}))
+
+	return h
+}
+
+func TestDynamicHandoff_AckWaitRedelivery_OverlapContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	t.Run("overlap-happens", func(t *testing.T) {
+		// Positive direction: NO WIPHandler. The handler runs bare.
+		identity := func(fn consumer.MessageHandlerFunc) func(context.Context, jetstream.Msg) error {
+			return fn
+		}
+		h := newOverlapHarness(t, "pos", identity)
+		ctx := context.Background()
+
+		// Publish the poison message while w1 owns the partition.
+		_, err := h.js.Publish(ctx, h.subject, []byte(overlapPoisonPayload))
+		require.NoError(t, err)
+
+		// Wait for w1 to enter the poison handler (gate passed, now sleeping).
+		select {
+		case <-h.firstStarted:
+		case <-time.After(10 * time.Second):
+			t.Fatal("w1 never started the poison handler")
+		}
+
+		// Flip ownership to w2/stable while w1's handler is mid-invocation. This
+		// opens w2's pull gate and makes w2's gate admit the redelivery.
+		h.res.set("w2", types.HandoffStateStable)
+
+		// Invariant proof: at the moment ownership moved, the resolver — which
+		// both the gate and pull gating consult — reports owner=w2/stable. So
+		// w2's later admission is the genuine stable owner, not a gate bug.
+		owner, state, _, ok := h.res.GetOwner(h.pid)
+		require.True(t, ok)
+		require.Equal(t, "w2", owner)
+		require.Equal(t, types.HandoffStateStable, state)
+
+		// Drive the remove on w1 (partition leaves w1's assignment) in the
+		// background: it cannot complete while w1's handler sleeps. removeSubject-
+		// Loops drains+waits up to DrainOnRemoveTimeout then SURFACES a timeout
+		// error. Assert that below (the Task-4 drain-timeout contract).
+		removeStart := time.Now()
+		removeErrCh := make(chan error, 1)
+		go func() {
+			removeErrCh <- h.w1.UpdateWorkerConsumer(context.Background(), "w1", []types.Partition{})
+		}()
+
+		// Poll the collector for the overlap. The redelivery retries every AckWait
+		// (2s) up to MaxDeliver, so the window is wide; give a generous deadline
+		// under CI load (~3*AckWait).
+		deadline := time.Now().Add(3 * 2 * time.Second)
+		var first, second invocationRecord
+		var found bool
+		for time.Now().Before(deadline) {
+			seq := h.poisonSeq.Load()
+			if seq != 0 {
+				if a, b, ok := h.collector.poisonOverlap(seq); ok {
+					first, second, found = a, b, true
+					break
+				}
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+
+		require.True(t, found,
+			"expected the poison stream sequence to be processed by two workers with "+
+				"overlapping invocations (the documented AckWait-redelivery window); if this "+
+				"never reproduces the lifecycle docs OVERCLAIM the window — see test doc comment")
+
+		require.NotEqual(t, first.workerID, second.workerID, "overlap must span two distinct workers")
+		require.True(t, second.start.After(first.start), "second invocation starts after the first")
+		overlapDur := first.end.Sub(second.start)
+		if first.end.IsZero() {
+			overlapDur = time.Since(second.start)
+		}
+		t.Logf("OVERLAP observed: seq=%d first=%s(start=%s) second=%s(start=%s) overlap=%s",
+			first.streamSeq, first.workerID, first.start.Format("15:04:05.000"),
+			second.workerID, second.start.Format("15:04:05.000"), overlapDur)
+
+		// Task-4 / drain-timeout contract: w1's remove cannot stop the loop while
+		// the handler sleeps. removeSubjectLoops waits up to DrainOnRemoveTimeout
+		// (500ms), then returns a non-nil timeout error WITHOUT waiting the full
+		// 8s handler and without aborting the in-flight invocation.
+		select {
+		case rerr := <-removeErrCh:
+			elapsed := time.Since(removeStart)
+			t.Logf("w1 remove returned after %s, err=%v (DrainOnRemoveTimeout=500ms)", elapsed, rerr)
+			require.Error(t, rerr,
+				"remove must surface the drain timeout while the in-flight handler still runs")
+			require.Less(t, elapsed, overlapW1Sleep,
+				"remove must give up at the bounded drain timeout, not wait the full handler sleep")
+		case <-time.After(overlapW1Sleep):
+			t.Fatal("w1 remove did not return within the handler sleep window")
+		}
+	})
+
+	t.Run("wip-handler-prevents", func(t *testing.T) {
+		// Negative control: wrap the handler with WIPHandler. The keepalive
+		// extends AckWait so the redelivery in the positive test never fires
+		// while w1's handler is still running, so no second invocation starts.
+		withWIP := func(fn consumer.MessageHandlerFunc) func(context.Context, jetstream.Msg) error {
+			wrapped := consumer.NewWIPHandler(fn, consumer.WIPConfig{
+				Interval:    500 * time.Millisecond, // << AckWait (2s); ~AckWait/4
+				MinInterval: -1,                     // disable clamping (match wip_handler_test.go)
+			})
+
+			return wrapped.Handle
+		}
+		h := newOverlapHarness(t, "neg", withWIP)
+		ctx := context.Background()
+
+		_, err := h.js.Publish(ctx, h.subject, []byte(overlapPoisonPayload))
+		require.NoError(t, err)
+
+		select {
+		case <-h.firstStarted:
+		case <-time.After(10 * time.Second):
+			t.Fatal("w1 never started the poison handler")
+		}
+
+		// Same ownership flip as the positive test.
+		h.res.set("w2", types.HandoffStateStable)
+
+		// Over a window comfortably longer than AckWait (so redelivery WOULD have
+		// fired without the keepalive), assert no second worker ever starts the
+		// poison sequence and no overlap is recorded.
+		require.Never(t, func() bool {
+			seq := h.poisonSeq.Load()
+			if seq == 0 {
+				return false
+			}
+			if h.collector.distinctWorkersStarted(seq) > 1 {
+				return true
+			}
+			_, _, ok := h.collector.poisonOverlap(seq)
+
+			return ok
+		}, 3*2*time.Second, 50*time.Millisecond,
+			"WIPHandler keepalive must prevent AckWait-redelivery, so no second worker "+
+				"invokes the poison sequence while w1's handler runs")
+
+		// Sanity: exactly one worker processed the poison sequence with WIPHandler.
+		seq := h.poisonSeq.Load()
+		require.NotZero(t, seq, "poison must have been delivered to w1")
+		require.Equal(t, 1, h.collector.distinctWorkersStarted(seq),
+			"exactly one worker processes the poison sequence with WIPHandler")
+	})
+}

--- a/test/integration/durable/processing_gate_exclusivity_test.go
+++ b/test/integration/durable/processing_gate_exclusivity_test.go
@@ -85,7 +85,10 @@ func TestProcessingGate_Exclusivity(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = w2.Close(context.Background()) }()
 
-	// Assign both workers the same partition (they will each have their own durable)
+	// Assign both workers the same partition. They share the same per-partition
+	// durable (prefix+partitionID+hash, no worker ID); exclusivity comes from the
+	// processing gate NAK-delaying deliveries on the non-owner, not from separate
+	// durables.
 	part := types.Partition{Keys: []string{pid}}
 	require.NoError(t, w1.UpdateWorkerConsumer(ctx, "w1", []types.Partition{part}))
 	require.NoError(t, w2.UpdateWorkerConsumer(ctx, "w2", []types.Partition{part}))

--- a/test/integration/failure/stream_missing_burst_path_test.go
+++ b/test/integration/failure/stream_missing_burst_path_test.go
@@ -1,0 +1,116 @@
+package failure_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestStreamMissingNoHook_HeartbeatBurstPath_ExhaustsWithMultiAttemptBudget
+// closes the gap the T4 test (stream_missing_no_hook_test.go) works around
+// with MaxAttempts=1. With a multi-attempt budget (the DEFAULT is 8), the
+// post-deletion failure sequence routes through the heartbeat-burst path:
+// the iterator stays bound, iter.Next() surfaces ErrNoHeartbeat, and the
+// burst confirmation probes consumer.Info() — which, for a deleted STREAM,
+// answers with the stream-scoped ErrStreamNotFound rather than
+// ErrConsumerNotFound.
+//
+// Pre-fix, that probe answer was treated as "consumer still exists" and the
+// loop fell into unbounded backoff: the stream-missing failure counter never
+// reached MaxAttempts, OnPermanentFailure never fired, the manager observer
+// never saw the loss, and the worker reported Stable with a permanently
+// stalled consumer — the silent-stall class one layer above the terminal
+// Degraded hold. Post-fix, the probe routes to the bounded stream-missing
+// detour and exhaustion fires within MaxAttempts cycles regardless of which
+// error (consumer-deleted vs heartbeat-burst) each cycle surfaces.
+func TestStreamMissingNoHook_HeartbeatBurstPath_ExhaustsWithMultiAttemptBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const streamName = "BURSTPATH_STREAM"
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     streamName,
+		Subjects: []string{"burstpath.*"},
+		Storage:  jetstream.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error {
+		return nil
+	})
+
+	dyn, err := consumer.NewDynamic(
+		js, streamName, "burstpath", "burstpath.{{.PartitionID}}", handler,
+		consumer.WithRecoveryStrategy(consumer.RecoverFromLastProcessed),
+		// NO StreamMissingHook: exhaustion must fire OnPermanentFailure and
+		// route to the manager observer. MaxAttempts=3 (NOT the T4
+		// workaround value of 1) so the budget requires the per-cycle
+		// classification to keep converging on the stream-missing detour —
+		// the exact multi-attempt sequencing the heartbeat-burst gap broke.
+		consumer.WithRecoveryRetry(consumer.RecoveryRetryConfig{
+			MaxAttempts: 3,
+			BaseBackoff: 100 * time.Millisecond,
+			MaxBackoff:  300 * time.Millisecond,
+		}),
+		consumer.WithBatchSize(1),
+		// PullExpiry has a hard 1s NATS minimum; PullHeartbeat = expiry/2,
+		// so ErrNoHeartbeat detection cycles at ~1-2s.
+		consumer.WithFetchTimeout(1*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dyn.Stop(context.Background()) })
+
+	cluster := testutil.NewFastWorkerCluster(t, nc, 4)
+	defer cluster.StopWorkers()
+
+	mgr := cluster.AddWorkerWithOptions(ctx,
+		parti.WithWorkerConsumerUpdater(dyn),
+	)
+	require.NoError(t, mgr.Start(ctx))
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	cluster.WaitForStableState(15 * time.Second)
+
+	// Seed a publish + dwell so partition consumers have ACTIVE, bound
+	// iterators before deletion — the heartbeat-burst path under test only
+	// exists for an already-bound iterator (a failed creation routes through
+	// Site A instead).
+	_, err = js.Publish(ctx, "burstpath.partition-0", []byte("seed"))
+	require.NoError(t, err)
+	time.Sleep(750 * time.Millisecond)
+
+	require.NoError(t, js.DeleteStream(ctx, streamName))
+
+	// Exhaustion must reach the manager within the multi-attempt budget:
+	// ~3 cycles x (heartbeat detection ~1-2s + burst window accumulation +
+	// detour backoff) plus scheduling slack. 45s is generous for the fixed
+	// path and far below the pre-fix behavior (never: the loop ping-pongs
+	// between ErrNoHeartbeat and backoff without ever counting a
+	// stream-missing failure).
+	require.Eventually(t, func() bool {
+		return mgr.State() == types.StateDegraded
+	}, 45*time.Second, 250*time.Millisecond,
+		"stream deletion with an active iterator and a multi-attempt recovery budget must exhaust "+
+			"through the stream-missing detour and reach Degraded; a timeout here means the "+
+			"heartbeat-burst Info probe is misclassifying the deleted stream as a transient issue "+
+			"and the consumer is stalled while the worker reports Stable")
+}

--- a/test/integration/failure/stream_missing_no_hook_test.go
+++ b/test/integration/failure/stream_missing_no_hook_test.go
@@ -103,14 +103,12 @@ func TestStreamMissingNoHook_RoutesPermanentFailureToManager(t *testing.T) {
 		// MaxAttempts=1 so the first stream-missing detour failure
 		// (handleStreamMissing returning a wrapped ErrStreamMissing
 		// because no hook is configured) immediately exhausts the
-		// envelope and fires OnPermanentFailure. The exhaustion-path
-		// classification of subsequent iter.Next failures has a
-		// known gap (iter.Next() → ErrNoHeartbeat after the first
-		// detour returns false from confirmConsumerGone when the
-		// underlying API surfaces ErrStreamNotFound rather than
-		// ErrConsumerNotFound); MaxAttempts=1 keeps this T4 focused
-		// on the manager-side wiring rather than the durable
-		// classification surface.
+		// envelope and fires OnPermanentFailure, keeping this T4
+		// focused on the manager-side wiring. The multi-attempt
+		// budget (post-deletion cycles routing through the
+		// heartbeat-burst Info probe) is pinned separately by
+		// TestStreamMissingNoHook_HeartbeatBurstPath_ExhaustsWithMultiAttemptBudget
+		// in stream_missing_burst_path_test.go.
 		consumer.WithRecoveryRetry(consumer.RecoveryRetryConfig{
 			MaxAttempts: 1,
 			BaseBackoff: 100 * time.Millisecond,
@@ -237,6 +235,20 @@ WaitForStreamMissing:
 			"degraded reason must never be the KV-threshold one for a stream-missing exhaustion (cross-feature contract); got %q in the observed sequence %v", r, degradedReasons)
 	}
 	degradedMu.Unlock()
+
+	// Terminal hold: the worker must STAY Degraded — recovery must not exit
+	// this reason. Pre-fix, the connection monitor (connection up the whole
+	// time) exited back to Stable once it had been up for one ExitThreshold,
+	// defeating the rotate-on-Degraded operator contract. The cluster uses
+	// the default ExitThreshold (5s) and the monitor ticks every 1s, so the
+	// exit empirically lands at ~6.2s after the Degraded entry. An 8s window
+	// comfortably exceeds one ExitThreshold plus one tick, so it catches the
+	// pre-fix flip while staying within the surrounding 60s context budget.
+	require.Never(t, func() bool {
+		return mgr.State() != types.StateDegraded
+	}, 8*time.Second, 100*time.Millisecond,
+		"stream-missing-recovery-exhausted must hold the worker terminally Degraded for rotation; "+
+			"an exit back to Stable leaves dead partition consumers reported as healthy")
 
 	// Post-exhaustion silence (spec T4 §"Post-exhaustion silence").
 	// Snapshot the call count right after the OnError fire, then

--- a/types/errors.go
+++ b/types/errors.go
@@ -151,6 +151,15 @@ var (
 	ErrCommitCASFailed = errors.New("commit CAS failed; surrendering")
 )
 
+// Consumer errors - Errors returned by consumer lifecycle operations.
+var (
+	// ErrConsumerStopped is returned when an operation requires a running
+	// consumer but the consumer has been stopped or closed. Stop/Close is
+	// terminal for Static, Broadcast, and Dynamic worker consumers: create a
+	// new instance to consume again.
+	ErrConsumerStopped = errors.New("consumer is stopped")
+)
+
 // Common errors - Shared errors used across multiple components.
 var (
 	// ErrContextCanceled is returned when an operation is canceled by context.

--- a/types/metrics_collector.go
+++ b/types/metrics_collector.go
@@ -332,7 +332,9 @@ type WorkerConsumerMetrics interface {
 	// IncrementWorkerConsumerGuardrailViolation increments violations (max_subjects, workerid_mutation).
 	IncrementWorkerConsumerGuardrailViolation(kind string)
 
-	// IncrementWorkerConsumerSubjectThresholdWarning increments threshold warning events.
+	// IncrementWorkerConsumerSubjectThresholdWarning increments updates rejected because the
+	// deduped subject count exceeded MaxConcurrentSubjects (fires once per rejected update,
+	// including retries).
 	IncrementWorkerConsumerSubjectThresholdWarning()
 
 	// RecordWorkerConsumerUpdate increments update results (success|failure|noop).


### PR DESCRIPTION
## Summary

Two consensus-reviewed fix batches accumulated for the next release, all found by QA sweeps of the consumer layer's auto-healing, error-handling, handoff, and lifecycle paths, each batch confirmed through external (codex) review loops with verify-first reproducers.

### Batch 1 — Dynamic consumer healing (commits `cf86af4..cd4c219`)

1. **Terminal Degraded hold** after stream-missing recovery exhaustion (was: back to Stable in ~1 tick with dead consumers; latch survives reason overlap).
2. **Over-cap rejection**: `Dynamic.Update` now returns the documented `ErrMaxSubjectsExceeded` pre-mutation (was: silent skip that could strand a partition unowned through a committed handoff).
3. **Remove-timeout error**: removed loops failing to stop within `DrainOnRemoveTimeout` now fail the update (was: silent success).
4. **Dual-dispatch observer**: `WithOnPermanentFailure` no longer suppresses the manager's degrade route; explicit opt-out via `WithSuppressManagerDegradeOnStreamMissing()`.

### Classifier fix (`dc3f87c`)

5. **Deleted stream now exhausts recovery instead of stalling silently**: the heartbeat-burst Info probe treated the stream-scoped `ErrStreamNotFound` as "consumer still exists" (transient-forever). Proven both ways: 45s stall pre-fix, Degraded in ~7s post-fix.

### Batch 2 — Queue/Static/Broadcast sweep + doc truth (commits `07f7ebb..HEAD`)

6. **FetchTimeout 1s floor** (was: sub-second configs passed validation and produced a dead consumer with successful Start).
7. **Nil-recovery stall signal**: `recovery_disabled` Warn + metric in all three consumers (was: Debug-only forever on a deleted durable — the default config).
8. **Terminal Stop/Close** for Static, Broadcast, AND the Dynamic worker consumer (new `ErrConsumerStopped`; the Dynamic case was a silent safety downgrade — post-Close restarts ran ungated). Sentinel takes precedence over the compat preflight.
9. **Key-worker idle-exit ordering race** fixed via send/exit mutual exclusion (reproducer: stranded messages under -race, 5/5 pre-fix).
10. **Retry backoff actually grows** in Broadcast + Dynamic loops (Multiplier/Max/Seed were dead config).
11. **Queue**: compat check before durable creation (was: orphaned exclusive durable blocking WorkQueue streams 24h); closed-iterator hot loop bounded (1.14M iterator creations/200ms → 10).
12. **`ErrInvalidConfig` wrapping** across all four constructors (was: partial phantom).
13. **Docs truth**: the "zero overlap" claims in LIFECYCLE/REFERENCE replaced with the per-tier overlap contract (two-phase orders release; the gate is pre-handler admission; irreducible window = in-flight handler + AckWait redelivery via the shared durable; mitigation `WIPHandler`); the fictional prepare/commit ACK protocol replaced with the actual worker-driven KV CAS flow.

## Behavior changes (see CHANGELOG)

- `WithOnPermanentFailure` no longer implies manager-degrade suppression (opt-out option added).
- Over-cap assignments: silent skip → hard rejection.
- `FetchTimeout` in (0, 1s): now fails construction.
- Stop/Close is terminal for all consumer types (`ErrConsumerStopped`).

## Validation

- `make pre-pr` (lint + unit `-race` + integration `-race`) green for both batches; cross-feature contract suites covered.
- Every fix landed verify-first: each reproducer confirmed failing on the parent commit before the fix.
- External post-impl reviews: batch 1 fix-then-merge (1 P1 godoc, fixed); batch 2 fix-then-merge (1 P1 sentinel precedence + 2 P2 docs, all fixed); consensus verdicts in `tmp/` review reports (untracked).
- Deferred with consensus (recorded for follow-up): retry-stash version-only coalescing (next planned correctness item), resolver stale-positive hardening, orphan stable-claim GC, overlap chaos test.

Plans: `docs/plans/dynamic-consumer-healing-fixes/01-implementation-plan.md` and `02-consumer-sweep-plan.md` (with review addenda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)