### PR TITLE
fix(assignment): suppress heartbeat-watcher scans for routine refreshes

### DIFF
--- a/internal/assignment/calculator_audit_test.go
+++ b/internal/assignment/calculator_audit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/partitest"
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
 )
@@ -732,24 +733,27 @@ func fullCapsAck(leaderRev uint64, appliedVer int64, srcRev uint64, srcKnown boo
 
 // --- merged from calculator_enumeration_stall_test.go ---
 
-// keysTimeoutKV wraps a real jetstream.KeyValue and, when armed, makes Keys()
-// return context.DeadlineExceeded while every other operation — notably the
+// keysFaultKV wraps a real jetstream.KeyValue and, when armed, makes Keys()
+// return the configured err while every other operation — notably the
 // single-key Put/Get a worker uses for its own heartbeat — passes through to
-// the real bucket unchanged. This is NP-10's defining asymmetry: the
-// stream-wide heartbeat-enumeration scan times out, single-key ops do not.
+// the real bucket unchanged. Configuring err as context.DeadlineExceeded
+// models NP-10's defining asymmetry: the stream-wide heartbeat-enumeration
+// scan times out, single-key ops do not. Configuring err as a connectivity
+// error (e.g. nats.ErrConnectionClosed) models the §5.4 connectivity row.
 //
-// The wrapper returns the deadline directly rather than blocking on ctx so the
-// calculator-level proof is deterministic and timing-free; the resulting error
-// value is identical to what a real Keys scan returns when WorkerMonitor's
-// bounded op-context (hbTTL/2) expires mid-scan.
-type keysTimeoutKV struct {
+// The wrapper returns err directly rather than blocking on ctx so the
+// calculator-level proof is deterministic and timing-free; the deadline
+// variant's error value is identical to what a real Keys scan returns when
+// WorkerMonitor's bounded op-context (hbTTL/2) expires mid-scan.
+type keysFaultKV struct {
 	jetstream.KeyValue
 	armed atomic.Bool
+	err   error
 }
 
-func (k *keysTimeoutKV) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+func (k *keysFaultKV) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
 	if k.armed.Load() {
-		return nil, context.DeadlineExceeded
+		return nil, k.err
 	}
 
 	return k.KeyValue.Keys(ctx, opts...)
@@ -814,7 +818,7 @@ func TestNP10_GetActiveWorkers_EnumerationDeadline_IsSwallowed(t *testing.T) {
 	_, err := heartbeatKV.Put(ctx, "worker-hb.worker-1", []byte(time.Now().Format(time.RFC3339Nano)))
 	require.NoError(t, err)
 
-	fault := &keysTimeoutKV{KeyValue: heartbeatKV}
+	fault := &keysFaultKV{KeyValue: heartbeatKV, err: context.DeadlineExceeded}
 	calc, err := NewCalculator(&Config{
 		AssignmentKV:     assignmentKV,
 		HeartbeatKV:      fault,
@@ -865,7 +869,7 @@ func TestNP10_GetActiveWorkers_SustainedEnumerationDeadline_FiresCallback(t *tes
 	_, err := heartbeatKV.Put(ctx, "worker-hb.worker-1", []byte(time.Now().Format(time.RFC3339Nano)))
 	require.NoError(t, err)
 
-	fault := &keysTimeoutKV{KeyValue: heartbeatKV}
+	fault := &keysFaultKV{KeyValue: heartbeatKV, err: context.DeadlineExceeded}
 	var enumErr, enumOK atomic.Int64
 	calc, err := NewCalculator(&Config{
 		AssignmentKV:                assignmentKV,
@@ -901,4 +905,42 @@ func TestNP10_GetActiveWorkers_SustainedEnumerationDeadline_FiresCallback(t *tes
 	_, _, err = calc.getActiveWorkers(ctx)
 	require.NoError(t, err)
 	require.Positive(t, enumOK.Load(), "a healthy enumeration must signal recovery via OnEnumerationSuccess")
+}
+
+// TestGetActiveWorkers_ConnectivityErrorBypassesStallCounter pins the
+// §5.4 connectivity row: a connectivity-classified enumeration failure
+// takes the cache-fallback path and must NOT feed the enumeration-stall
+// counter (that class stays owned by the heartbeat-Put circuit).
+func TestGetActiveWorkers_ConnectivityErrorBypassesStallCounter(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	assignmentKV := partitest.CreateJetStreamKV(t, nc, "connfb-assign")
+	heartbeatKV := partitest.CreateJetStreamKV(t, nc, "connfb-hb")
+
+	_, err := heartbeatKV.Put(ctx, "worker-hb.worker-1", []byte(time.Now().Format(time.RFC3339Nano)))
+	require.NoError(t, err)
+
+	fault := &keysFaultKV{KeyValue: heartbeatKV, err: nats.ErrConnectionClosed}
+	var enumErr atomic.Int64
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:                assignmentKV,
+		HeartbeatKV:                 fault,
+		AssignmentPrefix:            "assignment",
+		Source:                      &mockSource{partitions: []types.Partition{{Keys: []string{"p1"}}}},
+		Strategy:                    &mockStrategy{},
+		HeartbeatPrefix:             "worker-hb",
+		HeartbeatTTL:                6 * time.Second,
+		EnumerationFailureThreshold: 1, // even threshold=1 must not fire on connectivity errors
+		OnEnumerationError:          func(error) { enumErr.Add(1) },
+	})
+	require.NoError(t, err)
+
+	fault.armed.Store(true)
+	for range 3 {
+		_, _, _ = calc.getActiveWorkers(ctx)
+	}
+	require.Zero(t, enumErr.Load(),
+		"connectivity-classified enumeration failures must bypass the stall counter (cache-fallback path)")
 }

--- a/internal/assignment/calculator_test.go
+++ b/internal/assignment/calculator_test.go
@@ -647,7 +647,7 @@ func TestGetActiveWorkers_EnumRecoverySignalsBeforeCredibilityGate(t *testing.T)
 		require.NoError(t, err)
 	}
 
-	fault := &keysTimeoutKV{KeyValue: heartbeatKV}
+	fault := &keysFaultKV{KeyValue: heartbeatKV, err: context.DeadlineExceeded}
 	var enumErr, enumOK atomic.Int64
 	calc, err := NewCalculator(&Config{
 		AssignmentKV:                         assignmentKV,

--- a/internal/assignment/worker_monitor.go
+++ b/internal/assignment/worker_monitor.go
@@ -21,11 +21,38 @@ var (
 	workerWatcherJitter      = 0.3 // ±30%
 )
 
+// suppressionHolidayFactor scales HeartbeatTTL into the suppression-holiday
+// length opened by sweepExpired. 3×hbTTL covers the single-serialization
+// worst-case emergency-confirmation chain:
+//
+//	firstSeen ≤ flag + 100ms (debounce) + hbTTL/2 (pollMu wait: one
+//	in-flight observation) + hbTTL/2 (own scan, boundedOpCtx)
+//	deadline  ≤ firstSeen + EmergencyGracePeriod (≤ HeartbeatTTL —
+//	enforced by the PUBLIC parti.Config.Validate ltefield tag; the
+//	internal assignment.Config does NOT re-enforce it, so direct
+//	internal constructions must respect it themselves)
+//	confirming entry ≤ deadline + HeartbeatInterval (≤ hbTTL/2)
+//	              ≤ flag + 2.5×hbTTL + 100ms  < flag + 3×hbTTL
+//	              (margin positive for hbTTL > 200ms; valid sub-200ms
+//	              TTLs route through the polling backstop below, whose
+//	              hbTTL/2 bound is faster than the debounce there)
+//
+// Deeper adversarial pollMu stacking falls to the polling backstop
+// (+hbTTL/2) — the same worst-case bound the pre-suppression code
+// degrades to under identical stacking. Do not shorten: 1×hbTTL fails
+// at EmergencyGracePeriod == HeartbeatTTL; 2×hbTTL fails once the
+// pollMu wait term is modeled.
+const suppressionHolidayFactor = 3
+
 // WorkerMonitor handles worker health detection via NATS KV heartbeats.
 //
 // It provides hybrid monitoring:
-//   - Watcher (primary): Fast detection <100ms via NATS KV Watch
-//   - Polling (fallback): Reliable detection ~1.5s via periodic KV scan
+//   - Watcher (primary): Fast detection <100ms via NATS KV Watch.
+//     Routine heartbeat refreshes are classified against a session-local
+//     lastSeen map and suppressed (no check, no Keys() scan); joins,
+//     graceful leaves, and sweep-detected silent expiries trigger checks.
+//   - Polling (fallback): Reliable detection ~hbTTL/2 via periodic KV
+//     scan; the ground-truth path for silent TTL expiry.
 //
 // The monitor runs in a background goroutine and invokes a callback
 // when worker topology changes are detected.
@@ -47,6 +74,10 @@ type WorkerMonitor struct {
 	// Defaults to workerWatcherBaseBackoff; tests may set a smaller value
 	// on the struct before calling Start to avoid racy global mutations.
 	watchBaseBackoff time.Duration
+
+	// now returns the current time for watcher-entry classification and
+	// the expiry sweep. Defaults to time.Now; tests inject a fake clock.
+	now func() time.Time
 
 	// Lifecycle management
 	mu      sync.Mutex
@@ -82,6 +113,7 @@ func NewWorkerMonitor(
 		onChangeCb:       onChange,
 		logger:           logger,
 		watchBaseBackoff: workerWatcherBaseBackoff,
+		now:              time.Now,
 		stopCh:           make(chan struct{}),
 		doneCh:           make(chan struct{}),
 	}
@@ -351,7 +383,19 @@ func (m *WorkerMonitor) processWatcherEvents(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start heartbeat watcher: %w", err)
 	}
+	// Watcher-session-local classification state: suppressedCount,
+	// lastSeen, and unsuppressedUntil are owned exclusively by this
+	// goroutine and rebuilt from the initial replay after every watcher
+	// restart, so no staleness survives a session boundary. A PUT of a
+	// key last seen < hbTTL ago is a refresh — the worker was
+	// continuously alive, so topology cannot have changed and the
+	// (expensive) Keys()-scan check is skipped. Unknown/stale PUTs
+	// (joins) and DELETE/PURGE (graceful leaves) trigger as before.
+	var suppressedCount uint64
+	lastSeen := make(map[string]time.Time)
+	var unsuppressedUntil time.Time
 	defer func() {
+		m.logger.Debug("watcher session ended", "suppressed_refreshes", suppressedCount)
 		if serr := watcher.Stop(); serr != nil && !natsutil.IsBenignWatcherStopErr(serr) {
 			m.logger.Warn("failed to stop heartbeat watcher", "error", serr)
 		}
@@ -383,7 +427,32 @@ func (m *WorkerMonitor) processWatcherEvents(ctx context.Context) error {
 				continue
 			}
 			m.logger.Debug("watcher: received entry", "key", entry.Key(), "operation", entry.Operation())
-			if !pendingCheck {
+
+			now := m.now()
+			trigger := true
+			switch entry.Operation() {
+			case jetstream.KeyValuePut:
+				key := entry.Key()
+				prev, known := lastSeen[key]
+				lastSeen[key] = now
+				// hbTTL==0: now.Sub(prev) is never negative under a forward
+				// clock, so this never suppresses — mirrors the explicit
+				// guard in sweepExpired.
+				if known && now.Sub(prev) < m.hbTTL && now.After(unsuppressedUntil) {
+					// Refresh under active suppression: worker was
+					// continuously alive; skip the check.
+					trigger = false
+					suppressedCount++
+				}
+			case jetstream.KeyValueDelete, jetstream.KeyValuePurge:
+				delete(lastSeen, entry.Key())
+			}
+
+			if m.sweepExpired(lastSeen, now, &unsuppressedUntil) {
+				trigger = true
+			}
+
+			if trigger && !pendingCheck {
 				pendingCheck = true
 				debounceTimer.Reset(100 * time.Millisecond)
 			}
@@ -399,4 +468,41 @@ func (m *WorkerMonitor) processWatcherEvents(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// sweepExpired flags tracked workers whose heartbeat key must have
+// expired server-side (no PUT received for ≥ hbTTL). Flagged entries are
+// removed from lastSeen (a later PUT from the same worker classifies as
+// a join). When anything is flagged it opens a suppression holiday of
+// suppressionHolidayFactor×hbTTL so follow-up observation — including
+// emergency-grace progression and confirmation — runs at the
+// pre-suppression refresh-triggered cadence for the crash window.
+//
+// lastSeen records receive time, which trails server publish time, so a
+// delayed delivery can flag a still-alive worker (false flag). That is
+// safe by construction: the triggered check performs a real Keys() scan
+// and an unchanged worker set short-circuits; the cost is one extra
+// check when the flagged worker's next PUT re-joins.
+//
+// hbTTL == 0 disables the sweep (direct unit seams only; Start requires
+// a positive hbTTL for its polling ticker).
+func (m *WorkerMonitor) sweepExpired(lastSeen map[string]time.Time, now time.Time, unsuppressedUntil *time.Time) bool {
+	if m.hbTTL == 0 {
+		return false
+	}
+	holidayUntil := now.Add(suppressionHolidayFactor * m.hbTTL)
+	flagged := false
+	for k, seen := range lastSeen {
+		if now.Sub(seen) >= m.hbTTL {
+			delete(lastSeen, k)
+			flagged = true
+			m.logger.Debug("watcher: heartbeat key expired without event; forcing check",
+				"key", k, "holiday_until", holidayUntil)
+		}
+	}
+	if flagged {
+		*unsuppressedUntil = holidayUntil
+	}
+
+	return flagged
 }

--- a/internal/assignment/worker_monitor_test.go
+++ b/internal/assignment/worker_monitor_test.go
@@ -467,6 +467,20 @@ type fakeKV struct {
 	currentWatcher *fakeKeyWatcher
 	// keysBlocking, when true, causes Keys to block until ctx.Done().
 	keysBlocking bool
+	// keys is the server-side truth returned by Keys when keysBlocking is
+	// false. The zero value (nil) preserves the pre-existing behavior of
+	// every test that does not call SetKeys: Keys returns (nil, nil), which
+	// GetActiveWorkers treats as an empty worker set.
+	keys []string
+}
+
+// SetKeys configures the key list returned by a subsequent (non-blocking)
+// Keys call. Safe for concurrent use: GetActiveWorkers may call Keys from a
+// callback goroutine while the test goroutine drives the watcher loop.
+func (f *fakeKV) SetKeys(keys []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.keys = keys
 }
 
 func (f *fakeKV) WatchCallCount() int {
@@ -503,7 +517,10 @@ func (f *fakeKV) Keys(ctx context.Context, _ ...jetstream.WatchOpt) ([]string, e
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	return nil, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.keys, nil
 }
 
 // Unimplemented stubs required by the jetstream.KeyValue interface.
@@ -607,4 +624,613 @@ func TestWorkerMonitor_GetActiveWorkers_BoundedTimeout(t *testing.T) {
 	// Elapsed should be roughly fakeTTL/2 (100ms). Allow 3× for CI headroom.
 	require.Less(t, elapsed, 3*fakeTTL,
 		"GetActiveWorkers returned too late (%v); expected ~%v", elapsed, fakeTTL/2)
+}
+
+// fakeKVEntry is a minimal jetstream.KeyValueEntry double for driving
+// processWatcherEvents directly.
+type fakeKVEntry struct {
+	key string
+	op  jetstream.KeyValueOp
+}
+
+func (e *fakeKVEntry) Bucket() string                  { return "fake" }
+func (e *fakeKVEntry) Key() string                     { return e.key }
+func (e *fakeKVEntry) Value() []byte                   { return nil }
+func (e *fakeKVEntry) Revision() uint64                { return 0 }
+func (e *fakeKVEntry) Created() time.Time              { return time.Time{} }
+func (e *fakeKVEntry) Delta() uint64                   { return 0 }
+func (e *fakeKVEntry) Operation() jetstream.KeyValueOp { return e.op }
+
+// watcherSession drives one processWatcherEvents session against fakeKV.
+type watcherSession struct {
+	push func(jetstream.KeyValueEntry) // blocks until the loop consumes the entry
+	stop func()                        // cancels the session and waits for exit
+}
+
+// startWatcherSession starts processWatcherEvents in a goroutine and returns
+// a session handle. The fakeKV's unbuffered updates channel means push()
+// returns only after the loop has received (though not necessarily fully
+// processed) the entry.
+func startWatcherSession(t *testing.T, m *WorkerMonitor, kv *fakeKV) *watcherSession {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = m.processWatcherEvents(ctx)
+	}()
+	// Wait for the session's Watch call so currentWatcher is set.
+	require.Eventually(t, func() bool { return kv.WatchCallCount() >= 1 }, time.Second, time.Millisecond)
+
+	return &watcherSession{
+		push: func(e jetstream.KeyValueEntry) {
+			kv.mu.Lock()
+			w := kv.currentWatcher
+			kv.mu.Unlock()
+			require.NotNil(t, w)
+			select {
+			case w.updates <- e:
+			case <-time.After(2 * time.Second):
+				t.Fatal("watcher loop did not consume entry")
+			}
+		},
+		stop: func() {
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("watcher session did not exit")
+			}
+		},
+	}
+}
+
+// newFakeClockAt returns the package's fakeClock (see newFakeClock in
+// calculator_state_test.go) initialized to start rather than time.Now(), so
+// classifier tests below can pin the same documented base times used
+// throughout this file. fakeClock is mutex-guarded, so — unlike the
+// atomic.Pointer[time.Time] machinery this replaces — Advance/Now are safe
+// to call from the test goroutine while the watcher goroutine concurrently
+// reads via m.now.
+func newFakeClockAt(start time.Time) *fakeClock {
+	c := newFakeClock()
+	c.Advance(start.Sub(c.Now()))
+
+	return c
+}
+
+// newClassifierMonitor builds a monitor wired to a fake clock and an
+// onChange counter, suitable for driving processWatcherEvents directly.
+func newClassifierMonitor(hbTTL time.Duration, clock *fakeClock) (*WorkerMonitor, *fakeKV, *atomic.Int32) {
+	kv := &fakeKV{}
+	var calls atomic.Int32
+	m := NewWorkerMonitor(kv, "worker", hbTTL,
+		func(ctx context.Context) error { calls.Add(1); return nil },
+		logging.NewNop(),
+	)
+	m.now = clock.Now
+
+	return m, kv, &calls
+}
+
+// waitDebounce sleeps past the 100ms debounce window plus scheduling slack.
+func waitDebounce() { time.Sleep(250 * time.Millisecond) }
+
+func TestWorkerMonitor_RefreshSuppressed(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// First PUT of w1 is a join → one check.
+	s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load(), "first PUT (join) must trigger one check")
+
+	// Refreshes within hbTTL: advance clock 3s per beat, push 3 refreshes.
+	for i := 0; i < 3; i++ {
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load(), "refresh PUTs within hbTTL must be suppressed (no additional checks)")
+}
+
+func TestWorkerMonitor_JoinAndLeaveTrigger(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValuePut}) // join
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load())
+
+	s.push(&fakeKVEntry{key: "worker.w2", op: jetstream.KeyValuePut}) // another join
+	waitDebounce()
+	require.EqualValues(t, 2, calls.Load(), "unknown-key PUT must trigger")
+
+	s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValueDelete}) // graceful leave
+	waitDebounce()
+	require.EqualValues(t, 3, calls.Load(), "DELETE must trigger")
+
+	s.push(&fakeKVEntry{key: "worker.w2", op: jetstream.KeyValuePurge}) // purge
+	waitDebounce()
+	require.EqualValues(t, 4, calls.Load(), "PURGE must trigger")
+}
+
+func TestWorkerMonitor_StaleRejoinTriggers(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValuePut}) // join
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load())
+
+	// Gap > hbTTL: the worker's key must have expired server-side; the next
+	// PUT is a re-join and must trigger. This is a single stale key with no
+	// other tracked worker, so the PUT itself updates lastSeen[key] = now
+	// BEFORE sweepExpired runs (worker_monitor.go:434-452) — the same key
+	// can no longer be found stale by the sweep in the same event. The
+	// check fires from classification (join) alone, so exactly one
+	// additional check is expected.
+	clock.Advance(11 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.EqualValues(t, 2, calls.Load(), "PUT after >hbTTL gap must trigger exactly once (re-join)")
+}
+
+func TestWorkerMonitor_ZeroTTLAlwaysTriggers(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	// hbTTL == 0: direct unit seam only (Start would panic on ticker);
+	// every PUT must classify as join, reproducing pre-change behavior.
+	m, kv, calls := newClassifierMonitor(0, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	for i := 0; i < 3; i++ {
+		s.push(&fakeKVEntry{key: "worker.w1", op: jetstream.KeyValuePut})
+		waitDebounce()
+	}
+	require.EqualValues(t, 3, calls.Load(), "hbTTL==0 must trigger on every PUT (no suppression)")
+}
+
+func TestWorkerMonitor_SweepFlagsExpiredWorker(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// Join A and B.
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce()
+	joins := calls.Load()
+
+	// B refreshes on a 3s beat; A goes silent. When B's refresh arrives
+	// with A stale (>= hbTTL since A's lastSeen), the sweep must flag A
+	// and force a check even though B's PUT alone is a suppressed refresh.
+	for i := 0; i < 3; i++ { // t=+3s,+6s,+9s — A not yet stale, suppressed
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	require.Equal(t, joins, calls.Load(), "no check while A is within hbTTL and B refreshes")
+
+	clock.Advance(3 * time.Second) // t=+12s — A stale (12s >= 10s)
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.Equal(t, joins+1, calls.Load(), "sweep must force a check when a tracked worker exceeds hbTTL")
+}
+
+func TestWorkerMonitor_HolidayUnsuppressesThenResumes(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce()
+
+	// Make A stale → sweep fires at B's next refresh, opening a 3×hbTTL holiday.
+	clock.Advance(11 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce()
+	afterFlag := calls.Load()
+
+	// During the holiday every refresh triggers (crash-window behavior
+	// identical to pre-change code).
+	for i := 0; i < 3; i++ {
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+		waitDebounce()
+	}
+	require.Equal(t, afterFlag+3, calls.Load(), "refreshes during the holiday must trigger checks")
+
+	// Advance past the holiday (3×hbTTL = 30s from the flag at t=+11s,
+	// i.e. until t=+41s) with B fresh — suppression resumes. Beat every
+	// 3s so B never goes stale itself: pushes land at t=+23..+44s.
+	for i := 0; i < 8; i++ {
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	settled := calls.Load()
+	clock.Advance(3 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.Equal(t, settled, calls.Load(), "after the holiday, refreshes are suppressed again")
+}
+
+func TestWorkerMonitor_OverlappingCrashExtendsHoliday(t *testing.T) {
+	t.Parallel()
+	// A second worker crossing staleness DURING an open holiday must be
+	// swept too, and sweeping re-stamps unsuppressedUntil — the holiday
+	// EXTENDS. During a holiday every refresh triggers anyway, so the
+	// only observable that discriminates the second sweep is whether
+	// refreshes still trigger AFTER the first holiday would have ended.
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// Joins at t=0.
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	waitDebounce()
+
+	// Keep B and C fresh through t=+9s while A goes silent.
+	for i := 0; i < 3; i++ { // pushes at +3, +6, +9
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+		s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+
+	// t=+12s: A stale (12s ≥ 10s), B fresh (3s) → sweep flags ONLY A.
+	// First holiday: until +12+30 = +42s.
+	clock.Advance(3 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	waitDebounce()
+
+	// B goes silent after its +9s beat. C beats on: at t=+21s the sweep
+	// finds B stale (12s since +9s) → flags B → holiday RE-STAMPED to
+	// +21+30 = +51s.
+	for i := 0; i < 3; i++ { // C pushes at +15, +18, +21
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+
+	// C beats through the ORIGINAL holiday end (+42s): pushes at
+	// +24..+45s. Settle, then probe.
+	for i := 0; i < 8; i++ {
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	settled := calls.Load()
+
+	// Probe 1 — t=+48s: AFTER the first holiday (+42s) but INSIDE the
+	// extension (+51s): a C refresh must STILL trigger. This is the
+	// discriminator: without B's sweep-extension, this push would be
+	// suppressed.
+	clock.Advance(3 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.Equal(t, settled+1, calls.Load(),
+		"refresh after the first holiday's end must still trigger — the second crash extended the holiday")
+
+	// Probe 2 — t=+54s: past the extension (+51s): suppressed again.
+	clock.Advance(6 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.c", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.Equal(t, settled+1, calls.Load(), "suppression resumes after the extended holiday")
+
+	// B's rejoin after being swept classifies as a join and triggers.
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce()
+	require.Equal(t, settled+2, calls.Load(), "swept worker's rejoin must classify as join and trigger")
+}
+
+func TestWorkerMonitor_FalseFlagSelfCorrects(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+
+	kv := &fakeKV{}
+	var calls atomic.Int32
+	release := make(chan struct{})
+	m := NewWorkerMonitor(kv, "worker", 10*time.Second,
+		func(ctx context.Context) error {
+			calls.Add(1)
+			if calls.Load() == 2 { // block only the sweep-triggered check
+				<-release
+			}
+			return nil
+		},
+		logging.NewNop(),
+	)
+	m.now = clock.Now
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce() // check #1 (joins coalesced)
+
+	// Keep B FRESH with 3s beats while A goes silent. These are suppressed
+	// refreshes — no checks. Critical for the discriminator below: B must
+	// never itself classify as stale, so the only thing that can force a
+	// check at t=+12s is the sweep flagging A.
+	for i := 0; i < 3; i++ { // pushes at +3, +6, +9
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load(), "B's fresh refreshes must stay suppressed while A ages")
+
+	// t=+12s: B's entry is a fresh refresh (3s since its last beat) —
+	// suppressed by classification alone. The sweep, however, finds A
+	// stale (12s ≥ hbTTL) and forces check #2: this assertion FAILS if
+	// sweepExpired does not exist or does not fire. (False-flag framing:
+	// locally-stale lastSeen[a] simulates delivery delay; A may be alive
+	// server-side.) The callback blocks at check #2.
+	clock.Advance(3 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	require.Eventually(t, func() bool { return calls.Load() == 2 },
+		2*time.Second, 5*time.Millisecond,
+		"sweep must force a check off B's suppressed refresh when A is locally stale")
+
+	// A's own delayed PUT arrives while the callback blocks. Push from a
+	// goroutine: the loop is busy in onChangeCb, so this send parks until
+	// the callback returns.
+	pushed := make(chan struct{})
+	go func() {
+		defer close(pushed)
+		kv.mu.Lock()
+		w := kv.currentWatcher
+		kv.mu.Unlock()
+		w.updates <- &fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut}
+	}()
+
+	close(release) // unblock check #2
+	select {
+	case <-pushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued entry was not consumed after callback release")
+	}
+	waitDebounce()
+	// A was swept from lastSeen, so its delayed PUT is a join → check #3.
+	// Self-correction: the triggered check's real scan (in production)
+	// observes A alive; at this unit level we pin the classification and
+	// trigger behavior only — see TestWorkerMonitor_FalseFlagSelfCorrectsWithLiveScan
+	// for the companion test that proves the scan/emergency half.
+	require.EqualValues(t, 3, calls.Load(), "swept-then-reappearing worker must re-trigger exactly once (join)")
+}
+
+// TestWorkerMonitor_FalseFlagSelfCorrectsWithLiveScan is the companion to
+// TestWorkerMonitor_FalseFlagSelfCorrects: it proves the scan/emergency half
+// that the classification-only test above documents as out of scope. Server
+// truth (the fake KV's key list) holds A and B alive for the whole test —
+// only A's LOCAL lastSeen goes stale (simulating a delivery delay) — so the
+// sweep's flag on A is a false flag by construction. The onChange callback
+// wired here mirrors the real reconciliation shape used by
+// Calculator.observeAndDecideLocked (calculator.go:1017-1049): a fresh
+// GetActiveWorkers scan feeds a real EmergencyDetector.CheckEmergency, and
+// because A is visible in curr, the detector must clear it and claim
+// nothing.
+func TestWorkerMonitor_FalseFlagSelfCorrectsWithLiveScan(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+
+	kv := &fakeKV{}
+	// Server-side truth never changes: both workers stay heartbeat-visible
+	// for the whole test, even while A's local lastSeen goes stale.
+	kv.SetKeys([]string{"worker.a", "worker.b"})
+
+	detector := NewEmergencyDetector(10 * time.Second)
+	detector.now = clock.Now // same fake clock as the monitor: deterministic grace math
+
+	var calls atomic.Int32
+	var scanResult []string
+	var scanErr error
+	var emergencyClaimed atomic.Bool
+	var pendingClaimed atomic.Bool
+	release := make(chan struct{})
+
+	var m *WorkerMonitor
+	m = NewWorkerMonitor(kv, "worker", 10*time.Second,
+		func(ctx context.Context) error {
+			n := calls.Add(1)
+			if n == 2 { // the sweep-triggered check
+				// Real reconciliation shape: scan current KV truth via the
+				// monitor's own GetActiveWorkers, then reconcile against a
+				// real EmergencyDetector exactly as the calculator does.
+				workers, err := m.GetActiveWorkers(ctx)
+				scanResult = workers
+				scanErr = err
+
+				curr := make(map[string]bool, len(workers))
+				for _, w := range workers {
+					curr[w] = true
+				}
+				prev := map[string]bool{"a": true, "b": true} // last known-active set before the sweep
+				emergency, _, pending := detector.CheckEmergency(prev, curr)
+				emergencyClaimed.Store(emergency)
+				pendingClaimed.Store(pending)
+
+				<-release // block only the sweep-triggered check, same pattern as the classification-only test
+			}
+
+			return nil
+		},
+		logging.NewNop(),
+	)
+	m.now = clock.Now
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	waitDebounce() // check #1 (joins coalesced)
+
+	// Keep B fresh with 3s beats while A goes silent locally. Server truth
+	// (kv.keys) is untouched throughout: A stays alive from a live-scan
+	// perspective.
+	for i := 0; i < 3; i++ { // pushes at +3, +6, +9
+		clock.Advance(3 * time.Second)
+		s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load(), "B's fresh refreshes must stay suppressed while A ages")
+
+	// t=+12s: B's entry is a fresh refresh — suppressed by classification
+	// alone. The sweep finds A locally stale (12s >= hbTTL) and forces
+	// check #2, which blocks inside the scan/emergency reconciliation above.
+	clock.Advance(3 * time.Second)
+	s.push(&fakeKVEntry{key: "worker.b", op: jetstream.KeyValuePut})
+	require.Eventually(t, func() bool { return calls.Load() == 2 },
+		2*time.Second, 5*time.Millisecond,
+		"sweep must force a check off B's suppressed refresh when A is locally stale")
+
+	// A's own delayed PUT arrives while the callback blocks. Push from a
+	// goroutine: the loop is busy in onChangeCb, so this send parks until
+	// the callback returns — reusing the queued-PUT pattern from the
+	// classification-only test.
+	pushed := make(chan struct{})
+	go func() {
+		defer close(pushed)
+		kv.mu.Lock()
+		w := kv.currentWatcher
+		kv.mu.Unlock()
+		w.updates <- &fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut}
+	}()
+
+	close(release) // unblock check #2
+	select {
+	case <-pushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued entry was not consumed after callback release")
+	}
+	waitDebounce()
+
+	// (a) The sweep-triggered check's real scan observes A alive.
+	require.NoError(t, scanErr, "sweep-triggered GetActiveWorkers scan must succeed")
+	require.ElementsMatch(t, []string{"a", "b"}, scanResult,
+		"sweep-triggered check's real scan must observe A alive alongside B")
+
+	// (b) No emergency is claimed and nothing is left pending: A visible in
+	// curr must clear the detector's tracking for A.
+	require.False(t, emergencyClaimed.Load(), "A visible in curr must clear the detector; no emergency may be claimed")
+	require.False(t, pendingClaimed.Load(), "A visible in curr must clear the disappearance; nothing may remain pending")
+
+	// (c) A was swept from lastSeen, so its delayed PUT classifies as a
+	// join → exactly one additional check (#3), no oscillation.
+	require.EqualValues(t, 3, calls.Load(), "swept-then-reappearing worker must re-trigger exactly once (join)")
+}
+
+func TestWorkerMonitor_SweepDisabledAtZeroTTL(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(0, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	waitDebounce()
+	clock.Advance(time.Hour)
+	s.push(&fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut})
+	waitDebounce()
+	// Both PUTs trigger (zero-TTL: every PUT is a join); the sweep is a
+	// guard-disabled no-op and must not panic or double-fire.
+	require.EqualValues(t, 2, calls.Load())
+}
+
+func TestWorkerMonitor_InitialReplayCoalescesWithinWindow(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, calls := newClassifierMonitor(10*time.Second, clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// K replayed keys delivered within one 100ms debounce window →
+	// exactly one coalesced check (spec: window-scoped claim; a replay
+	// spanning multiple windows may produce multiple checks, same as
+	// pre-change code).
+	for i := 1; i <= 5; i++ {
+		s.push(&fakeKVEntry{key: fmt.Sprintf("worker.w%d", i), op: jetstream.KeyValuePut})
+	}
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load(), "replay entries within one debounce window must coalesce into one check")
+}
+
+func TestWorkerMonitor_RestartSessionResetsClassifierState(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+
+	kv := &fakeKV{}
+	var calls atomic.Int32
+	m := NewWorkerMonitor(kv, "worker", 10*time.Second,
+		func(ctx context.Context) error { calls.Add(1); return nil },
+		logging.NewNop(),
+	)
+	m.now = clock.Now
+	m.watchBaseBackoff = 10 * time.Millisecond // fast retry, matches existing restart tests
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.monitorWatcherWithRetry(ctx)
+	require.Eventually(t, func() bool { return kv.WatchCallCount() >= 1 }, time.Second, time.Millisecond)
+
+	// Session 1: a single join establishes classifier state.
+	kv.mu.Lock()
+	w := kv.currentWatcher
+	kv.mu.Unlock()
+	w.updates <- &fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut}
+	waitDebounce()
+	require.EqualValues(t, 1, calls.Load())
+
+	// Kill the session; the retry loop must start a fresh one.
+	kv.CloseUpdates()
+	require.Eventually(t, func() bool { return kv.WatchCallCount() >= 2 }, 2*time.Second, 10*time.Millisecond)
+
+	// Session 2: the SAME key replayed is unknown to the fresh session's
+	// lastSeen → join → triggers. (Fresh state; no staleness carryover.)
+	kv.mu.Lock()
+	w = kv.currentWatcher
+	kv.mu.Unlock()
+	w.updates <- &fakeKVEntry{key: "worker.a", op: jetstream.KeyValuePut}
+	waitDebounce()
+	require.EqualValues(t, 2, calls.Load(), "restarted session must rebuild classifier state from replay")
+}
+
+func TestWorkerMonitor_PollingCadenceUnaffectedBySuppression(t *testing.T) {
+	t.Parallel()
+	// Full monitor via Start: the polling ticker (hbTTL/2) must keep
+	// invoking onChange regardless of watcher-side suppression — it is
+	// the ground-truth crash detector and the enumeration-stall
+	// detector's designed sampling source (counter behavior itself is
+	// pinned in calculator_audit_test.go).
+	kv := &fakeKV{}
+	var calls atomic.Int32
+	m := NewWorkerMonitor(kv, "worker", 200*time.Millisecond, // ticker at 100ms
+		func(ctx context.Context) error { calls.Add(1); return nil },
+		logging.NewNop(),
+	)
+	require.NoError(t, m.Start(context.Background()))
+	defer func() { _ = m.Stop() }()
+
+	require.Eventually(t, func() bool { return calls.Load() >= 3 },
+		2*time.Second, 10*time.Millisecond,
+		"polling ticker must fire at hbTTL/2 cadence independent of watcher suppression")
 }

--- a/test/integration/manager/manager_heartbeat_scan_skip_test.go
+++ b/test/integration/manager/manager_heartbeat_scan_skip_test.go
@@ -1,0 +1,233 @@
+package manager_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHeartbeatScanSkip_SteadyStateConsumerFlatness proves the headline
+// contract: in steady state (all workers heartbeating on schedule) the
+// heartbeat bucket accrues ephemeral consumers only at the polling-ticker
+// rate, not per heartbeat refresh. Measured directly via JetStream's
+// consumer-created advisories on the heartbeat KV stream.
+//
+// Before the scan-skip change this test fails: every refresh triggers a
+// debounced check whose Keys() call creates one ordered consumer, so the
+// advisory count tracks the heartbeat write rate (~N_workers/interval)
+// instead of the polling budget.
+func TestHeartbeatScanSkip_SteadyStateConsumerFlatness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	cfg := testutil.IntegrationTestConfig()
+	partitions := testutil.CreateTestPartitions(10)
+	src := source.NewStatic(partitions)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	for range 3 {
+		cluster.AddWorker(ctx)
+	}
+	defer cluster.StopWorkers()
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(15 * time.Second)
+
+	// Count consumer creations on the heartbeat KV stream from NOW
+	// (post-startup, so watcher-establishment consumers are excluded).
+	var created atomic.Int64
+	hbStream := "KV_" + cfg.KVBuckets.HeartbeatBucket
+	sub, err := nc.Subscribe(
+		fmt.Sprintf("$JS.EVENT.ADVISORY.CONSUMER.CREATED.%s.>", hbStream),
+		func(_ *nats.Msg) { created.Add(1) },
+	)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	// Soak: several heartbeat intervals of pure steady state.
+	soak := 5 * time.Second
+	time.Sleep(soak)
+
+	// Budget: polling ticker fires every HeartbeatTTL/2 (= 2.5s at
+	// IntegrationTestConfig) on the LEADER's monitor only (one Keys()
+	// consumer per tick → ~2-3 in a 5s soak), plus generous slack for
+	// stray audit scans → budget ≈ 10. Pre-change, refresh-driven checks
+	// produce ~20-25 consumers in the same window (3 workers × 500ms
+	// interval, debounce-coalesced), so the two assertions discriminate.
+	pollTicks := int64(soak/(cfg.HeartbeatTTL/2)) + 1
+	budget := pollTicks*2 + 4 // ×2 + slack: audits, elections, jitter
+	refreshRate := int64(soak/cfg.HeartbeatInterval) * 3
+	require.Less(t, created.Load(), refreshRate/2,
+		"consumer creations must not track the heartbeat refresh rate")
+	require.LessOrEqual(t, created.Load(), budget,
+		"steady-state consumer creations on the heartbeat stream must stay within the polling budget")
+
+	// Join responsiveness (spec §7.3): a worker joining mid-run must
+	// still produce a prompt recompute — suppression must not swallow
+	// join events.
+	joiner := cluster.AddWorker(ctx)
+	require.NoError(t, joiner.Start(ctx))
+	require.NoError(t, <-joiner.WaitState(types.StateStable, 15*time.Second)) // WaitState returns <-chan error (manager_state.go:15)
+	require.Eventually(t, func() bool {
+		return len(joiner.CurrentAssignment().Partitions) > 0
+	}, 15*time.Second, 100*time.Millisecond,
+		"joining worker must receive partitions promptly (join-triggered check)")
+}
+
+// TestHeartbeatScanSkip_CrashDetectionPreserved pins the crash contract:
+// a worker that dies WITHOUT deleting its heartbeat key (abrupt
+// connection close) is detected and rebalanced-around within the spec's
+// disjunction bound. Asserts the bound class, not which path (sweep vs
+// polling) observes it first.
+func TestHeartbeatScanSkip_CrashDetectionPreserved(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	cfg := testutil.IntegrationTestConfig()
+	// Grace-boundary variant folded in: run at the spec's worst valid
+	// config, EmergencyGracePeriod == HeartbeatTTL.
+	cfg.EmergencyGracePeriod = cfg.HeartbeatTTL
+
+	src := source.NewStatic(testutil.CreateTestPartitions(10))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	for range 2 {
+		cluster.AddWorker(ctx)
+	}
+	defer cluster.StopWorkers()
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(15 * time.Second)
+
+	// The crash victim gets its OWN connection and manager (constructed
+	// directly, NOT via the cluster, so cluster helpers only see the two
+	// survivors) so we can sever its connection abruptly without touching
+	// the survivors. Mirrors AddWorkerWithoutTracking's construction
+	// (internal/testutil/nats.go:324) with a dedicated JS handle.
+	victimNC, err := nats.Connect(nc.ConnectedUrl())
+	require.NoError(t, err)
+	victimJS, err := jetstream.New(victimNC)
+	require.NoError(t, err)
+	victim, err := parti.NewManager(&cfg, victimJS, src, strategy.NewConsistentHash())
+	require.NoError(t, err)
+	require.NoError(t, victim.Start(ctx))
+	require.NoError(t, <-victim.WaitState(types.StateStable, 15*time.Second)) // WaitState returns <-chan error (manager_state.go:15)
+	defer func() {                                                            // tolerant: conn is closed by then; Stop takes a ctx (manager.go:797)
+		sctx, scancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer scancel()
+		_ = victim.Stop(sctx)
+	}()
+
+	// Guard: the victim must actually own partitions, or the test is vacuous.
+	require.Eventually(t, func() bool {
+		return len(victim.CurrentAssignment().Partitions) > 0
+	}, 15*time.Second, 100*time.Millisecond, "victim must own partitions before the crash")
+
+	// Crash: abrupt close — no graceful heartbeat DELETE. The key persists
+	// until HeartbeatTTL expiry (watcher-silent).
+	victimNC.Close()
+
+	// Disjunction bound (spec §5.3/§7.2), decomposed at
+	// IntegrationTestConfig values (hbTTL=5s, grace==hbTTL here):
+	//   key expiry            ≤ hbTTL        = 5s
+	//   first-miss observation ≤ hbTTL/2     = 2.5s (max(sweep≈interval, polling))
+	//   grace                  = hbTTL       = 5s
+	//   confirmation           ≤ hbTTL/2     = 2.5s (polling backstop)
+	//   rebalance+apply+slack               = 10s
+	// Σ = 3×hbTTL + 10s = 25s. Asserts the bound CLASS (either sweep or
+	// polling path may win each leg — do not assert which).
+	bound := 3*cfg.HeartbeatTTL + 10*time.Second
+
+	// Survivors must re-cover ALL partitions (the victim's included)
+	// within the bound. WaitForPartitionCoverage iterates only the
+	// cluster-tracked survivors (internal/testutil/cluster_helpers.go:76).
+	cluster.WaitForPartitionCoverage(10, bound)
+}
+
+// TestHeartbeatWatcher_NoRaceUnderConcurrentKVTraffic is the
+// monitor-goroutine concurrency stress test required by AGENTS.md for
+// changes to watcher loops — sibling of the epoch-monitor template.
+// The classification state is goroutine-local by design; this test
+// verifies no cross-goroutine access sneaks in between the watcher loop,
+// the polling ticker, and production KV traffic under -race.
+func TestHeartbeatWatcher_NoRaceUnderConcurrentKVTraffic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	cfg := testutil.IntegrationTestConfig()
+	// Aggressive heartbeat cadence maximizes classification and sweep
+	// activity per second.
+	cfg.HeartbeatInterval = 100 * time.Millisecond
+	cfg.HeartbeatTTL = 300 * time.Millisecond
+	cfg.EmergencyGracePeriod = 150 * time.Millisecond
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+	src := source.NewStatic(testutil.CreateTestPartitions(10))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	for range 3 {
+		cluster.AddWorker(ctx)
+	}
+	defer cluster.StopWorkers()
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(15 * time.Second)
+
+	// Drive foreign KV traffic against the heartbeat bucket (keys outside
+	// the hb prefix) concurrently with the watchers' classification loops.
+	hbKV, err := js.KeyValue(context.Background(), cfg.KVBuckets.HeartbeatBucket)
+	require.NoError(t, err)
+	soakCtx, soakCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer soakCancel()
+	go func() {
+		i := 0
+		for soakCtx.Err() == nil {
+			key := fmt.Sprintf("stress.k%d", i%7)
+			_, _ = hbKV.Put(soakCtx, key, []byte("x"))
+			if i%3 == 0 {
+				_ = hbKV.Delete(soakCtx, key)
+			}
+			i++
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+	<-soakCtx.Done()
+
+	// Race detector is the assertion; liveness sanity on top.
+	for _, mgr := range cluster.GetActiveWorkers() {
+		require.NotNil(t, mgr.CurrentAssignment())
+	}
+}


### PR DESCRIPTION

## Problem

The leader's heartbeat `WorkerMonitor` triggered a full KV `Keys()` scan for
**every** watcher entry — including routine heartbeat refreshes that cannot
change topology. Each `Keys()` call creates and destroys an ephemeral NATS
ordered consumer, so steady-state operation produced one throwaway consumer
per heartbeat refresh: **~12,000 consumers/hour** at 10 workers × 3s interval,
observed in production as continuous
`JetStream cluster new consumer leader for '... > KV_...-heartbeat > ...'`
log churn plus equivalent JetStream meta-layer create/delete proposals.

## Change

`processWatcherEvents` now classifies entries against a watcher-session-local
`lastSeen` map:

- **Refresh** (PUT of a key seen < `HeartbeatTTL` ago) → suppressed: no check,
  no scan, no consumer.
- **Join / stale rejoin / DELETE / PURGE** → trigger, exactly as before.
- **Silent TTL expiry** (no watcher event) → an O(workers) **expiry sweep** on
  every received entry detects it from the same map, forces a check, and opens
  a **3×HeartbeatTTL suppression holiday** (re-stamped on overlapping crashes)
  so crash-window observation, emergency-grace progression, and confirmation
  keep the pre-change refresh-triggered cadence. The holiday length carries a
  worst-case timing proof (debounce + pollMu wait + scan bound + grace + one
  arrival) in the const comment.
- `hbTTL == 0` (unit-test seams) disables classification and the sweep.

No public API, config, callback-contract, or calculator changes. The polling
ticker (`hbTTL/2`) remains the untouched ground-truth crash detector.

**Effect:** steady-state heartbeat-bucket consumer creation drops from
write-coupled (~12k/hr at the reporting deployment) to the fixed polling floor
(~720/hr), with a bounded burst (~100 scans) per crash window.

**Deliberate behavior delta (documented):** fast-fail non-connectivity
enumeration-stall degradation now enters at its designed polling cadence
(≤ threshold × HeartbeatTTL/2) instead of an undocumented
heartbeat-write-coupled cadence; timeout-class stalls are effectively
unchanged (per-attempt `boundedOpCtx` dominates in both worlds).

## Tests

- 12 new unit tests (classification both directions, sweep, holiday
  open/extend/expire, false-flag self-correction incl. a live-scan +
  real-EmergencyDetector companion proving no spurious emergency, replay
  coalescing, restart state reset, polling-cadence independence, zero-TTL
  seams) + a connectivity-error stall-counter-bypass pin.
- 3 integration contracts (`test/integration/manager/`):
  - **Consumer flatness** via JetStream consumer-created advisories —
    verified non-vacuous by reverting the production change (fails 14 > 10).
  - **Crash detection preserved** at the worst valid config
    (`EmergencyGracePeriod == HeartbeatTTL`), abrupt-disconnect victim,
    bound-class assertion.
  - **Concurrency stress** per AGENTS.md monitor-goroutine rule
    (aggressive cadence + concurrent KV traffic, `-race`).
- Cross-feature contract pins all green: `TestManager_LiveNATSBucketLoss*`,
  `TestStableID_StaleKeyTakeover_Reclaim`, `TestNP10_*`.

## Validation

`make pre-pr` (lint + unit `-race` + full live-NATS integration `-race`)
green at three checkpoints, including the final tree; no flake re-runs
needed on any pass.

## Review trail (all under `tmp/`)

- Spec `worker-monitor-scan-skip-spec.md` Draft v5 — clean after 5 external
  (codex) review rounds.
- Implementation plan — clean after 2 rounds (test timelines walked
  state-by-state).
- Per-task reviews (5 tasks) + final whole-branch review: READY TO MERGE.
- Post-impl reviews: v1 fix-then-merge → fix → **v2 MERGE, zero findings**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPUoEnYzc6dSE5TurTMhG
