### PR TITLE
feat(handoff): reap orphaned claims for partitions removed from the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Orphaned handoff claims are now reaped by the leader's sweep.** Since the
+  handoff bucket deliberately carries no `MaxAge` (stable ownership claims
+  must never age out from under the pull-gating resolver), claims for
+  partitions permanently removed from the partition source accumulated
+  forever — a slow leak walked by every resolver warm and every sweep. The
+  two-phase coordinator's claim sweep now deletes a stable, no-pending-owner
+  claim once its partition has been continuously absent from BOTH the
+  leader's source view and the latest committed assignment for a 10-minute
+  grace period — a partition the live commit still references is never an
+  orphan, so an owner consuming through a stalled rebalance window is never
+  cut off. The delete is revision-checked (compare-and-delete), so a
+  concurrently re-added partition's claim transition always wins over the
+  reaper. Followers never reap (a config-skewed follower, e.g. an old static
+  partition list mid-rolling-upgrade, must not be an authority on which
+  partitions exist), and any stretch where the leader cannot verify the
+  set — leadership loss, source or commit read failure — restarts the grace
+  clock.
+
 ## [v2.7.1] - 2026-06-12
 
 Patch release. One shutdown-diagnostics fix; no API or default-behavior

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -237,7 +237,7 @@ There is no leader→worker message exchange. Each worker independently drives i
         ▼                                     ▼
 ```
 
-A background sweeper reconciles stale or interrupted claims toward `stable` on `SweepInterval`, so a worker crashing mid-handoff does not strand a claim.
+A background sweeper reconciles stale or interrupted claims toward `stable` on `SweepInterval`, so a worker crashing mid-handoff does not strand a claim. On the leader, the same sweep also reaps orphaned claims — stable claims whose partition has been removed from the partition source — after the partition has been continuously absent from BOTH the leader's source view and the latest committed assignment for a 10-minute grace period (a partition the live commit still references is never an orphan, even if the source already dropped it). The delete is revision-checked, so a partition re-added concurrently always wins over the reaper; followers never reap (their source view could be config-skewed during a rolling upgrade), and any stretch where the leader cannot verify the set restarts the grace clock.
 
 ### Handoff States
 

--- a/internal/assignment/handoff/claim_test.go
+++ b/internal/assignment/handoff/claim_test.go
@@ -66,8 +66,30 @@ func (m *memStore) ListKeys(ctx context.Context) ([]string, error) {
 	return out, nil
 }
 
+func (m *memStore) Delete(_ context.Context, partitionID string, revision uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur, ok := m.rev[partitionID]
+	if !ok {
+		return errRevisionMismatch
+	}
+	// Mirror jetstream.LastRevision semantics: delete only at the exact
+	// revision the caller read; any concurrent transition wins.
+	if cur != revision {
+		return errRevisionMismatch
+	}
+	delete(m.data, partitionID)
+	delete(m.rev, partitionID)
+
+	return nil
+}
+
 // ErrEpochMismatch is a sentinel for test store CAS failures.
 var ErrEpochMismatch = errors.New("epoch mismatch")
+
+// errRevisionMismatch is the test-store analogue of the LastRevision
+// compare-and-delete failure NATS returns for a stale-revision Delete.
+var errRevisionMismatch = errors.New("revision mismatch")
 
 func TestSweeper_ResetsExpiredNonStableToStable(t *testing.T) {
 	t.Parallel()

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -121,6 +121,23 @@ type Config struct {
 	// negative is the "use default 20" sentinel set by the parti-side
 	// HandoffConfig contract; New() normalizes the value in place.
 	PhaseConcurrency int
+	// LivePartitions optionally supplies the authoritative current partition
+	// set, keyed by Partition.SubjectKey() (the same identity claims are keyed
+	// by). ok=false means the caller cannot vouch for the set right now — not
+	// the leader, or the source is unavailable — and the sweep skips orphan
+	// reaping entirely for that pass, including absence-clock bookkeeping.
+	//
+	// The supplier MUST be authoritative when it answers ok=true: the manager
+	// wires it leader-only, so a config-skewed follower (e.g. an old Static
+	// partition list mid-rolling-upgrade) can never reap claims for partitions
+	// it does not know about. A nil supplier disables reaping.
+	LivePartitions func(ctx context.Context) (map[string]struct{}, bool)
+	// OrphanGrace is how long a stable claim must be continuously observed
+	// absent from the vouched LivePartitions set before the sweep deletes it.
+	// The grace turns transient source churn (remove-then-readd) into a
+	// no-op; the revision-CAS delete additionally guarantees any concurrent
+	// claim transition wins over the reaper. <= 0 disables orphan reaping.
+	OrphanGrace time.Duration
 }
 
 // New returns a Coordinator implementation.
@@ -159,7 +176,10 @@ func New(cfg Config, enableTwoPhase bool) Coordinator {
 		cfg.TTL = 1 * time.Minute
 	}
 	if enableTwoPhase {
-		return &twoPhaseCoordinator{cfg: cfg}
+		return &twoPhaseCoordinator{
+			cfg:               cfg,
+			orphanAbsentSince: make(map[string]time.Time),
+		}
 	}
 
 	return &direct{cfg: cfg}

--- a/internal/assignment/handoff/kv_store.go
+++ b/internal/assignment/handoff/kv_store.go
@@ -55,6 +55,21 @@ type ClaimStore interface {
 	// The returned partition IDs correspond to the keys in the KV store
 	// under the claims prefix.
 	ListKeys(ctx context.Context) ([]string, error)
+
+	// Delete removes a partition's claim, but only if the claim is still at
+	// the given revision (compare-and-delete). A revision mismatch — the
+	// claim was transitioned or re-created since the caller read it — must
+	// fail the delete and return an error, so a concurrent legitimate
+	// writer always wins over a deleter working from a stale read.
+	//
+	// Parameters:
+	//   - ctx: Context for cancellation.
+	//   - partitionID: The ID of the partition whose claim to delete.
+	//   - revision: The KV revision the caller read the claim at.
+	//
+	// Returns:
+	//   - error: Any error encountered, including revision mismatches.
+	Delete(ctx context.Context, partitionID string, revision uint64) error
 }
 
 // natsClaimStore implements ClaimStore using a jetstream.KeyValue bucket.
@@ -123,6 +138,16 @@ func (s *natsClaimStore) PutIfEpoch(ctx context.Context, partitionID string, exp
 
 func (s *natsClaimStore) ListKeys(ctx context.Context) ([]string, error) {
 	return kvutil.ListKeys(ctx, s.kv, s.claimsPref, true)
+}
+
+func (s *natsClaimStore) Delete(ctx context.Context, partitionID string, revision uint64) error {
+	// LastRevision makes this a compare-and-delete: NATS rejects the delete
+	// (ErrKeyExists wrap) when the key has moved past the given revision.
+	if err := s.kv.Delete(ctx, s.key(partitionID), jetstream.LastRevision(revision)); err != nil {
+		return fmt.Errorf("kv delete: %w", err)
+	}
+
+	return nil
 }
 
 // Now returns time.Now() and allows override in tests.

--- a/internal/assignment/handoff/orphan_reap_test.go
+++ b/internal/assignment/handoff/orphan_reap_test.go
@@ -1,0 +1,380 @@
+package handoff
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Orphan-claim reap contract. A claim whose partition has left the
+// authoritative partition set (the source no longer lists it, so no
+// assignment can ever reference it again) is dead weight in the handoff
+// bucket: nothing reads it, but it is walked by every resolver warm and
+// every sweep, forever. The sweep deletes such claims — but only under
+// conditions that make a wrong delete impossible to sustain:
+//
+//   - only when LivePartitions vouches for the set (ok=true; the manager
+//     wires this leader-only so a config-skewed follower can never reap);
+//   - only stable claims with no pending owner (in-flight handoffs are
+//     reconciled by the existing sweep arms, never reaped);
+//   - only after the claim has been continuously absent from the vouched
+//     set for OrphanGrace (transient source churn never qualifies);
+//   - via a revision-CAS delete, so a concurrent re-add that recreates or
+//     transitions the claim wins over the reaper unconditionally.
+
+const orphanTestGrace = 10 * time.Minute
+
+// bigTTL keeps claims out of IsExpired territory for every time advance a
+// test makes, so the expired-reset sweep arm cannot interfere with what
+// these tests pin.
+const bigTTL = int64(24 * 60 * 60)
+
+func stableClaim(pid string, now time.Time) Claim {
+	return Claim{
+		PartitionID: pid,
+		Owner:       "w1",
+		State:       ClaimStateStable,
+		Epoch:       1,
+		LastUpdated: now.UTC(),
+		TTLSeconds:  bigTTL,
+	}
+}
+
+// reapHarness bundles the mutable clock and live-set the tests steer.
+type reapHarness struct {
+	store *memStore
+	coord Coordinator
+
+	mu   sync.Mutex
+	now  time.Time
+	live map[string]struct{}
+	ok   bool
+}
+
+func newReapHarness(t *testing.T, grace time.Duration) *reapHarness {
+	t.Helper()
+	h := &reapHarness{
+		store: newMemStore(),
+		now:   time.Now().UTC(),
+		ok:    true,
+		live:  map[string]struct{}{},
+	}
+	h.coord = New(Config{
+		Store: h.store,
+		Now: func() time.Time {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+
+			return h.now
+		},
+		LivePartitions: func(_ context.Context) (map[string]struct{}, bool) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+
+			return h.live, h.ok
+		},
+		OrphanGrace:   grace,
+		SweepInterval: -1, // sweep on every Apply (0 would default to 30s in New)
+		MaxRetries:    1,
+		BaseBackoff:   time.Millisecond,
+		MaxBackoff:    2 * time.Millisecond,
+	}, true)
+
+	return h
+}
+
+func (h *reapHarness) seed(c Claim) {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+	h.store.data[c.PartitionID] = c
+	h.store.rev[c.PartitionID] = 1
+}
+
+func (h *reapHarness) setLive(pids ...string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.live = make(map[string]struct{}, len(pids))
+	for _, p := range pids {
+		h.live[p] = struct{}{}
+	}
+}
+
+func (h *reapHarness) setOK(ok bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.ok = ok
+}
+
+func (h *reapHarness) advance(d time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.now = h.now.Add(d)
+}
+
+// sweep triggers one opportunistic sweep through the public Apply path.
+func (h *reapHarness) sweep(t *testing.T) {
+	t.Helper()
+	require.NoError(t, h.coord.Apply(context.Background(), "worker-1", types.Assignment{}, types.Assignment{}))
+}
+
+func (h *reapHarness) claimExists(t *testing.T, pid string) bool {
+	t.Helper()
+	_, rev, err := h.store.Get(context.Background(), pid)
+	require.NoError(t, err)
+
+	return rev != 0
+}
+
+func TestOrphanReap_DeletesOrphanAfterGrace(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	now := time.Now().UTC()
+	h.seed(stableClaim("p-live", now))
+	h.seed(stableClaim("p-gone", now))
+	h.setLive("p-live")
+
+	// First observation starts the absence clock; nothing is deleted yet.
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"), "first absent observation must not delete")
+	require.True(t, h.claimExists(t, "p-live"))
+
+	h.advance(orphanTestGrace + time.Second)
+	h.sweep(t)
+	require.False(t, h.claimExists(t, "p-gone"), "orphan past grace must be reaped")
+	require.True(t, h.claimExists(t, "p-live"), "in-set claim must never be reaped")
+}
+
+func TestOrphanReap_WithinGraceKept(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", time.Now().UTC()))
+	h.setLive() // empty set: p-gone is absent
+
+	h.sweep(t)
+	h.advance(orphanTestGrace - time.Second)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"), "claim within grace must be kept")
+}
+
+func TestOrphanReap_SupplierNotOKSkipsAndDoesNotStartClock(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", time.Now().UTC()))
+	h.setLive()
+	h.setOK(false)
+
+	// Unvouched passes must neither delete nor start the absence clock.
+	h.sweep(t)
+	h.advance(2 * orphanTestGrace)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"), "unvouched set must never reap")
+
+	// The clock starts at the first vouched absence, not at the not-ok pass.
+	h.setOK(true)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"),
+		"first vouched observation starts the clock; deleting here would credit unvouched time")
+
+	h.advance(orphanTestGrace + time.Second)
+	h.sweep(t)
+	require.False(t, h.claimExists(t, "p-gone"))
+}
+
+func TestOrphanReap_UnvouchedGapResetsExistingClock(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", time.Now().UTC()))
+	h.setLive()
+
+	// Vouched absence starts the clock.
+	h.sweep(t)
+
+	// A long unvouched gap (lost leadership / source down) must RESET the
+	// clock, not merely pause it: time spent unvouched is time the worker
+	// could not verify continuous absence, so it must not count toward grace.
+	h.setOK(false)
+	h.advance(2 * orphanTestGrace)
+	h.sweep(t)
+
+	h.setOK(true)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"),
+		"first vouched pass after an unvouched gap must restart grace, not reap on the stale clock")
+
+	h.advance(orphanTestGrace + time.Second)
+	h.sweep(t)
+	require.False(t, h.claimExists(t, "p-gone"), "a full vouched grace after the gap reaps")
+}
+
+func TestOrphanReap_NonStableOrphanKept(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	now := time.Now().UTC()
+	prep := Claim{
+		PartitionID:  "p-gone",
+		Owner:        "w2",
+		PendingOwner: "w1",
+		State:        ClaimStatePrepare,
+		Epoch:        2,
+		LastUpdated:  now,
+		TTLSeconds:   bigTTL, // not expired: the reset arm must not normalize it mid-test
+	}
+	h.seed(prep)
+	h.setLive()
+
+	h.sweep(t)
+	h.advance(orphanTestGrace + time.Second)
+	h.sweep(t)
+
+	got, rev, err := h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "in-flight (non-stable) claim must never be reaped")
+	require.Equal(t, ClaimStatePrepare, got.State)
+}
+
+func TestOrphanReap_ReturnToSetResetsGrace(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-flap", time.Now().UTC()))
+	h.setLive()
+
+	// Absent: clock starts.
+	h.sweep(t)
+
+	// Returns to the set past the original grace: candidate must clear.
+	h.advance(orphanTestGrace + time.Second)
+	h.setLive("p-flap")
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-flap"))
+
+	// Absent again: the clock must restart, not resume.
+	h.setLive()
+	h.advance(time.Second)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-flap"),
+		"re-absence must restart the grace clock, not inherit the earlier absence")
+
+	h.advance(orphanTestGrace + time.Second)
+	h.sweep(t)
+	require.False(t, h.claimExists(t, "p-flap"))
+}
+
+func TestOrphanReap_RevisionConflictKeepsClaim(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", time.Now().UTC()))
+	h.setLive()
+
+	// Simulate a concurrent transition between the sweep's read and its
+	// delete: every delete attempt fails the revision CAS.
+	h.swapStore(t, &conflictingDeleteStore{ClaimStore: h.store})
+
+	h.sweep(t)
+	h.advance(orphanTestGrace + time.Second)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"),
+		"a lost delete CAS means the claim moved; the reaper must yield")
+}
+
+func TestOrphanReap_ZeroGraceDisables(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, 0)
+	h.seed(stableClaim("p-gone", time.Now().UTC()))
+	h.setLive()
+
+	h.sweep(t)
+	h.advance(365 * 24 * time.Hour)
+	h.sweep(t)
+	require.True(t, h.claimExists(t, "p-gone"), "OrphanGrace<=0 must disable reaping entirely")
+}
+
+// swapStore replaces the coordinator's store mid-test. Reaches into the
+// concrete type; tests live in-package by design (see claim_test.go).
+func (h *reapHarness) swapStore(t *testing.T, s ClaimStore) {
+	t.Helper()
+	tp, ok := h.coord.(*twoPhaseCoordinator)
+	require.True(t, ok, "harness coordinator must be the two-phase implementation")
+	tp.cfg.Store = s
+}
+
+// conflictingDeleteStore fails every Delete with a revision conflict while
+// delegating everything else to the wrapped store.
+type conflictingDeleteStore struct {
+	ClaimStore
+}
+
+var errRevConflict = errors.New("revision conflict")
+
+func (c *conflictingDeleteStore) Delete(context.Context, string, uint64) error {
+	return errRevConflict
+}
+
+// gatedListStore blocks ListKeys until released, counting calls. Used to
+// hold one sweep body open while another pass arrives.
+type gatedListStore struct {
+	ClaimStore
+	entered chan struct{} // signaled once per ListKeys entry
+	release chan struct{} // close to let ListKeys proceed
+	calls   atomic.Int32
+}
+
+func (g *gatedListStore) ListKeys(ctx context.Context) ([]string, error) {
+	g.calls.Add(1)
+	g.entered <- struct{}{}
+	<-g.release
+
+	return g.ClaimStore.ListKeys(ctx)
+}
+
+// TestSweep_SingleFlight pins that sweep bodies never run concurrently: a
+// pass arriving while another sweep is mid-body is skipped outright. This
+// is what makes the orphan absence clock single-writer — without it, an
+// unvouched pass's clock-clear could interleave between a concurrent
+// vouched pass's reap decision and its delete, reaping on a clock the
+// clear should have invalidated.
+func TestSweep_SingleFlight(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-0", time.Now().UTC()))
+	gated := &gatedListStore{
+		ClaimStore: h.store,
+		entered:    make(chan struct{}, 2),
+		release:    make(chan struct{}),
+	}
+	h.swapStore(t, gated)
+
+	// First sweep: parks inside ListKeys, holding the sweep body open.
+	var wg sync.WaitGroup
+	wg.Go(func() { h.sweep(t) })
+	<-gated.entered
+
+	// Second sweep while the first is mid-body: must skip without listing.
+	wg.Go(func() { h.sweep(t) })
+	select {
+	case <-gated.entered:
+		// Pre-fix behavior: the second pass entered the body concurrently.
+		// Fall through; the assertion below reports it.
+	case <-time.After(100 * time.Millisecond):
+		// Post-fix behavior: the second pass skipped without listing.
+	}
+
+	close(gated.release)
+	wg.Wait()
+	require.EqualValues(t, 1, gated.calls.Load(),
+		"a sweep arriving mid-body must be skipped, not run concurrently")
+}

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -19,10 +19,27 @@ import (
 //
 // All latency / retries are internal; Apply should return quickly.
 type twoPhaseCoordinator struct {
-	cfg       Config
+	cfg Config
+	// sweepMu makes the sweep single-flight: maybeSweepClaims holds it
+	// across the WHOLE sweep body (TryLock; a pass that loses simply
+	// skips — the sweep is opportunistic and the winner is already doing
+	// the work). Serializing bodies is what makes orphanAbsentSince
+	// single-writer, and it closes the interleaving where an unvouched
+	// pass's clock-clear lands between a concurrent vouched pass's reap
+	// decision and its delete — reaping on a clock the clear should have
+	// invalidated. lastSweep is guarded by it too.
 	sweepMu   sync.Mutex
 	lastSweep time.Time
 	started   atomic.Bool
+
+	// orphanAbsentSince records, per claim key, when the sweep first observed
+	// the partition absent from a vouched LivePartitions set. Entries clear
+	// when the partition reappears, when the claim is reaped, when the claim
+	// key stops being listed, or wholesale on an unvouched pass. Guarded by
+	// sweepMu (single-flight sweep = single writer). In-memory only: a
+	// restart or leadership change restarts the grace clock, which is the
+	// conservative direction.
+	orphanAbsentSince map[string]time.Time
 }
 
 // Start launches a background goroutine that sweeps stale claims at SweepInterval.
@@ -452,22 +469,24 @@ func (t *twoPhaseCoordinator) stabilizePhase(ctx context.Context, workerID strin
 //  2. Any expired non-stable claim (e.g. a stuck prepare) is reset back to stable,
 //     clearing any pending owner (the original stale-claim safety net).
 //
-// Runs at most once per configured sweep interval. If SweepInterval <= 0, runs every time.
+// Runs at most once per configured sweep interval. If SweepInterval <= 0, runs
+// every time — but never concurrently: sweep bodies are single-flight (see the
+// sweepMu field doc), and a pass arriving while another sweep is mid-body is
+// skipped rather than blocked, so Apply never waits on another sweep's KV I/O.
 func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context) {
 	if t.cfg.Store == nil {
 		return
 	}
-	now := t.cfg.Now()
+	if !t.sweepMu.TryLock() {
+		return // another sweep is mid-body; this opportunistic pass skips
+	}
+	defer t.sweepMu.Unlock()
 
-	// Check sweep interval with lock
-	t.sweepMu.Lock()
+	now := t.cfg.Now()
 	if t.cfg.SweepInterval > 0 && !t.lastSweep.IsZero() && now.Sub(t.lastSweep) < t.cfg.SweepInterval {
-		t.sweepMu.Unlock()
 		return
 	}
-	// Update last sweep time and release lock immediately to avoid blocking Apply
 	t.lastSweep = now
-	t.sweepMu.Unlock()
 
 	keys, err := t.cfg.Store.ListKeys(ctx)
 	if err != nil || len(keys) == 0 {
@@ -476,6 +495,23 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context) {
 	if t.cfg.Metrics != nil {
 		t.cfg.Metrics.SetClaimStoreSize(len(keys))
 	}
+
+	// Resolve the live partition set once per pass for orphan reaping.
+	// liveOK=false (supplier not vouching: not the leader, source down)
+	// skips all reap decisions for the pass AND resets every absence clock:
+	// time spent unvouched is time this worker could not verify continuous
+	// absence, so it must not count toward OrphanGrace — otherwise a clock
+	// started before a long follower stint would reap instantly on the
+	// first vouched pass after it.
+	var live map[string]struct{}
+	liveOK := false
+	if t.cfg.OrphanGrace > 0 && t.cfg.LivePartitions != nil {
+		live, liveOK = t.cfg.LivePartitions(ctx)
+		if !liveOK {
+			clear(t.orphanAbsentSince)
+		}
+	}
+
 	for _, pid := range keys {
 		cur, rev, err := t.cfg.Store.Get(ctx, pid)
 		if err != nil || rev == 0 {
@@ -483,16 +519,106 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context) {
 		}
 		// Cheap pre-filter: skip a CAS write attempt when this claim needs no
 		// reconcile (the common case for already-stable claims).
-		if sweepReconcile(&cur, now) == nil {
+		if sweepReconcile(&cur, now) != nil {
+			if err := t.updateClaim(ctx, pid, func(cur *Claim) (*Claim, error) {
+				// Re-decide on the fresh read inside the CAS loop.
+				return sweepReconcile(cur, now), nil
+			}); err == nil {
+				if t.cfg.Metrics != nil {
+					t.cfg.Metrics.IncClaimStoreStale()
+				}
+			}
+			// A just-reconciled claim is in flux; it is not reap-eligible
+			// this pass. The next pass re-evaluates it from a fresh read.
 			continue
 		}
-		if err := t.updateClaim(ctx, pid, func(cur *Claim) (*Claim, error) {
-			// Re-decide on the fresh read inside the CAS loop.
-			return sweepReconcile(cur, now), nil
-		}); err == nil {
-			if t.cfg.Metrics != nil {
-				t.cfg.Metrics.IncClaimStoreStale()
-			}
+
+		if liveOK {
+			t.maybeReapOrphan(ctx, pid, cur, rev, live, now)
+		}
+	}
+
+	if liveOK {
+		t.pruneOrphanCandidates(keys)
+	}
+}
+
+// maybeReapOrphan applies the orphan-reap decision for one claim against a
+// vouched live partition set:
+//
+//   - in the set → clear any absence clock, keep;
+//   - not stable, or a pending owner recorded → keep (in-flight handoffs are
+//     the existing sweep arms' job, never the reaper's);
+//   - first vouched absence → start the clock, keep;
+//   - absent for >= OrphanGrace → compare-and-delete at the revision this
+//     pass read. A lost CAS means the claim transitioned concurrently (e.g.
+//     the partition was re-added and prepared) — the reaper yields and the
+//     next pass re-evaluates from a fresh read.
+func (t *twoPhaseCoordinator) maybeReapOrphan(
+	ctx context.Context,
+	pid string,
+	cur Claim,
+	rev uint64,
+	live map[string]struct{},
+	now time.Time,
+) {
+	// Runs under sweepMu (single-flight sweep) — the sole writer of
+	// orphanAbsentSince, so no further locking is needed here.
+	if _, ok := live[pid]; ok {
+		delete(t.orphanAbsentSince, pid)
+
+		return
+	}
+	// Only terminal, settled claims are reap candidates.
+	if cur.State != ClaimStateStable || cur.PendingOwner != "" {
+		return
+	}
+	since, seen := t.orphanAbsentSince[pid]
+	if !seen {
+		t.orphanAbsentSince[pid] = now
+
+		return
+	}
+	if now.Sub(since) < t.cfg.OrphanGrace {
+		return
+	}
+
+	if err := t.cfg.Store.Delete(ctx, pid, rev); err != nil {
+		// Revision conflict or transient KV failure: keep the claim and the
+		// clock; a genuine orphan is re-attempted next pass, a re-added
+		// partition clears via the in-set branch above.
+		if t.cfg.Logger != nil {
+			t.cfg.Logger.Debug("orphan claim reap skipped",
+				"partition_id", pid, "error", err)
+		}
+
+		return
+	}
+	delete(t.orphanAbsentSince, pid)
+	if t.cfg.Logger != nil {
+		t.cfg.Logger.Info("reaped orphan claim",
+			"partition_id", pid,
+			"owner", cur.Owner,
+			"absent_for", now.Sub(since).String(),
+		)
+	}
+}
+
+// pruneOrphanCandidates drops absence-clock entries for claim keys that are
+// no longer listed in the bucket (reaped by another instance, or deleted by
+// other means), so the bookkeeping map cannot grow past the claim count.
+// Runs under sweepMu (single-flight sweep).
+func (t *twoPhaseCoordinator) pruneOrphanCandidates(listed []string) {
+	if len(t.orphanAbsentSince) == 0 {
+		return
+	}
+	listedSet := make(map[string]struct{}, len(listed))
+	for _, k := range listed {
+		listedSet[k] = struct{}{}
+	}
+	for pid := range t.orphanAbsentSince {
+		if _, ok := listedSet[pid]; !ok {
+			delete(t.orphanAbsentSince, pid)
 		}
 	}
 }

--- a/internal/assignment/handoff/twophase_concurrency_test.go
+++ b/internal/assignment/handoff/twophase_concurrency_test.go
@@ -50,6 +50,10 @@ func (o *observingClaimStore) ListKeys(ctx context.Context) ([]string, error) {
 	return o.inner.ListKeys(ctx)
 }
 
+func (o *observingClaimStore) Delete(ctx context.Context, partitionID string, revision uint64) error {
+	return o.inner.Delete(ctx, partitionID, revision)
+}
+
 // compile-time assertion
 var _ ClaimStore = (*observingClaimStore)(nil)
 

--- a/internal/assignment/handoff/twophase_stuck_prepare_test.go
+++ b/internal/assignment/handoff/twophase_stuck_prepare_test.go
@@ -453,6 +453,10 @@ func (s *casConflictOnceStore) ListKeys(ctx context.Context) ([]string, error) {
 	return s.inner.ListKeys(ctx)
 }
 
+func (s *casConflictOnceStore) Delete(ctx context.Context, partitionID string, revision uint64) error {
+	return s.inner.Delete(ctx, partitionID, revision)
+}
+
 // TestTwoPhase_StaleHandoffResetMetric_NoOvercountOnCASRetry guards the
 // post-impl-review finding that
 // when preparePhase resets a stuck handoff and the underlying CAS conflicts

--- a/internal/assignment/handoff/twophase_test.go
+++ b/internal/assignment/handoff/twophase_test.go
@@ -56,6 +56,8 @@ func (f *flakyStore) PutIfEpoch(ctx context.Context, partitionID string, expecte
 
 func (f *flakyStore) ListKeys(ctx context.Context) ([]string, error) { return nil, nil }
 
+func (f *flakyStore) Delete(context.Context, string, uint64) error { return nil }
+
 // consumerUpdaterFunc is a test helper to satisfy ConsumerUpdater.
 type consumerUpdaterFunc func(ctx context.Context, workerID string, partitions []types.Partition) error
 

--- a/manager_handoff.go
+++ b/manager_handoff.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -43,6 +44,63 @@ type HandoffClaim struct {
 	LastUpdated   time.Time         `json:"last_updated"`
 	TTLSeconds    int64             `json:"ttl_seconds"`
 	ConflictCount int64             `json:"conflict_count,omitempty"`
+}
+
+// orphanClaimGrace is how long a stable handoff claim must be continuously
+// observed absent from the leader's vouched partition set (source ∪ latest
+// committed assignment — see livePartitionSet) before the coordinator's
+// sweep reaps it. Claims for partitions permanently removed from the source
+// otherwise accumulate forever (the handoff bucket deliberately carries no
+// MaxAge — see reconcileHandoffBucketMaxAge). The grace is deliberately
+// generous: orphan bloat is a slow leak, so the only hard requirement is
+// that transient source churn (remove-then-readd within minutes) never
+// qualifies. The revision-CAS delete in the sweep independently guarantees
+// any concurrent claim transition wins over the reaper.
+const orphanClaimGrace = 10 * time.Minute
+
+// livePartitionSet supplies the two-phase coordinator's orphan-reap pass
+// with the authoritative current partition set, keyed by SubjectKey (the
+// claim key). It vouches (ok=true) only when this worker is the leader: a
+// follower — whose source could be config-skewed during a rolling upgrade —
+// never vouches, and the reap pass is skipped.
+//
+// The vouched set is the UNION of the leader's source view and the latest
+// committed assignment's partition set. The source alone is not authority
+// enough: after a partition is removed from the source there is a window —
+// unbounded if the follow-up rebalance publish stalls — in which the live
+// commit still references the partition and its owner is still consuming
+// it through the processing gate. Reaping the claim in that window would
+// make the gate NAK the legitimate owner (unknown_ownership) until some
+// later apply recreates the claim. A partition referenced by EITHER view
+// is therefore never an orphan.
+func (m *Manager) livePartitionSet(ctx context.Context) (map[string]struct{}, bool) {
+	if !m.isLeader.Load() {
+		return nil, false
+	}
+	parts, err := m.source.List(ctx)
+	if err != nil {
+		return nil, false
+	}
+	commit, _, err := m.readCommitEntry(ctx)
+	if err != nil {
+		return nil, false
+	}
+	var commitSet map[string]struct{}
+	if commit != nil {
+		// Cached by (version, _commit revision); the payload fan-out only
+		// re-runs when the commit actually changes.
+		commitSet, err = m.currentCommitPartitionSet(ctx, commit.Version)
+		if err != nil {
+			return nil, false
+		}
+	}
+	set := make(map[string]struct{}, len(parts)+len(commitSet))
+	for _, p := range parts {
+		set[p.SubjectKey()] = struct{}{}
+	}
+	maps.Copy(set, commitSet)
+
+	return set, true
 }
 
 // runInitialHandoffResumeIfPending kicks the resume pass when the manager

--- a/manager_handoff_guard_test.go
+++ b/manager_handoff_guard_test.go
@@ -87,6 +87,8 @@ func (f *fakeClaimStore) ListKeys(_ context.Context) ([]string, error) {
 	return nil, nil
 }
 
+func (f *fakeClaimStore) Delete(context.Context, string, uint64) error { return nil }
+
 func part(key string) types.Partition {
 	return types.Partition{Keys: []string{key}}
 }

--- a/manager_handoff_live_partitions_test.go
+++ b/manager_handoff_live_partitions_test.go
@@ -1,0 +1,109 @@
+package parti
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// errListSource is a PartitionSource whose List always fails.
+type errListSource struct{ err error }
+
+func (e *errListSource) Start(_ context.Context) error                     { return nil }
+func (e *errListSource) List(_ context.Context) ([]types.Partition, error) { return nil, e.err }
+func (e *errListSource) Stop(_ context.Context) error                      { return nil }
+
+// TestLivePartitionSet pins the orphan-reap supplier's vouching contract:
+// only a leader with a healthy source AND a readable commit answers ok=true
+// (the reap pass deletes claims based on this set, so an unverifiable view
+// must never authorize deletion), and the vouched set is the union of the
+// source view and the latest committed assignment's partitions.
+func TestLivePartitionSet(t *testing.T) {
+	t.Parallel()
+
+	// newManager wires the commit-read seam to "no commit exists" by
+	// default; subtests override the hooks to exercise the commit arm.
+	newManager := func(src types.PartitionSource) *Manager {
+		return &Manager{
+			source: src,
+			testHookCommitRead: func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+				return nil, 0, nil
+			},
+		}
+	}
+
+	t.Run("non-leader never vouches", func(t *testing.T) {
+		t.Parallel()
+		m := newManager(source.NewStatic([]types.Partition{{Keys: []string{"p-0"}}}))
+		// isLeader defaults to false (zero value)
+
+		set, ok := m.livePartitionSet(t.Context())
+		require.False(t, ok, "a follower's source view must never authorize reaping")
+		require.Nil(t, set)
+	})
+
+	t.Run("leader vouches with SubjectKey-keyed set", func(t *testing.T) {
+		t.Parallel()
+		m := newManager(source.NewStatic([]types.Partition{
+			{Keys: []string{"p-0"}},
+			{Keys: []string{"region", "p-1"}}, // multi-key: claim key is dot-joined
+		}))
+		m.isLeader.Store(true)
+
+		set, ok := m.livePartitionSet(t.Context())
+		require.True(t, ok)
+		require.Len(t, set, 2)
+		require.Contains(t, set, "p-0")
+		require.Contains(t, set, "region.p-1",
+			"set must be keyed by SubjectKey — the identity claims are stored under")
+	})
+
+	t.Run("source error never vouches", func(t *testing.T) {
+		t.Parallel()
+		m := newManager(&errListSource{err: errors.New("boom")})
+		m.isLeader.Store(true)
+
+		set, ok := m.livePartitionSet(t.Context())
+		require.False(t, ok, "an unreadable source must never authorize reaping")
+		require.Nil(t, set)
+	})
+
+	t.Run("committed partitions stay live even when the source dropped them", func(t *testing.T) {
+		t.Parallel()
+		// Source no longer lists p-stalled, but the live commit still
+		// references it (the stalled-rebalance window): its owner is still
+		// consuming it through the gate, so it must not be reap-eligible.
+		m := newManager(source.NewStatic([]types.Partition{{Keys: []string{"p-0"}}}))
+		m.isLeader.Store(true)
+		m.testHookCommitRead = func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+			return &types.AssignmentCommit{Version: 7}, 42, nil
+		}
+		m.testHookCommitBatch = func(_ context.Context, c *types.AssignmentCommit) (map[string]struct{}, error) {
+			require.EqualValues(t, 7, c.Version)
+			return map[string]struct{}{"p-stalled": {}}, nil
+		}
+
+		set, ok := m.livePartitionSet(t.Context())
+		require.True(t, ok)
+		require.Contains(t, set, "p-0")
+		require.Contains(t, set, "p-stalled",
+			"a partition the live commit references is not an orphan, source view notwithstanding")
+	})
+
+	t.Run("commit read error never vouches", func(t *testing.T) {
+		t.Parallel()
+		m := newManager(source.NewStatic([]types.Partition{{Keys: []string{"p-0"}}}))
+		m.isLeader.Store(true)
+		m.testHookCommitRead = func(_ context.Context) (*types.AssignmentCommit, uint64, error) {
+			return nil, 0, errors.New("kv down")
+		}
+
+		set, ok := m.livePartitionSet(t.Context())
+		require.False(t, ok, "an unverifiable commit view must never authorize reaping")
+		require.Nil(t, set)
+	})
+}

--- a/manager_handoff_liveness_test.go
+++ b/manager_handoff_liveness_test.go
@@ -87,6 +87,19 @@ func (s *casClaimStore) ListKeys(_ context.Context) ([]string, error) {
 	return out, nil
 }
 
+func (s *casClaimStore) Delete(_ context.Context, partitionID string, revision uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.rev[partitionID]
+	if !ok || cur != revision {
+		return errors.New("revision mismatch")
+	}
+	delete(s.data, partitionID)
+	delete(s.rev, partitionID)
+
+	return nil
+}
+
 // TestGuardHandoffRemoval_GainingWorkerDeath_Liveness pins the safety/liveness
 // boundary documented in Task 4 of the G4 fix plan
 // (docs/plans/auto-healing-gap-closure/02-g4-handoff-rebalance-fix-plan.md).

--- a/manager_handoff_test.go
+++ b/manager_handoff_test.go
@@ -34,8 +34,8 @@ func (m *mockClaimStore) PutIfEpoch(ctx context.Context, key string, epoch int64
 	return ver, args.Error(1)
 }
 
-func (m *mockClaimStore) Delete(ctx context.Context, key string) error {
-	args := m.Called(ctx, key)
+func (m *mockClaimStore) Delete(ctx context.Context, key string, revision uint64) error {
+	args := m.Called(ctx, key, revision)
 	return args.Error(0)
 }
 

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -218,6 +218,10 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 		DelayBeforeStable: m.cfg.Handoff.DelayBeforeStable,
 		PhaseConcurrency:  m.cfg.Handoff.PhaseConcurrency,
 		Logger:            m.logger,
+		// Orphan-claim reaping: leader-vouched live set + a generous grace.
+		// See livePartitionSet and orphanClaimGrace (manager_handoff.go).
+		LivePartitions: m.livePartitionSet,
+		OrphanGrace:    orphanClaimGrace,
 	}, true)
 
 	// Hygiene + resumable detection


### PR DESCRIPTION
## What

The handoff bucket deliberately carries no `MaxAge` (stable ownership claims must never age out from under the pull-gating claim resolver — see `reconcileHandoffBucketMaxAge`), so claims for partitions permanently removed from the partition source accumulated forever: a benign but unbounded leak walked by every resolver warm and every claim sweep.

The two-phase coordinator's claim sweep now deletes a stable, no-pending-owner claim once its partition has been continuously absent from the leader's vouched partition set for a 10-minute grace period.

## Why a wrong delete cannot be sustained

- **Authority = leader's source view ∪ latest committed assignment.** A partition the live commit still references is never an orphan, so an owner consuming through a stalled-rebalance window (source dropped the partition, follow-up publish stalled) is never cut off by the reaper — the processing gate would otherwise NAK the legitimate owner.
- **Leader-only vouching.** A config-skewed follower (e.g. an old static partition list mid-rolling-upgrade) never authorizes reaping. Any stretch where the leader cannot verify the set — leadership loss, source or commit read failure — restarts every grace clock (`TestOrphanReap_UnvouchedGapResetsExistingClock`).
- **Revision-checked delete.** `ClaimStore.Delete` is a compare-and-delete (`jetstream.LastRevision`); a concurrent claim transition (re-added partition being prepared) always wins over the reaper.
- **Single-flight sweep.** Sweep bodies hold their mutex end-to-end via `TryLock` (contending opportunistic passes skip; `Apply` never blocks on another sweep's KV I/O), making the absence clock single-writer (`TestSweep_SingleFlight`).

## Validation

- `make pre-pr` (lint + unit `-race` + live-NATS integration `-race`): all gates passed, three times across the review loop
- 9 new contract tests in `internal/assignment/handoff/orphan_reap_test.go` + extended `TestLivePartitionSet` manager wiring tests; behavior-changing tests verified failing pre-fix
- External (codex) post-impl review: 3 rounds — two P1 findings (stale grace clock across unvouched gaps; source-only authority racing a stalled rebalance) plus one follow-on concurrency P1, all fixed verify-first; final verdict **MERGE, no findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)