### PR TITLE
feat: fleet-size-aware (adaptive) rate limiting for consumer-create and claim-write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Two opt-in rate-limit controls that bound the per-worker RPC rate Parti drives
+against the NATS cluster, plus the seam one of them is built on. Both default
+**OFF**, so upgrading is a behavioral no-op; enable them only after measuring
+your cluster's safe rate. They address two distinct flood vectors seen at large
+fleet scale: a **consumer-create storm** — a `Dynamic` worker whose partition
+set grows to tens of thousands, or a mass recovery, issuing back-to-back
+`CreateOrUpdateConsumer` RPCs — and a **claim-write storm** — two-phase handoff's
+`PutIfEpoch` calls bursting during a large-fleet restart or rapid rebalance.
+Either can drive the cluster to hang or OOM under load.
+
+### Added
+
+- **`consumer.WithConsumerCreateRate(perSec, burst)`** — opt-in per-worker
+  token-bucket that paces every physical `CreateOrUpdateConsumer` attempt
+  (including retries) across the initial-assignment add loop and the
+  per-partition recovery/recreation paths, from one shared budget. To share one
+  budget across multiple `Dynamic` consumers, build a
+  **`consumer.ConsumerCreateLimiter`** with **`consumer.NewConsumerCreateLimiter(perSec, burst)`**
+  and pass it to **`consumer.WithConsumerCreateLimiter(l)`** (the public limiter
+  interface and constructor keep this usable from outside the module — the option
+  no longer requires naming an internal type). See `docs/CONSUMERS.md` and
+  `docs/OPERATIONS.md` for sizing and the handoff-overlap / `StartupTimeout`
+  interactions.
+- **`jsutil.EnsureConsumerWithOptions(...)`** with **`jsutil.WithBeforeAttempt(fn)`**
+  (and the `jsutil.EnsureConsumerOption` type) — a per-attempt hook seam on the
+  retrying consumer-ensure helper, invoked before every physical RPC attempt
+  including retries. The existing `jsutil.EnsureConsumer` signature is preserved
+  and now delegates to it.
+- **`parti.HandoffConfig.ClaimWritePerSec` / `ClaimWriteBurst`** — opt-in
+  per-worker token-bucket that paces every physical handoff claim-write
+  (`PutIfEpoch`), including CAS retries, across the two-phase coordinator's
+  prepare/commit/stabilize/reap phases and the startup hygiene/resume loops,
+  from one shared budget. Requires `EnableTwoPhaseHandoff`. It complements
+  `PhaseConcurrency` (which caps how many claim-writes are in flight; this caps
+  their throughput). `ClaimWriteBurst` must be `>= 1` when the rate is `> 0`
+  (rejected at `Config.Validate` otherwise). See `docs/OPERATIONS.md`
+  §Claim-Write Rate Limiting and `docs/CONFIGURATION.md`.
+- **Throttle metrics** (Prometheus sidecar; emitted only when the relevant
+  collector is wired, and only on positive-delay waits — burst-absorbed RPCs are
+  not counted): `parti_worker_consumer_create_throttled_total` /
+  `parti_worker_consumer_create_throttle_wait_seconds` for consumer-create, and
+  `parti_handoff_claim_write_throttled_total` /
+  `parti_handoff_claim_write_throttle_wait_seconds` for claim-write.
+
 ## [v2.7.1] - 2026-06-12
 
 Patch release with two fixes: complete shutdown diagnostics, and a garbage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ fleet scale: a **consumer-create storm** — a `Dynamic` worker whose partition
 set grows to tens of thousands, or a mass recovery, issuing back-to-back
 `CreateOrUpdateConsumer` RPCs — and a **claim-write storm** — two-phase handoff's
 `PutIfEpoch` calls bursting during a large-fleet restart or rapid rebalance.
-Either can drive the cluster to hang or OOM under load.
+Either can drive the cluster to hang or OOM under load. Each per-worker limit
+now has an optional **fleet-size-aware (adaptive)** variant that bounds the
+cluster-wide aggregate (the `N × perWorkerRate` problem) to a configured target
+via `min(perWorkerCeiling, clusterRate / N)` — still default OFF, each knob
+independent.
 
 ### Added
 
@@ -44,6 +48,30 @@ Either can drive the cluster to hang or OOM under load.
   their throughput). `ClaimWriteBurst` must be `>= 1` when the rate is `> 0`
   (rejected at `Config.Validate` otherwise). See `docs/OPERATIONS.md`
   §Claim-Write Rate Limiting and `docs/CONFIGURATION.md`.
+- **`consumer.WithConsumerCreateClusterRate(clusterPerSec float64)`** — opt-in
+  fleet-size-aware overlay on `WithConsumerCreateRate`. Effective per-worker
+  rate = `min(perSec, clusterPerSec / N)`, where `N` is the committed
+  worker-count the manager observes live. Bounds the steady-state cluster-wide
+  aggregate to `clusterPerSec`; the per-worker ceiling (`perSec`) caps the
+  transient overshoot while workers converge on a new N. **Requires**
+  `WithConsumerCreateRate` (which supplies the per-worker ceiling and burst);
+  rejected at `NewDynamic` if used alone or with an injected
+  `WithConsumerCreateLimiter` (an injected/shared limiter is not adaptively
+  retuned). `clusterPerSec` must be ≥ 0; 0 = static per-worker behaviour (the
+  default). Caveats: the aggregate **burst** is `Σ burst` across workers, not
+  bounded by `clusterPerSec` — keep burst small if aggregate burst matters.
+  Retuning is eventually-consistent; observation lag ≈ assignment-watcher
+  reconcile floor (~30 s). See `docs/CONSUMERS.md` §Consumer-Create Rate
+  Limiting.
+- **`parti.HandoffConfig.ClaimWriteClusterRate float64`** — opt-in fleet-size-aware
+  overlay on `ClaimWritePerSec`. Effective per-worker rate = `min(ClaimWritePerSec,
+  ClaimWriteClusterRate / N)`. Bounds the steady-state cluster-wide aggregate;
+  `ClaimWritePerSec` caps transient overshoot. **Requires** `ClaimWritePerSec > 0`
+  and `EnableTwoPhaseHandoff`; `Config.Validate` errors if `ClaimWriteClusterRate > 0`
+  with `ClaimWritePerSec <= 0`; `ValidateWithWarnings` emits an inert WARN if
+  `ClaimWriteClusterRate > 0` with two-phase handoff OFF. Default 0 = static
+  per-worker behaviour. Same aggregate-burst and retuning-lag caveats apply. See
+  `docs/OPERATIONS.md` §Claim-Write Rate Limiting and `docs/CONFIGURATION.md`.
 - **Throttle metrics** (Prometheus sidecar; emitted only when the relevant
   collector is wired, and only on positive-delay waits — burst-absorbed RPCs are
   not counted): `parti_worker_consumer_create_throttled_total` /

--- a/claim_write_ratelimit_test.go
+++ b/claim_write_ratelimit_test.go
@@ -1,0 +1,342 @@
+package parti
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// countingClaimWriteLimiter records Wait calls and optionally returns an error.
+type countingClaimWriteLimiter struct {
+	mu      sync.Mutex
+	calls   int
+	waitErr error
+}
+
+func (c *countingClaimWriteLimiter) Wait(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	return c.waitErr
+}
+
+func (c *countingClaimWriteLimiter) Calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+var _ ratelimit.Limiter = (*countingClaimWriteLimiter)(nil)
+
+func expiredClaim(epoch int64) handoff.Claim {
+	return handoff.Claim{
+		State:       handoff.ClaimStatePrepare,
+		LastUpdated: time.Now().UTC().Add(-20 * time.Second), // expired vs TTL 10
+		TTLSeconds:  10,
+		Epoch:       epoch,
+	}
+}
+
+// TestManager_handoffStartupHygiene_PacesEveryReset is the site-2 reproducer:
+// the startup hygiene loop must consult the claim-write limiter before every
+// physical reset write. Three expired claims → three limiter consultations.
+func TestManager_handoffStartupHygiene_PacesEveryReset(t *testing.T) {
+	limiter := &countingClaimWriteLimiter{}
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: limiter}
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"p1", "p2", "p3"}, nil)
+	for i, k := range []string{"p1", "p2", "p3"} {
+		epoch := int64(i + 1)
+		store.On("Get", mock.Anything, k).Return(expiredClaim(epoch), uint64(1), nil)
+		store.On("PutIfEpoch", mock.Anything, k, epoch, mock.MatchedBy(func(c handoff.Claim) bool {
+			return c.State == handoff.ClaimStateStable
+		})).Return(uint64(2), nil)
+	}
+
+	resumable := m.handoffStartupHygiene(context.Background(), store)
+	require.False(t, resumable)
+	assert.Equal(t, 3, limiter.Calls(), "limiter must gate every physical reset write")
+	store.AssertExpectations(t)
+}
+
+// TestManager_handoffStartupHygiene_CtxCancelStops proves a limiter error
+// (e.g. the OperationTimeout firing) stops the best-effort pass before any
+// write: no PutIfEpoch is issued.
+func TestManager_handoffStartupHygiene_CtxCancelStops(t *testing.T) {
+	limiter := &countingClaimWriteLimiter{waitErr: context.Canceled}
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: limiter}
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"p1"}, nil)
+	store.On("Get", mock.Anything, "p1").Return(expiredClaim(1), uint64(1), nil)
+	// No PutIfEpoch expectation: the limiter aborts before the write.
+
+	resumable := m.handoffStartupHygiene(context.Background(), store)
+	require.True(t, resumable,
+		"a gate-cancelled hygiene pass conservatively flags resumable so the bounded resume pass still runs")
+	assert.Equal(t, 1, limiter.Calls())
+	store.AssertExpectations(t) // asserts PutIfEpoch was NOT called
+}
+
+// TestManager_handoffStartupHygiene_NilLimiterUnchanged proves a nil limiter
+// leaves the reset path behaving exactly as before the feature.
+func TestManager_handoffStartupHygiene_NilLimiterUnchanged(t *testing.T) {
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: nil}
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"p1"}, nil)
+	store.On("Get", mock.Anything, "p1").Return(expiredClaim(7), uint64(1), nil)
+	store.On("PutIfEpoch", mock.Anything, "p1", int64(7), mock.MatchedBy(func(c handoff.Claim) bool {
+		return c.State == handoff.ClaimStateStable
+	})).Return(uint64(2), nil)
+
+	resumable := m.handoffStartupHygiene(context.Background(), store)
+	require.False(t, resumable)
+	store.AssertExpectations(t)
+}
+
+// --- runHandoffResume core (site 3): finalizeResumeClaims ---
+
+func commitClaim(owner string, epoch int64) handoff.Claim {
+	return handoff.Claim{
+		Owner:       owner,
+		State:       handoff.ClaimStateCommit,
+		Epoch:       epoch,
+		LastUpdated: time.Now().UTC(),
+	}
+}
+
+// TestManager_finalizeResumeClaims_PacesEveryFinalize is the site-3 reproducer:
+// every physical commit->stable finalize write must consult the limiter.
+func TestManager_finalizeResumeClaims_PacesEveryFinalize(t *testing.T) {
+	limiter := &countingClaimWriteLimiter{}
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: limiter}
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"p1", "p2", "p3"}, nil)
+	for i, k := range []string{"p1", "p2", "p3"} {
+		epoch := int64(i + 1)
+		store.On("Get", mock.Anything, k).Return(commitClaim("w1", epoch), uint64(1), nil)
+		store.On("PutIfEpoch", mock.Anything, k, epoch, mock.MatchedBy(func(c handoff.Claim) bool {
+			return c.State == handoff.ClaimStateStable
+		})).Return(uint64(2), nil)
+	}
+
+	finalized, completed := m.finalizeResumeClaims(context.Background(), store, "w1")
+	require.True(t, completed)
+	assert.Equal(t, 3, finalized)
+	assert.Equal(t, 3, limiter.Calls(), "limiter must gate every physical finalize write")
+	store.AssertExpectations(t)
+}
+
+// TestManager_finalizeResumeClaims_CtxCancelLeavesIncomplete proves a cancelled
+// paced wait aborts before the write and reports incomplete (so the caller keeps
+// pendingHandoffResume set for a later retry).
+func TestManager_finalizeResumeClaims_CtxCancelLeavesIncomplete(t *testing.T) {
+	limiter := &countingClaimWriteLimiter{waitErr: context.Canceled}
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: limiter}
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"p1"}, nil)
+	store.On("Get", mock.Anything, "p1").Return(commitClaim("w1", 1), uint64(1), nil)
+	// No PutIfEpoch expectation: the limiter aborts before the write.
+
+	finalized, completed := m.finalizeResumeClaims(context.Background(), store, "w1")
+	assert.False(t, completed, "a cancelled pass must report incomplete so the resume flag stays set")
+	assert.Zero(t, finalized)
+	assert.Equal(t, 1, limiter.Calls())
+	store.AssertExpectations(t)
+}
+
+// TestManager_finalizeResumeClaims_NilLimiterUnchanged proves a nil limiter
+// leaves the finalize path behaving as before the feature.
+func TestManager_finalizeResumeClaims_NilLimiterUnchanged(t *testing.T) {
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: nil}
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"p1"}, nil)
+	store.On("Get", mock.Anything, "p1").Return(commitClaim("w1", 5), uint64(1), nil)
+	store.On("PutIfEpoch", mock.Anything, "p1", int64(5), mock.MatchedBy(func(c handoff.Claim) bool {
+		return c.State == handoff.ClaimStateStable
+	})).Return(uint64(2), nil)
+
+	finalized, completed := m.finalizeResumeClaims(context.Background(), store, "w1")
+	require.True(t, completed)
+	assert.Equal(t, 1, finalized)
+	store.AssertExpectations(t)
+}
+
+// TestManager_finalizeResumeClaims_SkipsForeignAndNonCommit proves the gate
+// fires only for this worker's commit-state claims; foreign-owner and
+// non-commit claims are skipped without consuming a token.
+func TestManager_finalizeResumeClaims_SkipsForeignAndNonCommit(t *testing.T) {
+	limiter := &countingClaimWriteLimiter{}
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: limiter}
+
+	prepare := commitClaim("w1", 1)
+	prepare.State = handoff.ClaimStatePrepare
+
+	store := new(mockClaimStore)
+	store.On("ListKeys", mock.Anything).Return([]string{"foreign", "prepare", "mine"}, nil)
+	store.On("Get", mock.Anything, "foreign").Return(commitClaim("w2", 1), uint64(1), nil)
+	store.On("Get", mock.Anything, "prepare").Return(prepare, uint64(1), nil)
+	store.On("Get", mock.Anything, "mine").Return(commitClaim("w1", 9), uint64(1), nil)
+	store.On("PutIfEpoch", mock.Anything, "mine", int64(9), mock.MatchedBy(func(c handoff.Claim) bool {
+		return c.State == handoff.ClaimStateStable
+	})).Return(uint64(2), nil)
+
+	finalized, completed := m.finalizeResumeClaims(context.Background(), store, "w1")
+	require.True(t, completed)
+	assert.Equal(t, 1, finalized)
+	assert.Equal(t, 1, limiter.Calls(), "gate fires only for the one owned commit claim")
+	store.AssertExpectations(t)
+}
+
+// --- Config validation ---
+
+func newTwoPhaseConfig() Config {
+	cfg := TestConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.KVBuckets.HandoffBucket = "parti-handoff"
+	cfg.KVBuckets.HandoffTTL = 2 * time.Minute
+	return cfg
+}
+
+func TestConfig_ClaimWriteRate_Validation(t *testing.T) {
+	t.Run("disabled is valid", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = 0
+		cfg.Handoff.ClaimWriteBurst = 0
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("positive rate with burst is valid", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = 100
+		cfg.Handoff.ClaimWriteBurst = 32
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("positive rate with zero burst is rejected", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = 100
+		cfg.Handoff.ClaimWriteBurst = 0
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ClaimWriteBurst")
+	})
+
+	t.Run("negative rate is rejected", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = -1
+		cfg.Handoff.ClaimWriteBurst = 1
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("burst contract enforced even when two-phase handoff is off", func(t *testing.T) {
+		// The (perSec>0, burst<1) invariant is validated unconditionally so the
+		// same pair is accepted/rejected consistently regardless of the flag.
+		cfg := TestConfig() // EnableTwoPhaseHandoff defaults to false
+		require.False(t, cfg.EnableTwoPhaseHandoff)
+		cfg.Handoff.ClaimWritePerSec = 100
+		cfg.Handoff.ClaimWriteBurst = 0
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ClaimWriteBurst")
+	})
+}
+
+// --- buildClaimWriteLimiter ---
+
+func TestManager_buildClaimWriteLimiter(t *testing.T) {
+	t.Run("disabled returns nil", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = 0
+		m := &Manager{cfg: cfg, handoffMetrics: types.NopHandoffMetricsRecorder{}}
+		require.Nil(t, m.buildClaimWriteLimiter())
+	})
+
+	t.Run("configured returns a limiter", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = 100
+		cfg.Handoff.ClaimWriteBurst = 8
+		m := &Manager{cfg: cfg, handoffMetrics: types.NopHandoffMetricsRecorder{}}
+		require.NotNil(t, m.buildClaimWriteLimiter())
+	})
+
+	t.Run("observer wired when metrics implements sidecar", func(t *testing.T) {
+		cfg := newTwoPhaseConfig()
+		cfg.Handoff.ClaimWritePerSec = 1000 // ~1ms spacing
+		cfg.Handoff.ClaimWriteBurst = 1
+		obs := &fakeClaimWriteMetrics{}
+		m := &Manager{cfg: cfg, handoffMetrics: obs}
+
+		lim := m.buildClaimWriteLimiter()
+		require.NotNil(t, lim)
+
+		// First Wait draws the single burst token immediately (no delay → no
+		// metric). The second must wait → observer fires.
+		require.NoError(t, lim.Wait(t.Context()))
+		require.NoError(t, lim.Wait(t.Context()))
+
+		assert.GreaterOrEqual(t, obs.Throttled(), 1, "a delayed claim-write must increment the throttle metric")
+	})
+}
+
+// --- adapter ---
+
+func TestClaimWriteThrottleAdapter_Bridges(t *testing.T) {
+	obs := &fakeClaimWriteMetrics{}
+	a := claimWriteThrottleAdapter{obs: obs}
+
+	a.IncrementThrottled()
+	a.ObserveWait(0.25)
+
+	assert.Equal(t, 1, obs.Throttled())
+	assert.InDelta(t, 0.25, obs.LastWait(), 0.0001)
+}
+
+// fakeClaimWriteMetrics implements HandoffMetricsRecorder and the optional
+// claimWriteThrottleObserver sidecar.
+type fakeClaimWriteMetrics struct {
+	types.NopHandoffMetricsRecorder
+	mu        sync.Mutex
+	throttled int
+	lastWait  float64
+}
+
+func (f *fakeClaimWriteMetrics) IncClaimWriteThrottled() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.throttled++
+}
+
+func (f *fakeClaimWriteMetrics) ObserveClaimWriteThrottleWait(seconds float64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastWait = seconds
+}
+
+func (f *fakeClaimWriteMetrics) Throttled() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.throttled
+}
+
+func (f *fakeClaimWriteMetrics) LastWait() float64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastWait
+}
+
+var _ claimWriteThrottleObserver = (*fakeClaimWriteMetrics)(nil)

--- a/composite_updater.go
+++ b/composite_updater.go
@@ -20,14 +20,18 @@ import (
 //   - Calls all updaters even if some fail
 //   - Returns a combined error with all failures
 type CompositeConsumerUpdater struct {
-	// mu guards updaters and currentObserver. Held only long enough to
-	// snapshot the slice (or update the observer); fan-out callbacks
-	// to children run unlocked so a slow child cannot serialize the
-	// rest and so re-entrant Add/SetOnStreamMissingError calls from a
-	// child never self-deadlock.
+	// mu guards updaters, currentObserver, and lastFleetN. Held only
+	// long enough to snapshot the slice (or update the observer/count);
+	// fan-out callbacks to children run unlocked so a slow child cannot
+	// serialize the rest and so re-entrant Add/SetOnStreamMissingError
+	// calls from a child never self-deadlock.
 	mu              sync.Mutex
 	updaters        []WorkerConsumerUpdater
 	currentObserver func(streamName string, err error)
+	// lastFleetN is the most recent worker-count observed via ObserveWorkerCount,
+	// replayed to children added later (mirrors the stream-missing replay). 0 =
+	// none observed yet.
+	lastFleetN int
 }
 
 // NewCompositeConsumerUpdater creates a composite from multiple updaters.
@@ -93,22 +97,53 @@ func (c *CompositeConsumerUpdater) UpdateWorkerConsumer(ctx context.Context, wor
 // Add appends additional updaters to the composite.
 // This is useful for dynamically registering consumers after creation.
 //
-// When a stream-missing observer has already been installed via
-// SetOnStreamMissingError, any newly-appended updater that implements
-// recovery.StreamMissingObserver inherits the callback so a later
-// registration does not silently miss it.
+// Newly-added children inherit any state the composite has already received:
+// an installed stream-missing observer (via SetOnStreamMissingError) and the
+// last observed fleet worker-count (via ObserveWorkerCount), so a late
+// registration does not silently miss either. Inherited-state forwarding runs
+// outside c.mu so a slow child cannot serialize peers or deadlock a re-entrant
+// Add.
 func (c *CompositeConsumerUpdater) Add(updaters ...WorkerConsumerUpdater) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	var added []WorkerConsumerUpdater
 	for _, u := range updaters {
 		if u == nil {
 			continue
 		}
 		c.updaters = append(c.updaters, u)
-		if c.currentObserver != nil {
+		added = append(added, u)
+	}
+	observer := c.currentObserver
+	fleetN := c.lastFleetN
+	c.mu.Unlock()
+
+	for _, u := range added {
+		if observer != nil {
 			if obs, ok := u.(recovery.StreamMissingObserver); ok {
-				obs.SetOnStreamMissingError(c.currentObserver)
+				obs.SetOnStreamMissingError(observer)
 			}
+		}
+		if fleetN > 0 {
+			if fo, ok := u.(FleetSizeObserver); ok {
+				fo.ObserveWorkerCount(fleetN)
+			}
+		}
+	}
+}
+
+// ObserveWorkerCount implements [FleetSizeObserver] by caching the worker-count
+// and forwarding it to every child that implements FleetSizeObserver. The cache
+// is replayed to children added later via Add.
+func (c *CompositeConsumerUpdater) ObserveWorkerCount(n int) {
+	c.mu.Lock()
+	c.lastFleetN = n
+	snapshot := make([]WorkerConsumerUpdater, len(c.updaters))
+	copy(snapshot, c.updaters)
+	c.mu.Unlock()
+
+	for _, u := range snapshot {
+		if fo, ok := u.(FleetSizeObserver); ok {
+			fo.ObserveWorkerCount(n)
 		}
 	}
 }
@@ -187,3 +222,7 @@ var _ CapabilityReporter = (*CompositeConsumerUpdater)(nil)
 // prepareStart forwards through this seam to each observer-capable
 // child.
 var _ recovery.StreamMissingObserver = (*CompositeConsumerUpdater)(nil)
+
+// Compile-time assertion: CompositeConsumerUpdater satisfies FleetSizeObserver so
+// the Manager's type-assertion picks it up.
+var _ FleetSizeObserver = (*CompositeConsumerUpdater)(nil)

--- a/composite_updater_fleet_test.go
+++ b/composite_updater_fleet_test.go
@@ -1,0 +1,43 @@
+package parti
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fleetChild struct {
+	last int
+}
+
+func (f *fleetChild) UpdateWorkerConsumer(_ context.Context, _ string, _ []Partition) error {
+	return nil
+}
+func (f *fleetChild) ObserveWorkerCount(n int) { f.last = n }
+
+func TestComposite_ForwardsObserveWorkerCount(t *testing.T) {
+	a, b := &fleetChild{}, &fleetChild{}
+	c := NewCompositeConsumerUpdater(a, b)
+	c.ObserveWorkerCount(7)
+	require.Equal(t, 7, a.last)
+	require.Equal(t, 7, b.last)
+}
+
+func TestComposite_ReplaysLastNToLateAddedChild(t *testing.T) {
+	a := &fleetChild{}
+	c := NewCompositeConsumerUpdater(a)
+	c.ObserveWorkerCount(9)
+	require.Equal(t, 9, a.last)
+
+	late := &fleetChild{}
+	c.Add(late)
+	require.Equal(t, 9, late.last, "late-added child must receive the cached N")
+}
+
+func TestComposite_LateAddBeforeAnyObserve_NoReplay(t *testing.T) {
+	c := NewCompositeConsumerUpdater()
+	late := &fleetChild{last: -1}
+	c.Add(late)
+	require.Equal(t, -1, late.last, "no N observed yet -> no replay")
+}

--- a/config.go
+++ b/config.go
@@ -153,6 +153,15 @@ type HandoffConfig struct {
 	// burst ≈ PhaseConcurrency so a single rebalance wave is absorbed without
 	// throttling and only sustained bursts are paced.
 	ClaimWriteBurst int `yaml:"claimWriteBurst" default:"0" validate:"gte=0"`
+
+	// ClaimWriteClusterRate, when > 0, makes claim-write rate limiting
+	// fleet-size-aware: each worker enforces
+	// min(ClaimWritePerSec, ClaimWriteClusterRate/N), where N is the observed
+	// committed worker count. It bounds the STEADY-STATE cluster-wide
+	// claim-write rate to ClaimWriteClusterRate instead of N*ClaimWritePerSec.
+	// Requires ClaimWritePerSec > 0 (the per-worker ceiling and burst source)
+	// and EnableTwoPhaseHandoff. Default 0 = static per-worker rate only.
+	ClaimWriteClusterRate float64 `yaml:"claimWriteClusterRate" default:"0" validate:"gte=0"`
 }
 
 // AlertLevel represents the severity level of degraded mode alerts.
@@ -706,6 +715,9 @@ func (cfg *Config) Validate() error {
 	if cfg.Handoff.ClaimWritePerSec > 0 && cfg.Handoff.ClaimWriteBurst < 1 {
 		return errors.New("Handoff.ClaimWriteBurst must be >= 1 when Handoff.ClaimWritePerSec > 0")
 	}
+	if cfg.Handoff.ClaimWriteClusterRate > 0 && cfg.Handoff.ClaimWritePerSec <= 0 {
+		return errors.New("Handoff.ClaimWriteClusterRate > 0 requires Handoff.ClaimWritePerSec > 0 (the per-worker ceiling and burst source)")
+	}
 
 	// Rule 11: ApplyStartJitter range
 	if cfg.ApplyStartJitter < 0 {
@@ -819,6 +831,13 @@ func (cfg *Config) ValidateWithWarnings(logger Logger) {
 			"Handoff.ClaimWritePerSec is set but EnableTwoPhaseHandoff is false; claim-write rate limiting has no effect",
 			"claim_write_per_sec", cfg.Handoff.ClaimWritePerSec,
 			"note", "claim-writes only occur under two-phase handoff; enable EnableTwoPhaseHandoff or unset ClaimWritePerSec",
+		)
+	}
+	if !cfg.EnableTwoPhaseHandoff && cfg.Handoff.ClaimWriteClusterRate > 0 {
+		logger.Warn(
+			"Handoff.ClaimWriteClusterRate is set but EnableTwoPhaseHandoff is false; cluster-rate claim-write limiting has no effect",
+			"claim_write_cluster_rate", cfg.Handoff.ClaimWriteClusterRate,
+			"note", "claim-writes only occur under two-phase handoff; enable EnableTwoPhaseHandoff or unset ClaimWriteClusterRate",
 		)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -125,6 +125,34 @@ type HandoffConfig struct {
 	// default of 20. Note: 0 means "use default", not "no parallelism"; set 1
 	// for strictly serial execution.
 	PhaseConcurrency int `yaml:"phaseConcurrency" default:"0" validate:"gte=0,lte=256"`
+
+	// ClaimWritePerSec optionally enables a per-worker token-bucket rate limit
+	// on every physical handoff claim-write (the KV PutIfEpoch the coordinator
+	// and startup loops issue), measured in writes/second. It paces the
+	// otherwise-unbounded startup hygiene/resume loops (which walk every claim
+	// key sequentially) and the two-phase coordinator's per-partition CAS
+	// writes — including CAS retries — so a large-fleet restart or rapid
+	// rebalance cannot drive a back-to-back KV write burst that stresses the
+	// NATS cluster. PhaseConcurrency bounds simultaneity; this bounds rate.
+	//
+	// Opt-in: 0 (the default) disables rate limiting and leaves behaviour
+	// unchanged. A single budget is shared across all claim-write sites for
+	// this worker. Must be >= 0.
+	//
+	// Note: the startup hygiene pass runs under OperationTimeout on the
+	// synchronous Manager.Start path, so a low rate combined with many
+	// pre-existing stale claims can extend Start's blocking return latency up
+	// to OperationTimeout before the best-effort pass stops early; the
+	// background resume pass and the coordinator are not OperationTimeout-bounded
+	// and run off the Start path. Sizing guidance lives in docs/OPERATIONS.md.
+	ClaimWritePerSec float64 `yaml:"claimWritePerSec" default:"0" validate:"gte=0"`
+
+	// ClaimWriteBurst is the token-bucket burst size for ClaimWritePerSec. It
+	// must be >= 1 when ClaimWritePerSec > 0 (rejected at Validate otherwise);
+	// it is ignored when ClaimWritePerSec == 0. Recommended starting point:
+	// burst ≈ PhaseConcurrency so a single rebalance wave is absorbed without
+	// throttling and only sustained bursts are paced.
+	ClaimWriteBurst int `yaml:"claimWriteBurst" default:"0" validate:"gte=0"`
 }
 
 // AlertLevel represents the severity level of degraded mode alerts.
@@ -669,6 +697,16 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	// Claim-write rate limit: burst must be a usable bucket size when a positive
+	// rate is configured. This is a pure intra-field invariant, validated
+	// regardless of EnableTwoPhaseHandoff so the same (perSec, burst) pair is
+	// accepted or rejected consistently — even though the limiter is only built
+	// when two-phase handoff is enabled. (perSec < 0 is caught by the gte=0
+	// struct tag.) Mirrors the consumer-create rate-limit contract.
+	if cfg.Handoff.ClaimWritePerSec > 0 && cfg.Handoff.ClaimWriteBurst < 1 {
+		return errors.New("Handoff.ClaimWriteBurst must be >= 1 when Handoff.ClaimWritePerSec > 0")
+	}
+
 	// Rule 11: ApplyStartJitter range
 	if cfg.ApplyStartJitter < 0 {
 		return errors.New("ApplyStartJitter must be >= 0")
@@ -768,6 +806,19 @@ func (cfg *Config) ValidateWithWarnings(logger Logger) {
 			"election_timeout", cfg.ElectionTimeout,
 			"recommended_minimum", minStartup,
 			"note", "workers starting during the leader's cold-start stabilization window may time out before they receive their first assignment",
+		)
+	}
+
+	// Warn when a claim-write rate limit is configured but two-phase handoff is
+	// off. Claim-writes only occur under two-phase handoff (the coordinator and
+	// the startup hygiene/resume loops), so the limiter is never built and the
+	// setting has no effect — surface it rather than silently ignoring an
+	// explicitly-set safety control.
+	if !cfg.EnableTwoPhaseHandoff && cfg.Handoff.ClaimWritePerSec > 0 {
+		logger.Warn(
+			"Handoff.ClaimWritePerSec is set but EnableTwoPhaseHandoff is false; claim-write rate limiting has no effect",
+			"claim_write_per_sec", cfg.Handoff.ClaimWritePerSec,
+			"note", "claim-writes only occur under two-phase handoff; enable EnableTwoPhaseHandoff or unset ClaimWritePerSec",
 		)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -124,6 +124,66 @@ func TestValidateWithWarnings_ClaimWriteRateWithoutTwoPhase(t *testing.T) {
 	})
 }
 
+// TestValidate_ClaimWriteClusterRate_RequiresPerWorker asserts that a
+// ClaimWriteClusterRate set without a ClaimWritePerSec ceiling is rejected by
+// the cross-field validation (the ceiling is also the burst source).
+func TestValidate_ClaimWriteClusterRate_RequiresPerWorker(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.Handoff.ClaimWriteClusterRate = 1000 // set
+	cfg.Handoff.ClaimWritePerSec = 0         // but no per-worker ceiling
+	cfg.Handoff.ClaimWriteBurst = 10
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ClaimWriteClusterRate")
+}
+
+func TestValidate_ClaimWriteClusterRate_NegativeRejected(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.Handoff.ClaimWriteClusterRate = -1
+	err := cfg.Validate()
+	require.Error(t, err)
+}
+
+func TestValidate_ClaimWriteClusterRate_ValidWithPerWorker(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.Handoff.ClaimWritePerSec = 200
+	cfg.Handoff.ClaimWriteBurst = 50
+	cfg.Handoff.ClaimWriteClusterRate = 1000
+	require.NoError(t, cfg.Validate())
+}
+
+// TestValidateWithWarnings_ClaimWriteClusterRateWithoutTwoPhase asserts that
+// ClaimWriteClusterRate set without EnableTwoPhaseHandoff emits an inert-config
+// warning, and stays silent when two-phase handoff is enabled.
+func TestValidateWithWarnings_ClaimWriteClusterRateWithoutTwoPhase(t *testing.T) {
+	const warnPrefix = "Handoff.ClaimWriteClusterRate is set but EnableTwoPhaseHandoff is false"
+
+	t.Run("warns when cluster rate set but two-phase off", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = false
+		cfg.Handoff.ClaimWritePerSec = 200
+		cfg.Handoff.ClaimWriteBurst = 50
+		cfg.Handoff.ClaimWriteClusterRate = 1000
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.True(t, log.contains(warnPrefix), "got %v", log.warns)
+	})
+
+	t.Run("no warning when two-phase on", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = true
+		cfg.Handoff.ClaimWritePerSec = 200
+		cfg.Handoff.ClaimWriteBurst = 50
+		cfg.Handoff.ClaimWriteClusterRate = 1000
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.False(t, log.contains(warnPrefix), "got %v", log.warns)
+	})
+}
+
 // TestValidateWithWarnings_EmergencyGracePeriodHysteresis asserts that
 // ValidateWithWarnings emits a warning when EmergencyGracePeriod consumes more
 // than half of HeartbeatTTL — leaving too little hysteresis budget for GC

--- a/config_test.go
+++ b/config_test.go
@@ -85,6 +85,45 @@ func TestValidateWithWarnings_StartupTimeout(t *testing.T) {
 	})
 }
 
