### PR TITLE
test: accept any connectivity-driven degrade reason during a full outage

### DIFF
--- a/manager_hooks_test.go
+++ b/manager_hooks_test.go
@@ -215,7 +215,16 @@ func TestManager_DegradedHook(t *testing.T) {
 	require.NotNil(t, val)
 	reason, ok := val.(string)
 	require.True(t, ok, "expected string reason")
-	require.Contains(t, reason, "NATS connection down")
+	// During a full outage the connection monitor races the KV-error
+	// circuit (failing heartbeat/election ops) to enter Degraded, and
+	// OnDegraded fires exactly once per entry — pinning one specific
+	// winner is a timing flake under CI load. Any connectivity-driven
+	// reason proves the hook contract this test is about.
+	require.Contains(t, []string{
+		parti.DegradeReasonNATSConnectionDown,
+		parti.DegradeReasonKVErrorThreshold,
+		parti.DegradeReasonKVUnavailable,
+	}, reason, "OnDegraded must report a connectivity-driven reason")
 }
 
 // orderingUpdater tracks the order in which UpdateWorkerConsumer is called

--- a/test/integration/failure/full_nats_outage_test.go
+++ b/test/integration/failure/full_nats_outage_test.go
@@ -2,6 +2,7 @@ package failure_test
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -30,15 +31,41 @@ func TestFullNATSOutage_UnlimitedReconnects_RecoversFleet(t *testing.T) {
 	rfBuildStream(t, ctx, realJS)
 	src := source.NewStatic([]types.Partition{{Keys: []string{"p0"}}})
 
+	// During a full outage, multiple legitimate paths race to enter
+	// Degraded: the connection monitor (DegradeReasonNATSConnectionDown)
+	// vs the KV-error circuit fed by failing heartbeat/election/renew ops
+	// (DegradeReasonKVErrorThreshold, or DegradeReasonKVUnavailable for
+	// timeout-classified ops). OnDegraded fires exactly once per Degraded
+	// entry, so asserting one specific winner is a timing flake under CI
+	// load — the simulation oracles already accept either production path
+	// (test/simulation/internal/coordinator/oracles.go). Count any
+	// connectivity-driven reason; record all reasons for diagnostics.
+	connectivityReasons := map[string]bool{
+		parti.DegradeReasonNATSConnectionDown: true,
+		parti.DegradeReasonKVErrorThreshold:   true,
+		parti.DegradeReasonKVUnavailable:      true,
+	}
 	var degradedCalls atomic.Int64
+	var reasonMu sync.Mutex
+	var reasons []string
 	stack := rfBuildWorkerStackCfg(t, ctx, realJS, src, 0, fastOutageConfig, func(h *parti.Hooks) {
 		h.OnDegraded = func(_ context.Context, reason string) error {
-			if reason == "NATS connection down" {
+			reasonMu.Lock()
+			reasons = append(reasons, reason)
+			reasonMu.Unlock()
+			if connectivityReasons[reason] {
 				degradedCalls.Add(1)
 			}
 			return nil
 		}
 	})
+	defer func() {
+		if t.Failed() {
+			reasonMu.Lock()
+			t.Logf("OnDegraded reasons observed: %v", reasons)
+			reasonMu.Unlock()
+		}
+	}()
 	require.NoError(t, <-stack.mgr.WaitState(parti.StateStable, 30*time.Second))
 
 	rfPublish(t, ctx, realJS, "p0", "before-outage")
@@ -50,7 +77,8 @@ func TestFullNATSOutage_UnlimitedReconnects_RecoversFleet(t *testing.T) {
 		5*time.Second, 50*time.Millisecond, "client did not observe NATS outage")
 	require.NoError(t, <-stack.mgr.WaitState(parti.StateDegraded, 10*time.Second))
 	require.Eventually(t, func() bool { return degradedCalls.Load() > 0 },
-		5*time.Second, 20*time.Millisecond, "OnDegraded must report NATS connection down")
+		5*time.Second, 20*time.Millisecond,
+		"OnDegraded must report a connectivity-driven reason during the outage")
 	require.Len(t, stack.mgr.CurrentAssignment().Partitions, 1,
 		"manager must retain cached assignment while NATS is down")
 


### PR DESCRIPTION
## What

Fixes the recurring `TestFullNATSOutage_UnlimitedReconnects_RecoversFleet` CI flake (latest occurrence: main run [27386392947](https://github.com/arloliu/parti/actions/runs/27386392947) on `7cbffcf`, a docs-only commit), plus the same latent race in `TestManager_DegradedHook` found by sweeping for sibling assertions.

## Mechanism

During a full NATS outage two legitimate paths race to enter Degraded: the connection monitor (1s tick → `NATS connection down`) and the KV-error circuit fed by failing heartbeat/election/renew ops (`KV error threshold exceeded` / `kv-unavailable`). `OnDegraded` fires **exactly once per Degraded entry** (pinned contract), so a test that counts only the connection-monitor reason fails permanently whenever CI load delays the monitor's tick long enough for the KV path to trip first — the CI evidence shows exactly that shape (`WaitState(Degraded)` passed, zero matching hook calls in 5s). The simulation oracles already accept either production path as a correct outage response.

## Change (test-only)

- Both tests count any connectivity-driven reason, via the exported `DegradeReason*` constants.
- The outage test records every observed reason and logs them on failure, so a future flake names the winning path directly.
- No production code changed; the reason-exactness contract remains pinned where it belongs (`TestDegradeReason_LiteralValues`, `TestManager_LiveNATSBucketLoss_OnDegradedHook`).

## Validation

- `make pre-pr` (lint + unit `-race` + live-NATS integration `-race`): all gates passed
- Fixed outage test: 20/20 green under 2-core-pinned CPU-starvation load
- Local reproduction of the original failure was attempted honestly (70 loaded/pinned runs, 0 hits — a 16-core box cannot faithfully starve the 1s ticker like a loaded 2-core CI runner); the diagnosis rests on the CI run's own evidence plus the exactly-once hook contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)