### PR TITLE
fix(manager): surface every component error from Stop via errors.Join

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -815,7 +815,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 	if err := m.election.ReleaseLeadership(releaseCtx); err != nil &&
 		!errors.Is(err, election.ErrNotLeader) {
 		m.logError("failed to release leadership on stop", "error", err)
-		shutdownErr = fmt.Errorf("leadership release failed: %w", err)
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("leadership release failed: %w", err))
 	}
 	releaseCancel()
 
@@ -832,23 +832,19 @@ func (m *Manager) Stop(ctx context.Context) error {
 	// Step 1.6: Stop partition source
 	if err := m.source.Stop(ctx); err != nil {
 		m.logError("failed to stop partition source", "error", err)
-		shutdownErr = fmt.Errorf("partition source stop failed: %w", err)
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("partition source stop failed: %w", err))
 	}
 
 	// Step 2: Stop heartbeat publisher (ignore ErrNotStarted)
 	if err := m.heartbeat.Stop(); err != nil && !errors.Is(err, heartbeat.ErrNotStarted) {
 		m.logError("failed to stop heartbeat", "error", err)
-		if shutdownErr == nil {
-			shutdownErr = fmt.Errorf("heartbeat stop failed: %w", err)
-		}
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("heartbeat stop failed: %w", err))
 	}
 
 	// Step 3: Release stable worker ID (ignore ErrNotClaimed)
 	if err := m.idClaimer.Release(ctx); err != nil && !errors.Is(err, stableid.ErrNotClaimed) {
 		m.logError("failed to release worker ID", "error", err)
-		if shutdownErr == nil {
-			shutdownErr = fmt.Errorf("worker ID release failed: %w", err)
-		}
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("worker ID release failed: %w", err))
 	}
 
 	// Step 4: Wait for all background goroutines with timeout
@@ -865,10 +861,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 		return shutdownErr
 	case <-ctx.Done():
 		m.logger.Warn("manager stop timed out")