+// TestValidateWithWarnings_ClaimWriteRateWithoutTwoPhase asserts that a
+// claim-write rate limit configured without two-phase handoff (where it has no
+// effect, since claim-writes only occur under two-phase handoff) emits a
+// warning, and stays silent when two-phase handoff is enabled or the rate is 0.
+func TestValidateWithWarnings_ClaimWriteRateWithoutTwoPhase(t *testing.T) {
+	const warnPrefix = "Handoff.ClaimWritePerSec is set but EnableTwoPhaseHandoff is false"
+
+	t.Run("warns when rate set but two-phase off", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = false
+		cfg.Handoff.ClaimWritePerSec = 100
+		cfg.Handoff.ClaimWriteBurst = 32
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.True(t, log.contains(warnPrefix),
+			"expected inert claim-write-rate warning, got %v", log.warns)
+	})
+
+	t.Run("no warning when two-phase on", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = true
+		cfg.Handoff.ClaimWritePerSec = 100
+		cfg.Handoff.ClaimWriteBurst = 32
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.False(t, log.contains(warnPrefix),
+			"did not expect warning when two-phase handoff is enabled, got %v", log.warns)
+	})
+
+	t.Run("no warning when rate is zero", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = false
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.False(t, log.contains(warnPrefix),
+			"default (no claim-write rate) must not warn, got %v", log.warns)
+	})
+}
+
 // TestValidateWithWarnings_EmergencyGracePeriodHysteresis asserts that
 // ValidateWithWarnings emits a warning when EmergencyGracePeriod consumes more
 // than half of HeartbeatTTL — leaving too little hysteresis budget for GC

--- a/consumer/consumer_create_clusterrate_test.go
+++ b/consumer/consumer_create_clusterrate_test.go
@@ -1,0 +1,84 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithConsumerCreateClusterRate_RequiresPerWorker(t *testing.T) {
+	_, err := buildDynamic(t, WithConsumerCreateClusterRate(1000)) // no WithConsumerCreateRate
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WithConsumerCreateClusterRate")
+}
+
+func TestWithConsumerCreateClusterRate_RejectedWithInjectedLimiter(t *testing.T) {
+	inj, err := NewConsumerCreateLimiter(50, 5)
+	require.NoError(t, err)
+	_, err = buildDynamic(t,
+		WithConsumerCreateLimiter(inj),
+		WithConsumerCreateClusterRate(1000),
+	)
+	require.Error(t, err)
+}
+
+func TestWithConsumerCreateClusterRate_NegativeRejected(t *testing.T) {
+	t.Run("with per-worker rate", func(t *testing.T) {
+		_, err := buildDynamic(t, WithConsumerCreateRate(200, 50), WithConsumerCreateClusterRate(-1))
+		require.Error(t, err)
+	})
+	t.Run("alone (no per-worker rate)", func(t *testing.T) {
+		_, err := buildDynamic(t, WithConsumerCreateClusterRate(-1))
+		require.Error(t, err)
+	})
+	t.Run("with injected limiter", func(t *testing.T) {
+		inj, err := NewConsumerCreateLimiter(50, 5)
+		require.NoError(t, err)
+		_, err = buildDynamic(t, WithConsumerCreateLimiter(inj), WithConsumerCreateClusterRate(-1))
+		require.Error(t, err)
+	})
+}
+
+func TestWithConsumerCreateClusterRate_ValidWithPerWorker(t *testing.T) {
+	d, err := buildDynamic(t,
+		WithConsumerCreateRate(200, 50),
+		WithConsumerCreateClusterRate(1000),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, d.inner.ConsumerCreateLimiter())
+}
+
+func TestDynamic_ObserveWorkerCount_RetunesBuiltInLimiter(t *testing.T) {
+	d, err := buildDynamic(t,
+		WithConsumerCreateRate(200, 50),
+		WithConsumerCreateClusterRate(1000),
+	)
+	require.NoError(t, err)
+
+	d.ObserveWorkerCount(5) // min(200, 1000/5=200) = 200
+	lim := d.inner.ConsumerCreateLimiter()
+	tb, ok := lim.(interface{ Limit() float64 })
+	require.True(t, ok)
+	require.InEpsilon(t, 200.0, tb.Limit(), 1e-9)
+
+	d.ObserveWorkerCount(20) // min(200, 1000/20=50) = 50
+	require.InEpsilon(t, 50.0, tb.Limit(), 1e-9)
+}
+
+func TestDynamic_ObserveWorkerCount_NoClusterRate_NoOp(t *testing.T) {
+	d, err := buildDynamic(t, WithConsumerCreateRate(200, 50)) // no cluster rate
+	require.NoError(t, err)
+	d.ObserveWorkerCount(20) // must not change the fixed 200/s
+	lim := d.inner.ConsumerCreateLimiter()
+	tb, ok := lim.(interface{ Limit() float64 })
+	require.True(t, ok)
+	require.InEpsilon(t, 200.0, tb.Limit(), 1e-9)
+}
+
+func TestDynamic_ObserveWorkerCount_InjectedLimiter_NoOp(t *testing.T) {
+	inj, err := NewConsumerCreateLimiter(50, 5)
+	require.NoError(t, err)
+	d, err := buildDynamic(t, WithConsumerCreateLimiter(inj))
+	require.NoError(t, err)
+	require.NotPanics(t, func() { d.ObserveWorkerCount(10) }) // no RateSetter captured -> no-op
+}

--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -82,6 +82,14 @@ type Dynamic struct {
 	// value); the dispatcher reads the pointer at fire time so a late
 	// Store is honored. nil pointer means "no manager observer wired".
 	managerOnStreamMissing atomic.Pointer[func(streamName string, err error)]
+
+	// Adaptive consumer-create rate (fleet-size-aware). createRateSetter is the
+	// built-in limiter cast to RateSetter, non-nil only when WithConsumerCreateRate
+	// AND WithConsumerCreateClusterRate are set. createPerSec is the per-worker
+	// ceiling; createClusterRate is the cluster target.
+	createRateSetter  ratelimit.RateSetter
+	createPerSec      float64
+	createClusterRate float64
 }
 
 // compatCheckResult is the immutable outcome of one WorkQueue
@@ -471,6 +479,14 @@ func NewDynamic(
 	}
 	d.inner = inner
 
+	if o.consumerCreateClusterRate > 0 {
+		if rs, ok := resolvedLimiter.(ratelimit.RateSetter); ok {
+			d.createRateSetter = rs
+			d.createPerSec = o.consumerCreatePerSec
+			d.createClusterRate = o.consumerCreateClusterRate
+		}
+	}
+
 	return d, nil
 }
 
@@ -635,6 +651,26 @@ func (d *Dynamic) Capabilities() uint32 {
 	return d.inner.Capabilities()
 }
 
+// ObserveWorkerCount implements the Parti manager's fleet-size-observer optional
+// interface. The Manager calls it with the current committed cluster worker-count
+// N so the Dynamic consumer can retune its consumer-create limiter to
+// min(perWorkerCeiling, clusterRate/N).
+//
+// It is a no-op unless both WithConsumerCreateRate and WithConsumerCreateClusterRate
+// were configured (createRateSetter is nil otherwise, e.g. an injected limiter).
+// Non-blocking and non-reentrant per the observer contract:
+// it only calls SetRate on the built-in limiter.
+func (d *Dynamic) ObserveWorkerCount(n int) {
+	if d.createRateSetter == nil {
+		return
+	}
+	d.createRateSetter.SetRate(ratelimit.EffectiveRate(d.createPerSec, d.createClusterRate, n))
+}
+
+// Compile-time assertion: *Dynamic satisfies the fleet-size-observer interface
+// expected by the Parti Manager's optional type-assertion.
+var _ interface{ ObserveWorkerCount(int) } = (*Dynamic)(nil)
+
 // Stop gracefully stops all partition consumers.
 //
 // Stop cancels all internal pull loops and waits for pending message processing
