### PR TITLE
test: fix flaky LSR-before-snapshot ordering test (reader read-order)

### DIFF
--- a/manager_commit_state_machine_test.go
+++ b/manager_commit_state_machine_test.go
@@ -857,11 +857,20 @@ func TestApplyAssignment_LSRAdvancesBeforeSnapshotStore(t *testing.T) {
 			Partitions:     []Partition{{Keys: []string{"beta"}}},
 		}
 
-		// Launch a tight-loop reader BEFORE applyAssignment. The reader
-		// records (Version, LSR) tuples as fast as it can; with the
-		// LSR-before-Store fix it should never observe Version == newAsgn.Version
-		// with LSR < newAsgn.LeaderRevision. The OLD order had a tiny
-		// Store→LSR window that this loop could occasionally catch.
+		// Launch a tight-loop reader BEFORE applyAssignment. To verify the
+		// "new snapshot implies an already-advanced LSR" invariant, the reader
+		// MUST read the snapshot FIRST and the LSR SECOND. Production advances
+		// LSR before it stores the snapshot (updateLastSeenLeaderRevision then
+		// m.assignment.Store), so once the reader observes the new snapshot, a
+		// subsequent LSR read is guaranteed to see the advanced LSR.
+		//
+		// Reading LSR first would be WRONG and is what made this test flaky: the
+		// reader could latch the OLD LSR, then production could advance LSR and
+		// store the snapshot, and the later snapshot read would yield a spurious
+		// (new snapshot, old LSR) tuple even though production ordered its two
+		// stores correctly. With snapshot-then-LSR, the only way to sample
+		// (new snapshot, old LSR) is if production stored the snapshot BEFORE
+		// advancing LSR — the actual regression this test guards.
 		var (
 			readerStop atomic.Bool
 			readerWG   sync.WaitGroup
@@ -871,8 +880,8 @@ func TestApplyAssignment_LSRAdvancesBeforeSnapshotStore(t *testing.T) {
 		readerWG.Go(func() {
 			close(ready)
 			for !readerStop.Load() {
-				lsr := m.lastSeenLeaderRevision.Load()
 				cur := m.CurrentAssignment()
+				lsr := m.lastSeenLeaderRevision.Load()
 				if cur.Version == newAsgn.Version && lsr < newAsgn.LeaderRevision {
 					badObs.Add(1)
 				}


### PR DESCRIPTION
## Summary

`bc21fc2`'s `lint-unit` check on `main` failed — not on lint (`golangci-lint found no issues`) but on a **flaky unit test**: `TestApplyAssignment_LSRAdvancesBeforeSnapshotStore/concurrent_reader_never_observes_(new_snapshot,_old_LSR)`. The current `main` HEAD is green; this fixes the underlying flake so it can't recur.

## Root cause — test bug, not a production bug

Production is correct: `applyAssignment` advances `lastSeenLeaderRevision` **before** `m.assignment.Store` (`manager_assignment.go:1568→1571`), so "new snapshot ⟹ advanced LSR" holds.

The test's concurrent reader read **LSR first, then the snapshot**. That order can't verify the invariant: the reader may latch the *old* LSR, then production advances LSR *and* stores the snapshot, then the reader reads the *new* snapshot — yielding a spurious `(new snapshot, old LSR)` sample even though production ordered its two stores correctly. A ~2% false-positive flake under `-race` (reproduced: **6 failures in 300 runs**).

## Fix

Read the **snapshot first, then the LSR**. Once the new snapshot is observed, the prior LSR advance is guaranteed visible (sequentially-consistent atomics), so the only way to sample the bad tuple is a genuine `Store`-before-LSR regression.

## Verification

- Fixed test: **0 failures in 500 runs** under `-race` (was ~2%).
- Red-green: temporarily inverting the production order (`Store` before LSR advance) makes the corrected test **fail reliably** ("Store happened before LSR advanced") — it still catches the real regression. Reverted.
- `make lint` clean; full root-package unit suite `-race` green.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