-		if shutdownErr == nil {
-			shutdownErr = ctx.Err()
-		}
-		return shutdownErr
+		return errors.Join(shutdownErr, ctx.Err())
 	}
 }
 

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -161,7 +161,10 @@ func (m *Manager) recordKVError(err error) {
 	// entries to accumulate.
 	m.kvErrorWindow = append(m.kvErrorWindow, kvErrorEvent{at: now, transient: decision.transient})
 
-	// Remove errors outside the window
+	// Remove errors outside the window. This scan assumes kvErrorWindow is
+	// ascending by .at — an invariant maintained solely because the window is
+	// only ever appended to (above) and head-trimmed (below). Do not insert or
+	// reorder entries, or the first-in-window scan breaks silently.
 	windowStart := now.Add(-m.cfg.DegradedBehavior.KVErrorWindow)
 	validIdx := 0
 	for i, e := range m.kvErrorWindow {

--- a/manager_stop_test.go
+++ b/manager_stop_test.go
@@ -2,6 +2,7 @@ package parti
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,9 +26,11 @@ func (b *blockingSource) Start(_ context.Context) error                     { re
 func (b *blockingSource) List(_ context.Context) ([]types.Partition, error) { return nil, nil }
 func (b *blockingSource) Stop(_ context.Context) error                      { <-b.stopGate; return nil }
 
-// spyElection records whether ReleaseLeadership was called.
+// spyElection records whether ReleaseLeadership was called. releaseErr, when
+// non-nil, is returned from ReleaseLeadership to exercise shutdown error paths.
 type spyElection struct {
 	releaseCalled atomic.Bool
+	releaseErr    error
 }
 
 func (s *spyElection) RequestLeadership(context.Context, string, int64) (bool, error) {
@@ -37,8 +40,16 @@ func (s *spyElection) RenewLeadership(context.Context) error  { return nil }
 func (s *spyElection) IsLeader(context.Context) (bool, error) { return false, nil }
 func (s *spyElection) ReleaseLeadership(_ context.Context) error {
 	s.releaseCalled.Store(true)
-	return nil
+	return s.releaseErr
 }
+
+// errStopSource is a fake PartitionSource whose Stop always fails with a fixed
+// sentinel, used to prove Stop surfaces multiple component errors.
+type errStopSource struct{ err error }
+
+func (e *errStopSource) Start(_ context.Context) error                     { return nil }
+func (e *errStopSource) List(_ context.Context) ([]types.Partition, error) { return nil, nil }
+func (e *errStopSource) Stop(_ context.Context) error                      { return e.err }
 
 func TestManager_Stop_ReleasesLeadershipBeforeSlowSourceStop(t *testing.T) {
 	// Short timeout so the test override doesn't bleed into other tests.
@@ -75,6 +86,40 @@ func TestManager_Stop_ReleasesLeadershipBeforeSlowSourceStop(t *testing.T) {
 	// Unblock the source so Stop can return.
 	close(gate)
 	require.NoError(t, <-stopDone)
+}
+
+// TestStop_JoinsAllComponentErrors pins that Stop surfaces EVERY failing
+// component, not just the first. The regression it guards: source.Stop's error
+// used to unconditionally overwrite an earlier leadership-release error (and the
+// later steps were gated on shutdownErr==nil), so a multi-component failure hid
+// all but one cause — exactly the kind of silent root-cause loss that misleads
+// operators during shutdown. errors.Join makes every cause inspectable.
+func TestStop_JoinsAllComponentErrors(t *testing.T) {
+	errLeadership := errors.New("boom: leadership")
+	errSource := errors.New("boom: source")
+
+	spy := &spyElection{releaseErr: errLeadership}
+	src := &errStopSource{err: errSource}
+
+	m := &Manager{
+		cfg:       Config{ShutdownTimeout: 5 * time.Second},
+		hooks:     &types.Hooks{},
+		metrics:   metrics.NewNop(),
+		logger:    logging.NewNop(),
+		idClaimer: stableid.NewNop(),
+		election:  spy,
+		heartbeat: heartbeat.NewNop(),
+		source:    src,
+	}
+	m.state.Store(int32(StateStable))
+	m.workerID.Store("worker-0")
+	m.assignment.Store(Assignment{})
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+
+	err := m.Stop(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errLeadership, "leadership-release error must survive in the joined error")
+	require.ErrorIs(t, err, errSource, "source-stop error must survive in the joined error")
 }
 
 func TestStop_AlwaysReleasesLeadership(t *testing.T) {


### PR DESCRIPTION
## What

`Manager.Stop()` collected shutdown errors with first-non-nil-wins semantics, where `source.Stop`'s error **unconditionally overwrote** an earlier leadership-release error and the remaining steps were gated on `shutdownErr == nil`. A shutdown in which multiple components fail therefore surfaced only one root cause — silent loss that misleads operators diagnosing a failed stop.

This joins all five error sites (leadership release / partition source / heartbeat / worker-ID release / stop-timeout) with `errors.Join`, so every failing component stays inspectable via `errors.Is`. The healthy-stop path is unchanged (still returns `nil`).

Also adds a one-line note documenting the append-only / ascending-by-time invariant the `kvErrorWindow` first-in-window trim scan silently relies on.

## Why it's safe

- No behavior change on the success path.
- No exported-signature change (`Stop` still returns `error`).
- New regression test `TestStop_JoinsAllComponentErrors` was confirmed to **fail on the pre-fix code** (leadership error dropped) and pass with the fix.

## Validation

- `make lint` — 0 issues
- `make pre-pr` — lint + unit `-race` + live-NATS integration `-race`, all gates passed
- Cross-feature contracts intact (stableid takeover, bucket-loss → Degraded, etc.)

## Context

Result of a full maintenance-quality + error-handling audit. The audit's broader finding was that the codebase is already exceptionally hardened — most raised concerns verified as false positives or intentional design — so this is the single substantive fix; structural refactors were deliberately not pursued.