@@ -733,13 +769,26 @@ func toSubscriptionResolverConfig(cfg ResolverConfig) durable.ResolverConfig {
 // Precedence (any option order): a non-nil injected limiter wins over a rate.
 // WithConsumerCreateLimiter(nil) is a no-op and never clears a configured rate.
 func resolveConsumerCreateLimiter(o options) (ratelimit.Limiter, error) {
-	// A non-nil injected limiter always wins.
+	// Validate the cluster-rate overlay up front — independent of which limiter
+	// wins — so a negative value is rejected on every path.
+	if o.consumerCreateClusterRate < 0 {
+		return nil, fmt.Errorf("WithConsumerCreateClusterRate: clusterPerSec must be >= 0, got %v", o.consumerCreateClusterRate)
+	}
+
+	// A non-nil injected limiter always wins; it is not adaptively retuned.
 	if o.consumerCreateLimiter != nil {
+		if o.consumerCreateClusterRate > 0 {
+			return nil, errors.New("WithConsumerCreateClusterRate cannot be combined with an injected WithConsumerCreateLimiter (an injected limiter is not adaptively retuned)")
+		}
 		return o.consumerCreateLimiter, nil
 	}
 
-	// No rate configured: return unlimited (nil) without error.
+	// No per-worker rate configured. A cluster rate alone is invalid (it needs
+	// the per-worker ceiling and burst); otherwise return unlimited (nil).
 	if o.consumerCreatePerSec == 0 {
+		if o.consumerCreateClusterRate > 0 {
+			return nil, errors.New("WithConsumerCreateClusterRate requires WithConsumerCreateRate (the per-worker ceiling and burst source)")
+		}
 		return ratelimit.Limiter(nil), nil //nolint:nilnil // nil limiter is the intended "unlimited" sentinel
 	}
 

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -871,17 +871,18 @@ func WithPartitionRefreshMinInterval(d time.Duration) DynamicOption {
 // gating were per-logical-create only.
 //
 // Validation: perSec must be >= 0; perSec == 0 leaves the limiter disabled
-// (no rate limiting). burst must be >= 1 when perSec > 0. Negative perSec
-// is rejected. Use [WithConsumerCreateLimiter] to supply a custom or shared
-// limiter instead.
+// (no rate limiting); burst must be >= 1 when perSec > 0. Invalid values are
+// rejected at [NewDynamic], which returns an error wrapping [ErrInvalidConfig]
+// when perSec < 0, or when perSec > 0 with burst < 1. Use
+// [WithConsumerCreateLimiter] to supply a custom or shared limiter instead.
 //
 // Sizing guidance: rate ≈ cluster-create-budget / max-workers.
 // Recommended starting values (validate by load test): rate ≈ 100/s, burst ≈ 256.
 //
 // # Interaction with handoff and readiness
 //
-// A paced apply holds applyStoreMu for its duration, serialising subsequent
-// applies and blocking Close. With the processing gate OFF, enabling pacing
+// A paced apply holds the Dynamic apply lock for its duration, serialising
+// subsequent applies and blocking Close. With the processing gate OFF, enabling pacing
 // lengthens the period during which old and new owners are both active
 // (processing-overlap window); co-enable the processing gate / pull-gating to
 // suppress that overlap. A large cold start (e.g. 20 000 partitions at 100/s ≈
@@ -896,24 +897,29 @@ func WithConsumerCreateRate(perSec float64, burst int) DynamicOption {
 	})
 }
 
-// WithConsumerCreateLimiter injects a custom or shared [ratelimit.Limiter]
+// WithConsumerCreateLimiter injects a custom or shared [ConsumerCreateLimiter]
 // that gates every physical CreateOrUpdateConsumer attempt. Use this when
 // multiple [Dynamic] consumers in the same process should share one rate budget
-// across all their consumer creates.
+// across all their consumer creates; build the shared limiter with
+// [NewConsumerCreateLimiter]. For a single consumer prefer [WithConsumerCreateRate].
 //
 // Precedence rules (any option order):
 //   - A non-nil injected limiter wins over [WithConsumerCreateRate].
 //   - Passing nil is a no-op: it does NOT clear a configured rate limiter.
 //
-// # Lock-order contract (D5)
+// An injected or shared limiter bypasses the per-consumer throttle metrics that
+// [WithConsumerCreateRate] wires up (a shared budget has no single owning
+// consumer to attribute throttle events to).
 //
-// The injected limiter's Wait(ctx) is invoked while internal locks
-// (applyStoreMu, updateMu) may be held. It MUST honour context cancellation
-// and MUST NOT call back into Manager, Dynamic, or any operation that acquires
-// those locks.
+// # Lock-order contract
+//
+// The injected limiter's Wait(ctx) is invoked while the Dynamic apply/update
+// locks may be held. It MUST honour context cancellation and MUST NOT call back
+// into Manager, Dynamic, or any operation that acquires those locks. See
+// [ConsumerCreateLimiter].
 //
 // Applies only to [Dynamic].
-func WithConsumerCreateLimiter(l ratelimit.Limiter) DynamicOption {
+func WithConsumerCreateLimiter(l ConsumerCreateLimiter) DynamicOption {
 	return dynamicOpt(func(o *options) {
 		if l != nil {
 			o.consumerCreateLimiter = l

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -190,9 +190,11 @@ type options struct {
 	// consumerCreateLimiter is the resolved limiter to thread into WorkerConsumerConfig.
 	// consumerCreatePerSec and consumerCreateBurst are raw inputs from WithConsumerCreateRate.
 	// A non-nil injected limiter (from WithConsumerCreateLimiter) wins over the rate option.
-	consumerCreateLimiter ratelimit.Limiter
-	consumerCreatePerSec  float64
-	consumerCreateBurst   int
+	// consumerCreateClusterRate is the aggregate overlay from WithConsumerCreateClusterRate.
+	consumerCreateLimiter     ratelimit.Limiter
+	consumerCreatePerSec      float64
+	consumerCreateBurst       int
+	consumerCreateClusterRate float64
 
 	// Dynamic specific
 	processingGate                        *ProcessingGateConfig
@@ -894,6 +896,29 @@ func WithConsumerCreateRate(perSec float64, burst int) DynamicOption {
 	return dynamicOpt(func(o *options) {
 		o.consumerCreatePerSec = perSec
 		o.consumerCreateBurst = burst
+	})
+}
+
+// WithConsumerCreateClusterRate makes consumer-create rate limiting
+// fleet-size-aware. Given a cluster-wide target (events/second), each worker
+// enforces min(perWorkerCeiling, clusterPerSec/N), where perWorkerCeiling is
+// the rate from [WithConsumerCreateRate] and N is the cluster worker-count the
+// Parti Manager observes and pushes to this consumer.
+//
+// This bounds the STEADY-STATE cluster-wide create rate to clusterPerSec
+// instead of N*perWorkerCeiling. The per-worker ceiling still caps any single
+// worker during fleet-size transitions.
+//
+// Requires [WithConsumerCreateRate] (which supplies burst and the ceiling) and
+// the built-in limiter; it is rejected at [NewDynamic] when used alone or with
+// an injected [WithConsumerCreateLimiter] (an injected, possibly shared limiter
+// is not adaptively retuned). clusterPerSec must be >= 0; 0 disables the
+// overlay (static per-worker behaviour).
+//
+// Applies only to [Dynamic].
+func WithConsumerCreateClusterRate(clusterPerSec float64) DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.consumerCreateClusterRate = clusterPerSec
 	})
 }
 

--- a/consumer/ratelimit.go
+++ b/consumer/ratelimit.go
@@ -1,0 +1,47 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/arloliu/parti/v2/internal/ratelimit"
+)
+
+// ConsumerCreateLimiter gates consumer-create RPC attempts. Its Wait blocks
+// until the limiter grants permission or ctx is cancelled (returning ctx.Err()).
+//
+// Obtain one from [NewConsumerCreateLimiter] (a token-bucket limiter), or supply
+// your own implementation, and pass it to [WithConsumerCreateLimiter] to share a
+// single rate budget across multiple [Dynamic] consumers in the same process.
+//
+// # Lock-order contract
+//
+// Wait is invoked while internal locks (the Dynamic apply/update mutexes) may be
+// held. An implementation MUST honour context cancellation and MUST NOT call
+// back into a Manager or Dynamic, or any operation that acquires those locks,
+// from within Wait.
+type ConsumerCreateLimiter interface {
+	// Wait blocks until the limiter grants one token or ctx is cancelled.
+	Wait(ctx context.Context) error
+}
+
+// NewConsumerCreateLimiter returns a token-bucket [ConsumerCreateLimiter] with
+// the given steady rate (events/second) and burst size. It is the public
+// constructor for a limiter that can be shared across multiple [Dynamic]
+// consumers via [WithConsumerCreateLimiter]; for a single consumer prefer the
+// simpler [WithConsumerCreateRate].
+//
+// perSec must be > 0 and burst must be >= 1. A shared limiter built this way
+// does not emit the per-consumer throttle metrics that [WithConsumerCreateRate]
+// wires up (an injected limiter bypasses the metrics adapter), since a shared
+// budget has no single owning consumer to attribute throttle events to.
+func NewConsumerCreateLimiter(perSec float64, burst int) (ConsumerCreateLimiter, error) {
+	if perSec <= 0 {
+		return nil, fmt.Errorf("NewConsumerCreateLimiter: perSec must be > 0, got %v", perSec)
+	}
+	if burst < 1 {
+		return nil, fmt.Errorf("NewConsumerCreateLimiter: burst must be >= 1, got %d", burst)
+	}
+
+	return ratelimit.New(perSec, burst, nil), nil
+}

--- a/consumer/ratelimit_external_test.go
+++ b/consumer/ratelimit_external_test.go
@@ -1,0 +1,78 @@
+package consumer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arloliu/parti/v2/consumer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// externalLimiter is a user-supplied ConsumerCreateLimiter implemented WITHOUT
+// importing any internal package — proving external code can satisfy the public
+// interface (the whole point of exporting ConsumerCreateLimiter). The compile
+// of this file in package consumer_test, importing only consumer/, is itself the
+// proof that the limiter API is usable from outside the module.
+type externalLimiter struct{}
+
+func (externalLimiter) Wait(ctx context.Context) error { return ctx.Err() }
+
+var _ consumer.ConsumerCreateLimiter = externalLimiter{}
+
+func TestNewConsumerCreateLimiter_Validation(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		lim, err := consumer.NewConsumerCreateLimiter(100, 10)
+		require.NoError(t, err)
+		require.NotNil(t, lim)
+	})
+	t.Run("zero perSec rejected", func(t *testing.T) {
+		_, err := consumer.NewConsumerCreateLimiter(0, 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "perSec")
+	})
+	t.Run("negative perSec rejected", func(t *testing.T) {
+		_, err := consumer.NewConsumerCreateLimiter(-1, 10)
+		require.Error(t, err)
+	})
+	t.Run("burst below one rejected", func(t *testing.T) {
+		_, err := consumer.NewConsumerCreateLimiter(100, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "burst")
+	})
+}
+
+// TestNewConsumerCreateLimiter_WaitGrantsAndHonoursCtx proves the constructed
+// limiter both grants the burst token immediately and honours ctx cancellation
+// on a subsequent paced wait.
+func TestNewConsumerCreateLimiter_WaitGrantsAndHonoursCtx(t *testing.T) {
+	lim, err := consumer.NewConsumerCreateLimiter(1000, 1) // burst 1
+	require.NoError(t, err)
+
+	// First call draws the single burst token immediately.
+	require.NoError(t, lim.Wait(context.Background()))
+
+	// The bucket is now empty; the next token is ~1ms out. A cancelled ctx must
+	// make Wait return promptly with the ctx error rather than block.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, lim.Wait(ctx), context.Canceled)
+}
+
+// TestWithConsumerCreateLimiter_AcceptsPublicAndCustom proves the option accepts
+// both a constructed shared limiter and a user-implemented one, using only the
+// public surface — the exact path an external caller takes to share one budget
+// across multiple Dynamic consumers.
+func TestWithConsumerCreateLimiter_AcceptsPublicAndCustom(t *testing.T) {
+	shared, err := consumer.NewConsumerCreateLimiter(50, 5)
+	require.NoError(t, err)
+
+	// The option must accept a constructed shared limiter, a user-implemented
+	// one, and nil — all referenced through the public surface alone.
+	opts := []consumer.DynamicOption{
+		consumer.WithConsumerCreateLimiter(shared),
+		consumer.WithConsumerCreateLimiter(externalLimiter{}),
+		consumer.WithConsumerCreateLimiter(nil),
+	}
+	require.Len(t, opts, 3)
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -230,6 +230,9 @@ cfg := &parti.Config{
         Jitter:            0.2,
         DelayAfterPrepare: 0,                   // Testing only
         DelayBeforeStable: 0,                   // Testing only
+        PhaseConcurrency:  0,                   // 0 = default 20 in-flight per phase
+        ClaimWritePerSec:  0,                   // 0 = claim-write rate limiting off
+        ClaimWriteBurst:   0,                   // burst; must be >=1 when PerSec > 0
     },
 }
 ```
@@ -245,6 +248,9 @@ cfg := &parti.Config{
 | `Jitter`            | `0.2`    | Backoff randomization factor (0.0-1.0)     |
 | `DelayAfterPrepare` | `0`      | Artificial delay after prepare (testing)   |
 | `DelayBeforeStable` | `0`      | Artificial delay before stable (testing)   |
+| `PhaseConcurrency`  | `20`     | Max in-flight per-partition KV ops per phase (simultaneity cap) |
+| `ClaimWritePerSec`  | `0` (off)| Per-worker token-bucket rate cap on physical claim-writes (throughput cap); opt-in. See [OPERATIONS.md §Claim-Write Rate Limiting](OPERATIONS.md#claim-write-rate-limiting) |
+| `ClaimWriteBurst`   | `0`      | Token-bucket burst for `ClaimWritePerSec`; must be ≥ 1 when the rate is > 0 |
 
 See [Lifecycle Guide](LIFECYCLE.md#two-phase-handoff) for details on the handoff protocol.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -231,8 +231,9 @@ cfg := &parti.Config{
         DelayAfterPrepare: 0,                   // Testing only
         DelayBeforeStable: 0,                   // Testing only
         PhaseConcurrency:  0,                   // 0 = default 20 in-flight per phase
-        ClaimWritePerSec:  0,                   // 0 = claim-write rate limiting off
-        ClaimWriteBurst:   0,                   // burst; must be >=1 when PerSec > 0
+        ClaimWritePerSec:       0,              // 0 = claim-write rate limiting off
+        ClaimWriteBurst:        0,              // burst; must be >=1 when PerSec > 0
+        ClaimWriteClusterRate:  0,              // 0 = static per-worker (adaptive overlay off)
     },
 }
 ```
@@ -249,8 +250,9 @@ cfg := &parti.Config{
 | `DelayAfterPrepare` | `0`      | Artificial delay after prepare (testing)   |
 | `DelayBeforeStable` | `0`      | Artificial delay before stable (testing)   |
 | `PhaseConcurrency`  | `20`     | Max in-flight per-partition KV ops per phase (simultaneity cap) |
-| `ClaimWritePerSec`  | `0` (off)| Per-worker token-bucket rate cap on physical claim-writes (throughput cap); opt-in. See [OPERATIONS.md §Claim-Write Rate Limiting](OPERATIONS.md#claim-write-rate-limiting) |
-| `ClaimWriteBurst`   | `0`      | Token-bucket burst for `ClaimWritePerSec`; must be ≥ 1 when the rate is > 0 |
+| `ClaimWritePerSec`         | `0` (off)| Per-worker token-bucket rate cap on physical claim-writes (throughput cap); opt-in. See [OPERATIONS.md §Claim-Write Rate Limiting](OPERATIONS.md#claim-write-rate-limiting) |
+| `ClaimWriteBurst`          | `0`      | Token-bucket burst for `ClaimWritePerSec`; must be ≥ 1 when the rate is > 0 |
+| `ClaimWriteClusterRate`    | `0` (off)| Fleet-size-aware overlay: effective rate = `min(ClaimWritePerSec, ClaimWriteClusterRate/N)`; requires `ClaimWritePerSec > 0` and `EnableTwoPhaseHandoff`. See [OPERATIONS.md §Claim-Write Rate Limiting](OPERATIONS.md#claim-write-rate-limiting) |
 
 See [Lifecycle Guide](LIFECYCLE.md#two-phase-handoff) for details on the handoff protocol.
 

--- a/docs/CONSUMERS.md
+++ b/docs/CONSUMERS.md
@@ -780,6 +780,7 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 | `WithOnPermanentFailure(fn)`                   | Application callback for permanent partition failure (fires before manager observer) |
 | `WithSuppressManagerDegradeOnStreamMissing()`  | Suppress the manager's auto-degraded route for stream-missing exhaustion    |
 | `WithConsumerCreateRate(perSec, burst)`        | Enable per-attempt token-bucket rate limiting on consumer-create RPCs (opt-in, default off) — see [Consumer-Create Rate Limiting](#consumer-create-rate-limiting) |
+| `WithConsumerCreateClusterRate(clusterPerSec)` | Fleet-size-aware overlay on `WithConsumerCreateRate`; bounds the cluster-wide aggregate to `clusterPerSec` via `min(perSec, clusterPerSec/N)` — requires `WithConsumerCreateRate`, incompatible with `WithConsumerCreateLimiter`, default 0 (off) |
 | `WithConsumerCreateLimiter(l)`                 | Inject a custom or shared `consumer.ConsumerCreateLimiter` (build one with `consumer.NewConsumerCreateLimiter`); non-nil value wins over `WithConsumerCreateRate`; nil is a no-op |
 
 ---
@@ -836,6 +837,63 @@ recommended burst ≈ 256 (absorbs small reassignments instantly; validate by lo
 ```
 
 Starting values (validate against your cluster): `rate ≈ 100/s, burst ≈ 256`.
+
+### Fleet-size-aware (adaptive) rate: WithConsumerCreateClusterRate
+
+**Default:** 0 (disabled). Requires `WithConsumerCreateRate`. Incompatible with `WithConsumerCreateLimiter`.
+
+`WithConsumerCreateClusterRate(clusterPerSec)` adds a fleet-size-aware overlay
+on top of `WithConsumerCreateRate`. Each worker enforces an effective rate of:
+
+```
+effective rate = min(perSec, clusterPerSec / N)
+```
+
+where `N` is the committed worker-count the manager observes live (updated each
+time the committed assignment changes). This bounds the **steady-state** cluster-wide
+aggregate to `clusterPerSec` instead of letting it grow as `N × perSec`.
+
+```go
+c, err := consumer.NewDynamic(
+    js, "my-stream", "prefix", "orders.{{.PartitionID}}",
+    handler,
+    consumer.WithConsumerCreateRate(100, 256),        // per-worker ceiling + burst
+    consumer.WithConsumerCreateClusterRate(500),       // cluster-wide target: 500/s
+)
+```
+
+**Requirements and restrictions:**
+
+- `WithConsumerCreateRate` must also be set — it supplies the per-worker ceiling
+  (`perSec`) and burst. `WithConsumerCreateClusterRate` is rejected at `NewDynamic`
+  if used alone.
+- Incompatible with `WithConsumerCreateLimiter`: an injected/shared limiter is a
+  fixed-rate object that cannot be adaptively retuned, so the combination is rejected
+  at `NewDynamic`.
+- `clusterPerSec` must be ≥ 0; setting it to 0 disables the adaptive overlay and
+  reverts to static per-worker behaviour.
+
+**Sizing guidance:**
+
+```
+clusterPerSec ≈ cluster-wide create budget (measure under load)
+perSec        ≈ safe per-worker ceiling (transient overshoot cap)
+burst         ≈ 256 (absorb small reassignments; keep small if aggregate burst matters)
+```
+
+**Caveats:**
+
+- **Steady-state guarantee, not instantaneous.** The effective rate converges once
+  all workers in the fleet have observed the same committed N. During a scale-out
+  or scale-in transition, workers briefly disagree on N; `perSec` (the per-worker
+  ceiling) bounds the per-worker transient overshoot until convergence.
+- **Aggregate burst is `Σ burst` across workers, not bounded by `clusterPerSec`.**
+  A burst of 256 on 20 workers means the cluster can absorb 5 120 creates instantly
+  before the rate kicks in. Keep `burst` small if aggregate burst matters to your
+  cluster.
+- **Observation lag.** Worker-count updates are eventually-consistent; the worst-case
+  lag is the assignment-watcher reconcile floor (approximately 30 s). Retuning is
+  not instantaneous.
 
 ### Throttle metrics (optional sidecar)
 

--- a/docs/CONSUMERS.md
+++ b/docs/CONSUMERS.md
@@ -780,13 +780,13 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 | `WithOnPermanentFailure(fn)`                   | Application callback for permanent partition failure (fires before manager observer) |
 | `WithSuppressManagerDegradeOnStreamMissing()`  | Suppress the manager's auto-degraded route for stream-missing exhaustion    |
 | `WithConsumerCreateRate(perSec, burst)`        | Enable per-attempt token-bucket rate limiting on consumer-create RPCs (opt-in, default off) — see [Consumer-Create Rate Limiting](#consumer-create-rate-limiting) |
-| `WithConsumerCreateLimiter(l)`                 | Inject a custom or shared `ratelimit.Limiter`; non-nil value wins over `WithConsumerCreateRate`; nil is a no-op |
+| `WithConsumerCreateLimiter(l)`                 | Inject a custom or shared `consumer.ConsumerCreateLimiter` (build one with `consumer.NewConsumerCreateLimiter`); non-nil value wins over `WithConsumerCreateRate`; nil is a no-op |
 
 ---
 
 ## Consumer-Create Rate Limiting
 
-**Default:** disabled (nil limiter). Behavior is byte-for-byte unchanged until this option is explicitly configured.
+**Default:** disabled (nil limiter). Behavior is unchanged until this option is explicitly configured — with no limiter the gate is a nil-safe no-op on the create paths. (The `golang.org/x/time/rate` dependency becomes direct, and the Prometheus throttle series are registered at zero, but no create path is paced.)
 
 Large dynamic-partition assignments (e.g. a fresh source growing to 20 000 partitions) or mass consumer-recovery events can flood the NATS cluster with `CreateOrUpdateConsumer` RPCs. `WithConsumerCreateRate` installs a per-worker token-bucket that gates **every physical RPC attempt** — including retry attempts — across the initial-assignment add loop and the per-partition recovery/recreation paths.
 
@@ -800,13 +800,19 @@ c, err := consumer.NewDynamic(
 )
 ```
 
-Or inject a shared limiter to pool the budget across multiple `Dynamic` consumers:
+Or inject a shared limiter to pool the budget across multiple `Dynamic` consumers
+in the same process:
 
 ```go
-limiter := ratelimit.New(100, 256, nil)
+limiter, err := consumer.NewConsumerCreateLimiter(100, 256) // 100 creates/s, burst 256
+if err != nil { /* perSec must be > 0, burst >= 1 */ }
 c1, _ := consumer.NewDynamic(js, "stream-a", ..., consumer.WithConsumerCreateLimiter(limiter))
 c2, _ := consumer.NewDynamic(js, "stream-b", ..., consumer.WithConsumerCreateLimiter(limiter))
 ```
+
+`ConsumerCreateLimiter` is a one-method interface (`Wait(ctx) error`), so you can
+also supply your own implementation. A shared/injected limiter does not emit the
+per-consumer throttle metrics that `WithConsumerCreateRate` wires up.
 
 ### Per-attempt gating
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1048,6 +1048,40 @@ The rate limiter is opt-in. To enable on an existing deployment:
 4. Consider increasing `StartupTimeout` for large cold starts.
 5. Roll out gradually (canary / blue-green); monitor `parti_worker_consumer_create_throttled_total` and `parti_worker_consumer_create_throttle_wait_seconds` (Prometheus sidecar metrics) to confirm the limiter is active and the delay distribution is within target.
 
-### Claim-write residual (out of scope)
+### Claim-write rate limiting (related control)
 
-The consumer-create limiter does not gate **claim-write** RPCs (`PutIfEpoch` calls in the two-phase coordinator and the startup handoff hygiene loops). Those are a separate, related flood vector documented in [`docs/plans/consumer-create-rate-limit/10-claim-write-ratelimit-plan.md`](plans/consumer-create-rate-limit/10-claim-write-ratelimit-plan.md).
+The consumer-create limiter does not gate **claim-write** RPCs (`PutIfEpoch` calls in the two-phase coordinator and the startup handoff hygiene/resume loops). Those are a separate, related flood vector with their own opt-in control — see [Claim-Write Rate Limiting](#claim-write-rate-limiting) below.
+
+## Claim-Write Rate Limiting
+
+**Default:** opt-in, default OFF. Requires `EnableTwoPhaseHandoff`. Existing deployments upgrading to this version see no behaviour change.
+
+Two-phase handoff writes per-partition ownership claims to a KV bucket via `PutIfEpoch`. Two scenarios can turn that into a write storm: a **large-fleet restart**, where each worker's startup hygiene/resume loops walk every claim key sequentially with no bound, and a **rapid rebalance**, where the coordinator's prepare/commit/stabilize phases issue a per-partition CAS for the whole moved set. `HandoffConfig.ClaimWritePerSec` / `ClaimWriteBurst` install a per-worker token-bucket that paces **every physical `PutIfEpoch` attempt — including CAS retries** — across all of those sites from a single shared budget.
+
+This is distinct from `PhaseConcurrency`, which caps how many claim writes are *in flight* at once. `PhaseConcurrency` bounds simultaneity; `ClaimWritePerSec` bounds throughput. The two compose: a burst is absorbed up to `ClaimWriteBurst`, then sustained writes are released at `ClaimWritePerSec`.
+
+### Sizing
+
+```
+rate ≈ cluster-kv-write-budget / max-workers
+burst ≈ PhaseConcurrency        # absorb one rebalance wave without throttling
+```
+
+```go
+cfg.Handoff.ClaimWritePerSec = 100 // 100 claim-writes/s steady
+cfg.Handoff.ClaimWriteBurst  = 20  // matches the default PhaseConcurrency
+```
+
+`ClaimWriteBurst` must be ≥ 1 whenever `ClaimWritePerSec > 0` (rejected at `Config.Validate` otherwise); it is ignored when the rate is 0.
+
+### OperationTimeout and Start-latency interaction
+
+The **startup hygiene** pass runs under `OperationTimeout` **on the synchronous `Manager.Start` path** (before `Start` returns). With a low `ClaimWritePerSec` and many pre-existing stale claims, hygiene can pace its reset writes up to the `OperationTimeout` deadline, extending how long `Start` blocks before returning by that much (it then stops early — the remaining stale claims are reset on a later startup or by the coordinator's periodic sweep, so this is safe but means a very low rate will not finish hygiene in one pass, and `Start` itself can be slower). Size `OperationTimeout` with headroom, or set `ClaimWriteBurst` at least as large as the expected stale-claim count so a one-time cold sweep is absorbed without throttling. The **background resume** pass and the **two-phase coordinator** are not `OperationTimeout`-bounded and run off the synchronous `Start` path; a paced coordinator write unwinds promptly on shutdown because `Wait` honours context cancellation.
+
+### Migration note
+
+The limiter is opt-in. To enable on an existing deployment:
+
+1. Measure your cluster's safe aggregate KV-write rate under load and divide by `max-workers`.
+2. Set `cfg.Handoff.ClaimWritePerSec` and `cfg.Handoff.ClaimWriteBurst` (start with `burst ≈ PhaseConcurrency`).
+3. Roll out gradually (canary / blue-green); monitor `parti_handoff_claim_write_throttled_total` and `parti_handoff_claim_write_throttle_wait_seconds` (Prometheus sidecar metrics, emitted when a `handoff.PrometheusRecorder` is wired via `WithHandoffMetricsRecorder`) to confirm the limiter is active and the delay distribution is within target.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1060,6 +1060,49 @@ Two-phase handoff writes per-partition ownership claims to a KV bucket via `PutI
 
 This is distinct from `PhaseConcurrency`, which caps how many claim writes are *in flight* at once. `PhaseConcurrency` bounds simultaneity; `ClaimWritePerSec` bounds throughput. The two compose: a burst is absorbed up to `ClaimWriteBurst`, then sustained writes are released at `ClaimWritePerSec`.
 
+### Fleet-size-aware (adaptive) rate: ClaimWriteClusterRate
+
+**Default:** 0 (disabled). Requires `ClaimWritePerSec > 0` and `EnableTwoPhaseHandoff`.
+
+`HandoffConfig.ClaimWriteClusterRate` adds a fleet-size-aware overlay on top of
+`ClaimWritePerSec`. Each worker enforces an effective rate of:
+
+```
+effective rate = min(ClaimWritePerSec, ClaimWriteClusterRate / N)
+```
+
+where `N` is the committed worker-count the manager observes live. This bounds the
+**steady-state** cluster-wide aggregate to `ClaimWriteClusterRate` instead of the
+uncontrolled `N × ClaimWritePerSec`.
+
+```go
+cfg.Handoff.ClaimWritePerSec       = 100  // per-worker ceiling
+cfg.Handoff.ClaimWriteBurst        = 20   // matches default PhaseConcurrency
+cfg.Handoff.ClaimWriteClusterRate  = 500  // cluster-wide target: 500/s
+```
+
+**Requirements and validation:**
+
+- `ClaimWritePerSec > 0` must be set — it supplies the per-worker ceiling and is the
+  source for burst. `Config.Validate` returns an error if `ClaimWriteClusterRate > 0`
+  with `ClaimWritePerSec <= 0`.
+- Requires `EnableTwoPhaseHandoff`. `ValidateWithWarnings` emits an inert WARN if
+  `ClaimWriteClusterRate > 0` with two-phase handoff OFF; behaviour is unchanged
+  (the cluster-rate field is silently ignored by the coordinator, which is not
+  constructed when two-phase is off).
+- `ClaimWriteClusterRate` must be ≥ 0; 0 = static per-worker behaviour (the default).
+
+**Caveats:**
+
+- **Steady-state guarantee, not instantaneous.** The effective rate converges once all
+  workers have observed the same committed N. During fleet transitions, `ClaimWritePerSec`
+  (the per-worker ceiling) bounds the per-worker transient overshoot.
+- **Aggregate burst is `Σ ClaimWriteBurst` across workers, not bounded by
+  `ClaimWriteClusterRate`.** Keep `ClaimWriteBurst` small (≈ `PhaseConcurrency`) if
+  aggregate burst matters.
+- **Observation lag.** Worker-count updates are eventually-consistent; worst-case lag is
+  approximately the assignment-watcher reconcile floor (~30 s).
+
 ### Sizing
 
 ```

--- a/docs/plans/consumer-create-rate-limit/10-claim-write-ratelimit-plan.md
+++ b/docs/plans/consumer-create-rate-limit/10-claim-write-ratelimit-plan.md
@@ -1,8 +1,12 @@
-# Claim-Write Rate Limit — Fast-Follow Stub
+# Claim-Write Rate Limit — Fast-Follow
 
-> **Status:** Deferred (D4). Consumer-create rate limiting landed first
-> (`consumer.WithConsumerCreateRate`). This document stubs the next vector for
-> a measurement-driven follow-on.
+> **Status:** Shipped. Consumer-create rate limiting landed first
+> (`consumer.WithConsumerCreateRate`); claim-write rate limiting followed as
+> `parti.HandoffConfig.ClaimWritePerSec` / `ClaimWriteBurst` (opt-in, default
+> off). One per-worker token-bucket gates every physical `PutIfEpoch` across all
+> three verified sites from a single shared budget. Operator guidance lives in
+> [`docs/OPERATIONS.md` §Claim-Write Rate Limiting](../../OPERATIONS.md#claim-write-rate-limiting).
+> The sections below are retained as the design/enumeration record.
 
 ---
 
@@ -22,16 +26,23 @@ stresses the NATS cluster independently of the consumer-create rate.
    are already **concurrency-bounded** by `HandoffConfig.PhaseConcurrency`
    (default 20, opt-in via `Config.EnableTwoPhaseHandoff`).
 
-2. **`manager_handoff.go:172` `handoffStartupHygiene`** — `store.PutIfEpoch`
-   directly, sequential loop over all keys (`:152-179`), startup-only, **not**
-   `PhaseConcurrency`-bounded. Unbounded on large fleets.
+2. **`manager_handoff.go:handoffStartupHygiene`** (repo root, package `parti`)
+   — `store.PutIfEpoch` directly, sequential loop over all keys, startup-only,
+   **not** `PhaseConcurrency`-bounded. Unbounded on large fleets.
 
-3. **`manager_handoff.go:226` `runHandoffResume`** — `store.PutIfEpoch`
-   directly, sequential loop over all keys (`:213-229`), startup-only, **not**
-   `PhaseConcurrency`-bounded. Unbounded on large fleets.
+3. **`manager_handoff.go:runHandoffResume`** (repo root, package `parti`) —
+   `store.PutIfEpoch` directly, sequential loop over all keys, startup-only,
+   **not** `PhaseConcurrency`-bounded. Unbounded on large fleets.
 
 Sites 2 and 3 are the primary concern: startup loops that are currently
 unbounded and fire sequentially over all KV keys.
+
+> **As shipped:** all three sites are gated by one per-worker
+> `ratelimit.Limiter`, built in `manager_setup.go` from
+> `HandoffConfig.ClaimWrite{PerSec,Burst}` and threaded into
+> `handoff.Config.ClaimWriteLimiter` (site 1) and `m.claimWriteLimiter`
+> (sites 2–3). The earlier path note `manager_handoff.go:172/:226` was relative
+> to `internal/assignment/handoff/`; the file is actually at the repo root.
 
 ## Deferred rationale
 

--- a/docs/plans/thundering-herd-hardening/README.md
+++ b/docs/plans/thundering-herd-hardening/README.md
@@ -24,9 +24,9 @@ no-op behavior — upgrading the library is observably identical to current
 | `2efad05` | `Config.AssignmentWatcherDebounce` (`time.Duration`) + `ManagerMetrics.RecordApplyAttempt(workerID, version)` | `0` (off) for the debounce | Idle-window timer in `runAssignmentWatchSession` coalesces watcher events. Cap at 1s. Prometheus counter `parti_manager_apply_attempts_total{worker_id}` (single label, version discarded for bounded cardinality). Opt-in `TestApplyCoalescing_UnderReElectionBurst` diagnostic for operator window sizing. |
 | follow-up | `Config.AssignmentWatcherDebounce` also covers `assignment._commit` watcher updates | `0` (off) | Rapid commit bursts are staged for one idle window; identical-assignment bursts collapse to one apply, while same-or-higher commits that change this worker's partition set early-flush pending to preserve two-phase handoff. Stale lower-version commits are dropped. |
 
-## Related: consumer-create rate limiting
+## Related: consumer-create and claim-write rate limiting
 
-A fourth, independent opt-in control bounds the per-worker `CreateOrUpdateConsumer` RPC rate during large partition assignments and mass recovery events. See [`docs/plans/consumer-create-rate-limit/00-plan.md`](../consumer-create-rate-limit/00-plan.md) and [`consumer.WithConsumerCreateRate`](../../../consumer/options.go).
+Two further independent opt-in controls bound per-worker RPC rates against the NATS cluster. `consumer.WithConsumerCreateRate` paces `CreateOrUpdateConsumer` RPCs during large partition assignments and mass recovery; `parti.HandoffConfig.ClaimWritePerSec` / `ClaimWriteBurst` pace handoff claim-writes (`PutIfEpoch`) across the startup hygiene/resume loops and the two-phase coordinator. See [`docs/plans/consumer-create-rate-limit/00-plan.md`](../consumer-create-rate-limit/00-plan.md), its [claim-write fast-follow](../consumer-create-rate-limit/10-claim-write-ratelimit-plan.md), and [`consumer.WithConsumerCreateRate`](../../../consumer/options.go).
 
 ## Files in this directory
 

--- a/docs/superpowers/plans/2026-06-17-adaptive-rate-limit.md
+++ b/docs/superpowers/plans/2026-06-17-adaptive-rate-limit.md
@@ -1,0 +1,1316 @@
+# Adaptive (fleet-size-aware) rate limiting — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the two v2.8.0 opt-in rate limits (consumer-create, claim-write) fleet-size-aware so each worker enforces `effective_rate = min(perWorkerMax, clusterRate / observed_N)`, bounding the steady-state cluster-wide aggregate instead of letting it scale as `N × perWorkerMax`.
+
+**Architecture:** Each worker observes the committed worker-count `N = len(commit.Workers)` at the pre-debounce commit-decode point (freshness-fenced so a stale commit cannot regress N), then live-retunes one shared token-bucket limiter via a new `SetRate`. Claim-write is fully manager-local. Consumer-create config + limiter live on the consumer, so the manager pushes `N` through a new optional `FleetSizeObserver` interface (mirror of the existing `CapabilityReporter`) and the consumer recomputes its own rate.
+
+**Tech Stack:** Go, `golang.org/x/time/rate` (wrapped in `internal/ratelimit`), NATS JetStream, testify (`require`/`assert`), `make test` (`-race`), `make test-integration` (`-race`).
+
+**Design spec:** `docs/superpowers/specs/2026-06-17-adaptive-rate-limit-design.md` (read it first — this plan implements it).
+
+**Conventions (this repo):**
+- Reproducer/test-first: write the failing test, confirm it fails, then implement.
+- Commit messages: conventional-commit prefix, **no plan jargon** (no "P0", "task N", "spec"), **no attribution trailers**.
+- Run `make lint` and fix findings **before every commit**.
+- Pre-PR gate (touches `manager/`, `config.go`, `internal/...`): run `make pre-pr` before opening the PR (Task 10).
+- Branch: continue on `feat/claim-write-ratelimit` (unreleased v2.8.0 work). These symbols are unreleased and freely shapeable.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/ratelimit/ratelimit.go` | token-bucket primitive | add `RateSetter` interface, `SetRate`, `Limit()` |
+| `config.go` | `HandoffConfig` + validation | add `ClaimWriteClusterRate`, Validate rule, inert WARN |
+| `fleet_size_observer.go` (new) | manager→consumer N push interface | new `FleetSizeObserver` |
+| `manager.go` | manager state + construction | `fleetMu`+tuple, `fleetSizeObserver`, `asFleetSizeObserver` |
+| `manager_assignment.go` | commit-watch + N observation | `observeFleetSize`, hook in `runCommitWatchSession` |
+| `composite_updater.go` | composite updater | forward `ObserveWorkerCount` + late-add replay |
+| `consumer/options.go` | Dynamic options | `consumerCreateClusterRate` + `WithConsumerCreateClusterRate` |
+| `consumer/dynamic.go` | Dynamic consumer | capture `RateSetter`, `ObserveWorkerCount`, cluster validation |
+
+Metrics (spec §9) are intentionally **out of scope** for this plan (optional follow-up).
+
+---
+
+## Task 1: ratelimit primitive — `SetRate` + `RateSetter`
+
+**Files:**
+- Modify: `internal/ratelimit/ratelimit.go`
+- Test: `internal/ratelimit/ratelimit_setrate_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/ratelimit/ratelimit_setrate_test.go`:
+
+```go
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenBucketLimiter_SetRate_ChangesSteadyState(t *testing.T) {
+	l := New(100, 1, nil) // 100/s, burst 1
+	require.InEpsilon(t, 100.0, l.Limit(), 1e-9)
+
+	l.SetRate(10) // tighten to 10/s
+	require.InEpsilon(t, 10.0, l.Limit(), 1e-9)
+
+	l.SetRate(1000) // loosen
+	require.InEpsilon(t, 1000.0, l.Limit(), 1e-9)
+}
+
+func TestTokenBucketLimiter_SetRate_PreservesBurst(t *testing.T) {
+	l := New(100, 7, nil)
+	l.SetRate(5)
+	require.Equal(t, 7, l.rl.Burst(), "SetRate must not change burst")
+}
+
+func TestTokenBucketLimiter_RateSetter_Assertion(t *testing.T) {
+	var lim Limiter = New(100, 1, nil)
+	rs, ok := lim.(RateSetter)
+	require.True(t, ok, "*TokenBucketLimiter must satisfy RateSetter")
+	rs.SetRate(50)
+	require.InEpsilon(t, 50.0, lim.(*TokenBucketLimiter).Limit(), 1e-9)
+}
+
+func TestTokenBucketLimiter_SetRate_ConcurrentWithWait(t *testing.T) {
+	l := New(1000, 100, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				_ = l.Wait(ctx)
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			l.SetRate(500)
+			l.SetRate(2000)
+		}
+	}()
+	wg.Wait() // -race must stay clean
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/ratelimit/ -run SetRate -v`
+Expected: FAIL — `l.SetRate undefined`, `l.Limit undefined`, `RateSetter` undefined.
+
+- [ ] **Step 3: Implement `SetRate`, `Limit`, and `RateSetter`**
+
+In `internal/ratelimit/ratelimit.go`, after the `Limiter` interface block (around line 35) add:
+
+```go
+// RateSetter is an optional capability implemented by limiters whose
+// steady-state rate can be retuned at runtime (the built-in
+// [TokenBucketLimiter]). Adaptive, fleet-size-aware callers type-assert a
+// [Limiter] to RateSetter; a limiter that does not implement it (e.g. a
+// user-injected custom limiter) keeps its constructed rate.
+//
+// Kept separate from [Limiter] deliberately: widening Limiter would force every
+// implementation (including injected, Wait-only ones) to add SetRate.
+type RateSetter interface {
+	// SetRate changes the steady-state rate (events/second), leaving burst
+	// unchanged. Safe to call concurrently with Wait.
+	SetRate(perSec float64)
+}
+```
+
+Then, after the `Wait` method on `*TokenBucketLimiter` (around line 116) add:
+
+```go
+// SetRate changes the steady-state rate to perSec events/second, leaving the
+// burst unchanged. It is safe to call concurrently with Wait: the underlying
+// rate.Limiter guards its limit with an internal mutex. A rate decrease does
+// not retroactively cancel reservations already granted by an in-flight Wait
+// (golang.org/x/time/rate semantics); the effect is a brief, self-correcting
+// transient.
+func (l *TokenBucketLimiter) SetRate(perSec float64) {
+	l.rl.SetLimit(rate.Limit(perSec))
+}
+
+// Limit returns the current steady-state rate (events/second).
+func (l *TokenBucketLimiter) Limit() float64 {
+	return float64(l.rl.Limit())
+}
+```
+
+Add the compile-time assertion next to the existing `var _ Limiter = (*TokenBucketLimiter)(nil)` (line 44):
+
+```go
+var _ RateSetter = (*TokenBucketLimiter)(nil)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/ratelimit/ -run SetRate -race -v`
+Expected: PASS (all four tests, race-clean).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make lint
+git add internal/ratelimit/ratelimit.go internal/ratelimit/ratelimit_setrate_test.go
+git commit -m "feat(ratelimit): add runtime SetRate and RateSetter capability"
+```
+
+---
+
+## Task 2: claim-write cluster-rate config + validation + inert warning
+
+**Files:**
+- Modify: `config.go` (HandoffConfig struct ~148-156; `Validate` ~706; `ValidateWithWarnings` ~817)
+- Test: `config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `config_test.go`:
+
+```go
+func TestValidate_ClaimWriteClusterRate_RequiresPerWorker(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.Handoff.ClaimWriteClusterRate = 1000 // set
+	cfg.Handoff.ClaimWritePerSec = 0          // but no per-worker ceiling
+	cfg.Handoff.ClaimWriteBurst = 10
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ClaimWriteClusterRate")
+}
+
+func TestValidate_ClaimWriteClusterRate_NegativeRejected(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.Handoff.ClaimWriteClusterRate = -1
+	err := cfg.Validate()
+	require.Error(t, err)
+}
+
+func TestValidate_ClaimWriteClusterRate_ValidWithPerWorker(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.Handoff.ClaimWritePerSec = 200
+	cfg.Handoff.ClaimWriteBurst = 50
+	cfg.Handoff.ClaimWriteClusterRate = 1000
+	require.NoError(t, cfg.Validate())
+}
+
+func TestValidateWithWarnings_ClaimWriteClusterRateWithoutTwoPhase(t *testing.T) {
+	const warnPrefix = "Handoff.ClaimWriteClusterRate is set but EnableTwoPhaseHandoff is false"
+
+	t.Run("warns when cluster rate set but two-phase off", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = false
+		cfg.Handoff.ClaimWritePerSec = 200
+		cfg.Handoff.ClaimWriteBurst = 50
+		cfg.Handoff.ClaimWriteClusterRate = 1000
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.True(t, log.contains(warnPrefix), "got %v", log.warns)
+	})
+
+	t.Run("no warning when two-phase on", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.EnableTwoPhaseHandoff = true
+		cfg.Handoff.ClaimWritePerSec = 200
+		cfg.Handoff.ClaimWriteBurst = 50
+		cfg.Handoff.ClaimWriteClusterRate = 1000
+		log := &warnCapture{}
+		cfg.ValidateWithWarnings(log)
+		require.False(t, log.contains(warnPrefix), "got %v", log.warns)
+	})
+}
+```
+
+> `warnCapture` (with `.contains(prefix)` and `.warns`) is the existing helper in `config_test.go` used by `TestValidateWithWarnings_ClaimWriteRateWithoutTwoPhase`. The warning message in Step 5 must start with exactly `warnPrefix`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run 'ClaimWriteClusterRate' -v`
+Expected: FAIL — field `ClaimWriteClusterRate` undefined.
+
+- [ ] **Step 3: Add the field**
+
+In `config.go`, in `HandoffConfig`, immediately after the `ClaimWriteBurst` field:
+
+```go
+	// ClaimWriteClusterRate, when > 0, makes claim-write rate limiting
+	// fleet-size-aware: each worker enforces
+	// min(ClaimWritePerSec, ClaimWriteClusterRate/N), where N is the observed
+	// committed worker count. It bounds the STEADY-STATE cluster-wide
+	// claim-write rate to ClaimWriteClusterRate instead of N*ClaimWritePerSec.
+	// Requires ClaimWritePerSec > 0 (the per-worker ceiling and burst source)
+	// and EnableTwoPhaseHandoff. Default 0 = static per-worker rate only.
+	ClaimWriteClusterRate float64 `yaml:"claimWriteClusterRate" default:"0" validate:"gte=0"`
+```
+
+> Match the tag shape of the adjacent `ClaimWritePerSec`/`ClaimWriteBurst` fields exactly (`yaml:"..." default:"0" validate:"gte=0"`) — this repo loads config via YAML + `SetDefaults`, not JSON. `SetDefaults` is a package function, not a method: add a quick default-applied assertion to one of the Task 2 tests (`var cfg Config; require.NoError(t, SetDefaults(&cfg))` leaves `ClaimWriteClusterRate` at 0 and still validates).
+
+- [ ] **Step 4: Add the Validate cross-field rule**
+
+In `config.go` `Validate`, beside the existing `ClaimWriteBurst >= 1 when ClaimWritePerSec > 0` check (~706):
+
+```go
+	if cfg.Handoff.ClaimWriteClusterRate > 0 && cfg.Handoff.ClaimWritePerSec <= 0 {
+		return fmt.Errorf("Handoff.ClaimWriteClusterRate > 0 requires Handoff.ClaimWritePerSec > 0 (the per-worker ceiling and burst source)")
+	}
+```
+
+(The `validate:"gte=0"` tag already rejects negatives; the explicit test above documents it.)
+
+- [ ] **Step 5: Add the inert-config warning**
+
+In `config.go` `ValidateWithWarnings`, beside the existing `ClaimWritePerSec`-without-two-phase warning (~817):
+
+```go
+	if !cfg.EnableTwoPhaseHandoff && cfg.Handoff.ClaimWriteClusterRate > 0 {
+		logger.Warn("Handoff.ClaimWriteClusterRate is set but EnableTwoPhaseHandoff is false; cluster-rate claim-write limiting has no effect")
+	}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test . -run 'ClaimWriteClusterRate' -v`
+Expected: PASS.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+make lint
+git add config.go config_test.go
+git commit -m "feat(config): add ClaimWriteClusterRate for fleet-aware claim-write limiting"
+```
+
+---
+
+## Task 3: `FleetSizeObserver` interface + manager fleet state + `observeFleetSize`
+
+**Files:**
+- Create: `fleet_size_observer.go`
+- Modify: `manager.go` (struct fields; `asFleetSizeObserver`)
+- Modify: `manager_assignment.go` (`observeFleetSize`)
+- Test: `fleet_size_observer_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `fleet_size_observer_test.go`:
+
+```go
+package parti
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingObserver struct{ ns []int }
+
+func (r *recordingObserver) ObserveWorkerCount(n int) { r.ns = append(r.ns, n) }
+
+func newFleetTestManager(lim ratelimit.Limiter, obs FleetSizeObserver, clusterRate, perSec float64) *Manager {
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: lim, fleetSizeObserver: obs}
+	m.cfg.Handoff.ClaimWriteClusterRate = clusterRate
+	m.cfg.Handoff.ClaimWritePerSec = perSec
+	return m
+}
+
+func commit(version int64, lr uint64, workers ...string) *types.AssignmentCommit {
+	return &types.AssignmentCommit{Version: version, LeaderRevision: lr, Workers: workers}
+}
+
+func TestObserveFleetSize_RetunesClaimWriteAndPushes(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil) // perSec ceiling 200
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000, 200)
+
+	m.observeFleetSize(commit(1, 1, "a", "b", "c", "d", "e")) // N=5
+	require.InEpsilon(t, 200.0, lim.Limit(), 1e-9, "min(200, 1000/5=200) = 200")
+	require.Equal(t, []int{5}, obs.ns)
+
+	m.observeFleetSize(commit(2, 1, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")) // N=10
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9, "min(200, 1000/10=100) = 100")
+	require.Equal(t, []int{5, 10}, obs.ns)
+}
+
+func TestObserveFleetSize_StaleCommit_NoRegression(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000, 200)
+
+	m.observeFleetSize(commit(5, 2, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")) // v5, N=10 -> 100
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9)
+
+	// Stale: lower version. Must NOT retune back to N=2.
+	m.observeFleetSize(commit(3, 2, "a", "b")) // v3 < v5
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9, "stale commit must not regress rate")
+	require.Equal(t, []int{10}, obs.ns, "stale commit must not push")
+
+	// Stale by leader-revision at same version.
+	m.observeFleetSize(commit(5, 1, "a", "b")) // same v5, lower lr
+	require.Equal(t, []int{10}, obs.ns)
+}
+
+func TestObserveFleetSize_NoOpWhenNUnchanged(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000, 200)
+	m.observeFleetSize(commit(1, 1, "a", "b")) // N=2
+	m.observeFleetSize(commit(2, 1, "a", "b")) // version advanced, N still 2
+	require.Equal(t, []int{2}, obs.ns, "unchanged N must not push again")
+}
+
+func TestObserveFleetSize_NoClusterRate_NoRetune(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	m := newFleetTestManager(lim, nil, 0, 200) // clusterRate=0
+	m.observeFleetSize(commit(1, 1, "a", "b", "c"))
+	require.InEpsilon(t, 200.0, lim.Limit(), 1e-9, "clusterRate=0 leaves limiter at perSec")
+}
+
+func TestObserveFleetSize_ClampsNToOne(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	m := newFleetTestManager(lim, nil, 50, 200)
+	m.observeFleetSize(commit(1, 1)) // empty Workers -> clamp N=1
+	require.InEpsilon(t, 50.0, lim.Limit(), 1e-9, "min(200, 50/1=50) = 50")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run ObserveFleetSize -v`
+Expected: FAIL — `FleetSizeObserver` undefined, `fleetSizeObserver` field undefined, `observeFleetSize` undefined.
+
+- [ ] **Step 3: Create the `FleetSizeObserver` interface**
+
+Create `fleet_size_observer.go`:
+
+```go
+package parti
+
+// FleetSizeObserver is an optional interface a [WorkerConsumerUpdater] MAY
+// implement to receive the observed cluster worker-count (N) for fleet-size-
+// aware (adaptive) rate limiting.
+//
+// When the registered updater (or any child of a composite updater) satisfies
+// this interface, the Manager calls ObserveWorkerCount whenever the committed
+// worker-set size changes — and once during startup, before the first apply —
+// so the consumer can retune its consumer-create rate to
+// min(perWorkerCeiling, clusterRate/N).
+//
+// Implementations MUST be:
+//   - Non-blocking. ObserveWorkerCount runs on the Manager's commit-watch
+//     goroutine while the Manager holds an internal lock; it must not perform
+//     I/O or block.
+//   - Safe for concurrent use.
+//   - Non-reentrant: it MUST NOT call back into the Manager or any apply/update
+//     path (mirrors the [CapabilityReporter] contract and the D5 lock-order
+//     rule).
+//
+// n is always >= 1.
+type FleetSizeObserver interface {
+	// ObserveWorkerCount reports the current committed cluster worker-count.
+	ObserveWorkerCount(n int)
+}
+```
+
+- [ ] **Step 4: Add manager fleet state + `asFleetSizeObserver`**
+
+In `manager.go`, add fields to the `Manager` struct (near `capReporter`):
+
+```go
+	// fleetSizeObserver is the consumer updater cast to FleetSizeObserver at
+	// construction (nil when the updater does not implement it). Used to push
+	// the observed worker-count N for adaptive consumer-create rate limiting.
+	fleetSizeObserver FleetSizeObserver
+
+	// fleetMu guards the last-observed commit identity and worker-count so the
+	// freshness fence and the recorded N never split. Held across the limiter
+	// retune + the FleetSizeObserver push (both non-blocking, non-reentrant).
+	fleetMu            sync.Mutex
+	lastFleetVersion   int64
+	lastFleetLeaderRev uint64
+	lastObservedN      int
+```
+
+Add the constructor helper near `asCapabilityReporter` (manager.go:981):
+
+```go
+// asFleetSizeObserver returns u as a FleetSizeObserver when it implements the
+// interface; otherwise nil. Called once at construction so the commit-watch
+// hot path does not repeat the type assertion. Mirrors asCapabilityReporter.
+func asFleetSizeObserver(u WorkerConsumerUpdater) FleetSizeObserver {
+	fo, _ := u.(FleetSizeObserver)
+	return fo
+}
+```
+
+- [ ] **Step 5: Implement `observeFleetSize`**
+
+In `manager_assignment.go`, add (near the commit-watch helpers, e.g. after `workerAssignmentChanged`):
+
+```go
+// observeFleetSize records the cluster worker-count from a committed assignment
+// and live-retunes the fleet-size-aware rate limiters. It runs at the
+// pre-debounce commit-decode point so it sees every commit the watcher
+// delivers — including those the apply debounce suppresses when this worker's
+// own slice is unchanged.
+//
+// It is freshness-fenced: only a commit that strictly supersedes the last
+// observed one on (Version, LeaderRevision) lex order retunes, so a stale or
+// out-of-order commit (e.g. a reconcile snapshot racing a newer watcher event)
+// can never regress N. Guarded by fleetMu; the retune and push are non-blocking
+// and non-reentrant by contract.
+func (m *Manager) observeFleetSize(commit *types.AssignmentCommit) {
+	if commit == nil {
+		return
+	}
+	n := len(commit.Workers)
+	if n < 1 {
+		n = 1 // defensive: the publisher never emits an empty worker-set
+	}
+
+	m.fleetMu.Lock()
+	defer m.fleetMu.Unlock()
+
+	// Freshness fence: same (Version, LeaderRevision) lex PREFIX the apply stale
+	// gate uses (commitSupersedesForStash also compares BatchDigest/source at
+	// equal (V,LR), but N is fixed for a given (V,LR), so the lex prefix is
+	// sufficient and correct here). Drop non-superseding commits so a stale or
+	// out-of-order reconcile snapshot can never regress N.
+	if commit.Version < m.lastFleetVersion ||
+		(commit.Version == m.lastFleetVersion && commit.LeaderRevision <= m.lastFleetLeaderRev) {
+		return
+	}
+	m.lastFleetVersion = commit.Version
+	m.lastFleetLeaderRev = commit.LeaderRevision
+
+	if n == m.lastObservedN {
+		return // version advanced but N unchanged: no retune
+	}
+	m.lastObservedN = n
+
+	// Claim-write (manager-local): retune the shared limiter in place.
+	if m.cfg.Handoff.ClaimWriteClusterRate > 0 {
+		if rs, ok := m.claimWriteLimiter.(ratelimit.RateSetter); ok {
+			rs.SetRate(effectiveRate(m.cfg.Handoff.ClaimWritePerSec, m.cfg.Handoff.ClaimWriteClusterRate, n))
+		}
+	}
+
+	// Consumer-create: push N; the consumer owns its rate policy.
+	if m.fleetSizeObserver != nil {
+		m.fleetSizeObserver.ObserveWorkerCount(n)
+	}
+}
+
+// effectiveRate returns min(perWorkerMax, clusterRate/n). n must be >= 1.
+func effectiveRate(perWorkerMax, clusterRate float64, n int) float64 {
+	r := clusterRate / float64(n)
+	if perWorkerMax > 0 && perWorkerMax < r {
+		return perWorkerMax
+	}
+	return r
+}
+```
+
+Ensure `manager_assignment.go` imports `"github.com/arloliu/parti/v2/internal/ratelimit"` (add to the import block if absent).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test . -run 'ObserveFleetSize' -race -v`
+Expected: PASS (all five observe tests).
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+make lint
+git add fleet_size_observer.go fleet_size_observer_test.go manager.go manager_assignment.go
+git commit -m "feat(manager): add FleetSizeObserver and freshness-fenced observeFleetSize"
+```
+
+---
+
+## Task 4: wire `observeFleetSize` into the commit watcher + bootstrap + construction
+
+**Files:**
+- Modify: `manager.go` (construction: set `fleetSizeObserver`; bootstrap observe ~692-701)
+- Modify: `manager_assignment.go` (`runCommitWatchSession` `onUpdate`/`onReconcile`)
+- Test: `manager_fleet_wiring_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `manager_fleet_wiring_test.go`:
+
+```go
+package parti
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the observeFleetSize contract used by the watcher seam: sequential fresh
+// commits observe in order. This is NOT a test of runCommitWatchSession itself —
+// the production wiring (onUpdate/onReconcile actually call observeFleetSize) is
+// proven end-to-end by the integration test in Task 8, where a real fleet change
+// flows through the watcher. A pure-unit assertion on the watcher closure is
+// brittle, so the integration test is the real wiring proof.
+func TestObserveFleetSize_SequentialFreshCommits(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000, 200)
+
+	m.observeFleetSize(commit(1, 1, "a", "b")) // N=2
+	m.observeFleetSize(commit(2, 1, "a", "b", "c", "d")) // N=4
+	require.Equal(t, []int{2, 4}, obs.ns)
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (uses Task 3 code)**
+
+Run: `go test . -run TestObserveFleetSize_SequentialFreshCommits -v`
+Expected: PASS — this task adds the production wiring that the Task 8 integration test exercises end-to-end.
+
+- [ ] **Step 3: Hook the watcher decode points**
+
+In `manager_assignment.go` `runCommitWatchSession`, update the `onUpdate` and `onReconcile` handlers to observe N before staging:
+
+```go
+		onUpdate: func(entry jetstream.KeyValueEntry) {
+			if commit, ok := m.decodeCommitEntry(entry); ok {
+				m.observeFleetSize(commit)
+				db.stage(commit)
+			}
+		},
+		flush:  db.flush,
+		timerC: db.timerC,
+		onReconcile: func() {
+			if kv == nil {
+				return
+			}
+			current, _, gerr := kvutil.GetJSON[types.AssignmentCommit](ctx, kv, key)
+			if gerr != nil || current == nil {
+				return
+			}
+			m.observeFleetSize(current)
+			db.stage(current)
+		},
+```
+
+- [ ] **Step 4: Hook the bootstrap path**
+
+In `manager.go`, in the initial-bootstrap commit path (lines 692-701), the
+structural skeleton is `newAsg, ok := m.buildAssignmentFromCommit(...)`, then
+`if ok {` (with an existing explanatory comment), then
+`if err := m.applyAssignmentWithPrev(Assignment{}, newAsg); err != nil`. Insert
+the observe right after `if ok {` and **before** `applyAssignmentWithPrev` (after
+the existing comment block; keep that comment), so the consumer receives N before
+the first create storm:
+
+```go
+		newAsg, ok := m.buildAssignmentFromCommit(commit, m.WorkerID())
+		if ok {
+			// (existing comment block stays here, unchanged)
+			m.observeFleetSize(commit) // retune before the first consumer-create storm
+			if err := m.applyAssignmentWithPrev(Assignment{}, newAsg); err != nil {
+				return err
+			}
+```
+
+For the **alias-fallback** apply path — the real code at line 759 is
+`if err := m.applyAssignmentWithPrev(Assignment{}, initial); err != nil {` where
+`initial := m.CurrentAssignment()` (line 680) carries `TotalWorkers` from the
+legacy alias — insert right before that apply:
+
+```go
+		if initial.TotalWorkers > 0 {
+			m.observeFleetSizeN(initial.Version, initial.LeaderRevision, initial.TotalWorkers)
+		}
+```
+
+Add a small sibling helper next to `observeFleetSize` in `manager_assignment.go` so the alias path (which has an `Assignment`, not a `*AssignmentCommit`) shares the fenced logic:
+
+```go
+// observeFleetSizeN is observeFleetSize for callers that already hold the
+// (version, leaderRevision, N) triple (e.g. the legacy-alias bootstrap path)
+// rather than a *AssignmentCommit. n is clamped to >= 1.
+func (m *Manager) observeFleetSizeN(version int64, leaderRev uint64, n int) {
+	if n < 1 {
+		n = 1
+	}
+	m.fleetMu.Lock()
+	defer m.fleetMu.Unlock()
+	if version < m.lastFleetVersion ||
+		(version == m.lastFleetVersion && leaderRev <= m.lastFleetLeaderRev) {
+		return
+	}
+	m.lastFleetVersion = version
+	m.lastFleetLeaderRev = leaderRev
+	if n == m.lastObservedN {
+		return
+	}
+	m.lastObservedN = n
+	if m.cfg.Handoff.ClaimWriteClusterRate > 0 {
+		if rs, ok := m.claimWriteLimiter.(ratelimit.RateSetter); ok {
+			rs.SetRate(effectiveRate(m.cfg.Handoff.ClaimWritePerSec, m.cfg.Handoff.ClaimWriteClusterRate, n))
+		}
+	}
+	if m.fleetSizeObserver != nil {
+		m.fleetSizeObserver.ObserveWorkerCount(n)
+	}
+}
+```
+
+Then refactor `observeFleetSize` to delegate (DRY):
+
+```go
+func (m *Manager) observeFleetSize(commit *types.AssignmentCommit) {
+	if commit == nil {
+		return
+	}
+	m.observeFleetSizeN(commit.Version, commit.LeaderRevision, len(commit.Workers))
+}
+```
+
+(Delete the now-duplicated body from Task 3 step 5; `effectiveRate` stays.)
+
+- [ ] **Step 5: Wire `fleetSizeObserver` at construction**
+
+In `manager.go` where `capReporter` is set (line 447), add the sibling assignment:
+
+```go
+		capReporter:       asCapabilityReporter(options.consumerUpdater),
+		fleetSizeObserver: asFleetSizeObserver(options.consumerUpdater),
+```
+
+- [ ] **Step 6: Run unit tests**
+
+Run: `go test . -run 'ObserveFleetSize' -race -v`
+Expected: PASS (all observe tests, including the sequential-fresh-commits wiring contract).
+
+- [ ] **Step 7: Build + lint + commit**
+
+```bash
+go build ./...
+make lint
+git add manager.go manager_assignment.go manager_fleet_wiring_test.go
+git commit -m "feat(manager): observe committed worker-count and retune limiters live"
+```
+
+---
+
+## Task 5: consumer `WithConsumerCreateClusterRate` option + validation
+
+**Files:**
+- Modify: `consumer/options.go` (options struct ~193; new option ~900)
+- Modify: `consumer/dynamic.go` (`resolveConsumerCreateLimiter` ~735)
+- Test: `consumer/consumer_create_clusterrate_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `consumer/consumer_create_clusterrate_test.go`:
+
+```go
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithConsumerCreateClusterRate_RequiresPerWorker(t *testing.T) {
+	_, err := buildDynamic(t, WithConsumerCreateClusterRate(1000)) // no WithConsumerCreateRate
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WithConsumerCreateClusterRate")
+}
+
+func TestWithConsumerCreateClusterRate_RejectedWithInjectedLimiter(t *testing.T) {
+	inj, err := NewConsumerCreateLimiter(50, 5)
+	require.NoError(t, err)
+	_, err = buildDynamic(t,
+		WithConsumerCreateLimiter(inj),
+		WithConsumerCreateClusterRate(1000),
+	)
+	require.Error(t, err)
+}
+
+func TestWithConsumerCreateClusterRate_NegativeRejected(t *testing.T) {
+	t.Run("with per-worker rate", func(t *testing.T) {
+		_, err := buildDynamic(t, WithConsumerCreateRate(200, 50), WithConsumerCreateClusterRate(-1))
+		require.Error(t, err)
+	})
+	t.Run("alone (no per-worker rate)", func(t *testing.T) {
+		_, err := buildDynamic(t, WithConsumerCreateClusterRate(-1))
+		require.Error(t, err)
+	})
+	t.Run("with injected limiter", func(t *testing.T) {
+		inj, err := NewConsumerCreateLimiter(50, 5)
+		require.NoError(t, err)
+		_, err = buildDynamic(t, WithConsumerCreateLimiter(inj), WithConsumerCreateClusterRate(-1))
+		require.Error(t, err)
+	})
+}
+
+func TestWithConsumerCreateClusterRate_ValidWithPerWorker(t *testing.T) {
+	d, err := buildDynamic(t,
+		WithConsumerCreateRate(200, 50),
+		WithConsumerCreateClusterRate(1000),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, d.inner.ConsumerCreateLimiter())
+}
+```
+
+> `buildDynamic(t, ...opts)` is the existing test helper in `consumer/consumer_create_ratelimit_test.go`. Reuse it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./consumer/ -run ClusterRate -v`
+Expected: FAIL — `WithConsumerCreateClusterRate` undefined.
+
+- [ ] **Step 3: Add the option field**
+
+In `consumer/options.go`, in the options struct beside `consumerCreatePerSec`:
+
+```go
+	consumerCreateClusterRate float64
+```
+
+- [ ] **Step 4: Add the option**
+
+In `consumer/options.go`, after `WithConsumerCreateRate`:
+
+```go
+// WithConsumerCreateClusterRate makes consumer-create rate limiting
+// fleet-size-aware. Given a cluster-wide target (events/second), each worker
+// enforces min(perWorkerCeiling, clusterPerSec/N), where perWorkerCeiling is
+// the rate from [WithConsumerCreateRate] and N is the cluster worker-count the
+// Parti Manager observes and pushes to this consumer.
+//
+// This bounds the STEADY-STATE cluster-wide create rate to clusterPerSec
+// instead of N*perWorkerCeiling. The per-worker ceiling still caps any single
+// worker during fleet-size transitions.
+//
+// Requires [WithConsumerCreateRate] (which supplies burst and the ceiling) and
+// the built-in limiter; it is rejected at [NewDynamic] when used alone or with
+// an injected [WithConsumerCreateLimiter] (an injected, possibly shared limiter
+// is not adaptively retuned). clusterPerSec must be >= 0; 0 disables the
+// overlay (static per-worker behaviour).
+//
+// Applies only to [Dynamic].
+func WithConsumerCreateClusterRate(clusterPerSec float64) DynamicOption {
+	return dynamicOpt(func(o *options) {
+		o.consumerCreateClusterRate = clusterPerSec
+	})
+}
+```
+
+- [ ] **Step 5: Add validation in `resolveConsumerCreateLimiter`**
+
+In `consumer/dynamic.go`, replace the head of `resolveConsumerCreateLimiter` (the injected-limiter and no-rate early returns at ~735-743) so the negative-cluster-rate check runs **before all branches** (otherwise `WithConsumerCreateClusterRate(-1)` slips through the injected / `perSec == 0` early returns):
+
+```go
+func resolveConsumerCreateLimiter(o options) (ratelimit.Limiter, error) {
+	// Validate the cluster-rate overlay up front — independent of which limiter
+	// wins — so a negative value is rejected on every path.
+	if o.consumerCreateClusterRate < 0 {
+		return nil, fmt.Errorf("WithConsumerCreateClusterRate: clusterPerSec must be >= 0, got %v", o.consumerCreateClusterRate)
+	}
+
+	// A non-nil injected limiter always wins; it is not adaptively retuned.
+	if o.consumerCreateLimiter != nil {
+		if o.consumerCreateClusterRate > 0 {
+			return nil, fmt.Errorf("WithConsumerCreateClusterRate cannot be combined with an injected WithConsumerCreateLimiter (an injected limiter is not adaptively retuned)")
+		}
+		return o.consumerCreateLimiter, nil
+	}
+
+	// No per-worker rate configured. A cluster rate alone is invalid (it needs
+	// the per-worker ceiling and burst); otherwise return unlimited (nil).
+	if o.consumerCreatePerSec == 0 {
+		if o.consumerCreateClusterRate > 0 {
+			return nil, fmt.Errorf("WithConsumerCreateClusterRate requires WithConsumerCreateRate (the per-worker ceiling and burst source)")
+		}
+		return ratelimit.Limiter(nil), nil //nolint:nilnil // nil limiter is the intended "unlimited" sentinel
+	}
+```
+
+Leave the remainder of the function (the `perSec < 0` check, the `burst < 1` check, the throttle-observer wiring, and the `return ratelimit.New(...)`) unchanged.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./consumer/ -run ClusterRate -v`
+Expected: PASS.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+make lint
+git add consumer/options.go consumer/dynamic.go consumer/consumer_create_clusterrate_test.go
+git commit -m "feat(consumer): add WithConsumerCreateClusterRate option and validation"
+```
+
+---
+
+## Task 6: consumer `Dynamic.ObserveWorkerCount` + `RateSetter` capture
+
+**Files:**
+- Modify: `consumer/dynamic.go` (`Dynamic` struct fields; `NewDynamic` capture; new method)
+- Test: `consumer/consumer_create_clusterrate_test.go` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `consumer/consumer_create_clusterrate_test.go`:
+
+```go
+func TestDynamic_ObserveWorkerCount_RetunesBuiltInLimiter(t *testing.T) {
+	d, err := buildDynamic(t,
+		WithConsumerCreateRate(200, 50),
+		WithConsumerCreateClusterRate(1000),
+	)
+	require.NoError(t, err)
+
+	d.ObserveWorkerCount(5) // min(200, 1000/5=200) = 200
+	lim := d.inner.ConsumerCreateLimiter()
+	tb, ok := lim.(interface{ Limit() float64 })
+	require.True(t, ok)
+	require.InEpsilon(t, 200.0, tb.Limit(), 1e-9)
+
+	d.ObserveWorkerCount(20) // min(200, 1000/20=50) = 50
+	require.InEpsilon(t, 50.0, tb.Limit(), 1e-9)
+}
+
+func TestDynamic_ObserveWorkerCount_NoClusterRate_NoOp(t *testing.T) {
+	d, err := buildDynamic(t, WithConsumerCreateRate(200, 50)) // no cluster rate
+	require.NoError(t, err)
+	d.ObserveWorkerCount(20) // must not change the fixed 200/s
+	lim := d.inner.ConsumerCreateLimiter()
+	tb := lim.(interface{ Limit() float64 })
+	require.InEpsilon(t, 200.0, tb.Limit(), 1e-9)
+}
+
+func TestDynamic_ObserveWorkerCount_InjectedLimiter_NoOp(t *testing.T) {
+	inj, err := NewConsumerCreateLimiter(50, 5)
+	require.NoError(t, err)
+	d, err := buildDynamic(t, WithConsumerCreateLimiter(inj))
+	require.NoError(t, err)
+	require.NotPanics(t, func() { d.ObserveWorkerCount(10) }) // no RateSetter captured -> no-op
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./consumer/ -run ObserveWorkerCount -v`
+Expected: FAIL — `d.ObserveWorkerCount` undefined.
+
+- [ ] **Step 3: Add fields to the `Dynamic` struct**
+
+In `consumer/dynamic.go`, in the `Dynamic` struct:
+
+```go
+	// Adaptive consumer-create rate (fleet-size-aware). createRateSetter is the
+	// built-in limiter cast to RateSetter, non-nil only when WithConsumerCreateRate
+	// AND WithConsumerCreateClusterRate are set. createPerSec is the per-worker
+	// ceiling; createClusterRate is the cluster target.
+	createRateSetter  ratelimit.RateSetter
+	createPerSec      float64
+	createClusterRate float64
+```
+
+- [ ] **Step 4: Capture the handle in `NewDynamic`**
+
+In `consumer/dynamic.go` `NewDynamic`, after `resolvedLimiter, err := resolveConsumerCreateLimiter(o)` succeeds and after `d` is constructed (and before/after `d.inner = inner`), capture the adaptive handle:
+
+```go
+	if o.consumerCreateClusterRate > 0 {
+		if rs, ok := resolvedLimiter.(ratelimit.RateSetter); ok {
+			d.createRateSetter = rs
+			d.createPerSec = o.consumerCreatePerSec
+			d.createClusterRate = o.consumerCreateClusterRate
+		}
+	}
+```
+
+> `resolveConsumerCreateLimiter` has already rejected cluster-without-rate and cluster-with-injected, so when `consumerCreateClusterRate > 0` the resolved limiter is the built-in `*TokenBucketLimiter`, which implements `RateSetter`.
+
+- [ ] **Step 5: Add `ObserveWorkerCount`**
+
+In `consumer/dynamic.go` (near `Capabilities`, the other manager-facing optional method):
+
+```go
+// ObserveWorkerCount implements parti.FleetSizeObserver. The Parti Manager calls
+// it with the current committed cluster worker-count N so the Dynamic consumer
+// can retune its consumer-create limiter to min(perWorkerCeiling, clusterRate/N).
+//
+// It is a no-op unless both WithConsumerCreateRate and WithConsumerCreateClusterRate
+// were configured. Non-blocking and non-reentrant per the FleetSizeObserver
+// contract: it only calls SetRate on the built-in limiter.
+func (d *Dynamic) ObserveWorkerCount(n int) {
+	if d.createRateSetter == nil || d.createClusterRate <= 0 {
+		return
+	}
+	if n < 1 {
+		n = 1
+	}
+	r := d.createClusterRate / float64(n)
+	if d.createPerSec > 0 && d.createPerSec < r {
+		r = d.createPerSec
+	}
+	d.createRateSetter.SetRate(r)
+}
+```
+
+Add a compile-time assertion (in `consumer/dynamic.go`, package-level) that documents the optional-interface satisfaction without importing `parti` (avoid an import cycle — assert structurally):
+
+```go
+var _ interface{ ObserveWorkerCount(int) } = (*Dynamic)(nil)
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./consumer/ -run 'ObserveWorkerCount|ClusterRate' -race -v`
+Expected: PASS.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+make lint
+git add consumer/dynamic.go consumer/consumer_create_clusterrate_test.go
+git commit -m "feat(consumer): retune built-in create limiter on observed worker-count"
+```
+
+---
+
+## Task 7: composite updater — forward `ObserveWorkerCount` + late-add replay
+
+**Files:**
+- Modify: `composite_updater.go`
+- Test: `composite_updater_test.go` (extend or create `composite_updater_fleet_test.go`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `composite_updater_fleet_test.go`:
+
+```go
+package parti
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fleetChild struct {
+	last int
+}
+
+func (f *fleetChild) UpdateWorkerConsumer(_ context.Context, _ string, _ []Partition) error {
+	return nil
+}
+func (f *fleetChild) ObserveWorkerCount(n int) { f.last = n }
+
+func TestComposite_ForwardsObserveWorkerCount(t *testing.T) {
+	a, b := &fleetChild{}, &fleetChild{}
+	c := NewCompositeConsumerUpdater(a, b)
+	c.ObserveWorkerCount(7)
+	require.Equal(t, 7, a.last)
+	require.Equal(t, 7, b.last)
+}
+
+func TestComposite_ReplaysLastNToLateAddedChild(t *testing.T) {
+	a := &fleetChild{}
+	c := NewCompositeConsumerUpdater(a)
+	c.ObserveWorkerCount(9)
+	require.Equal(t, 9, a.last)
+
+	late := &fleetChild{}
+	c.Add(late)
+	require.Equal(t, 9, late.last, "late-added child must receive the cached N")
+}
+
+func TestComposite_LateAddBeforeAnyObserve_NoReplay(t *testing.T) {
+	c := NewCompositeConsumerUpdater()
+	late := &fleetChild{last: -1}
+	c.Add(late)
+	require.Equal(t, -1, late.last, "no N observed yet -> no replay")
+}
+
+var _ FleetSizeObserver = (*CompositeConsumerUpdater)(nil)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run 'Composite_(Forwards|Replays|LateAdd)' -v`
+Expected: FAIL — `ObserveWorkerCount` undefined on `*CompositeConsumerUpdater`.
+
+- [ ] **Step 3: Add cached-N state to the composite**
+
+In `composite_updater.go`, in the `CompositeConsumerUpdater` struct, add (beside the existing mutex-guarded state, e.g. near the stream-missing fields):
+
+```go
+	// lastFleetN is the most recent worker-count observed via ObserveWorkerCount,
+	// replayed to children added later (mirrors the stream-missing replay). 0 =
+	// none observed yet.
+	lastFleetN int
+```
+
+- [ ] **Step 4: Implement `ObserveWorkerCount` + replay on `Add`**
+
+In `composite_updater.go`:
+
+```go
+// ObserveWorkerCount implements [FleetSizeObserver] by caching the worker-count
+// and forwarding it to every child that implements FleetSizeObserver. The cache
+// is replayed to children added later via Add.
+func (c *CompositeConsumerUpdater) ObserveWorkerCount(n int) {
+	c.mu.Lock()
+	c.lastFleetN = n
+	snapshot := make([]WorkerConsumerUpdater, len(c.updaters))
+	copy(snapshot, c.updaters)
+	c.mu.Unlock()
+
+	for _, u := range snapshot {
+		if fo, ok := u.(FleetSizeObserver); ok {
+			fo.ObserveWorkerCount(n)
+		}
+	}
+}
+
+var _ FleetSizeObserver = (*CompositeConsumerUpdater)(nil)
+```
+
+Replace the existing `Add` method **in full** with the version below. The current
+`Add` (composite_updater.go:100-114) forwards the stream-missing observer *under*
+`c.mu` (via `defer c.mu.Unlock()`), which contradicts the struct's documented
+"callbacks run unlocked" contract and the correct pattern in
+`SetOnStreamMissingError`. This rewrite snapshots the newly-added children +
+inherited state under the lock, then forwards **both** stream-missing and
+fleet-N **outside** the lock — fixing that inconsistency and adding the replay:
+
+```go
+// Add appends additional updaters to the composite.
+// This is useful for dynamically registering consumers after creation.
+//
+// Newly-added children inherit any state the composite has already received:
+// an installed stream-missing observer (via SetOnStreamMissingError) and the
+// last observed fleet worker-count (via ObserveWorkerCount), so a late
+// registration does not silently miss either. Inherited-state forwarding runs
+// outside c.mu so a slow child cannot serialize peers or deadlock a re-entrant
+// Add.
+func (c *CompositeConsumerUpdater) Add(updaters ...WorkerConsumerUpdater) {
+	c.mu.Lock()
+	var added []WorkerConsumerUpdater
+	for _, u := range updaters {
+		if u == nil {
+			continue
+		}
+		c.updaters = append(c.updaters, u)
+		added = append(added, u)
+	}
+	observer := c.currentObserver
+	fleetN := c.lastFleetN
+	c.mu.Unlock()
+
+	for _, u := range added {
+		if observer != nil {
+			if obs, ok := u.(recovery.StreamMissingObserver); ok {
+				obs.SetOnStreamMissingError(observer)
+			}
+		}
+		if fleetN > 0 {
+			if fo, ok := u.(FleetSizeObserver); ok {
+				fo.ObserveWorkerCount(fleetN)
+			}
+		}
+	}
+}
+```
+
+> This preserves the existing stream-missing replay behaviour (the child still
+> receives the observer) — it only moves the forward out of the lock, matching
+> `SetOnStreamMissingError`. Run the existing composite tests to confirm no
+> regression: `go test . -run Composite -race -v`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test . -run 'Composite_(Forwards|Replays|LateAdd)' -race -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+make lint
+git add composite_updater.go composite_updater_fleet_test.go
+git commit -m "feat(manager): forward and replay observed worker-count in composite updater"
+```
+
+---
+
+## Task 8: integration tests (fleet retune, steady-state bound, concurrency stress)
+
+**Files:**
+- Create: `test/integration/manager/adaptive_ratelimit_test.go`
+
+**What is proven where:** the rate *math* `min(ceiling, cluster/N)` for both
+features is already unit-proven (Task 3 for claim-write via `lim.Limit()`; Task 6
+for consumer via `d.inner.ConsumerCreateLimiter().Limit()`). The integration test
+proves what units cannot: that a *real* fleet-size change this worker observes —
+**even when its own partition slice is unchanged** (the pre-debounce hook) —
+actually reaches `observeFleetSize`, that the consumer push retunes end-to-end,
+and that the new commit-watch work is race-clean. It does **not** try to read the
+unexported `m.claimWriteLimiter` from the external test package.
+
+- [ ] **Step 1: Add the test-only N accessor**
+
+In `manager.go`, add a same-package test seam (the integration package is
+external `manager_test`, so this must be an exported-for-test method; mirror
+existing `*ForTest` seams in the codebase):
+
+```go
+// ObservedWorkerCountForTest returns the last observed committed worker-count.
+// Exported solely for integration tests of the adaptive rate limiter.
+func (m *Manager) ObservedWorkerCountForTest() int {
+	m.fleetMu.Lock()
+	defer m.fleetMu.Unlock()
+	return m.lastObservedN
+}
+```
+
+> If the repo already has an unexported `*ForTest` convention reachable from
+> `test/integration/manager` (e.g. via an export_test.go bridge in package
+> `parti`), follow that instead of exporting on the public type. Check for an
+> existing pattern before adding a new exported method.
+
+- [ ] **Step 2: Write the integration tests**
+
+Create `test/integration/manager/adaptive_ratelimit_test.go`. Follow the existing
+patterns in that directory (`claim_write_ratelimit_startup_test.go`,
+`epoch_monitor_concurrency_test.go`). Structure:
+
+```go
+//go:build integration
+
+package manager_test
+
+// TestAdaptive_WorkerObservesFleetGrowthWithUnchangedSlice:
+//   - embedded NATS + manager-1 with a Dynamic consumer configured
+//     WithConsumerCreateRate(1000, big) + WithConsumerCreateClusterRate(100),
+//     and ClaimWritePerSec=1000 + ClaimWriteClusterRate=100 + two-phase handoff
+//   - drive the cluster to N=2 (a second worker joins) WITHOUT changing
+//     manager-1's partition slice (e.g. extra partitions assigned only to w2)
+//   - require.Eventually: manager-1.ObservedWorkerCountForTest() == 2  (proves
+//     the pre-debounce hook fires on a slice-unchanged fleet change)
+//   - require.InEpsilon the Dynamic consumer's create limiter Limit() == 50
+//     (min(1000, 100/2)) — proves the FleetSizeObserver push retunes end-to-end.
+//     (Claim-write rate math is unit-proven in Task 3; here we only assert the
+//     observed N reached the manager, since m.claimWriteLimiter is unexported.)
+//
+// TestAdaptive_CommitChurnRaceClean:
+//   - 2-3 managers, aggressive commit churn (rapid join/leave or source changes),
+//     OperationTimeout small, run ~5s, assert no -race trigger (monitor-goroutine
+//     rule). Pure -race gate; no rate assertion.
+```
+
+> Use `require.Eventually` for the observation (commit propagation is async), and
+> assert the consumer limiter's `Limit()` (reachable via the Dynamic) rather than
+> timing-based pacing, which is flaky. Keep the concurrency-stress test a pure
+> `-race` gate.
+
+- [ ] **Step 3: Run the integration tests**
+
+Run: `go test -tags=integration -race ./test/integration/manager/ -run Adaptive -v`
+Expected: PASS, race-clean.
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+make lint
+git add test/integration/manager/adaptive_ratelimit_test.go manager.go
+git commit -m "test(integration): cover fleet-aware retune and commit-churn race safety"
+```
+
+---
+
+## Task 9: documentation + CHANGELOG
+
+**Files:**
+- Modify: `docs/CONSUMERS.md` (consumer-create rate section)
+- Modify: `CHANGELOG.md` (`## [Unreleased]`)
+- Modify: relevant handoff/config doc if present (e.g. `docs/HANDOFF.md` or `docs/CONFIG.md`)
+
+- [ ] **Step 1: Document the consumer option**
+
+In `docs/CONSUMERS.md`, in the consumer-create rate-limit section, add a subsection for `WithConsumerCreateClusterRate` with the `min(perWorkerCeiling, clusterRate/N)` formula, the "requires WithConsumerCreateRate / not with injected limiter" rule, and the steady-state-vs-transient note (the aggregate bound holds at steady state; the ceiling bounds transients; aggregate burst is `Σ burst`).
+
+- [ ] **Step 2: Document the claim-write knob**
+
+Document `HandoffConfig.ClaimWriteClusterRate` wherever `ClaimWritePerSec` is documented (same formula, requires-two-phase + requires-perSec rules, inert WARN behaviour).
+
+- [ ] **Step 3: Update CHANGELOG**
+
+Under `## [Unreleased]`, in the existing rate-limit entry, add: fleet-size-aware (adaptive) variants — `WithConsumerCreateClusterRate` and `HandoffConfig.ClaimWriteClusterRate` — bounding the steady-state cluster-wide rate to the configured target.
+
+- [ ] **Step 4: Commit**
+
+```bash
+make lint
+git add docs/ CHANGELOG.md
+git commit -m "docs: document fleet-aware consumer-create and claim-write rate limits"
+```
+
+---
+
+## Task 10: full pre-PR gate
+
+- [ ] **Step 1: Run the full gate**
+
+```bash
+make pre-pr
+```
+
+Expected: lint clean; `make test` (`-race`) green; `make test-integration` (`-race`) green, including the three cross-feature contracts (whole-bucket-missing → degraded; peer-takeover; OnDegraded-once) and the new adaptive tests.
+
+- [ ] **Step 2: Verify the static-rate path is byte-for-byte unchanged**
+
+Run the pre-existing static rate-limit tests to confirm `clusterRate == 0` behaviour is untouched:
+
+Run: `go test ./consumer/ ./internal/durable/ . -run 'ConsumerCreate|ClaimWrite' -race -v`
+Expected: PASS (the unrelated static tests still green).
+
+- [ ] **Step 3: Final confirmation**
+
+Confirm: no plan jargon in commit messages (`git log --oneline feat/claim-write-ratelimit`), no attribution trailers, lint clean. Ready for `/post-impl-review` and squash-by-scope per the repo workflow.
+
+---
+
+## Self-review checklist (completed by plan author)
+
+- **Spec coverage:** §2 model → Tasks 1,3,6; §3 API → Tasks 2,5; §4 N-observation + fence → Tasks 3,4; §5.1 SetRate → Task 1; §5.2 claim-write → Tasks 2,3,4; §5.3 consumer push → Tasks 5,6; §5.3 composite → Task 7; §6 edges (clamp, stale, no-op, clusterRate=0) → Task 3 tests; §7 concurrency → Tasks 1,3,8; §8 validation → Tasks 2,5; §10 testing → every task + Task 8; §9 metrics → explicitly deferred. No gaps.
+- **Placeholders:** none — every code step shows full code; the two `>` notes point at existing helpers to reuse, not unwritten code.
+- **Type consistency:** `observeFleetSize(*types.AssignmentCommit)` / `observeFleetSizeN(int64, uint64, int)` / `effectiveRate(float64, float64, int) float64` / `RateSetter.SetRate(float64)` / `FleetSizeObserver.ObserveWorkerCount(int)` / `Dynamic.ObserveWorkerCount(int)` used consistently across tasks. `commit.Version int64`, `commit.LeaderRevision uint64` match `types/assignment_commit.go`.

--- a/docs/superpowers/specs/2026-06-17-adaptive-rate-limit-design.md
+++ b/docs/superpowers/specs/2026-06-17-adaptive-rate-limit-design.md
@@ -1,0 +1,466 @@
+# Adaptive (fleet-size-aware) rate limiting for consumer-create and claim-write
+
+Status: design (pre-implementation)
+Date: 2026-06-17
+Target release: v2.8.0 (the same release that first ships the static per-worker
+rate limits, so the adaptive knob is designed into the API before it freezes)
+
+## 1. Problem
+
+v2.8.0 introduces two opt-in, default-off, per-worker token-bucket rate limits:
+
+- consumer-create — gates every physical `CreateOrUpdateConsumer` RPC
+  (`consumer.WithConsumerCreateRate(perSec, burst)` / `WithConsumerCreateLimiter`).
+- claim-write — gates every physical `PutIfEpoch` in the two-phase handoff
+  (`parti.HandoffConfig.ClaimWritePerSec` / `ClaimWriteBurst`).
+
+Both gates fire on **every** worker (Parti's apply is decentralized: the leader
+calculates and publishes assignments; every worker — leader and followers —
+reads its own slice and applies it locally, creating consumers and writing
+claims). Each worker enforces its own per-worker rate independently.
+
+Therefore the **cluster-wide** rate is `N × per_worker_rate`, where `N` is the
+worker count. `N` is operationally uncontrollable (it can be 1 or 30 depending
+on deployment and on transient fleet events), so a per-worker setting of
+`100/s` yields anywhere from `100/s` to `3000/s` of aggregate load against the
+shared NATS metacontroller. The operator cannot bound the aggregate.
+
+## 2. Goal and control model
+
+Let the operator bound the **aggregate** while keeping a **per-worker ceiling**.
+The effective per-worker rate each worker enforces becomes:
+
+```
+effective_per_worker_rate = min( perWorkerMax , clusterRate / observed_N )
+```
+
+- `perWorkerMax` — the existing per-worker knob (`WithConsumerCreateRate.perSec`,
+  `HandoffConfig.ClaimWritePerSec`). Reinterpreted as a **ceiling**.
+- `clusterRate` — a **new** aggregate target knob.
+- `observed_N` — the cluster worker-count this worker currently observes,
+  clamped to `>= 1`.
+
+Properties (the reason this model was chosen over a pure `clusterRate / N`):
+
+- **Steady-state aggregate is `clusterRate`.** This is a *steady-state* (post-
+  convergence) guarantee, not an instantaneous one. Once every live worker has
+  observed the *same* committed worker-set (they converge because `N` derives
+  from the monotonic committed assignment — §4), each runs at
+  `clusterRate / N`, so the sustained aggregate sums to `clusterRate`.
+- **No single worker exceeds `perWorkerMax`,** regardless of `N` — the only
+  *local*, always-true bound. This is what bounds the **transient**.
+- **Transient bound (be honest — workers do not retune atomically).** While a
+  fresh commit propagates (watcher delivery skew, the 30s reconcile floor,
+  watcher gaps, and slow-to-observe workers), workers briefly disagree on `N`.
+  The instantaneous configured aggregate is
+  `Σ_i min(perWorkerMax, clusterRate / observed_N_i)`. Worst case is during a
+  *grow* `a → b`: workers still on the old commit use `clusterRate / a` while
+  `b` workers are active, so the aggregate can reach
+  `b · min(perWorkerMax, clusterRate / a)` — i.e. up to a `b/a` overshoot factor
+  when `perWorkerMax` is the non-binding (high) ceiling. The `perWorkerMax`
+  ceiling caps this at `perWorkerMax · N`. Commit monotonicity converges all
+  workers back to `clusterRate` after propagation.
+- **Burst is per-worker and does not scale with `N`.** The instantaneous
+  aggregate *burst* is `Σ_i burst_i` (up to `N · burst`) and is **not** bounded
+  by `clusterRate`. Operators who must bound the aggregate burst keep `burst`
+  small. (This matches the static-limit semantics; burst is the per-worker
+  instantaneous allowance.)
+- **In-flight reservations are not retroactively retuned.** A `SetRate` that
+  *lowers* the rate does not cancel reservations already granted by `Wait`
+  (golang.org/x/time/rate semantics: `SetLimitAt` may let existing reservations
+  violate or underutilize the new limit). The effect is a brief, bounded
+  transient that self-corrects.
+- **Optional future tightening (non-goal for v1):** a conservative-N strategy
+  (e.g. tighten immediately on grow, decay slowly on shrink) would shrink the
+  grow-transient. Deliberately deferred — the ceiling already bounds it and the
+  chosen model accepts the ceiling-bounded transient.
+
+## 3. Public API (frozen in v2.8.0)
+
+The design is **purely additive** to the static knobs already built for v2.8.0.
+When the new cluster knob is unset (`0`), behavior is **identical to today**
+(fixed per-worker rate); the limiter is still built exactly as it is now.
+
+### consumer-create (consumer package)
+
+- `WithConsumerCreateRate(perSec float64, burst int)` — **exists.** `perSec` is
+  now documented as the per-worker ceiling; `burst` is unchanged.
+- `WithConsumerCreateClusterRate(clusterPerSec float64)` — **new.** Aggregate
+  target. Effective rate = `min(perSec, clusterPerSec / N)`.
+- Requires `WithConsumerCreateRate` to also be set (it supplies `burst` and the
+  ceiling). Using the cluster option without the per-worker option is a
+  construction error from `NewDynamic` (fail-fast; it would otherwise be silently
+  inert). To express "aggregate cap with no meaningful per-worker ceiling", set
+  `perSec` to a high value.
+- `WithConsumerCreateLimiter` (injected custom/shared limiter) — **exists,
+  unchanged.** Adaptive retuning is **not** applied to an injected limiter
+  (Parti cannot assume a third-party limiter is reconfigurable); the cluster
+  option is rejected at `NewDynamic` when an injected limiter is supplied. The
+  injected-limiter path remains the way to share one fixed budget across
+  consumers.
+
+### claim-write (root package)
+
+- `HandoffConfig.ClaimWritePerSec` / `ClaimWriteBurst` — **exist.** `PerSec` is
+  now the per-worker ceiling.
+- `HandoffConfig.ClaimWriteClusterRate float64` — **new.** Aggregate target;
+  `validate:"gte=0"`. Effective rate = `min(ClaimWritePerSec, ClaimWriteClusterRate / N)`.
+- Requires `ClaimWritePerSec > 0` (ceiling + enables the limiter) and
+  `EnableTwoPhaseHandoff`. `ClaimWriteClusterRate > 0` with `ClaimWritePerSec == 0`
+  is a `Config.Validate` error. `ClaimWriteClusterRate > 0` with
+  `EnableTwoPhaseHandoff == false` is an inert-config WARN in
+  `ValidateWithWarnings` (mirrors the existing `ClaimWritePerSec`-without-two-phase
+  warning at config.go ~817).
+
+## 4. Observing N
+
+### Source: the committed worker-set
+
+`N = len(commit.Workers)` from the committed assignment
+(`types.AssignmentCommit.Workers`, the sorted worker-id list; already surfaced as
+`Assignment.TotalWorkers = len(commit.Workers)` at
+`manager_assignment.go:1109,1146`).
+
+Chosen over the heartbeat active-worker scan (`GetActiveWorkers`,
+`internal/assignment/worker_monitor.go`) because:
+
+- **Consistency.** Every worker reads the *same* committed `Workers` list, so all
+  workers compute the *same* `N` and the *same* `clusterRate / N`. This is what
+  makes the aggregate bound actually hold. A heartbeat scan is eventually
+  consistent and per-worker-divergent.
+- **Availability.** The heartbeat scan is only consumed by the leader's
+  calculator during rebalance; followers have no live view of it.
+- It is monotone via commit `Version`, so it converges after a fleet change.
+
+### Hook: the pre-debounce commit-decode point
+
+Critical constraint discovered during grounding: the commit watcher's
+**debouncer suppresses *apply* dispatch** when `N` changes but *this worker's*
+partition slice is unchanged (`workerAssignmentChanged`, `manager_assignment.go:790`).
+So hooking N-observation at apply time would **miss** fleet changes that don't
+touch this worker's partitions — the exact common case (a peer joins/leaves; my
+slice is stable).
+
+Therefore N-observation is hooked **before** the debouncer, where every commit
+the watcher delivers is decoded — but **fenced on commit freshness** so a stale
+commit cannot regress N (see the P0 below):
+
+- In `runCommitWatchSession` (`manager_assignment.go:856-874`), both the
+  `onUpdate` handler (every watcher event) and the `onReconcile` handler (the
+  30s re-fetch floor) decode the commit and call `db.stage(commit)`. Insert
+  `m.observeFleetSize(commit)` immediately after a successful decode and
+  **before** `db.stage(commit)`.
+- This delivers prompt N updates on every *fresh* commit, plus a 30s reconcile
+  floor, fully decoupled from the apply debounce/dedup and the two-phase handoff
+  diff. Deletes (`decodeCommitEntry` returns `(nil,false)` on a KV delete,
+  `manager_assignment.go:893`) and failed reconcile reads do not observe N; the
+  next watcher event or reconcile tick covers them (bounded by the reconcile
+  floor). N is never zero in practice: the publisher does not publish a commit
+  with an empty worker-set (`assignment_publisher.go:332`), and a worker absent
+  from `Workers` is a revoke-for-this-worker, not empty-N.
+
+**P0 — fence against stale-N regression.** The pre-debounce decode point sees
+*every* decoded commit, including ones the debouncer/apply path would reject as
+stale: `stage()` drops a lower-version pending race at `manager_assignment.go:781`,
+and the reconcile arm can surface an older snapshot racing a newer in-flight
+watcher event (the comment at `:778-780`). An *unconditional* observe would
+regress the limiter to an older worker-count. `observeFleetSize` must therefore
+replicate the apply path's freshness gate — pre-`workerAssignmentChanged`,
+pre-apply, but **post-freshness** — using the **same `(Version, LeaderRevision)`
+lex prefix** the apply stale gate / commit dedup use (`commitSupersedesForStash`,
+`manager_assignment.go:1291`, additionally compares `BatchDigest`/source at an
+equal `(V, LR)`; that tail is irrelevant here because N is fixed for a given
+`(V, LR)`, so the lex prefix alone is the correct and sufficient fence).
+
+`observeFleetSize(commit *types.AssignmentCommit)`:
+
+1. `n := len(commit.Workers)`; clamp `n` to `>= 1` (defensive; the publisher
+   won't emit empty `Workers`).
+2. Under a small `fleetMu sync.Mutex` (commits are infrequent; this is not a hot
+   path):
+   - **Freshness fence:** if `(commit.Version, commit.LeaderRevision)` does not
+     strictly supersede the last observed `(version, leaderRevision)` (same lex
+     rule as `commitSupersedesForStash`), return — do **not** regress N.
+   - Record the new `(version, leaderRevision)`.
+   - If `n == lastObservedN`, return (version advanced but N unchanged → no
+     retune).
+   - Record `lastObservedN = n` and retune:
+     - claim-write (manager-local): if `ClaimWriteClusterRate > 0` and
+       `m.claimWriteLimiter` implements `ratelimit.RateSetter`, call
+       `SetRate(min(ClaimWritePerSec, ClaimWriteClusterRate / n))`.
+     - consumer-create (push): if `m.fleetSizeObserver != nil`, call
+       `m.fleetSizeObserver.ObserveWorkerCount(n)`.
+   The lock is held across the retune + push so a higher-version observe cannot
+   interleave and leave the consumer/limiter at a stale N. Both calls are
+   non-blocking and non-reentrant by contract (§7), so holding `fleetMu` across
+   them is safe (mirrors the `CapabilityReporter` non-blocking/non-reentrant
+   contract).
+
+The cold-start ordering (consumer receives N before its first create storm) is
+handled by the bootstrap path below.
+
+### Cold-start / bootstrap ordering
+
+At construction (before any commit) the limiters are built at `perWorkerMax` (the
+ceiling) — the safe upper bound. To tighten before the first consumer-create
+storm:
+
+- **Commit bootstrap path:** `manager.go` builds the initial Assignment from the
+  commit at `:692` and applies it at `:701`. Insert `m.observeFleetSize(commit)`
+  **between those two lines** — after the commit is decoded, before
+  `applyAssignmentWithPrev`, so the consumer's `ObserveWorkerCount` runs before
+  the first create. The freshness fence is a no-op here (first observation).
+- **Alias-fallback path:** if the commit read/verify fails, startup falls back to
+  applying the legacy alias (`manager.go:759`; `waitForAssignment` pre-stores the
+  alias into `m.assignment` at `manager_election.go:473`). The alias carries no
+  `commit.Workers`. Handling: if the alias Assignment has `TotalWorkers > 0`,
+  observe it (`observeFleetSize` accepting an explicit `(version, leaderRev, n)`
+  for this path); otherwise the worker runs **ceiling-bounded** until the first
+  commit is observed by the watcher, which then retunes. This residual is safe by
+  the `perWorkerMax` ceiling and self-corrects on the first commit.
+
+Because `setupHandoff` (which builds `m.claimWriteLimiter`, `manager_setup.go:209`)
+runs **synchronously during `Start`**, before the commit watcher
+(`monitorCommitChanges`) is spawned in the background runner
+(`manager_startup_async.go:128`), the claim-write limiter always exists before
+any `observeFleetSize` call — so the first observation retunes an already-built
+limiter. This ordering is **load-bearing**: keep limiter construction ahead of
+the first N observation if this startup sequence is ever refactored.
+
+## 5. Live retune mechanism
+
+### 5.1 ratelimit primitive — add `SetRate`
+
+`internal/ratelimit`:
+
+- The `Limiter` interface stays `Wait(ctx) error`-only. **Do not** add `SetRate`
+  to the interface: a user-injected `consumer.ConsumerCreateLimiter` (Wait-only)
+  is stored structurally as a `ratelimit.Limiter`, and widening the interface
+  would break that path.
+- Add a method on the concrete type:
+  `func (l *TokenBucketLimiter) SetRate(perSec float64)` →
+  `l.rl.SetLimit(rate.Limit(perSec))`. `rate.Limiter.SetLimit` takes the
+  limiter's internal mutex and is safe to call concurrently with `Wait`
+  (golang.org/x/time/rate is documented goroutine-safe).
+- Add a narrow optional-capability interface used by callers that hold the
+  limiter only as the `Limiter` interface:
+  ```go
+  // RateSetter is implemented by limiters whose steady-state rate can be
+  // retuned at runtime (the built-in TokenBucketLimiter). Adaptive rate
+  // limiting type-asserts a Limiter to RateSetter; a limiter that does not
+  // implement it keeps its constructed rate.
+  type RateSetter interface{ SetRate(perSec float64) }
+  ```
+- `*TokenBucketLimiter` satisfies `RateSetter`. Optionally add `Limit() float64`
+  for tests/metrics (read current rate). `SetRate` keeps the existing burst
+  unchanged (burst is the per-worker instantaneous allowance and does not scale
+  with N).
+
+Because the one `*TokenBucketLimiter` instance is reference-shared across all
+gate sites (claim-write: coordinator + startup hygiene + resume; consumer-create:
+`WorkerConsumer.limiter` + every `PartitionConsumer`), a single `SetRate`
+retunes every gate at once.
+
+### 5.2 claim-write — manager-local
+
+Fully contained in the root package:
+
+- New config field + validation + inert-warning (§3, §8).
+- `buildClaimWriteLimiter` is unchanged in *when* it builds (still iff
+  `ClaimWritePerSec > 0`); its constructed rate stays `ClaimWritePerSec` (the
+  ceiling) — the safe upper bound until the first N is observed.
+- `observeFleetSize` (§4) type-asserts `m.claimWriteLimiter` to `RateSetter` and
+  calls `SetRate(min(ClaimWritePerSec, ClaimWriteClusterRate / n))` when N
+  changes and `ClaimWriteClusterRate > 0`.
+
+### 5.3 consumer-create — manager pushes N, consumer computes
+
+The consumer-create knobs and the limiter live on the consumer; only the manager
+knows N. So the manager **pushes N** and the consumer **owns the policy**:
+
+- New optional interface in the root package, mirroring `CapabilityReporter` but
+  in the push direction:
+  ```go
+  // FleetSizeObserver is an optional interface a WorkerConsumerUpdater MAY
+  // implement to receive the observed cluster worker-count (N) for
+  // fleet-size-aware (adaptive) rate limiting. The Manager calls
+  // ObserveWorkerCount whenever the committed worker-set size changes (and
+  // once at startup, before the first apply). Implementations MUST be
+  // non-blocking, safe for concurrent use, and MUST NOT call back into the
+  // Manager or any apply/update path (mirrors the CapabilityReporter contract
+  // and the D5 lock-order rule).
+  type FleetSizeObserver interface{ ObserveWorkerCount(n int) }
+  ```
+- Manager: `m.fleetSizeObserver = asFleetSizeObserver(options.consumerUpdater)`
+  at construction (`manager.go:447`, beside `capReporter`). `asFleetSizeObserver`
+  mirrors `asCapabilityReporter` (manager.go:981).
+- `CompositeConsumerUpdater` forwards `ObserveWorkerCount(n)` to every child that
+  implements `FleetSizeObserver` (mirrors its `Capabilities()` forwarding at
+  composite_updater.go:157-183) and asserts
+  `var _ FleetSizeObserver = (*CompositeConsumerUpdater)(nil)`.
+  - **Late-add replay (P1).** `CompositeConsumerUpdater.Add` admits children
+    after construction (composite_updater.go:100). A push-only observer would
+    leave a late-added adaptive consumer at the ceiling rate until the next N
+    change. So the composite **caches the last observed N** and **replays it** to
+    any newly-added `FleetSizeObserver` child in `Add` — exactly mirroring the
+    existing `SetOnStreamMissingError` store-and-replay at composite_updater.go:137.
+    `ObserveWorkerCount` updates the cache (under the composite's existing mutex)
+    and forwards; `Add` replays the cached N (when one has been observed) to the
+    new child.
+- `consumer.Dynamic` implements `ObserveWorkerCount(n int)`:
+  - It keeps `consumerCreatePerSec` (ceiling), the new
+    `consumerCreateClusterRate`, and a `ratelimit.RateSetter` handle obtained by
+    type-asserting the limiter resolved at `NewDynamic` (non-nil only for the
+    built-in `WithConsumerCreateRate` path with a cluster rate set).
+  - On call: if the `RateSetter` handle is non-nil and `clusterRate > 0`, call
+    `SetRate(min(perSec, clusterRate / max(1, n)))`. Otherwise no-op.
+
+## 6. Edge cases and ordering
+
+- **`clusterRate == 0` (default):** no retune path is armed; the limiter keeps
+  its constructed `perSec`. Byte-for-byte identical to today. Full backward
+  compatibility.
+- **N clamp:** `observeFleetSize` clamps `n >= 1` (a revoke-all commit can omit
+  this worker; division must never see 0).
+- **Cold-start window:** at construction (before any commit) the limiter rate is
+  `perSec` (the ceiling). The initial-bootstrap commit fetch observes N and
+  pushes it **before** the first apply/create storm, so the storm runs at the
+  adapted rate in the normal path. Any residual transient is bounded by the
+  ceiling (`perWorkerMax × N`) — the §2 guarantee.
+- **N-transition transient:** while a fresh commit propagates, workers briefly
+  disagree on N; the per-worker ceiling bounds the aggregate overshoot (§2
+  formula), in-flight reservations are not retroactively retuned, and commit
+  monotonicity converges all workers to the same N.
+- **Stale / out-of-order commit:** the reconcile arm or a watcher race can
+  surface a lower-`(Version, LeaderRevision)` commit; the freshness fence in
+  `observeFleetSize` drops it, so N never regresses (P0, §4).
+- **Deletes / failed reconcile reads:** do not observe N; covered by the next
+  watcher event or the 30s reconcile floor.
+- **Injected limiter (`WithConsumerCreateLimiter`):** not retunable; the cluster
+  option is rejected at `NewDynamic` when an injected limiter is present.
+- **Shrink to N=1:** effective rate rises to `min(perSec, clusterRate)` —
+  correct (one worker may use the whole budget, still capped at the ceiling).
+
+## 7. Concurrency
+
+- `observeFleetSize` is invoked from the commit-watch goroutine
+  (`onUpdate`/`onReconcile`) and the initial-bootstrap path. These can overlap
+  (bootstrap apply runs in the background runner while the watch session spawns),
+  so the freshness fence + retune + push run under a dedicated `fleetMu`
+  serializing them; the fence guarantees only strictly-superseding
+  `(Version, LeaderRevision)` commits retune, so a stale observe never regresses
+  N even under concurrency. `fleetMu` is never held with `applyStoreMu`/`updateMu`
+  and guards no I/O.
+- `rate.Limiter.SetLimit`/`SetLimitAt` is internally mutex-guarded; concurrent
+  with the `Wait`/`Reserve` calls issued from apply / handoff / partition-consumer
+  goroutines it is race-free. Caveat (§2): a rate *decrease* does not cancel
+  reservations already granted — a bounded, self-correcting transient, not a race.
+- `FleetSizeObserver.ObserveWorkerCount` and the consumer's `RateSetter` call are
+  non-blocking, lock-free (compute + `SetRate`), and must not re-enter the
+  manager — codified in the interface contract — so holding `fleetMu` across the
+  push is safe.
+- `manager_assignment.go` is in the pre-PR gate set, and this adds work to a
+  monitor-goroutine path; per repo rules the change needs an integration
+  concurrency stress test (template:
+  `test/integration/manager/epoch_monitor_concurrency_test.go`).
+
+## 8. Config and validation
+
+- `config.go`: add `HandoffConfig.ClaimWriteClusterRate float64` `validate:"gte=0"`
+  immediately after `ClaimWriteBurst`. In `Config.Validate` (~706): error if
+  `ClaimWriteClusterRate > 0 && ClaimWritePerSec == 0`; the existing
+  `burst >= 1 when perSec > 0` rule already covers burst because cluster requires
+  perSec. In `ValidateWithWarnings` (~817): inert WARN when
+  `ClaimWriteClusterRate > 0 && !EnableTwoPhaseHandoff`.
+- `consumer/options.go`: add `consumerCreateClusterRate float64` field +
+  `WithConsumerCreateClusterRate(clusterPerSec float64)` option. In
+  `resolveConsumerCreateLimiter` (`consumer/dynamic.go:735`): explicitly reject
+  `clusterPerSec < 0` (mirrors the existing `perSec >= 0` check at
+  `consumer/dynamic.go:746` and the claim-write `gte=0`); error if cluster set
+  without `WithConsumerCreateRate`, or with an injected limiter; otherwise build
+  the `*TokenBucketLimiter` as today and capture its `RateSetter` handle.
+
+## 9. Metrics (optional, low priority)
+
+Following the existing D7 sidecar pattern
+(`claimWriteThrottleObserver` / `ConsumerCreateThrottleObserver`), optionally add
+a sidecar that records the live effective per-worker rate and observed N as
+gauges (e.g. `parti_claim_write_effective_rate`,
+`parti_consumer_create_effective_rate`, `parti_observed_worker_count`). Emitted
+on each retune. Type-asserted at build time; public
+`HandoffMetricsRecorder` / `WorkerConsumerMetrics` interfaces stay unchanged.
+This is observability sugar and may ship in a follow-up if it risks scope creep.
+
+## 10. Testing
+
+Unit:
+- `ratelimit`: `SetRate` changes the steady-state rate; concurrent
+  `SetRate` + `Wait` under `-race`; `RateSetter` type-assertion; `SetRate`
+  preserves burst.
+- `observeFleetSize`: rate computation `min(ceiling, cluster/N)` across N
+  transitions; clamp at N=1; no-op when N unchanged; no-op when `clusterRate==0`;
+  claim-write `SetRate` is called with the expected value.
+- **Stale-fence (P0):** feeding a commit with a *lower* `(Version, LeaderRevision)`
+  than the last observed one must **not** retune (no N regression); an
+  out-of-order reconcile snapshot is ignored; a strictly-superseding commit does
+  retune.
+- consumer `Dynamic.ObserveWorkerCount`: recomputes and retunes the built-in
+  limiter; no-op for injected limiter / no cluster rate.
+- composite forwarding: `ObserveWorkerCount` reaches all `FleetSizeObserver`
+  children; **late-add replay (P1):** a child added via `Add` *after* an N
+  observation receives the cached N immediately.
+- config: validation errors (cluster without per-worker; cluster + injected
+  limiter; negative cluster rate) and inert-config warnings.
+- Negative-space (per repo discipline): a *single* N change that returns to the
+  original N must not leave a wrong rate; observing the same N repeatedly issues
+  no `SetRate`; a stale commit issues no `SetRate`.
+
+Integration (`test/integration/manager/`):
+- Fleet grows/shrinks (workers join/leave) while this worker's slice is
+  unchanged → this worker still retunes (proves the pre-debounce hook).
+- Steady-state aggregate bound: with `clusterRate` set and a *stable* N workers
+  (post-convergence), measured aggregate create/claim-write rate stays
+  `<= clusterRate` within per-worker burst tolerance (`Σ burst`). Asserted at
+  steady state, not during a transition.
+- Concurrency stress: aggressive commit churn + concurrent applies under `-race`
+  (monitor-goroutine rule).
+- Cross-feature contracts (1)-(4) from AGENTS.md must still pass unchanged — this
+  feature touches neither failure classification nor error routing.
+
+## 11. Non-goals
+
+- No distributed rate oracle / no cross-worker coordination beyond the shared
+  committed `Workers` list.
+- No retuning of injected custom limiters.
+- No change to `PhaseConcurrency` (caps simultaneity; orthogonal to rate).
+- No change to burst semantics (burst stays the per-worker instantaneous
+  allowance; it does not scale with N).
+- No change to the static-rate default-off behavior.
+
+## 12. Backward compatibility and version
+
+All additions are new optional config fields, a new option, and two new optional
+interfaces. No released API changes (the static rate limits are themselves
+unreleased, shipping in this same v2.8.0). With the cluster knobs unset, runtime
+behavior is identical to the static design. Target version remains **v2.8.0**.
+
+## 13. File touch-list (for the implementation plan)
+
+- `internal/ratelimit/ratelimit.go` — `SetRate` method, `RateSetter` interface,
+  optional `Limit()`.
+- `config.go` — `ClaimWriteClusterRate` field, `Validate`, `ValidateWithWarnings`.
+- `manager.go` — `fleetMu sync.Mutex` guarding the last-observed tuple
+  `(lastFleetVersion, lastFleetLeaderRev, lastObservedN)` (kept together so the
+  freshness fence and the recorded N never split); `fleetSizeObserver`;
+  `asFleetSizeObserver`; construction wiring beside `capReporter` (manager.go:447).
+- `manager_assignment.go` — `observeFleetSize`, hook in `runCommitWatchSession`
+  `onUpdate`/`onReconcile`; initial-bootstrap observe in `manager.go:692` path.
+- `fleet_size_observer.go` (new) — `FleetSizeObserver` interface.
+- `composite_updater.go` — forward `ObserveWorkerCount`.
+- `consumer/options.go` — `consumerCreateClusterRate` field +
+  `WithConsumerCreateClusterRate`.
+- `consumer/dynamic.go` — capture `RateSetter` handle, `ObserveWorkerCount`,
+  validation in `resolveConsumerCreateLimiter`.
+- `manager_handoff_ratelimit.go` — (no build-time change; retune lives in
+  `observeFleetSize`) optional metrics sidecar if §9 is included.
+- Tests per §10.

--- a/fleet_size_observer.go
+++ b/fleet_size_observer.go
@@ -1,0 +1,26 @@
+package parti
+
+// FleetSizeObserver is an optional interface a [WorkerConsumerUpdater] MAY
+// implement to receive the observed cluster worker-count (N) for fleet-size-
+// aware (adaptive) rate limiting.
+//
+// When the registered updater (or any child of a composite updater) satisfies
+// this interface, the Manager calls ObserveWorkerCount whenever the committed
+// worker-set size changes — and once during startup, before the first apply —
+// so the consumer can retune its consumer-create rate to
+// min(perWorkerCeiling, clusterRate/N).
+//
+// Implementations MUST be:
+//   - Non-blocking. ObserveWorkerCount runs on the Manager's commit-watch
+//     goroutine while the Manager holds an internal lock; it must not perform
+//     I/O or block.
+//   - Safe for concurrent use.
+//   - Non-reentrant: it MUST NOT call back into the Manager or any apply/update
+//     path (mirrors the [CapabilityReporter] contract and the D5 lock-order
+//     rule).
+//
+// n is always >= 1.
+type FleetSizeObserver interface {
+	// ObserveWorkerCount reports the current committed cluster worker-count.
+	ObserveWorkerCount(n int)
+}

--- a/fleet_size_observer_test.go
+++ b/fleet_size_observer_test.go
@@ -1,0 +1,223 @@
+package parti
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingObserver struct{ ns []int }
+
+func (r *recordingObserver) ObserveWorkerCount(n int) { r.ns = append(r.ns, n) }
+
+// syncObserver is a concurrency-safe FleetSizeObserver for the commit-watch
+// decode-path test, where ObserveWorkerCount runs on the watch-session
+// goroutine while the test goroutine asserts.
+type syncObserver struct {
+	mu sync.Mutex
+	ns []int
+}
+
+func (o *syncObserver) ObserveWorkerCount(n int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.ns = append(o.ns, n)
+}
+
+func (o *syncObserver) snapshot() []int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]int(nil), o.ns...)
+}
+
+func newFleetTestManager(lim ratelimit.Limiter, obs FleetSizeObserver, clusterRate float64) *Manager {
+	m := &Manager{logger: logging.NewNop(), claimWriteLimiter: lim, fleetSizeObserver: obs}
+	m.cfg.Handoff.ClaimWriteClusterRate = clusterRate
+	m.cfg.Handoff.ClaimWritePerSec = 200
+	return m
+}
+
+func commit(version int64, lr uint64, workers ...string) *types.AssignmentCommit {
+	return &types.AssignmentCommit{Version: version, LeaderRevision: lr, Workers: workers}
+}
+
+func TestObserveFleetSize_RetunesClaimWriteAndPushes(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000)
+
+	m.observeFleetSize(commit(1, 1, "a", "b", "c", "d", "e")) // N=5
+	require.InEpsilon(t, 200.0, lim.Limit(), 1e-9, "min(200, 1000/5=200) = 200")
+	require.Equal(t, []int{5}, obs.ns)
+
+	m.observeFleetSize(commit(2, 1, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")) // N=10
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9, "min(200, 1000/10=100) = 100")
+	require.Equal(t, []int{5, 10}, obs.ns)
+}
+
+func TestObserveFleetSize_StaleCommit_NoRegression(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000)
+
+	m.observeFleetSize(commit(5, 2, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")) // v5, N=10 -> 100
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9)
+
+	m.observeFleetSize(commit(3, 2, "a", "b")) // v3 < v5: stale
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9, "stale commit must not regress rate")
+	require.Equal(t, []int{10}, obs.ns, "stale commit must not push")
+
+	m.observeFleetSize(commit(5, 1, "a", "b")) // same v5, lower lr: stale
+	require.Equal(t, []int{10}, obs.ns)
+}
+
+func TestObserveFleetSize_StaleLeaderCommit_NoRegression(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000)
+	m.lastSeenLeaderRevision.Store(100) // we have applied a commit from leader-rev 100
+
+	// Authoritative commit from the current leader: 10 workers -> min(200,1000/10)=100.
+	m.observeFleetSize(commit(7, 100, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j"))
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9)
+	require.Equal(t, []int{10}, obs.ns)
+
+	// Split-brain: a stale former leader writes a HIGHER version with a LOWER
+	// (stale) leader-revision and a shrunken worker-set. The apply path rejects
+	// it (LeaderRevision 50 < lastSeen 100); observe must reject it too and NOT
+	// regress N to 1.
+	m.observeFleetSize(commit(8, 50, "a"))
+	require.InEpsilon(t, 100.0, lim.Limit(), 1e-9, "stale-leader commit must not regress the rate")
+	require.Equal(t, []int{10}, obs.ns, "stale-leader commit must not push N=1")
+}
+
+func TestObserveFleetSize_NoOpWhenNUnchanged(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000)
+	m.observeFleetSize(commit(1, 1, "a", "b"))
+	m.observeFleetSize(commit(2, 1, "a", "b")) // version advanced, N still 2
+	require.Equal(t, []int{2}, obs.ns, "unchanged N must not push again")
+}
+
+func TestObserveFleetSize_NoClusterRate_NoRetune(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	m := newFleetTestManager(lim, nil, 0) // clusterRate=0
+	m.observeFleetSize(commit(1, 1, "a", "b", "c"))
+	require.InEpsilon(t, 200.0, lim.Limit(), 1e-9, "clusterRate=0 leaves limiter at perSec")
+}
+
+func TestObserveFleetSize_ClampsNToOne(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	m := newFleetTestManager(lim, nil, 50)
+	m.observeFleetSize(commit(1, 1)) // empty Workers -> clamp N=1
+	require.InEpsilon(t, 50.0, lim.Limit(), 1e-9, "min(200, 50/1=50) = 50")
+}
+
+func TestObserveFleetSize_NilCommit(t *testing.T) {
+	lim := ratelimit.New(200, 50, nil)
+	obs := &recordingObserver{}
+	m := newFleetTestManager(lim, obs, 1000)
+	require.NotPanics(t, func() { m.observeFleetSize(nil) })
+	require.Empty(t, obs.ns, "nil commit must not push")
+}
+
+// fleetCommitEntry builds a fake KV entry for an AssignmentCommit whose full
+// Workers slice and this-worker payload hash are controllable, so the test can
+// hold THIS worker's assignment fixed (stable PayloadHash) while the fleet
+// size (len(Workers)) changes.
+func fleetCommitEntry(version int64, lr uint64, selfID, selfHash string, workers ...string) jetstream.KeyValueEntry {
+	payloads := map[string]types.AssignmentPayloadRef{
+		selfID: {PayloadHash: selfHash},
+	}
+	b, _ := json.Marshal(types.AssignmentCommit{
+		Version:        version,
+		LeaderRevision: lr,
+		Workers:        workers,
+		Payloads:       payloads,
+	})
+
+	return fakeVersionEntry{value: b}
+}
+
+// TestObserveFleetSize_FiresPreDebounce_OnSliceUnchangedFleetGrowth proves the
+// fleet observation is wired at the pre-debounce decode point: it fires for
+// every decoded commit even when the commit debouncer suppresses the APPLY
+// because THIS worker's own partition slice is unchanged.
+//
+// Two commits are fed through the real runCommitWatchSession decode path with
+// a fake watcher. This worker (worker-test) holds the same PayloadHash in both
+// (so workerAssignmentChanged is false and the debouncer collapses them into a
+// single dispatch), but the fleet grows from N=1 to N=2 as a peer joins. The
+// observer must record BOTH worker-counts while only one commit reaches the
+// post-debounce dispatch surface.
+func TestObserveFleetSize_FiresPreDebounce_OnSliceUnchangedFleetGrowth(t *testing.T) {
+	const window = 100 * time.Millisecond
+	m, _, _, _ := newTestManager(t)
+	m.cfg.AssignmentWatcherDebounce = window
+	workerID := m.WorkerID()
+
+	obs := &syncObserver{}
+	m.fleetSizeObserver = obs
+	lim := ratelimit.New(200, 50, nil)
+	m.claimWriteLimiter = lim
+	m.cfg.Handoff.ClaimWritePerSec = 200
+	// clusterRate=300 makes N=1 and N=2 produce DISTINCT effective rates
+	// (N=1 -> min(200,300)=200; N=2 -> min(200,150)=150), so the final
+	// limit proves the retune followed the grown (suppressed-apply) fleet.
+	m.cfg.Handoff.ClaimWriteClusterRate = 300
+
+	// Count post-debounce dispatches so we can assert the debouncer DID
+	// suppress the second apply (slice unchanged for this worker).
+	var (
+		mu         sync.Mutex
+		dispatches []*types.AssignmentCommit
+	)
+	m.testHookHandleCommitValue = func(c *types.AssignmentCommit) {
+		mu.Lock()
+		defer mu.Unlock()
+		dispatches = append(dispatches, c)
+	}
+
+	watcher := newFakeKeyWatcher()
+	go func() {
+		_ = m.runCommitWatchSession(m.ctx, nil, watcher, nil, "assignment._commit")
+	}()
+
+	// V=10: this worker alone owns hash "aaaa" -> N=1.
+	watcher.ch <- fleetCommitEntry(10, 10, workerID, "aaaa", workerID)
+	time.Sleep(20 * time.Millisecond)
+
+	// V=11: a peer joins. This worker still owns hash "aaaa" (slice
+	// unchanged for us) -> workerAssignmentChanged is false, so the
+	// debouncer collapses V=10 into V=11 and only ONE apply dispatches.
+	// But N grows 1 -> 2, which the pre-debounce observer must still see.
+	watcher.ch <- fleetCommitEntry(11, 11, workerID, "aaaa", workerID, "peer")
+
+	// Wait past the idle window for the single timer-flush.
+	time.Sleep(window + 100*time.Millisecond)
+
+	// The observer must have seen BOTH fleet sizes, even though only one
+	// commit reached the apply path.
+	require.Equal(t, []int{1, 2}, obs.snapshot(),
+		"pre-debounce observer must see both N=1 and N=2 even when the slice-unchanged apply is debounced")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, dispatches, 1,
+		"slice-unchanged commits must collapse to a single apply (debouncer suppression)")
+	require.Equal(t, int64(11), dispatches[0].Version,
+		"the single dispatched apply is the highest-version commit")
+
+	// The retune followed the latest observed N=2: min(200, 300/2=150)=150,
+	// distinct from the N=1 rate (200), proving observation tracked the
+	// grown fleet even though the second apply was debounced away.
+	require.InEpsilon(t, 150.0, lim.Limit(), 1e-9)
+}

--- a/internal/assignment/handoff/claim_write_ratelimit_test.go
+++ b/internal/assignment/handoff/claim_write_ratelimit_test.go
@@ -1,0 +1,174 @@
+package handoff
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/ratelimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingLimiter is a test double for ratelimit.Limiter that records Wait
+// calls and optionally returns an error.
+type countingLimiter struct {
+	mu      sync.Mutex
+	calls   int
+	waitErr error
+}
+
+func (c *countingLimiter) Wait(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	return c.waitErr
+}
+
+func (c *countingLimiter) Calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+var _ ratelimit.Limiter = (*countingLimiter)(nil)
+
+// newTwoPhaseForTest builds a *twoPhaseCoordinator with the given store and
+// limiter, retries low so the test runs fast.
+func newTwoPhaseForTest(t *testing.T, store ClaimStore, limiter ratelimit.Limiter) *twoPhaseCoordinator {
+	t.Helper()
+	c := New(Config{
+		Store:             store,
+		ClaimWriteLimiter: limiter,
+		MaxRetries:        3,
+		BaseBackoff:       time.Millisecond,
+		MaxBackoff:        2 * time.Millisecond,
+	}, true)
+	tp, ok := c.(*twoPhaseCoordinator)
+	require.True(t, ok, "expected a *twoPhaseCoordinator")
+
+	return tp
+}
+
+func stableTransform() func(*Claim) (*Claim, error) {
+	return func(cur *Claim) (*Claim, error) {
+		if cur != nil {
+			next := cur.NextStable(time.Now())
+			return &next, nil
+		}
+		next := NewInitialClaim("seed", "w1", time.Now(), time.Minute)
+
+		return &next, nil
+	}
+}
+
+// TestClaimWriteRateLimit_GatesEveryWrite is the reproducer: updateClaim must
+// consult the claim-write limiter before EVERY physical PutIfEpoch, including
+// the retry after a CAS conflict. Without the gate the limiter is never called.
+func TestClaimWriteRateLimit_GatesEveryWrite(t *testing.T) {
+	const pid = "p1"
+	store := &casConflictOnceStore{inner: newMemStore(), targetID: pid}
+	limiter := &countingLimiter{}
+	tp := newTwoPhaseForTest(t, store, limiter)
+
+	// First PutIfEpoch conflicts (forced), the retry succeeds → 2 physical
+	// writes → limiter must be consulted exactly twice.
+	err := tp.updateClaim(t.Context(), pid, stableTransform())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, limiter.Calls(),
+		"limiter must gate every physical PutIfEpoch attempt including the CAS retry")
+}
+
+// casConflictNStore forces the first n PutIfEpoch calls to conflict, then
+// delegates to the inner store. It lets a test pin that the gate fires on every
+// physical attempt across the full retry budget, not just the first conflict.
+type casConflictNStore struct {
+	inner     *memStore
+	remaining int
+}
+
+var _ ClaimStore = (*casConflictNStore)(nil)
+
+func (s *casConflictNStore) Get(ctx context.Context, pid string) (Claim, uint64, error) {
+	return s.inner.Get(ctx, pid)
+}
+
+func (s *casConflictNStore) PutIfEpoch(ctx context.Context, pid string, epoch int64, next Claim) (uint64, error) {
+	if s.remaining > 0 {
+		s.remaining--
+		return 0, ErrEpochMismatch
+	}
+
+	return s.inner.PutIfEpoch(ctx, pid, epoch, next)
+}
+
+func (s *casConflictNStore) ListKeys(ctx context.Context) ([]string, error) {
+	return s.inner.ListKeys(ctx)
+}
+
+func (s *casConflictNStore) Delete(ctx context.Context, pid string, rev uint64) error {
+	return s.inner.Delete(ctx, pid, rev)
+}
+
+// TestClaimWriteRateLimit_GatesEveryRetryToExhaustion pins that the gate fires on
+// EVERY physical attempt across the full MaxRetries budget. With MaxRetries=3 and
+// 3 forced conflicts then success, updateClaim makes 4 physical PutIfEpoch
+// attempts → 4 limiter consultations. A regression that gated only the first
+// attempt or two would slip past the single-conflict test but fail this one.
+func TestClaimWriteRateLimit_GatesEveryRetryToExhaustion(t *testing.T) {
+	const pid = "p1"
+	store := &casConflictNStore{inner: newMemStore(), remaining: 3}
+	limiter := &countingLimiter{}
+	tp := newTwoPhaseForTest(t, store, limiter)
+
+	require.NoError(t, tp.updateClaim(t.Context(), pid, stableTransform()))
+	assert.Equal(t, 4, limiter.Calls(),
+		"limiter must gate every physical PutIfEpoch across all CAS retries, not just the first")
+}
+
+// TestClaimWriteRateLimit_SingleWrite covers the common no-conflict path: one
+// physical write → one limiter consultation.
+func TestClaimWriteRateLimit_SingleWrite(t *testing.T) {
+	const pid = "p1"
+	limiter := &countingLimiter{}
+	tp := newTwoPhaseForTest(t, newMemStore(), limiter)
+
+	require.NoError(t, tp.updateClaim(t.Context(), pid, stableTransform()))
+	assert.Equal(t, 1, limiter.Calls())
+}
+
+// TestClaimWriteRateLimit_NilLimiterUnchanged proves a nil limiter is unlimited
+// and the write still succeeds (behaviour unchanged from before the feature).
+func TestClaimWriteRateLimit_NilLimiterUnchanged(t *testing.T) {
+	const pid = "p1"
+	store := newMemStore()
+	tp := newTwoPhaseForTest(t, store, nil)
+
+	require.NoError(t, tp.updateClaim(t.Context(), pid, stableTransform()))
+
+	got, rev, err := store.Get(t.Context(), pid)
+	require.NoError(t, err)
+	require.NotZero(t, rev)
+	assert.Equal(t, ClaimStateStable, got.State)
+}
+
+// TestClaimWriteRateLimit_CtxCancelAborts proves a limiter error (e.g. ctx
+// cancellation during a paced wait) aborts updateClaim before the write and is
+// propagated, so the apply fails pre-commit rather than writing unthrottled.
+func TestClaimWriteRateLimit_CtxCancelAborts(t *testing.T) {
+	const pid = "p1"
+	store := newMemStore()
+	limiter := &countingLimiter{waitErr: context.Canceled}
+	tp := newTwoPhaseForTest(t, store, limiter)
+
+	err := tp.updateClaim(t.Context(), pid, stableTransform())
+	require.ErrorIs(t, err, context.Canceled)
+
+	// No write should have landed.
+	_, rev, getErr := store.Get(t.Context(), pid)
+	require.NoError(t, getErr)
+	assert.Zero(t, rev, "no claim should be written when the limiter aborts")
+	assert.Equal(t, 1, limiter.Calls())
+}

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/types"
 )
 
@@ -121,6 +122,17 @@ type Config struct {
 	// negative is the "use default 20" sentinel set by the parti-side
 	// HandoffConfig contract; New() normalizes the value in place.
 	PhaseConcurrency int
+	// ClaimWriteLimiter optionally gates every physical claim-write
+	// (PutIfEpoch) attempt in updateClaim — including CAS retries — across the
+	// prepare/commit/stabilize/reap phases. nil (the default) is unlimited.
+	// The manager threads the same per-worker limiter it uses for the startup
+	// hygiene/resume loops, so all of a worker's claim-writes share one rate
+	// budget. PhaseConcurrency caps simultaneity; this caps throughput.
+	//
+	// Contract: Wait(ctx) is invoked inside the phase errgroup goroutines. The
+	// coordinator holds no manager-side locks across the call, but it MUST
+	// honour ctx cancellation so a shutdown/timeout unwinds the apply promptly.
+	ClaimWriteLimiter ratelimit.Limiter
 	// LivePartitions optionally supplies the authoritative current partition
 	// set, keyed by Partition.SubjectKey() (the same identity claims are keyed
 	// by). ok=false means the caller cannot vouch for the set right now — not

--- a/internal/assignment/handoff/metrics_prometheus.go
+++ b/internal/assignment/handoff/metrics_prometheus.go
@@ -26,6 +26,8 @@ import (
 //   - claim_store_size
 //   - claim_store_stale_total
 //   - claim_stale_handoff_reset_total
+//   - claim_write_throttled_total
+//   - claim_write_throttle_wait_seconds
 //
 // These cover end-to-end outcomes, latency, and basic KV conflict/health.
 type PrometheusRecorder struct {
@@ -41,6 +43,8 @@ type PrometheusRecorder struct {
 	claimStoreSize         prometheus.Gauge
 	claimStoreStale        prometheus.Counter
 	claimStaleHandoffReset prometheus.Counter
+	claimWriteThrottled    prometheus.Counter
+	claimWriteThrottleWait prometheus.Histogram
 }
 
 // NewPrometheusRecorder creates a new recorder.
@@ -100,6 +104,19 @@ func (p *PrometheusRecorder) ensure() {
 			Name:      "claim_stale_handoff_reset_total",
 			Help:      "Total number of stuck-prepare claims reset to stable on re-acquire by the existing owner.",
 		})
+		p.claimWriteThrottled = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: p.namespace,
+			Subsystem: "handoff",
+			Name:      "claim_write_throttled_total",
+			Help:      "Total claim-write attempts that were delayed by the claim-write rate limiter.",
+		})
+		p.claimWriteThrottleWait = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: p.namespace,
+			Subsystem: "handoff",
+			Name:      "claim_write_throttle_wait_seconds",
+			Help:      "Duration in seconds that claim-write attempts waited due to rate limiting.",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5},
+		})
 
 		p.reg.MustRegister(
 			p.handoffTotal,
@@ -109,6 +126,8 @@ func (p *PrometheusRecorder) ensure() {
 			p.claimStoreSize,
 			p.claimStoreStale,
 			p.claimStaleHandoffReset,
+			p.claimWriteThrottled,
+			p.claimWriteThrottleWait,
 		)
 	})
 }
@@ -146,4 +165,20 @@ func (p *PrometheusRecorder) IncClaimStoreStale() {
 func (p *PrometheusRecorder) IncClaimStaleHandoffReset() {
 	p.ensure()
 	p.claimStaleHandoffReset.Inc()
+}
+
+// IncClaimWriteThrottled increments the claim-write throttle counter. It
+// satisfies the optional claim-write throttle sidecar the Manager type-asserts
+// for when building the claim-write rate limiter; only positive-delay waits are
+// recorded.
+func (p *PrometheusRecorder) IncClaimWriteThrottled() {
+	p.ensure()
+	p.claimWriteThrottled.Inc()
+}
+
+// ObserveClaimWriteThrottleWait records a claim-write throttle wait duration in
+// seconds. Companion to IncClaimWriteThrottled.
+func (p *PrometheusRecorder) ObserveClaimWriteThrottleWait(seconds float64) {
+	p.ensure()
+	p.claimWriteThrottleWait.Observe(seconds)
 }

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/types"
 	"golang.org/x/sync/errgroup"
 )
@@ -182,7 +183,15 @@ func (t *twoPhaseCoordinator) updateClaim(ctx context.Context, pid string, trans
 			return nil // No update needed
 		}
 
-		// 3. Attempt CAS
+		// 3. Attempt CAS. Pace the physical write first if a claim-write limiter
+		// is configured: this gates every PutIfEpoch attempt, including CAS
+		// retries (the loop re-enters here), so a contention storm is paced at
+		// the same rate as a first-try write. A nil limiter is unlimited (no
+		// wait). ctx cancellation (shutdown/timeout during a paced wait) aborts
+		// the loop so the apply fails pre-commit and the manager retries.
+		if err := ratelimit.Wait(ctx, t.cfg.ClaimWriteLimiter); err != nil {
+			return err
+		}
 		var casErr error
 		if rev == 0 {
 			_, casErr = t.cfg.Store.PutIfEpoch(ctx, pid, 0, *next)

--- a/internal/durable/consumer_create_ratelimit_test.go
+++ b/internal/durable/consumer_create_ratelimit_test.go
@@ -204,6 +204,28 @@ func (l *onNthCancelLimiter) Wait(ctx context.Context) error {
 	return nil
 }
 
+// --- Test: recreateFn aborts before the RPC when the gate returns an error ---
+
+func TestConsumerCreateRateLimit_RecreateFn_CtxCancelAborts(t *testing.T) {
+	fakeJS := newRateLimitJS(nil) // would succeed, but the gate must abort first
+	limiter := newFakeLimiter()
+	limiter.SetError(context.Canceled)
+
+	pc := &partitionConsumer{
+		streamName: "test-stream",
+		js:         fakeJS,
+		config: partitionConsumerConfig{
+			ConsumerCreateLimiter: limiter,
+		},
+	}
+
+	recreate := pc.recreateFn()
+	_, err := recreate(t.Context(), jetstream.ConsumerConfig{Durable: "test-durable"})
+	require.ErrorIs(t, err, context.Canceled, "gate ctx error must propagate from recreateFn")
+	assert.Equal(t, 0, fakeJS.RPCCalls(), "no RPC must be issued when the gate aborts")
+	assert.Equal(t, 1, limiter.Calls())
+}
+
 // --- Test: nil limiter → unlimited → ensureConsumer behavior unchanged ---
 
 func TestConsumerCreateRateLimit_NilLimiter_EnsureConsumerUnchanged(t *testing.T) {

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -8,10 +8,17 @@ package ratelimit
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"golang.org/x/time/rate"
 )
+
+// ErrUnsatisfiable is returned by [TokenBucketLimiter.Wait] when the underlying
+// token-bucket reservation can never be satisfied (a burst smaller than a single
+// token). Public constructors reject such configs, so this only surfaces on
+// direct misuse of the primitive; it prevents a near-infinite Wait.
+var ErrUnsatisfiable = errors.New("ratelimit: reservation cannot be satisfied (burst too small)")
 
 // Limiter is the interface callers use to gate RPC attempts.
 //
@@ -59,9 +66,25 @@ func New(perSec float64, burst int, observer ThrottleObserver) *TokenBucketLimit
 // Wait blocks until the limiter grants a token or ctx is cancelled.
 // A positive delay triggers an optional metrics callback.
 func (l *TokenBucketLimiter) Wait(ctx context.Context) error {
+	// Honor cancellation up front: a caller whose context is already cancelled
+	// must not be granted a token, even when one is immediately available.
+	// Without this, the burst-absorbed fast path below would return nil and let
+	// the caller proceed into an already-doomed RPC.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Use Reserve to detect whether this attempt will actually wait,
 	// so we can emit metrics only on real throttling (not burst-absorbed).
 	r := l.rl.Reserve()
+	if !r.OK() {
+		// The reservation can never be satisfied (e.g. burst smaller than a
+		// single token), which would otherwise yield an unbounded Delay and a
+		// near-infinite sleep. Public constructors validate burst >= 1, so this
+		// only guards against direct misuse of the primitive.
+		r.Cancel()
+		return ErrUnsatisfiable
+	}
 	delay := r.Delay()
 
 	if delay <= 0 {

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -34,6 +34,20 @@ type Limiter interface {
 	Wait(ctx context.Context) error
 }
 
+// RateSetter is an optional capability implemented by limiters whose
+// steady-state rate can be retuned at runtime (the built-in
+// [TokenBucketLimiter]). Adaptive, fleet-size-aware callers type-assert a
+// [Limiter] to RateSetter; a limiter that does not implement it (e.g. a
+// user-injected custom limiter) keeps its constructed rate.
+//
+// Kept separate from [Limiter] deliberately: widening Limiter would force every
+// implementation (including injected, Wait-only ones) to add SetRate.
+type RateSetter interface {
+	// SetRate changes the steady-state rate (events/second), leaving burst
+	// unchanged. Safe to call concurrently with Wait.
+	SetRate(perSec float64)
+}
+
 // TokenBucketLimiter wraps [rate.Limiter] and implements [Limiter].
 // It optionally emits throttle metrics via [ThrottleObserver].
 type TokenBucketLimiter struct {
@@ -42,6 +56,7 @@ type TokenBucketLimiter struct {
 }
 
 var _ Limiter = (*TokenBucketLimiter)(nil)
+var _ RateSetter = (*TokenBucketLimiter)(nil)
 
 // ThrottleObserver is an optional metrics hook for throttle events.
 // It is separate from the sidecar defined in internal/durable so that the
@@ -113,6 +128,38 @@ func (l *TokenBucketLimiter) Wait(ctx context.Context) error {
 	case <-t.C:
 		return nil
 	}
+}
+
+// SetRate changes the steady-state rate to perSec events/second, leaving the
+// burst unchanged. It is safe to call concurrently with Wait: the underlying
+// rate.Limiter guards its limit with an internal mutex. A rate decrease does
+// not retroactively cancel reservations already granted by an in-flight Wait
+// (golang.org/x/time/rate semantics); the effect is a brief, self-correcting
+// transient.
+func (l *TokenBucketLimiter) SetRate(perSec float64) {
+	l.rl.SetLimit(rate.Limit(perSec))
+}
+
+// Limit returns the current steady-state rate (events/second).
+func (l *TokenBucketLimiter) Limit() float64 {
+	return float64(l.rl.Limit())
+}
+
+// EffectiveRate returns the fleet-size-aware per-worker rate
+// min(perWorkerMax, clusterRate/n): the cluster-wide target divided across n
+// workers, capped by the per-worker ceiling. n is clamped to >= 1. A
+// perWorkerMax <= 0 means "no ceiling". This is the single definition shared by
+// the manager (claim-write) and the consumer (consumer-create) adaptive paths.
+func EffectiveRate(perWorkerMax, clusterRate float64, n int) float64 {
+	if n < 1 {
+		n = 1
+	}
+	r := clusterRate / float64(n)
+	if perWorkerMax > 0 && perWorkerMax < r {
+		return perWorkerMax
+	}
+
+	return r
 }
 
 // Wait is a nil-safe helper: if l is nil it returns nil immediately without

--- a/internal/ratelimit/ratelimit_setrate_test.go
+++ b/internal/ratelimit/ratelimit_setrate_test.go
@@ -1,0 +1,74 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveRate(t *testing.T) {
+	// clusterRate/n = 1000/5 = 200; perWorkerMax=200 is not less than 200 → 200
+	require.InEpsilon(t, 200.0, EffectiveRate(200, 1000, 5), 1e-9)
+	// clusterRate/n = 1000/20 = 50; perWorkerMax=200 is not less than 50 → 50
+	require.InEpsilon(t, 50.0, EffectiveRate(200, 1000, 20), 1e-9)
+	// clusterRate/n = 50/1 = 50; perWorkerMax=200 is not less than 50 → 50
+	require.InEpsilon(t, 50.0, EffectiveRate(200, 50, 1), 1e-9)
+	// no ceiling (perWorkerMax<=0): 1000/10 = 100 → 100
+	require.InEpsilon(t, 100.0, EffectiveRate(0, 1000, 10), 1e-9)
+	// n=0 clamped to 1: 1000/1 = 1000; perWorkerMax=200 < 1000 → 200
+	require.InEpsilon(t, 200.0, EffectiveRate(200, 1000, 0), 1e-9)
+	// n=0 clamped to 1, no ceiling: 1000/1 = 1000 → 1000
+	require.InEpsilon(t, 1000.0, EffectiveRate(0, 1000, 0), 1e-9)
+}
+
+func TestTokenBucketLimiter_SetRate_ChangesSteadyState(t *testing.T) {
+	l := New(100, 1, nil) // 100/s, burst 1
+	require.InEpsilon(t, 100.0, l.Limit(), 1e-9)
+
+	l.SetRate(10) // tighten to 10/s
+	require.InEpsilon(t, 10.0, l.Limit(), 1e-9)
+
+	l.SetRate(1000) // loosen
+	require.InEpsilon(t, 1000.0, l.Limit(), 1e-9)
+}
+
+func TestTokenBucketLimiter_SetRate_PreservesBurst(t *testing.T) {
+	l := New(100, 7, nil)
+	l.SetRate(5)
+	require.Equal(t, 7, l.rl.Burst(), "SetRate must not change burst")
+}
+
+func TestTokenBucketLimiter_RateSetter_Assertion(t *testing.T) {
+	var lim Limiter = New(100, 1, nil)
+	rs, ok := lim.(RateSetter)
+	require.True(t, ok, "*TokenBucketLimiter must satisfy RateSetter")
+	rs.SetRate(50)
+	tbl, ok := lim.(*TokenBucketLimiter)
+	require.True(t, ok)
+	require.InEpsilon(t, 50.0, tbl.Limit(), 1e-9)
+}
+
+func TestTokenBucketLimiter_SetRate_ConcurrentWithWait(t *testing.T) {
+	l := New(1000, 100, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for ctx.Err() == nil {
+				_ = l.Wait(ctx)
+			}
+		})
+	}
+	wg.Go(func() {
+		for ctx.Err() == nil {
+			l.SetRate(500)
+			l.SetRate(2000)
+		}
+	})
+	wg.Wait() // -race must stay clean
+}

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -13,6 +13,30 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// TestWaitHonoursAlreadyCancelledCtxWithFreeToken pins that Wait does NOT grant
+// a token to an already-cancelled context even when the burst makes one
+// immediately available. Before the up-front ctx check, the delay<=0 fast path
+// returned nil and let the caller proceed into an already-doomed RPC.
+func TestWaitHonoursAlreadyCancelledCtxWithFreeToken(t *testing.T) {
+	l := ratelimit.New(100, 10, nil) // burst 10: a token is immediately available
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the very first Wait, while burst tokens remain
+
+	require.ErrorIs(t, l.Wait(ctx), context.Canceled,
+		"Wait must honour an already-cancelled ctx even when a burst token is free")
+}
+
+// TestWaitUnsatisfiableReservation pins the burst-too-small guard: a limiter
+// built with burst 0 (only reachable by direct misuse of the primitive, since
+// public constructors reject it) returns ErrUnsatisfiable instead of sleeping
+// for a near-infinite Delay.
+func TestWaitUnsatisfiableReservation(t *testing.T) {
+	l := ratelimit.New(100, 0, nil) // burst 0: a 1-token reservation can never be satisfied
+
+	require.ErrorIs(t, l.Wait(context.Background()), ratelimit.ErrUnsatisfiable)
+}
+
 // TestNilLimiterNeverBlocks verifies that a nil Limiter never blocks.
 func TestNilLimiterNeverBlocks(t *testing.T) {
 	ctx := t.Context()

--- a/internal/recovery/controller.go
+++ b/internal/recovery/controller.go
@@ -401,7 +401,14 @@ func (c *Controller) RebuildAfterStreamRecreated(
 
 	newCons, err := recreate(ctx, cfg)
 	if err != nil {
-		// All errors during post-hook recovery wrap types.ErrStreamMissing
+		// A cancelled/expired context (e.g. shutdown or deadline during a paced
+		// recreate) is not a stream-missing condition; return it unwrapped so it
+		// is not misclassified as a permanent stream loss that trips the manager
+		// observer / degraded route. Matches the ctx-guard discipline in recover().
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// All other errors during post-hook recovery wrap types.ErrStreamMissing
 		// so the manager observer route is consistent regardless of the
 		// underlying cause (still-missing-stream, incompatible-restored-
 		// consumer-config, etc.).

--- a/jsutil/consumer.go
+++ b/jsutil/consumer.go
@@ -43,13 +43,14 @@ type ensureConsumerOptions struct {
 	beforeAttempt func(ctx context.Context) error
 }
 
-// WithBeforeAttempt installs a hook invoked before every physical
-// CreateOrUpdateConsumer attempt, including retries. A non-nil error from the
-// hook aborts the retry loop and is returned to the caller.
+// WithBeforeAttempt installs a hook invoked synchronously before every physical
+// CreateOrUpdateConsumer attempt, including retries — the seam used to enforce a
+// rate limit on consumer creates. A non-nil error from the hook aborts the retry
+// loop and is returned to the caller.
 //
-// This is the per-attempt gating seam used to enforce a rate limit on consumer
-// creates. The hook must honour context cancellation; it must not call back
-// into any component that holds applyStoreMu or updateMu.
+// The hook must honour context cancellation, avoid long or blocking work, and
+// must not call back into any operation that may itself be waiting on this same
+// create/update path. A nil hook is a no-op.
 func WithBeforeAttempt(fn func(ctx context.Context) error) EnsureConsumerOption {
 	return func(o *ensureConsumerOptions) {
 		o.beforeAttempt = fn

--- a/manager.go
+++ b/manager.go
@@ -68,6 +68,19 @@ type Manager struct {
 	// the interface. Avoids a per-Apply type assertion.
 	capReporter CapabilityReporter
 
+	// fleetSizeObserver is the consumer updater cast to FleetSizeObserver at
+	// construction (nil when the updater does not implement it). Used to push
+	// the observed worker-count N for adaptive consumer-create rate limiting.
+	fleetSizeObserver FleetSizeObserver
+
+	// fleetMu guards the last-observed commit identity and worker-count so the
+	// freshness fence and the recorded N never split. Held across the limiter
+	// retune + the FleetSizeObserver push (both non-blocking, non-reentrant).
+	fleetMu            sync.Mutex
+	lastFleetVersion   int64
+	lastFleetLeaderRev uint64
+	lastObservedN      int
+
 	// Handoff coordinator (feature-flagged); abstracts assignment application.
 	handoffCoordinator handoff.Coordinator
 	handoffMetrics     HandoffMetricsRecorder
@@ -435,17 +448,18 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 	// This ensures that these fields are never nil, simplifying lifecycle management
 	// and avoiding nil pointer checks in operational methods.
 	m := &Manager{
-		cfg:             *cfg,
-		js:              js,
-		source:          source,
-		strategy:        strategy,
-		electionAgent:   options.electionAgent,
-		hooks:           hooksInstance,
-		metrics:         metricsCollector,
-		logger:          logger,
-		consumerUpdater: options.consumerUpdater,
-		capReporter:     asCapabilityReporter(options.consumerUpdater),
-		kvErrorWindow:   make([]kvErrorEvent, 0, cfg.DegradedBehavior.KVErrorThreshold),
+		cfg:               *cfg,
+		js:                js,
+		source:            source,
+		strategy:          strategy,
+		electionAgent:     options.electionAgent,
+		hooks:             hooksInstance,
+		metrics:           metricsCollector,
+		logger:            logger,
+		consumerUpdater:   options.consumerUpdater,
+		capReporter:       asCapabilityReporter(options.consumerUpdater),
+		fleetSizeObserver: asFleetSizeObserver(options.consumerUpdater),
+		kvErrorWindow:     make([]kvErrorEvent, 0, cfg.DegradedBehavior.KVErrorThreshold),
 		// Initialize internal components with Nop implementations
 		idClaimer:  stableid.NewNop(),
 		election:   election.NewNopElection(),
@@ -691,6 +705,7 @@ func (m *Manager) applyInitialAssignment(ctx context.Context, assignmentKV jetst
 		// but routing via applyAssignmentWithPrev directly afterwards.
 		newAsg, ok := m.buildAssignmentFromCommit(commit, m.WorkerID())
 		if ok {
+			m.observeFleetSize(commit) // retune before the first consumer-create storm
 			// Commit-path success: run the apply with explicit empty previous
 			// FIRST. Only advance lastObservedCommit after the apply returns
 			// nil — on failure, the commit must not be surfaced to the
@@ -755,6 +770,12 @@ func (m *Manager) applyInitialAssignment(ctx context.Context, assignmentKV jetst
 		m.markStartupAssignmentApplied()
 
 		return nil
+	}
+	// A legacy alias may carry TotalWorkers==0 (the field is omitempty and the
+	// publisher may not have set it). Skip rather than let observeFleetSizeN's
+	// n<1 clamp record a bogus N=1, which would under-divide the cluster rate.
+	if initial.TotalWorkers > 0 {
+		m.observeFleetSizeN(initial.Version, initial.LeaderRevision, initial.TotalWorkers)
 	}
 	if err := m.applyAssignmentWithPrev(Assignment{}, initial); err != nil {
 		return err
@@ -981,6 +1002,14 @@ const reportableCapBits = types.CapProcessingGate
 func asCapabilityReporter(u WorkerConsumerUpdater) CapabilityReporter {
 	cr, _ := u.(CapabilityReporter)
 	return cr
+}
+
+// asFleetSizeObserver returns u as a FleetSizeObserver when it implements the
+// interface; otherwise nil. Called once at construction so the commit-watch
+// hot path does not repeat the type assertion. Mirrors asCapabilityReporter.
+func asFleetSizeObserver(u WorkerConsumerUpdater) FleetSizeObserver {
+	fo, _ := u.(FleetSizeObserver)
+	return fo
 }
 
 // reportConsumerCapabilities samples the cached CapabilityReporter (if any)

--- a/manager.go
+++ b/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/hooks"
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/internal/recovery"
 	"github.com/arloliu/parti/v2/internal/stableid"
 	"github.com/arloliu/parti/v2/kvutil"
@@ -75,6 +76,14 @@ type Manager struct {
 	// nil when two-phase handoff is disabled. The removal guard reads it to
 	// decide whether a transfer has committed elsewhere.
 	handoffStore handoff.ClaimStore
+
+	// claimWriteLimiter paces every physical handoff claim-write (PutIfEpoch)
+	// across the startup hygiene/resume loops and the two-phase coordinator's
+	// updateClaim. nil (the default) is unlimited. Built once in setupHandoff
+	// from cfg.Handoff.ClaimWrite{PerSec,Burst} and shared with the coordinator
+	// via handoff.Config.ClaimWriteLimiter, so all of a worker's claim-writes
+	// draw on one rate budget. See buildClaimWriteLimiter.
+	claimWriteLimiter ratelimit.Limiter
 
 	// commitBatchCache memoizes the partition set of the current "_commit"
 	// entry, keyed by (commit version, _commit KV revision), so the removal

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/assignment/handoff"
 	"github.com/arloliu/parti/v2/internal/heartbeat"
 	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/internal/retry"
 	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/arloliu/parti/v2/types"
@@ -856,6 +857,7 @@ func (m *Manager) runCommitWatchSession(
 	return m.runWatchSession(ctx, watcher, reconcileTickC, "commit", watchSessionHandlers{
 		onUpdate: func(entry jetstream.KeyValueEntry) {
 			if commit, ok := m.decodeCommitEntry(entry); ok {
+				m.observeFleetSize(commit)
 				db.stage(commit)
 			}
 		},
@@ -869,6 +871,7 @@ func (m *Manager) runCommitWatchSession(
 			if gerr != nil || current == nil {
 				return
 			}
+			m.observeFleetSize(current)
 			db.stage(current)
 		},
 	})
@@ -939,6 +942,76 @@ func commitContainsWorker(c *types.AssignmentCommit, workerID string) bool {
 		return false
 	}
 	return slices.Contains(c.Workers, workerID)
+}
+
+// observeFleetSize records the cluster worker-count from a committed assignment
+// and live-retunes the fleet-size-aware rate limiters. It runs at the
+// pre-debounce commit-decode point so it sees every commit the watcher
+// delivers — including those the apply debounce suppresses when this worker's
+// own slice is unchanged.
+func (m *Manager) observeFleetSize(commit *types.AssignmentCommit) {
+	if commit == nil {
+		return
+	}
+	m.observeFleetSizeN(commit.Version, commit.LeaderRevision, len(commit.Workers))
+}
+
+// observeFleetSizeN records (version, leaderRevision, n) and retunes the
+// fleet-size-aware limiters. It is doubly fenced so a stale or out-of-order
+// commit can never regress N:
+//
+//   - Stale-leader fence (mirrors handleCommitValueOnce case (b)): a commit
+//     whose LeaderRevision is below the highest applied one is rejected, so a
+//     split-brain former leader's higher-Version/lower-LeaderRevision commit
+//     — which the apply path drops — cannot retune to a worker-count this
+//     worker never applies.
+//   - Supersession fence: only a (version, leaderRevision) pair that strictly
+//     supersedes the last observed one retunes, so an in-leadership reorder
+//     (e.g. a reconcile snapshot racing a newer watcher event) is ignored.
+//
+// Guarded by fleetMu; the retune and push are non-blocking and non-reentrant
+// by contract, so holding fleetMu across them is safe. n is clamped to >= 1.
+func (m *Manager) observeFleetSizeN(version int64, leaderRev uint64, n int) {
+	if n < 1 {
+		n = 1
+	}
+
+	m.fleetMu.Lock()
+	defer m.fleetMu.Unlock()
+
+	// Stale-leader fence: mirror handleCommitValueOnce case (b)
+	// (manager_assignment.go). A split-brain former leader can write a
+	// higher-Version commit with a lower (stale) LeaderRevision; the apply path
+	// rejects it via lastSeenLeaderRevision, so observing its worker-count would
+	// regress N to a value this worker never applies. leaderRev==0 (e.g. a
+	// legacy alias) is treated as "unknown" and not rejected.
+	if leaderRev != 0 && leaderRev < m.lastSeenLeaderRevision.Load() {
+		return
+	}
+
+	if version < m.lastFleetVersion ||
+		(version == m.lastFleetVersion && leaderRev <= m.lastFleetLeaderRev) {
+		return
+	}
+	m.lastFleetVersion = version
+	m.lastFleetLeaderRev = leaderRev
+
+	if n == m.lastObservedN {
+		return
+	}
+	m.lastObservedN = n
+
+	// Claim-write (manager-local): retune the shared limiter in place.
+	if m.cfg.Handoff.ClaimWriteClusterRate > 0 {
+		if rs, ok := m.claimWriteLimiter.(ratelimit.RateSetter); ok {
+			rs.SetRate(ratelimit.EffectiveRate(m.cfg.Handoff.ClaimWritePerSec, m.cfg.Handoff.ClaimWriteClusterRate, n))
+		}
+	}
+
+	// Consumer-create: push N; the consumer owns its rate policy.
+	if m.fleetSizeObserver != nil {
+		m.fleetSizeObserver.ObserveWorkerCount(n)
+	}
 }
 
 // handleCommitValue implements §3.6 case 1 (commit-path state machine).

--- a/manager_handoff.go
+++ b/manager_handoff.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -168,6 +169,18 @@ func (m *Manager) handoffStartupHygiene(ctx context.Context, store handoff.Claim
 		next.PendingOwner = ""
 		next.LastUpdated = now
 
+		// Pace the physical write if a claim-write limiter is configured. ctx
+		// cancellation (this pass runs under OperationTimeout) stops the
+		// best-effort sweep early — the remaining stale claims are reset on a
+		// later startup or by the coordinator's periodic sweep. Conservatively
+		// flag resumable: the truncated scan may not have reached a later
+		// non-expired prepare/commit claim, so let the bounded, idempotent
+		// resume pass run rather than risk skipping it.
+		if err := ratelimit.Wait(ctx, m.claimWriteLimiter); err != nil {
+			resumable = true
+			break
+		}
+
 		// Best-effort CAS; ignore failures.
 		_, _ = store.PutIfEpoch(ctx, pid, cur.Epoch, next)
 		resets++
@@ -202,12 +215,31 @@ func (m *Manager) runHandoffResume(ctx context.Context) {
 	}
 	store := handoff.NewNATSClaimStore(kv, "claims/")
 
-	keys, err := store.ListKeys(ctx)
-	if err != nil || len(keys) == 0 {
-		return
+	wid := m.WorkerID()
+	finalized, completed := m.finalizeResumeClaims(ctx, store, wid)
+	if finalized > 0 {
+		m.logger.Info("handoff_resume_finalize", "worker_id", wid, "finalized", finalized)
 	}
 
-	wid := m.WorkerID()
+	// Clear the flag only when the pass ran to completion. A paced Wait
+	// cancelled mid-pass leaves it set so a later pass can finish finalizing.
+	if completed {
+		m.pendingHandoffResume.Store(false)
+	}
+}
+
+// finalizeResumeClaims is the testable core of runHandoffResume: it finalizes
+// commit->stable transitions for the claims this worker (wid) owns, pacing every
+// physical PutIfEpoch by the claim-write limiter. It returns the number
+// finalized and whether the pass ran to completion — completed is false when the
+// store cannot be enumerated or a paced Wait is cancelled, signalling the caller
+// to leave pendingHandoffResume set for a later retry.
+func (m *Manager) finalizeResumeClaims(ctx context.Context, store handoff.ClaimStore, wid string) (int, bool) {
+	keys, err := store.ListKeys(ctx)
+	if err != nil || len(keys) == 0 {
+		return 0, false
+	}
+
 	now := time.Now().UTC()
 	finalized := 0
 	for _, pid := range keys {
@@ -221,18 +253,20 @@ func (m *Manager) runHandoffResume(ctx context.Context) {
 		if cur.State != handoff.ClaimStateCommit {
 			continue
 		}
+		// Pace the physical write if a claim-write limiter is configured. ctx
+		// cancellation (shutdown) stops the resume pass.
+		if err := ratelimit.Wait(ctx, m.claimWriteLimiter); err != nil {
+			return finalized, false
+		}
+
 		// Finalize commit -> stable (epoch++ handled by NextStable)
 		next := cur.NextStable(now)
 		if _, err := store.PutIfEpoch(ctx, pid, cur.Epoch, next); err == nil {
 			finalized++
 		}
 	}
-	if finalized > 0 {
-		m.logger.Info("handoff_resume_finalize", "worker_id", wid, "finalized", finalized)
-	}
 
-	// Clear flag to avoid repeated runs
-	m.pendingHandoffResume.Store(false)
+	return finalized, true
 }
 
 // InspectHandoffClaims returns all current handoff claims from the configured

--- a/manager_handoff_ratelimit.go
+++ b/manager_handoff_ratelimit.go
@@ -1,0 +1,61 @@
+package parti
+
+import "github.com/arloliu/parti/v2/internal/ratelimit"
+
+// claimWriteThrottleObserver is an optional sidecar interface that a
+// HandoffMetricsRecorder implementation MAY satisfy. When the configured
+// handoff metrics value implements it, claim-write throttle events are emitted
+// through it.
+//
+// It is intentionally kept off the public HandoffMetricsRecorder interface (the
+// same D7 pattern the consumer-create limiter uses for WorkerConsumerMetrics)
+// so external recorders that implement only the published interface are
+// unaffected — they simply never receive throttle calls. The built-in
+// handoff.PrometheusRecorder implements it.
+//
+// Only positive-delay waits are recorded; a claim-write that draws an
+// immediately-available token does not trigger these methods.
+type claimWriteThrottleObserver interface {
+	// IncClaimWriteThrottled increments the count of claim-writes that were
+	// actually delayed by the rate limiter.
+	IncClaimWriteThrottled()
+	// ObserveClaimWriteThrottleWait records the actual wait duration in seconds.
+	ObserveClaimWriteThrottleWait(seconds float64)
+}
+
+// claimWriteThrottleAdapter bridges a claimWriteThrottleObserver to the
+// ratelimit.ThrottleObserver the limiter calls on every positive-delay wait.
+type claimWriteThrottleAdapter struct {
+	obs claimWriteThrottleObserver
+}
+
+var _ ratelimit.ThrottleObserver = claimWriteThrottleAdapter{}
+
+func (a claimWriteThrottleAdapter) IncrementThrottled() { a.obs.IncClaimWriteThrottled() }
+func (a claimWriteThrottleAdapter) ObserveWait(seconds float64) {
+	a.obs.ObserveClaimWriteThrottleWait(seconds)
+}
+
+// buildClaimWriteLimiter constructs the per-worker claim-write rate limiter from
+// cfg.Handoff, or returns nil (unlimited) when ClaimWritePerSec is not positive.
+//
+// The same limiter is threaded into the two-phase coordinator and used directly
+// by the startup hygiene/resume loops, so every claim-write this worker issues
+// shares one rate budget. Validation (perSec >= 0, burst >= 1 when perSec > 0)
+// is enforced at Config.Validate; this constructs from already-valid values.
+//
+// When the configured handoff metrics recorder implements
+// claimWriteThrottleObserver, a throttle observer is wired so positive-delay
+// waits surface as metrics. The type assertion happens once here, not per wait.
+func (m *Manager) buildClaimWriteLimiter() ratelimit.Limiter {
+	if m.cfg.Handoff.ClaimWritePerSec <= 0 {
+		return nil
+	}
+
+	var obs ratelimit.ThrottleObserver
+	if sidecar, ok := m.handoffMetrics.(claimWriteThrottleObserver); ok {
+		obs = claimWriteThrottleAdapter{obs: sidecar}
+	}
+
+	return ratelimit.New(m.cfg.Handoff.ClaimWritePerSec, m.cfg.Handoff.ClaimWriteBurst, obs)
+}

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -203,6 +203,10 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 
 	store := handoff.NewNATSClaimStore(handoffKV, "claims/")
 	m.handoffStore = store
+	// Build the per-worker claim-write limiter once and share it across the
+	// coordinator (site 1) and the startup hygiene/resume loops (sites 2-3) so
+	// every claim-write draws on one rate budget. nil when not configured.
+	m.claimWriteLimiter = m.buildClaimWriteLimiter()
 	m.handoffCoordinator = handoff.New(handoff.Config{
 		ConsumerUpdater:   m.consumerUpdater,
 		Metrics:           m.handoffMetrics,
@@ -217,6 +221,7 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 		DelayAfterPrepare: m.cfg.Handoff.DelayAfterPrepare,
 		DelayBeforeStable: m.cfg.Handoff.DelayBeforeStable,
 		PhaseConcurrency:  m.cfg.Handoff.PhaseConcurrency,
+		ClaimWriteLimiter: m.claimWriteLimiter,
 		Logger:            m.logger,
 		// Orphan-claim reaping: leader-vouched live set + a generous grace.
 		// See livePartitionSet and orphanClaimGrace (manager_handoff.go).

--- a/test/integration/manager/adaptive_ratelimit_test.go
+++ b/test/integration/manager/adaptive_ratelimit_test.go
@@ -1,0 +1,314 @@
+package manager_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+)
+
+// fleetObserverUpdater is a test WorkerConsumerUpdater that ALSO implements the
+// optional parti.FleetSizeObserver interface. UpdateWorkerConsumer is a no-op
+// (this test does not exercise consumer reconciliation); ObserveWorkerCount
+// records every cluster worker-count (N) the Manager pushes to it.
+//
+// This is the observation seam for the fleet-size-aware rate-limit feature: the
+// integration package is external (package manager_test) and cannot read the
+// Manager's unexported fleet-size fields. By registering this updater with
+// parti.WithWorkerConsumerUpdater, the test observes the FULL chain end-to-end
+// (commit watcher decode → observeFleetSize freshness fence → ObserveWorkerCount
+// push) purely through the recorded N values, with no manager internals and no
+// exported test accessor.
+//
+// All access is mutex-guarded because ObserveWorkerCount runs on the Manager's
+// commit-watch goroutine while the test reads from the test goroutine.
+type fleetObserverUpdater struct {
+	mu   sync.Mutex
+	last int
+	seen []int
+}
+
+// UpdateWorkerConsumer satisfies parti.WorkerConsumerUpdater. It is a no-op: this
+// test does not assert on consumer subject reconciliation, only on the fleet-size
+// observation that piggybacks on the same updater seam.
+func (u *fleetObserverUpdater) UpdateWorkerConsumer(context.Context, string, []parti.Partition) error {
+	return nil
+}
+
+// ObserveWorkerCount satisfies parti.FleetSizeObserver. The Manager calls it
+// whenever the observed committed worker-set size changes (and once at startup,
+// before the first apply). n is always >= 1 by contract.
+func (u *fleetObserverUpdater) ObserveWorkerCount(n int) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.last = n
+	u.seen = append(u.seen, n)
+}
+
+// lastN returns the most recently observed worker-count (0 if none yet).
+func (u *fleetObserverUpdater) lastN() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.last
+}
+
+// Compile-time assertions: the test updater must satisfy BOTH interfaces, else
+// the Manager would never cast it to a FleetSizeObserver and the wiring proof
+// would silently pass for the wrong reason.
+var (
+	_ parti.WorkerConsumerUpdater = (*fleetObserverUpdater)(nil)
+	_ parti.FleetSizeObserver     = (*fleetObserverUpdater)(nil)
+)
+
+// TestAdaptive_FleetGrowthIsObserved is the end-to-end wiring proof for the
+// fleet-size-aware rate-limit feature: a real fleet-size change that a worker
+// observes through its commit watcher actually reaches ObserveWorkerCount.
+//
+// Mechanism under test (manager_assignment.go observeFleetSize, wired into the
+// commit-watch onUpdate at the pre-debounce decode point, plus the startup
+// bootstrap call in manager.go): the Manager records len(commit.Workers) from
+// every committed assignment it decodes and, when the value changes, pushes the
+// new N to a registered WorkerConsumerUpdater that implements FleetSizeObserver.
+//
+// Scenario:
+//   - Start worker-1 alone with a fleetObserverUpdater wired in. Wait for Stable.
+//   - Assert worker-1 eventually observes N=1 (it sees itself as the sole worker
+//     in the committed assignment it bootstraps from).
+//   - Start worker-2 joining the same coordination buckets. The leader
+//     republishes a commit whose Workers slice now has 2 entries.
+//   - Assert worker-1 eventually observes N=2, proving it picked up the fleet
+//     growth end-to-end through the commit watcher — not just at its own startup.
+//   - Clean shutdown of both.
+//
+// require.Eventually (not a fixed sleep) is used for both observations: commit
+// propagation plus the 30s reconcile floor mean N=2 can take several seconds to
+// surface, and the precise timing must never be asserted.
+func TestAdaptive_FleetGrowthIsObserved(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	cfg := testutil.IntegrationTestConfig()
+
+	// Enough partitions to form a real cluster and give every worker a slice.
+	partitions := testutil.CreateTestPartitions(12)
+	src := source.NewStatic(partitions)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	cluster := &testutil.WorkerCluster{
+		Workers:  make([]*parti.Manager, 0),
+		Config:   cfg,
+		Source:   src,
+		Strategy: strategy.NewConsistentHash(),
+		NC:       nc,
+		JS:       js,
+		T:        t,
+	}
+	defer cluster.StopWorkers()
+
+	// Worker-1 carries the observation seam.
+	observer := &fleetObserverUpdater{}
+	w1 := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(observer))
+
+	require.NoError(t, w1.Start(ctx), "worker-1 failed to start")
+	require.NoError(t, <-w1.WaitState(parti.StateStable, 15*time.Second),
+		"worker-1 did not reach StateStable")
+
+	// Worker-1 observes itself as the sole committed worker (N=1). This is the
+	// startup bootstrap observation (observeFleetSize at the commit-path apply)
+	// and/or the first commit-watch delivery.
+	require.Eventually(t, func() bool {
+		return observer.lastN() == 1
+	}, 10*time.Second, 100*time.Millisecond,
+		"worker-1 must observe itself as the sole worker (N=1)")
+
+	// Add worker-2. It joins the same coordination buckets, the leader recomputes
+	// the assignment, and the committed worker-set grows to N=2. Worker-1's commit
+	// watcher must surface that change to its observer.
+	w2 := cluster.AddWorkerWithOptions(ctx)
+	require.NoError(t, w2.Start(ctx), "worker-2 failed to start")
+	require.NoError(t, <-w2.WaitState(parti.StateStable, 15*time.Second),
+		"worker-2 did not reach StateStable")
+
+	// The core proof: worker-1 observed the fleet growth end-to-end through the
+	// commit watcher. Generous timeout because commit republish + propagation +
+	// the reconcile floor can take several seconds.
+	require.Eventually(t, func() bool {
+		return observer.lastN() == 2
+	}, 20*time.Second, 200*time.Millisecond,
+		"worker-1 must observe the fleet growth to N=2 through its commit watcher")
+
+	// Sanity: worker-1 should have seen 1 before 2 (monotonic growth), proving the
+	// observation tracked the real fleet timeline rather than jumping straight to 2.
+	observer.mu.Lock()
+	seen := append([]int(nil), observer.seen...)
+	observer.mu.Unlock()
+	require.Contains(t, seen, 1, "worker-1 should have observed the N=1 phase")
+	require.Contains(t, seen, 2, "worker-1 should have observed the N=2 phase")
+
+	// NOTE on the bonus "unchanged-own-slice" sub-goal: with ConsistentHash over
+	// 12 partitions, adding worker-2 generally reshuffles worker-1's slice, so this
+	// test does not isolate the case where worker-1's own slice is unchanged. The
+	// pre-debounce hook placement (observeFleetSize runs in onUpdate BEFORE the
+	// apply debounce, so it fires even when this worker's slice does not change) is
+	// covered by the unit tests; the N=2 observation here is the live-NATS core
+	// proof that the wiring reaches ObserveWorkerCount at all.
+
+	// Cleanup is the deferred cluster.StopWorkers() (StateShutdown-guarded and
+	// non-fatal on teardown races); no explicit per-worker Stop needed.
+}
+
+// TestAdaptive_CommitChurnRaceClean is the monitor-goroutine concurrency stress
+// test required by AGENTS.md for any new work added to a watch/monitor goroutine.
+// The fleet-size feature adds an observeFleetSize call on the commit-watch
+// goroutine (manager_assignment.go onUpdate + onReconcile), which runs
+// concurrently with the production apply/heartbeat/election paths sharing nats.go
+// cached *stream state. The unit tests exercise observeFleetSize in isolation and
+// cannot find a race between it and those production paths.
+//
+// This test follows the manager_epoch_monitor_concurrency_test.go template:
+//   - Start a small real cluster (3 workers, embedded NATS) with each worker
+//     carrying a fleetObserverUpdater so the observeFleetSize → ObserveWorkerCount
+//     push is actually exercised (not short-circuited by a nil observer).
+//   - Drive ~5 seconds of repeated commit churn by cycling a worker out and back
+//     in, forcing the leader to republish commits (each republish flows through
+//     every worker's commit watcher and its observeFleetSize call).
+//   - Assert no -race trigger, no panic, and clean Stop.
+//
+// This is a PURE race gate: no rate-value or pacing assertion. Pacing is timing-
+// dependent and must never be asserted; correctness of the retune math lives in
+// the unit tests.
+func TestAdaptive_CommitChurnRaceClean(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	// Aggressive OperationTimeout drives the watch-session reconcile/monitor
+	// cadence high, maximising the number of commit-watch onUpdate/onReconcile
+	// invocations (each running observeFleetSize) during the soak window.
+	cfg := testutil.IntegrationTestConfig()
+	cfg.OperationTimeout = 50 * time.Millisecond
+
+	partitions := testutil.CreateTestPartitions(12)
+	src := source.NewStatic(partitions)
+	assignStrat := strategy.NewConsistentHash()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
+	defer cancel()
+
+	cluster := &testutil.WorkerCluster{
+		Workers:  make([]*parti.Manager, 0),
+		Config:   cfg,
+		Source:   src,
+		Strategy: assignStrat,
+		NC:       nc,
+		JS:       js,
+		T:        t,
+	}
+	defer cluster.StopWorkers()
+
+	// Every worker carries an observer so observeFleetSize actually pushes N on
+	// every commit it decodes — the push is the new work we want exercised under
+	// the race detector, not just the decode.
+	const numWorkers = 3
+	for range numWorkers {
+		cluster.AddWorkerWithOptions(ctx, parti.WithWorkerConsumerUpdater(&fleetObserverUpdater{}))
+	}
+
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(15 * time.Second)
+
+	// Drive ~5 seconds of commit churn. Each cycle removes a worker (leader
+	// recomputes and republishes a commit with N-1 workers) and adds a fresh one
+	// back (republish with N workers), so every surviving worker's commit watcher
+	// repeatedly runs observeFleetSize concurrently with heartbeat/election/apply
+	// traffic against the same KV buckets. The race detector trips on any
+	// unsynchronised cross-goroutine access exercised during this window.
+	soakCtx, soakCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer soakCancel()
+
+	churnCycles := 0 // single-writer (this goroutine only); diagnostic count
+	for soakCtx.Err() == nil {
+		// Remove the last worker (simulates a crash → fleet shrinks → republish).
+		idx := cluster.WorkerCount() - 1
+		if idx < 1 {
+			break
+		}
+		cluster.RemoveWorker(idx)
+
+		// Let the shrink commit propagate, bounded by the soak deadline.
+		if !waitOrDeadline(soakCtx, 300*time.Millisecond) {
+			break
+		}
+
+		// Add a fresh worker back (fleet grows → republish).
+		w := cluster.AddWorkerWithOptions(soakCtx, parti.WithWorkerConsumerUpdater(&fleetObserverUpdater{}))
+		if err := w.Start(soakCtx); err != nil {
+			// soakCtx may have expired mid-start; that is a benign end-of-soak,
+			// not a failure of the race gate.
+			break
+		}
+
+		churnCycles++
+
+		if !waitOrDeadline(soakCtx, 300*time.Millisecond) {
+			break
+		}
+	}
+
+	// Drain the remaining soak window so late deliveries to ObserveWorkerCount
+	// settle before the race check below.
+	<-soakCtx.Done()
+
+	t.Logf("commit-churn soak complete: %d churn cycles driven", churnCycles)
+
+	// The race gate: if the race detector or any sub-assertion fired during the
+	// concurrent soak, the test is already marked failed. t.Failed() is the most
+	// reliable in-body signal; Go also writes WARNING: DATA RACE to stderr at
+	// detection time.
+	require.False(t, t.Failed(),
+		"race detector or sub-assertion failed during the commit-churn soak; "+
+			"check stderr for WARNING: DATA RACE blocks around observeFleetSize / the commit watcher")
+}
+
+// waitOrDeadline sleeps for d unless ctx finishes first. It returns true if the
+// full duration elapsed and false if ctx was cancelled/expired during the wait —
+// letting the churn loop end cleanly at the soak deadline instead of sleeping
+// past it.
+func waitOrDeadline(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/test/integration/manager/claim_write_ratelimit_startup_test.go
+++ b/test/integration/manager/claim_write_ratelimit_startup_test.go
@@ -1,0 +1,143 @@
+package manager_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	partitesting "github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// claimWriteThrottleSpy implements types.HandoffMetricsRecorder plus the
+// optional claim-write throttle sidecar (matched structurally by the Manager),
+// so the test can observe that a configured claim-write rate limiter actually
+// paced the startup hygiene writes end-to-end through real NATS.
+type claimWriteThrottleSpy struct {
+	types.NopHandoffMetricsRecorder
+	mu        sync.Mutex
+	throttled int
+}
+
+func (s *claimWriteThrottleSpy) IncClaimWriteThrottled() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.throttled++
+}
+
+func (s *claimWriteThrottleSpy) ObserveClaimWriteThrottleWait(float64) {}
+
+func (s *claimWriteThrottleSpy) Throttled() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.throttled
+}
+
+// TestClaimWriteRateLimit_StartupHygienePaced is the end-to-end proof that the
+// HandoffConfig.ClaimWrite{PerSec,Burst} settings flow through the Manager build
+// into the startup hygiene loop and actually pace the physical claim-writes.
+//
+// It pre-seeds the handoff bucket with several expired non-stable claims, then
+// starts a Manager with a low claim-write rate (burst=1). The startup hygiene
+// pass resets each stale claim to stable; because the rate forces a wait on
+// every write after the first burst token, the throttle sidecar fires. The test
+// asserts (a) the manager reaches Stable, (b) the throttle metric incremented
+// (the limiter was on the path), and (c) the seeded claims were reset to stable.
+func TestClaimWriteRateLimit_StartupHygienePaced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := t.Context()
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const bucket = "parti-handoff"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	// Pre-seed N expired (TTL 1s, stamped 1h ago) prepare-state claims so the
+	// startup hygiene pass has real work to pace.
+	const n = 8
+	store := handoff.NewNATSClaimStore(kv, "claims/")
+	staleStamp := time.Now().UTC().Add(-time.Hour)
+	for i := range n {
+		pid := "seed-" + strconv.Itoa(i)
+		claim := handoff.Claim{
+			PartitionID: pid,
+			Owner:       "dead-worker",
+			State:       handoff.ClaimStatePrepare,
+			Epoch:       1,
+			TTLSeconds:  1,
+			LastUpdated: staleStamp,
+		}
+		_, perr := store.PutIfEpoch(ctx, pid, 0, claim)
+		require.NoError(t, perr)
+	}
+
+	cfg := parti.TestConfig()
+	cfg.WorkerIDPrefix = "cwrl-w"
+	cfg.WorkerIDMax = 10
+	cfg.StartupTimeout = 30 * time.Second
+	cfg.OperationTimeout = 5 * time.Second // generous: paced hygiene must finish within it
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.KVBuckets.HandoffBucket = bucket
+	cfg.KVBuckets.HandoffTTL = 2 * time.Minute
+	// Low rate, burst 1: the first write draws the token immediately, every
+	// subsequent write waits (~50ms at 20/s) → the throttle sidecar fires.
+	cfg.Handoff.ClaimWritePerSec = 20
+	cfg.Handoff.ClaimWriteBurst = 1
+
+	partitions := []parti.Partition{{Keys: []string{"a"}}, {Keys: []string{"b"}}}
+	src := source.NewStatic(partitions)
+	chStrat := strategy.NewConsistentHash()
+	spy := &claimWriteThrottleSpy{}
+
+	mgr, err := parti.NewManager(&cfg, js, src, chStrat,
+		parti.WithHandoffMetricsRecorder(spy),
+	)
+	require.NoError(t, err)
+
+	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer startCancel()
+	require.NoError(t, mgr.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = mgr.Stop(stopCtx)
+	})
+
+	require.NoError(t, <-mgr.WaitState(parti.StateStable, 30*time.Second),
+		"manager must reach Stable after paced startup hygiene")
+
+	// The limiter must have been on the write path (burst=1 forces waits).
+	assert.Positive(t, spy.Throttled(),
+		"paced startup hygiene must increment the claim-write throttle metric")
+
+	// All seeded stale claims (owner "dead-worker") must have been reset to
+	// stable by the paced hygiene pass. The manager's own initial apply may add
+	// further claims for partitions a/b, so filter to the seeded owner.
+	claims, err := mgr.InspectHandoffClaims(ctx)
+	require.NoError(t, err)
+	seeded := 0
+	for _, c := range claims {
+		if c.Owner != "dead-worker" {
+			continue
+		}
+		seeded++
+		assert.Equalf(t, parti.HandoffClaimStable, c.State,
+			"seeded claim %q must be reset to stable by paced hygiene", c.PartitionID)
+	}
+	require.Equal(t, n, seeded, "all seeded claims should still be present and inspected")
+}


### PR DESCRIPTION
## Summary

Completes the **v2.8.0 rate-limiting** work. Building on the per-worker consumer-create limit already on `main`, this branch adds a per-worker **claim-write** limit and, the headline of this PR, **fleet-size-aware (adaptive)** variants of both limits.

### Why adaptive

The per-worker limits fire on *every* worker (Parti's apply is decentralized), so the cluster-wide aggregate is `N × per_worker_rate` — operationally uncontrollable, since the worker count `N` can be 1 or 30. The adaptive variants let operators bound the **aggregate** instead.

### Mechanism

Each worker observes the committed worker-count `N = len(commit.Workers)` live and retunes its limiters to:

```
effective_rate = min(perWorkerMax, clusterRate / N)
```

This bounds the **steady-state** cluster-wide rate to the configured `clusterRate`, while the per-worker ceiling bounds the transient during fleet-size changes. (Aggregate *burst* is `Σ` per-worker burst, and the bound is steady-state, not instantaneous — documented honestly.)

- **consumer-create:** `consumer.WithConsumerCreateClusterRate(clusterPerSec)` — overlay on `WithConsumerCreateRate`.
- **claim-write:** `parti.HandoffConfig.ClaimWriteClusterRate`.
- `clusterRate == 0` (default) ⇒ byte-for-byte the existing static behavior.

`N` is observed at the **pre-debounce commit-decode point**, so a fleet change that does *not* alter this worker's own partition slice still retunes it. The observation is **freshness-fenced on leader-revision + version** (mirroring the apply path's stale-leader reject), so a stale or split-brain commit cannot regress `N`. Claim-write retunes manager-locally; consumer-create config lives on the consumer, so the manager pushes `N` through a new optional `FleetSizeObserver` interface (a mirror of the existing `CapabilityReporter`), forwarded and replayed to late children by the composite updater.

### Commits (scope-pure)

- `feat(handoff)` — per-worker claim-write rate limit
- `fix(consumer)` — make the injectable consumer-create limiter usable externally
- `docs(plans)` — design spec + implementation plan
- `feat(ratelimit)` — runtime `SetRate` + shared `EffectiveRate`
- `feat(consumer)` — `WithConsumerCreateClusterRate`
- `feat(manager)` — fleet-size observation + adaptive `ClaimWriteClusterRate` + composite forwarding
- `test(integration)` / `docs`

### Testing

- **Unit:** rate math, the freshness fence (including a stale-leader regression test), config/option validation, composite forwarding + late-add replay, and the pre-debounce wiring (via a fake watcher).
- **Integration (`-race`):** end-to-end fleet-growth observation and a commit-churn race-stress (the monitor-goroutine rule).
- `make pre-pr` green (lint + unit `-race` + live-NATS integration `-race`); the 4 cross-feature contracts hold; each commit builds (bisectable).

### Review

Design, implementation plan, and the implementation each went through a cross-model review loop (codex `gpt-5.5`, ≠ implementer) to consensus, plus per-task spec + code-quality reviews. The cross-model impl review caught and fixed a real correctness bug — the freshness fence was version-primary and would have accepted a split-brain stale-leader commit (higher Version, lower LeaderRevision), regressing `N`; now gated on leader-revision with a red-green regression test.

> Targets **v2.8.0** (additive, opt-in, default-off). At release: rename CHANGELOG `## [Unreleased]` → `## [v2.8.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
