### PR TITLE
feat: gate handoff bucket scans behind a stream-position probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Idle handoff-bucket scan gating** — the claim resolver's periodic
+  reconcile and the two-phase sweep ticker no longer pay fixed-rate scan
+  costs while the handoff bucket is unchanged. Each ticker pass first
+  probes the bucket's backing stream position (one read-only
+  `STREAM.INFO` request through a dedicated KV handle — no consumer
+  creation) and skips the `Keys()`/`ListKeys()` walk and per-key reads
+  once two consecutive probes taken 2s apart confirm the bucket
+  byte-identical to the last clean pass. At 10 workers / 2,000 claims
+  with default intervals this removes ~40 ephemeral consumer
+  creations/min (each a JetStream meta-layer Raft proposal) and ~80k
+  per-key reads/min at idle across the two scan sites; idle scan cost
+  now scales with worker count instead of workers × partitions.
+- **Fail-open safety** — full-rate scanning resumes automatically on any
+  bucket write, probe failure, or unsafe bucket config, and an
+  unconditional full scan still runs at least every 20 passes, bounding
+  the effect of a stale probe answer to a single interval. An
+  edge-triggered warning fires once if the handoff bucket's config is
+  changed to permit TTL-based expiry (which would break position-based
+  change detection), with an info line on recovery.
+- **Recovery semantics unchanged** — sweep expiry resets, commit
+  finalization, and orphan reaping still run every tick (from a cached
+  claim view when the bucket is provably unchanged), and `Apply`-path
+  sweeps are entirely unaffected. No new public APIs or configuration
+  knobs; observability is log-only.
+
 ## [v2.8.1] - 2026-06-21
 
 Maintenance release on top of v2.8.0. Two small correctness fixes — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.8.2] - 2026-07-03
+
+Scalability release: Parti's coordination buckets no longer pay steady-state
+scan costs. Routine heartbeat refreshes stop triggering full key scans of the
+heartbeat bucket — the source of the "JetStream cluster new consumer leader"
+log churn at scale — and the two handoff-bucket scan sites (claim-resolver
+reconcile, two-phase sweep) are gated behind a cheap read-only
+stream-position probe. Idle scan cost now scales with worker count instead
+of workers × partitions, cutting idle meta-layer consumer churn and KV read
+load by ~95% — the property that matters on the path to 10,000-partition
+deployments. All recovery guarantees, public APIs, and defaults are
+unchanged; upgrading is a drop-in.
+
 ### Changed
 
+- **Heartbeat watcher scan suppression** — routine heartbeat refreshes no
+  longer trigger a full key scan of the heartbeat bucket, eliminating
+  steady-state ephemeral-consumer churn (~12k consumer creations/hour at
+  10 workers × 3s heartbeat interval — the "JetStream cluster new consumer
+  leader" log spam at scale). Crash-detection cadence is preserved via a
+  client-side expiry sweep that suspends suppression for the crash window;
+  non-connectivity enumeration-stall degradation now enters at its designed
+  polling cadence (≤ threshold × HeartbeatTTL/2) instead of an undocumented
+  heartbeat-write-coupled cadence.
 - **Idle handoff-bucket scan gating** — the claim resolver's periodic
   reconcile and the two-phase sweep ticker no longer pay fixed-rate scan
   costs while the handoff bucket is unchanged. Each ticker pass first

--- a/consumer/metrics.go
+++ b/consumer/metrics.go
@@ -42,7 +42,7 @@ type ResolverMetrics interface {
 	// Reasons: "channel_closed", "drift_detected", "establish_failed".
 	IncWatcherRestart(reason string)
 
-	// IncReconcileRescue increments when reconcileOnce applies any
+	// IncReconcileRescue increments when reconcileScan applies any
 	// change to the cache — i.e., the reconciler observed drift between
 	// KV and the in-memory cache and rescued the cache. Persistent
 	// non-zero values are strong evidence the KV watcher is silently

--- a/consumer/resolver_config.go
+++ b/consumer/resolver_config.go
@@ -58,6 +58,14 @@ type ResolverConfig struct {
 	// HeartbeatTTL below ~6s, set ReconcileInterval to HeartbeatTTL or
 	// HeartbeatTTL/2.
 	//
+	// Idle-bucket cost note: reconcile passes are scan-gated — when a
+	// cheap stream-position probe proves the bucket unchanged since the
+	// last full pass, the pass skips its key walk entirely (no ephemeral
+	// consumer creation). Shortening this interval therefore no longer
+	// multiplies steady-state consumer churn on an idle handoff bucket;
+	// the interval still bounds worst-case staleness recovery as described
+	// above.
+	//
 	// Zero uses the default (30s). Negative values are rejected at startup.
 	// Ignored when a custom OwnershipResolver is provided.
 	ReconcileInterval time.Duration `default:"30s" validate:"gte=0"`

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/types"
 )
@@ -102,8 +103,13 @@ type Config struct {
 	Store ClaimStore
 	// TTL provides an advisory TTL to set on created claims.
 	TTL time.Duration
-	// SweepInterval controls how often stale/expired claims are opportunistically
-	// swept during Apply calls. If zero or negative, a sweep is attempted on every Apply.
+	// SweepInterval controls the cadence of the background claim-sweep
+	// ticker started by Start, and the throttle on opportunistic sweeps
+	// attempted during Apply (at most one sweep body per interval).
+	// Zero is defaulted to 30s by New. A NEGATIVE value disables the
+	// background ticker AND the throttle: a sweep is then attempted on
+	// every Apply. Ticker sweeps are scan-gated when the store can
+	// probe its backing stream position; Apply-origin sweeps never are.
 	SweepInterval time.Duration
 	// Retry/backoff settings for CAS operations. Zero values get sensible defaults in New().
 	MaxRetries  int
@@ -188,10 +194,16 @@ func New(cfg Config, enableTwoPhase bool) Coordinator {
 		cfg.TTL = 1 * time.Minute
 	}
 	if enableTwoPhase {
-		return &twoPhaseCoordinator{
+		coord := &twoPhaseCoordinator{
 			cfg:               cfg,
 			orphanAbsentSince: make(map[string]time.Time),
+			sweepConfirmGap:   natsutil.ScanGateDefaultConfirmGap,
 		}
+		// Optional store capability: probing the backing stream position
+		// lets ticker sweeps skip provably-no-op ListKeys+Get storms.
+		coord.prober, _ = cfg.Store.(bucketPosProber)
+
+		return coord
 	}
 
 	return &direct{cfg: cfg}

--- a/internal/assignment/handoff/kv_store.go
+++ b/internal/assignment/handoff/kv_store.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/kvutil"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -76,15 +77,36 @@ type ClaimStore interface {
 type natsClaimStore struct {
 	kv         jetstream.KeyValue
 	claimsPref string // e.g., "claims/"
+	probeKV    jetstream.KeyValue
 }
 
-// NewNATSClaimStore constructs a ClaimStore.
-func NewNATSClaimStore(kv jetstream.KeyValue, prefix string) ClaimStore {
+// buildNATSClaimStore builds the concrete store, normalizing the claims
+// prefix to a trailing slash. Shared by both exported constructors.
+func buildNATSClaimStore(kv jetstream.KeyValue, prefix string) *natsClaimStore {
 	p := prefix
 	if p != "" && !strings.HasSuffix(p, "/") {
 		p += "/"
 	}
 	return &natsClaimStore{kv: kv, claimsPref: p}
+}
+
+// NewNATSClaimStore constructs a ClaimStore.
+func NewNATSClaimStore(kv jetstream.KeyValue, prefix string) ClaimStore {
+	return buildNATSClaimStore(kv, prefix)
+}
+
+// NewNATSClaimStoreWithProbe constructs a ClaimStore whose sweep gate
+// can probe the backing stream position. probeKV MUST be a dedicated
+// handle for the same bucket, used only by the sweep goroutine's
+// probes — never the handle production reads/writes go through
+// (kv.Status mutates shared *stream state under concurrent Get/Put;
+// the epoch-monitor race class). A nil probeKV yields the same
+// (ungated) behavior as NewNATSClaimStore.
+func NewNATSClaimStoreWithProbe(kv, probeKV jetstream.KeyValue, prefix string) ClaimStore {
+	store := buildNATSClaimStore(kv, prefix)
+	store.probeKV = probeKV
+
+	return store
 }
 
 func (s *natsClaimStore) key(partitionID string) string { return s.claimsPref + partitionID }
@@ -148,6 +170,22 @@ func (s *natsClaimStore) Delete(ctx context.Context, partitionID string, revisio
 	}
 
 	return nil
+}
+
+// BucketPos reports the position of the stream backing the claims
+// bucket via one read-only STREAM.INFO request on the dedicated probe
+// handle — the optional bucketPosProber capability the sweep gate
+// activates on. Prefix scoping does not matter here: any mutation
+// anywhere in the bucket advances the position, which is exactly the
+// conservative signal the gate needs. Without a probe handle it
+// returns errNoProbeHandle, which permanently disables the gate for
+// this coordinator (fail open into full sweeps).
+func (s *natsClaimStore) BucketPos(ctx context.Context) (natsutil.KVStreamPos, error) {
+	if s.probeKV == nil {
+		return natsutil.KVStreamPos{}, errNoProbeHandle
+	}
+
+	return natsutil.ProbeKVStreamPos(ctx, s.probeKV)
 }
 
 // Now returns time.Now() and allows override in tests.

--- a/internal/assignment/handoff/sweep_gate_test.go
+++ b/internal/assignment/handoff/sweep_gate_test.go
@@ -1,0 +1,717 @@
+package handoff
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/stretchr/testify/require"
+)
+
+// probeMemStore is memStore plus the bucketPosProber capability and
+// call counters. Writes advance the fake stream position (LastSeq),
+// mirroring real KV semantics where every mutation consumes a sequence.
+type probeMemStore struct {
+	*memStore
+	mu         sync.Mutex
+	pos        natsutil.KVStreamPos
+	probeErr   error
+	probeCalls int
+	script     []sweepProbeResult
+	listCalls  atomic.Int32
+	getCalls   atomic.Int32
+}
+
+type sweepProbeResult struct {
+	pos natsutil.KVStreamPos
+	err error
+}
+
+func newProbeMemStore() *probeMemStore {
+	return &probeMemStore{
+		memStore: newMemStore(),
+		pos:      natsutil.KVStreamPos{Created: time.Unix(1000, 0), LastSeq: 1, Msgs: 0},
+	}
+}
+
+func (s *probeMemStore) BucketPos(ctx context.Context) (natsutil.KVStreamPos, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.probeCalls++
+	if len(s.script) > 0 {
+		r := s.script[0]
+		s.script = s.script[1:]
+
+		return r.pos, r.err
+	}
+
+	return s.pos, s.probeErr
+}
+
+func (s *probeMemStore) probeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.probeCalls
+}
+
+func (s *probeMemStore) setPos(mutate func(*natsutil.KVStreamPos)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mutate(&s.pos)
+}
+
+func (s *probeMemStore) advancePos() {
+	s.setPos(func(p *natsutil.KVStreamPos) { p.LastSeq++; p.Msgs++ })
+}
+
+func (s *probeMemStore) ListKeys(ctx context.Context) ([]string, error) {
+	s.listCalls.Add(1)
+
+	return s.memStore.ListKeys(ctx)
+}
+
+func (s *probeMemStore) Get(ctx context.Context, pid string) (Claim, uint64, error) {
+	s.getCalls.Add(1)
+
+	return s.memStore.Get(ctx, pid)
+}
+
+func (s *probeMemStore) PutIfEpoch(ctx context.Context, pid string, epoch int64, next Claim) (uint64, error) {
+	rev, err := s.memStore.PutIfEpoch(ctx, pid, epoch, next)
+	if err == nil {
+		s.advancePos()
+	}
+
+	return rev, err
+}
+
+func (s *probeMemStore) Delete(ctx context.Context, pid string, rev uint64) error {
+	err := s.memStore.Delete(ctx, pid, rev)
+	if err == nil {
+		// A KV delete writes a tombstone marker: LastSeq advances.
+		s.setPos(func(p *natsutil.KVStreamPos) { p.LastSeq++ })
+	}
+
+	return err
+}
+
+// sweepGateHarness bundles a two-phase coordinator over a probeMemStore
+// with a controllable clock and live-set supplier.
+type sweepGateHarness struct {
+	store     *probeMemStore
+	coord     *twoPhaseCoordinator
+	mu        sync.Mutex
+	now       time.Time
+	live      map[string]struct{}
+	vouch     bool
+	liveCalls atomic.Int32 // LivePartitions resolutions (fresh per pass)
+	log       *sweepCaptureLogger
+}
+
+// sweepCaptureLogger is a minimal types.Logger capturing messages for
+// substring assertions (mirrors internal/durable's captureLogger).
+type sweepCaptureLogger struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (l *sweepCaptureLogger) record(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs = append(l.msgs, msg)
+}
+
+func (l *sweepCaptureLogger) Debug(msg string, _ ...any) { l.record(msg) }
+func (l *sweepCaptureLogger) Info(msg string, _ ...any)  { l.record(msg) }
+func (l *sweepCaptureLogger) Warn(msg string, _ ...any)  { l.record(msg) }
+func (l *sweepCaptureLogger) Error(msg string, _ ...any) { l.record(msg) }
+func (l *sweepCaptureLogger) Fatal(msg string, _ ...any) { l.record(msg) }
+
+func (l *sweepCaptureLogger) count(substr string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, m := range l.msgs {
+		if strings.Contains(m, substr) {
+			n++
+		}
+	}
+
+	return n
+}
+
+func newSweepGateHarness(t *testing.T, grace time.Duration) *sweepGateHarness {
+	t.Helper()
+	h := &sweepGateHarness{
+		store: newProbeMemStore(),
+		now:   time.Now().UTC(),
+		live:  map[string]struct{}{},
+		vouch: true,
+		log:   &sweepCaptureLogger{},
+	}
+	cfg := Config{
+		Store:         h.store,
+		Logger:        h.log,
+		TTL:           time.Minute,
+		SweepInterval: -1, // no throttle; tests drive passes directly
+		OrphanGrace:   grace,
+		Now: func() time.Time {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+
+			return h.now
+		},
+		LivePartitions: func(ctx context.Context) (map[string]struct{}, bool) {
+			h.liveCalls.Add(1)
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			out := make(map[string]struct{}, len(h.live))
+			for k := range h.live {
+				out[k] = struct{}{}
+			}
+
+			return out, h.vouch
+		},
+	}
+	coord, ok := New(cfg, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	coord.sweepConfirmGap = time.Millisecond
+	h.coord = coord
+
+	return h
+}
+
+func (h *sweepGateHarness) advance(d time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.now = h.now.Add(d)
+}
+
+func (h *sweepGateHarness) setLive(pids ...string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.live = make(map[string]struct{}, len(pids))
+	for _, p := range pids {
+		h.live[p] = struct{}{}
+	}
+}
+
+func (h *sweepGateHarness) setVouch(v bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.vouch = v
+}
+
+func (h *sweepGateHarness) tick(ctx context.Context) {
+	h.advance(time.Second)
+	h.coord.maybeSweepClaims(ctx, sweepOriginTicker)
+}
+
+// seedStable writes a stable claim directly into the store and advances
+// the fake position, as any external writer would.
+func (h *sweepGateHarness) seedStable(t *testing.T, pid string) {
+	t.Helper()
+	h.mu.Lock()
+	now := h.now
+	h.mu.Unlock()
+	c := NewInitialClaim(pid, "worker-1", now, time.Minute)
+	_, err := h.store.PutIfEpoch(context.Background(), pid, 0, c)
+	require.NoError(t, err)
+}
+
+func TestSweepCachedPassSkipsListAndGets(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.seedStable(t, "p2")
+	h.setLive("p1", "p2")
+
+	h.tick(ctx) // full pass: lists, reads, latches
+	require.EqualValues(t, 1, h.store.listCalls.Load())
+	baseGets := h.store.getCalls.Load()
+	baseLive := h.liveCalls.Load()
+
+	for i := 0; i < 5; i++ {
+		h.tick(ctx) // cached passes
+	}
+	require.EqualValues(t, 1, h.store.listCalls.Load(), "cached passes must not list")
+	require.Equal(t, baseGets, h.store.getCalls.Load(), "cached passes must not read per key")
+	require.Equal(t, baseLive+5, h.liveCalls.Load(),
+		"every cached pass must resolve the live set fresh")
+}
+
+func TestSweepExpiryResetFiresFromCachedPass(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, 0) // reaping off; isolate the expiry arm
+	ctx := context.Background()
+
+	// Three stable claims plus one stuck prepare with a short TTL.
+	h.seedStable(t, "p1")
+	h.seedStable(t, "p2")
+	h.seedStable(t, "p3")
+	h.mu.Lock()
+	now := h.now
+	h.mu.Unlock()
+	stuck := Claim{
+		PartitionID:  "p4",
+		Owner:        "worker-1",
+		PendingOwner: "worker-2",
+		State:        ClaimStatePrepare,
+		Epoch:        3,
+		LastUpdated:  now,
+		TTLSeconds:   2,
+	}
+	_, err := h.store.PutIfEpoch(ctx, "p4", 0, stuck)
+	require.NoError(t, err)
+
+	h.tick(ctx) // full pass latches; prepare not yet expired
+	listsAfterLatch := h.store.listCalls.Load()
+	getsAfterLatch := h.store.getCalls.Load()
+
+	// Cross the TTL with zero bucket writes: the position is unchanged,
+	// so the pass is cached — and the expiry arm must still fire.
+	h.advance(3 * time.Second)
+	h.coord.maybeSweepClaims(ctx, sweepOriginTicker)
+
+	got, _, err := h.store.Get(ctx, "p4")
+	require.NoError(t, err)
+	require.Equal(t, ClaimStateStable, got.State, "expired prepare must reset from a cached pass")
+	require.Empty(t, got.PendingOwner)
+	require.Equal(t, listsAfterLatch, h.store.listCalls.Load(), "the reset must not need a list scan")
+	// The only extra reads are updateClaim's fresh CAS-loop read plus
+	// this assertion's own Get — far below a full 4-key walk.
+	require.LessOrEqual(t, h.store.getCalls.Load()-getsAfterLatch, int32(3))
+}
+
+func TestSweepOrphanReapFiresFromCachedPass(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, 2*time.Second)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.seedStable(t, "p2")
+	h.setLive("p1", "p2")
+
+	h.tick(ctx) // full pass latches
+
+	// The live set stops vouching for p2 — a manager-local change, no
+	// bucket write. Cached passes must run the absence clock and reap.
+	h.setLive("p1")
+	h.tick(ctx) // cached: clock starts
+	h.tick(ctx) // cached: grace not yet elapsed (1s)
+	h.tick(ctx) // cached: grace elapsed (2s) ⇒ compare-and-delete at cached rev
+	_, rev, err := h.store.Get(ctx, "p2")
+	require.NoError(t, err)
+	require.Zero(t, rev, "orphan must be reaped from a cached pass")
+	require.EqualValues(t, 1, h.store.listCalls.Load(), "reap must not need a list scan")
+}
+
+func TestSweepFullPassAfterAnyWrite(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+	h.mu.Lock()
+	now := h.now
+	h.mu.Unlock()
+	stuck := Claim{
+		PartitionID: "p2", Owner: "worker-1", PendingOwner: "worker-2",
+		State: ClaimStatePrepare, Epoch: 3, LastUpdated: now, TTLSeconds: 2,
+	}
+	_, err := h.store.PutIfEpoch(ctx, "p2", 0, stuck)
+	require.NoError(t, err)
+
+	h.tick(ctx) // full pass latches
+	h.advance(3 * time.Second)
+	h.coord.maybeSweepClaims(ctx, sweepOriginTicker) // cached pass WRITES (expiry reset)
+	require.EqualValues(t, 1, h.store.listCalls.Load())
+
+	h.tick(ctx) // the write advanced the position ⇒ full pass rebuilds
+	require.EqualValues(t, 2, h.store.listCalls.Load(), "a write during a cached pass must force the next pass full")
+
+	h.tick(ctx) // and the rebuilt latch skips again
+	require.EqualValues(t, 2, h.store.listCalls.Load())
+}
+
+func TestSweepFullPassEmptyListClearsCacheAndLatches(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.seedStable(t, "p2")
+	h.setLive("p1", "p2")
+
+	h.tick(ctx) // full pass latches a 2-claim cache
+
+	// All claims deleted externally (position advances).
+	require.NoError(t, h.store.Delete(ctx, "p1", 1))
+	require.NoError(t, h.store.Delete(ctx, "p2", 1))
+
+	h.tick(ctx) // mismatch ⇒ full pass sees the empty list, latches empty
+	require.EqualValues(t, 2, h.store.listCalls.Load())
+
+	getsAfter := h.store.getCalls.Load()
+	for i := 0; i < 5; i++ {
+		h.tick(ctx) // empty cached passes: short-circuit
+	}
+	require.EqualValues(t, 2, h.store.listCalls.Load(), "an emptied bucket must not full-scan forever")
+	require.Equal(t, getsAfter, h.store.getCalls.Load())
+}
+
+func TestSweepMsgsDropForcesFullPass(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	h.tick(ctx) // latch
+	h.tick(ctx) // cached
+	require.EqualValues(t, 1, h.store.listCalls.Load())
+
+	// Invisible removal: Msgs drops, LastSeq/Created unchanged.
+	h.store.setPos(func(p *natsutil.KVStreamPos) { p.Msgs-- })
+	h.tick(ctx)
+	require.EqualValues(t, 2, h.store.listCalls.Load(), "Msgs drop must force a full pass")
+}
+
+func TestSweepUnsafeConfigDisablesGate(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+	h.store.setPos(func(p *natsutil.KVStreamPos) { p.MaxAge = time.Hour })
+
+	for i := 0; i < 3; i++ {
+		h.tick(ctx)
+	}
+	require.EqualValues(t, 3, h.store.listCalls.Load(), "unsafe config must full-pass every tick")
+	// Edge-triggered Warn semantics: "gate disabled" appears only in
+	// the one Warn line, not in the per-tick Debug lines.
+	require.Equal(t, 1, h.log.count("gate disabled"),
+		"exactly one Warn on the safe→unsafe transition")
+
+	h.store.setPos(func(p *natsutil.KVStreamPos) { p.MaxAge = 0 })
+	h.tick(ctx) // clean full pass latches
+	require.Equal(t, 1, h.log.count("config restored"),
+		"one Info on the unsafe→safe transition")
+	h.tick(ctx) // cached
+	require.EqualValues(t, 4, h.store.listCalls.Load())
+}
+
+func TestSweepNoProbeHandlePermanentlyUngates(t *testing.T) {
+	t.Parallel()
+
+	// A store that advertises the capability but has no probe handle
+	// (natsClaimStore built via NewNATSClaimStore): the first ticker
+	// pass drops the prober for good — full sweeps, one probe total.
+	store := &noHandleStore{memStore: newMemStore()}
+	coord, ok := New(Config{
+		Store:         store,
+		TTL:           time.Minute,
+		SweepInterval: -1,
+		Now:           time.Now,
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	require.NotNil(t, coord.prober)
+
+	ctx := context.Background()
+	c := NewInitialClaim("p1", "worker-1", time.Now().UTC(), time.Minute)
+	_, err := store.PutIfEpoch(ctx, "p1", 0, c)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		coord.maybeSweepClaims(ctx, sweepOriginTicker)
+	}
+	require.EqualValues(t, 3, store.lists.Load(), "every pass full-sweeps")
+	require.EqualValues(t, 1, store.probes.Load(), "the prober is dropped after the first probe")
+	require.Nil(t, coord.prober)
+}
+
+// noHandleStore advertises bucketPosProber but always reports the
+// missing-handle condition, mirroring NewNATSClaimStore without a probe.
+type noHandleStore struct {
+	*memStore
+	lists  atomic.Int32
+	probes atomic.Int32
+}
+
+func (s *noHandleStore) ListKeys(ctx context.Context) ([]string, error) {
+	s.lists.Add(1)
+
+	return s.memStore.ListKeys(ctx)
+}
+
+func (s *noHandleStore) BucketPos(context.Context) (natsutil.KVStreamPos, error) {
+	s.probes.Add(1)
+
+	return natsutil.KVStreamPos{}, errNoProbeHandle
+}
+
+func TestSweepDoesNotLatchOnGetError(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	// One Get fails during the full pass: no latch, next pass is full.
+	failing := &getFailOnceStore{probeMemStore: h.store}
+	h.coord.cfg.Store = failing
+
+	h.tick(ctx) // full pass with a Get error ⇒ must not latch
+	h.tick(ctx) // still full (nothing latched); the read succeeds now ⇒ latches
+	require.EqualValues(t, 2, h.store.listCalls.Load())
+
+	h.tick(ctx) // cached
+	require.EqualValues(t, 2, h.store.listCalls.Load())
+}
+
+// getFailOnceStore fails exactly the first per-key Get it sees.
+type getFailOnceStore struct {
+	*probeMemStore
+	failed atomic.Bool
+}
+
+func (s *getFailOnceStore) Get(ctx context.Context, pid string) (Claim, uint64, error) {
+	if s.failed.CompareAndSwap(false, true) {
+		return Claim{}, 0, context.DeadlineExceeded
+	}
+
+	return s.probeMemStore.Get(ctx, pid)
+}
+
+func TestSweepFailsOpenOnProbeError(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	h.tick(ctx) // latch
+	h.store.mu.Lock()
+	h.store.probeErr = context.DeadlineExceeded
+	h.store.mu.Unlock()
+
+	h.tick(ctx)
+	h.tick(ctx)
+	require.EqualValues(t, 3, h.store.listCalls.Load(), "probe errors must full-pass every tick")
+
+	h.store.mu.Lock()
+	h.store.probeErr = nil
+	h.store.mu.Unlock()
+	h.tick(ctx) // clean full pass re-latches
+	h.tick(ctx) // cached
+	require.EqualValues(t, 4, h.store.listCalls.Load())
+}
+
+func TestSweepForcedFullPassAfterMax(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	// Tick 1 latches (full). Ticks 2..20 cached (19). Tick 21 forced full.
+	for i := 0; i < 21; i++ {
+		h.tick(ctx)
+	}
+	require.EqualValues(t, 2, h.store.listCalls.Load(), "exactly one forced full pass per 20 gated ticks")
+}
+
+func TestSweepDoubleProbeConfirms(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	h.tick(ctx) // full pass: 1 probe
+	require.Equal(t, 1, h.store.probeCount())
+
+	h.tick(ctx) // cached pass: first probe + confirm probe
+	require.Equal(t, 3, h.store.probeCount(), "a cached pass requires two probes")
+	require.EqualValues(t, 1, h.store.listCalls.Load())
+}
+
+func TestSweepSecondProbeMismatchRunsFull(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	h.tick(ctx) // latch (steady pos: LastSeq 2 after the seed write)
+
+	// Deposed-leader shape: first probe stale-matches the latch, the
+	// confirm probe reports the truth.
+	h.store.mu.Lock()
+	stale := h.store.pos
+	truth := stale
+	truth.LastSeq++
+	truth.Msgs++
+	h.store.script = []sweepProbeResult{{pos: stale}, {pos: truth}}
+	h.store.pos = truth
+	h.store.mu.Unlock()
+
+	h.tick(ctx) // confirm mismatch ⇒ full pass
+	require.EqualValues(t, 2, h.store.listCalls.Load())
+}
+
+func TestSweepWithoutProberUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// A store without BucketPos: every ticker pass lists + reads.
+	store := newMemStore()
+	var lists atomic.Int32
+	counting := &countingListStore{ClaimStore: store, lists: &lists}
+	coord, ok := New(Config{
+		Store:         counting,
+		TTL:           time.Minute,
+		SweepInterval: -1,
+		Now:           time.Now,
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+
+	ctx := context.Background()
+	c := NewInitialClaim("p1", "worker-1", time.Now().UTC(), time.Minute)
+	_, err := store.PutIfEpoch(ctx, "p1", 0, c)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		coord.maybeSweepClaims(ctx, sweepOriginTicker)
+	}
+	require.EqualValues(t, 3, lists.Load(), "no probe capability ⇒ today's full sweep every pass")
+}
+
+// countingListStore counts ListKeys on an arbitrary ClaimStore without
+// adding the probe capability.
+type countingListStore struct {
+	ClaimStore
+	lists *atomic.Int32
+}
+
+func (s *countingListStore) ListKeys(ctx context.Context) ([]string, error) {
+	s.lists.Add(1)
+
+	return s.ClaimStore.ListKeys(ctx)
+}
+
+func TestSweepUnvouchedCachedPassClearsClocks(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.seedStable(t, "p2")
+	h.setLive("p1", "p2")
+
+	h.tick(ctx) // latch
+	h.setLive("p1")
+	h.tick(ctx) // cached, vouched: p2's absence clock starts
+	require.Len(t, h.coord.orphanAbsentSince, 1)
+
+	h.setVouch(false)
+	h.tick(ctx) // cached, UNVOUCHED: clocks must clear
+	require.Empty(t, h.coord.orphanAbsentSince)
+}
+
+func TestSweepApplyOriginBypassesGate(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	h.coord.sweepConfirmGap = 30 * time.Second // Apply must never wait this
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	h.tick(ctx) // ticker full pass latches
+	probes := h.store.probeCount()
+	lists := h.store.listCalls.Load()
+
+	start := time.Now()
+	h.advance(time.Second)
+	h.coord.maybeSweepClaims(ctx, sweepOriginApply)
+	elapsed := time.Since(start)
+
+	require.Equal(t, probes, h.store.probeCount(), "Apply-origin sweeps must not probe")
+	require.EqualValues(t, lists+1, h.store.listCalls.Load(), "Apply-origin sweeps run the full body")
+	require.Less(t, elapsed, 5*time.Second, "Apply-origin sweeps must not wait the confirm gap")
+
+	// Gate state untouched: the latch is still valid, so (no writes
+	// having happened) the next ticker pass is cached.
+	h.tick(ctx)
+	require.EqualValues(t, lists+1, h.store.listCalls.Load())
+}
+
+func TestSweepConcurrentApplySkipsDuringConfirmGap(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	h.coord.sweepConfirmGap = 500 * time.Millisecond
+	ctx := context.Background()
+	h.seedStable(t, "p1")
+	h.setLive("p1")
+
+	h.tick(ctx) // latch
+	probesBefore := h.store.probeCount()
+
+	tickerDone := make(chan struct{})
+	go func() {
+		defer close(tickerDone)
+		h.advance(time.Second)
+		h.coord.maybeSweepClaims(ctx, sweepOriginTicker) // enters the confirm gap holding sweepMu
+	}()
+	require.Eventually(t, func() bool { return h.store.probeCount() == probesBefore+1 },
+		2*time.Second, time.Millisecond, "ticker pass must take its first probe")
+
+	// A concurrent Apply-origin sweep must TryLock-skip, not block.
+	start := time.Now()
+	h.coord.maybeSweepClaims(ctx, sweepOriginApply)
+	require.Less(t, time.Since(start), 200*time.Millisecond,
+		"Apply must not block on the ticker's confirm gap")
+	require.Equal(t, probesBefore+1, h.store.probeCount(),
+		"the concurrent Apply happened during the gap (confirm probe not yet taken)")
+
+	<-tickerDone
+}
+
+func TestSweepForcedFullPassFromEmptyCache(t *testing.T) {
+	t.Parallel()
+
+	h := newSweepGateHarness(t, time.Hour)
+	ctx := context.Background()
+
+	// Empty bucket from the start: pass 1 latches an EMPTY cache.
+	h.tick(ctx)
+	require.EqualValues(t, 1, h.store.listCalls.Load())
+
+	// Ticks 2..20 are empty cached passes (19). They must still count
+	// toward the forced-pass budget: tick 21 lists again.
+	for i := 0; i < 19; i++ {
+		h.tick(ctx)
+	}
+	require.EqualValues(t, 1, h.store.listCalls.Load())
+	h.tick(ctx)
+	require.EqualValues(t, 2, h.store.listCalls.Load(),
+		"the forced full pass must fire from an empty-cache latch")
+}

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/types"
 	"golang.org/x/sync/errgroup"
@@ -41,6 +42,56 @@ type twoPhaseCoordinator struct {
 	// restart or leadership change restarts the grace clock, which is the
 	// conservative direction.
 	orphanAbsentSince map[string]time.Time
+
+	// Sweep scan-gate state, all guarded by sweepMu like every other
+	// sweep field. sweepCache holds the (claim, revision) view of the
+	// bucket from the last clean ticker-origin full pass; it is valid
+	// only while sweepCacheValid and the probed position still equals
+	// sweepCachePos. The cache is only ever replaced whole by a clean
+	// full pass — never patched.
+	sweepCacheValid     bool
+	sweepCachePos       natsutil.KVStreamPos
+	sweepCache          map[string]cachedClaim
+	sweepSkipsSinceFull int
+	sweepConfigGuard    natsutil.ScanGateConfigGuard
+	// sweepConfirmGap is the double-probe confirmation wait; tests
+	// shorten it. Set by New to natsutil.ScanGateDefaultConfirmGap.
+	sweepConfirmGap time.Duration
+	// prober is cfg.Store's optional position-probe capability,
+	// type-asserted once by New; nil disables the gate.
+	prober bucketPosProber
+}
+
+// sweepOrigin tags who initiated a sweep pass. The scan gate is
+// ticker-only: Apply-origin passes run the full sweep body verbatim and
+// leave all gate state untouched, so the manager's apply pipeline never
+// pays a probe or a confirm-gap wait.
+type sweepOrigin int
+
+const (
+	sweepOriginApply sweepOrigin = iota
+	sweepOriginTicker
+)
+
+// bucketPosProber is an optional capability of a ClaimStore: reporting
+// the backing stream's position without creating a consumer. The sweep
+// gate activates only when the store implements it; stores that do not
+// (test fakes, alternative backends) get today's full-sweep behavior
+// unchanged.
+type bucketPosProber interface {
+	BucketPos(ctx context.Context) (natsutil.KVStreamPos, error)
+}
+
+// errNoProbeHandle signals a store that implements bucketPosProber but
+// was constructed without a dedicated probe handle. The coordinator
+// treats it as "capability permanently absent" and stops probing.
+var errNoProbeHandle = errors.New("handoff: no dedicated probe handle configured")
+
+// cachedClaim is one entry of the sweep's claim cache: the body and KV
+// revision a clean full pass read.
+type cachedClaim struct {
+	claim Claim
+	rev   uint64
 }
 
 // Start launches a background goroutine that sweeps stale claims at SweepInterval.
@@ -64,7 +115,7 @@ func (t *twoPhaseCoordinator) Start(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				t.maybeSweepClaims(ctx)
+				t.maybeSweepClaims(ctx, sweepOriginTicker)
 			}
 		}
 	}()
@@ -75,7 +126,7 @@ func (t *twoPhaseCoordinator) Start(ctx context.Context) {
 func (t *twoPhaseCoordinator) Apply(ctx context.Context, workerID string, previous, next types.Assignment) error {
 	// Opportunistic sweep of expired/non-stable claims; skip metrics as requested.
 	// Runs before any early returns to maximize cleanup.
-	t.maybeSweepClaims(ctx)
+	t.maybeSweepClaims(ctx, sweepOriginApply)
 
 	inst := newInstrumenter(t.cfg.Metrics)
 
@@ -482,7 +533,18 @@ func (t *twoPhaseCoordinator) stabilizePhase(ctx context.Context, workerID strin
 // every time — but never concurrently: sweep bodies are single-flight (see the
 // sweepMu field doc), and a pass arriving while another sweep is mid-body is
 // skipped rather than blocked, so Apply never waits on another sweep's KV I/O.
-func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context) {
+//
+// Ticker-origin passes are additionally scan-gated: when the store can
+// report its backing stream position (bucketPosProber) and two probes
+// sweepConfirmGap apart both equal the position latched by the last
+// clean full pass, the pass body runs against the cached claim view
+// instead of a fresh ListKeys + per-key Get storm. The cached pass runs
+// every decision arm — commit finalization, TTL-expiry reset, orphan
+// reaping against a FRESH LivePartitions resolution — so time-triggered
+// work keeps firing at today's cadence on an idle bucket. Apply-origin
+// passes never use the gate (no probe, no confirm wait, no gate-state
+// mutation): the manager's apply pipeline is byte-for-byte unchanged.
+func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweepOrigin) {
 	if t.cfg.Store == nil {
 		return
 	}
@@ -497,58 +559,286 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context) {
 	}
 	t.lastSweep = now
 
+	// The gate is ticker-only; stores without the probe capability are
+	// never gated either. Both cases run today's body verbatim and leave
+	// all gate state untouched (coherence needs no bookkeeping: any
+	// write such a pass performs advances the stream position, so a
+	// stale cache can never satisfy the next ticker probe).
+	if origin != sweepOriginTicker || t.prober == nil {
+		t.sweepPass(ctx, now, nil)
+
+		return
+	}
+
+	pos, ok, reason := t.sweepProbe(ctx)
+	if ok && t.sweepCacheValid && pos.Same(t.sweepCachePos) {
+		if t.sweepSkipsSinceFull >= natsutil.ScanGateMaxSkippedPasses {
+			reason = "forced"
+		} else {
+			// Double-probe confirmation. The wait holds sweepMu on the
+			// ticker goroutine (which has no other duties); a concurrent
+			// Apply's opportunistic sweep TryLock-skips rather than
+			// blocks. ctx cancellation aborts the pass with gate state
+			// untouched.
+			if !t.sweepConfirmWait(ctx) {
+				return
+			}
+			pos2, ok2, reason2 := t.sweepProbe(ctx)
+			if ok2 && pos2.Same(t.sweepCachePos) {
+				t.sweepCachedPass(ctx, now)
+
+				return
+			}
+			pos, ok = pos2, ok2
+			reason = reason2
+			if reason == "" {
+				reason = "mismatch"
+			}
+		}
+	} else if ok && reason == "" {
+		if t.sweepCacheValid {
+			reason = "mismatch"
+		} else {
+			reason = "unlatched"
+		}
+	}
+
+	var latch *natsutil.KVStreamPos
+	if ok {
+		latch = &pos
+	}
+	t.sweepPass(ctx, now, latch)
+	if t.cfg.Logger != nil {
+		t.cfg.Logger.Debug("handoff sweep full pass",
+			"cached_passes_since_last_full", t.sweepSkipsSinceFull,
+			"reason", reason,
+		)
+	}
+	t.sweepSkipsSinceFull = 0
+}
+
+// sweepProbe takes one stream-position probe under the fail-open and
+// config-validation rules: any error or unsafe config invalidates the
+// cache so no cached pass can run until a clean full pass re-latches.
+// Runs under sweepMu.
+func (t *twoPhaseCoordinator) sweepProbe(ctx context.Context) (natsutil.KVStreamPos, bool, string) {
+	pos, err := t.prober.BucketPos(ctx)
+	if err != nil {
+		t.sweepCacheValid = false
+		if errors.Is(err, errNoProbeHandle) {
+			// The store implements the capability interface but has no
+			// probe handle: permanently ungate this coordinator so we
+			// stop paying a doomed probe (and a log line) every tick.
+			t.prober = nil
+			if t.cfg.Logger != nil {
+				t.cfg.Logger.Debug("handoff sweep gate disabled: store has no probe handle")
+			}
+
+			return natsutil.KVStreamPos{}, false, "no_probe_handle"
+		}
+		if t.cfg.Logger != nil {
+			t.cfg.Logger.Debug("handoff sweep: stream position probe failed", "error", err)
+		}
+
+		return natsutil.KVStreamPos{}, false, "probe_error"
+	}
+	if !t.sweepConfigGuard.Check(pos, t.cfg.Logger) {
+		t.sweepCacheValid = false
+
+		return pos, false, "unsafe_config"
+	}
+
+	return pos, true, ""
+}
+
+// sweepConfirmWait blocks for sweepConfirmGap or until ctx cancellation.
+// Returns false when the pass should be aborted.
+func (t *twoPhaseCoordinator) sweepConfirmWait(ctx context.Context) bool {
+	timer := time.NewTimer(t.sweepConfirmGap)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// resolveLiveSet resolves the live partition set once per pass for
+// orphan reaping. liveOK=false (supplier not vouching: not the leader,
+// source down) skips all reap decisions for the pass AND resets every
+// absence clock: time spent unvouched is time this worker could not
+// verify continuous absence, so it must not count toward OrphanGrace —
+// otherwise a clock started before a long follower stint would reap
+// instantly on the first vouched pass after it. Runs under sweepMu.
+func (t *twoPhaseCoordinator) resolveLiveSet(ctx context.Context) (map[string]struct{}, bool) {
+	if t.cfg.OrphanGrace <= 0 || t.cfg.LivePartitions == nil {
+		return nil, false
+	}
+	live, liveOK := t.cfg.LivePartitions(ctx)
+	if !liveOK {
+		clear(t.orphanAbsentSince)
+	}
+
+	return live, liveOK
+}
+
+// sweepClaim runs the per-claim sweep decision arms shared by full and
+// cached passes: the sweepReconcile pre-filter (with the authoritative
+// re-decide on a fresh read inside updateClaim's CAS loop) and, for
+// claims needing no reconcile, the orphan-reap check.
+func (t *twoPhaseCoordinator) sweepClaim(
+	ctx context.Context,
+	pid string,
+	cur Claim,
+	rev uint64,
+	live map[string]struct{},
+	liveOK bool,
+	now time.Time,
+) {
+	// Cheap pre-filter: skip a CAS write attempt when this claim needs
+	// no reconcile (the common case for already-stable claims).
+	if sweepReconcile(&cur, now) != nil {
+		if err := t.updateClaim(ctx, pid, func(cur *Claim) (*Claim, error) {
+			// Re-decide on the fresh read inside the CAS loop.
+			return sweepReconcile(cur, now), nil
+		}); err == nil {
+			if t.cfg.Metrics != nil {
+				t.cfg.Metrics.IncClaimStoreStale()
+			}
+		}
+		// A just-reconciled claim is in flux; it is not reap-eligible
+		// this pass. The next pass re-evaluates it from a fresh read.
+		return
+	}
+
+	if liveOK {
+		t.maybeReapOrphan(ctx, pid, cur, rev, live, now)
+	}
+}
+
+// sweepPass is the full sweep body: ListKeys + per-key Get + decision
+// arms. When latch is non-nil (a gated ticker-origin pass with a usable
+// probe), the pass additionally rebuilds the claim cache and latches
+// the probed position iff the pass was clean: list succeeded (an empty
+// list is clean — latch an empty cache), and zero per-key Gets errored
+// (reads returning rev == 0 — deleted between list and get — do not
+// block latching; that deletion consumed a sequence after the probe, so
+// the very next probe unlatches anyway). When latch is nil (Apply
+// origin, no prober, or an unusable probe) the body is today's sweep,
+// byte-for-byte, and gate state is untouched. Runs under sweepMu.
+func (t *twoPhaseCoordinator) sweepPass(ctx context.Context, now time.Time, latch *natsutil.KVStreamPos) {
 	keys, err := t.cfg.Store.ListKeys(ctx)
-	if err != nil || len(keys) == 0 {
+	if err != nil {
+		if latch != nil {
+			t.sweepCacheValid = false
+		}
+
+		return
+	}
+	if len(keys) == 0 {
+		if latch != nil {
+			// A clean empty pass: without latching here, a bucket whose
+			// last claim was deleted would either full-scan forever or
+			// retain a stale non-empty cache. The early return itself is
+			// today's behavior (no metric call, no live-set resolution,
+			// no prune).
+			t.latchCache(make(map[string]cachedClaim), *latch)
+		}
+
 		return
 	}
 	if t.cfg.Metrics != nil {
 		t.cfg.Metrics.SetClaimStoreSize(len(keys))
 	}
 
-	// Resolve the live partition set once per pass for orphan reaping.
-	// liveOK=false (supplier not vouching: not the leader, source down)
-	// skips all reap decisions for the pass AND resets every absence clock:
-	// time spent unvouched is time this worker could not verify continuous
-	// absence, so it must not count toward OrphanGrace — otherwise a clock
-	// started before a long follower stint would reap instantly on the
-	// first vouched pass after it.
-	var live map[string]struct{}
-	liveOK := false
-	if t.cfg.OrphanGrace > 0 && t.cfg.LivePartitions != nil {
-		live, liveOK = t.cfg.LivePartitions(ctx)
-		if !liveOK {
-			clear(t.orphanAbsentSince)
-		}
+	live, liveOK := t.resolveLiveSet(ctx)
+
+	var cache map[string]cachedClaim
+	if latch != nil {
+		cache = make(map[string]cachedClaim, len(keys))
 	}
+	getFailed := false
 
 	for _, pid := range keys {
 		cur, rev, err := t.cfg.Store.Get(ctx, pid)
-		if err != nil || rev == 0 {
-			continue
-		}
-		// Cheap pre-filter: skip a CAS write attempt when this claim needs no
-		// reconcile (the common case for already-stable claims).
-		if sweepReconcile(&cur, now) != nil {
-			if err := t.updateClaim(ctx, pid, func(cur *Claim) (*Claim, error) {
-				// Re-decide on the fresh read inside the CAS loop.
-				return sweepReconcile(cur, now), nil
-			}); err == nil {
-				if t.cfg.Metrics != nil {
-					t.cfg.Metrics.IncClaimStoreStale()
-				}
-			}
-			// A just-reconciled claim is in flux; it is not reap-eligible
-			// this pass. The next pass re-evaluates it from a fresh read.
-			continue
-		}
+		if err != nil {
+			getFailed = true
 
-		if liveOK {
-			t.maybeReapOrphan(ctx, pid, cur, rev, live, now)
+			continue
 		}
+		if rev == 0 {
+			continue
+		}
+		if cache != nil {
+			cache[pid] = cachedClaim{claim: cur, rev: rev}
+		}
+		t.sweepClaim(ctx, pid, cur, rev, live, liveOK, now)
 	}
 
 	if liveOK {
 		t.pruneOrphanCandidates(keys)
+	}
+
+	if latch != nil {
+		if getFailed {
+			// A transient read failure: do not trust this pass's view.
+			// The cache is invalidated so the next ticker pass re-walks —
+			// today's retry-on-next-pass semantics, unweakened.
+			t.sweepCacheValid = false
+		} else {
+			t.latchCache(cache, *latch)
+		}
+	}
+}
+
+// latchCache replaces the sweep's cached bucket view whole and records the
+// probed position it is valid at. Callers latch only after a clean full
+// pass; the cache is never patched incrementally.
+func (t *twoPhaseCoordinator) latchCache(cache map[string]cachedClaim, pos natsutil.KVStreamPos) {
+	t.sweepCache = cache
+	t.sweepCachePos = pos
+	t.sweepCacheValid = true
+}
+
+// sweepCachedPass runs the sweep decision arms against the cached claim
+// view. Under the gate invariant the cached bodies and revisions ARE the
+// current KV state, so this pass is behavior-identical to a full pass —
+// minus the ListKeys and per-key Get storm. Time and the live set are
+// the only inputs that legitimately change without bucket writes, and
+// both are re-read fresh. Runs under sweepMu.
+func (t *twoPhaseCoordinator) sweepCachedPass(ctx context.Context, now time.Time) {
+	// Accounting first: empty cached passes must count toward the
+	// forced full pass too.
+	t.sweepSkipsSinceFull++
+	if t.sweepSkipsSinceFull == 1 && t.cfg.Logger != nil {
+		t.cfg.Logger.Debug("handoff sweep gate engaged")
+	}
+	if len(t.sweepCache) == 0 {
+		return // mirrors today's empty-list early return
+	}
+	if t.cfg.Metrics != nil {
+		// Identical to a fresh list's count: the key set provably has
+		// not changed.
+		t.cfg.Metrics.SetClaimStoreSize(len(t.sweepCache))
+	}
+
+	live, liveOK := t.resolveLiveSet(ctx)
+
+	for pid, cc := range t.sweepCache {
+		t.sweepClaim(ctx, pid, cc.claim, cc.rev, live, liveOK, now)
+	}
+
+	// The cached key set IS the current bucket key set (the gate proved
+	// the bucket unchanged), so prune absence clocks directly against the
+	// cache instead of materializing a throwaway key slice for
+	// pruneOrphanCandidates.
+	if liveOK && len(t.orphanAbsentSince) > 0 {
+		for pid := range t.orphanAbsentSince {
+			if _, ok := t.sweepCache[pid]; !ok {
+				delete(t.orphanAbsentSince, pid)
+			}
+		}
 	}
 }
 

--- a/internal/durable/claim_resolver.go
+++ b/internal/durable/claim_resolver.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/retry"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
@@ -86,13 +87,39 @@ func WithReconcileInterval(d time.Duration) ResolverOption {
 	}
 }
 
+// WithStreamPosProbe enables the reconcile scan gate by supplying a
+// DEDICATED KV handle used only for stream-position probes on the
+// reconciler goroutine. The handle must not be shared with any other
+// goroutine's KV operations: kv.Status resolves through stream.Info,
+// which mutates the handle's cached *stream state and races concurrent
+// Get/Put/Watch on the same handle (the race class fixed for the epoch
+// monitor by a dedicated probe handle). Passing nil leaves the gate
+// disabled: every reconcile tick runs the full scan, the pre-gate
+// behavior.
+//
+// Parameters:
+//   - probeKV: Dedicated KV handle for probing; nil disables the gate.
+//
+// Returns:
+//   - ResolverOption: Option function
+func WithStreamPosProbe(probeKV jetstream.KeyValue) ResolverOption {
+	return func(r *ClaimBasedResolver) {
+		if probeKV == nil {
+			return
+		}
+		r.streamPos = func(ctx context.Context) (natsutil.KVStreamPos, error) {
+			return natsutil.ProbeKVStreamPos(ctx, probeKV)
+		}
+	}
+}
+
 // WithDriftRestartCooldown sets the minimum interval between
-// reconciler-triggered watcher restarts. When reconcileOnce observes drift
+// reconciler-triggered watcher restarts. When reconcileScan observes drift
 // between KV and the in-memory cache, it asks the supervisor to tear down
 // and re-establish the watcher; this signal is rate-limited so that a
 // persistently unreachable NATS server cannot trigger a restart storm.
 //
-// A value of 0 disables drift-driven restarts entirely: reconcileOnce will
+// A value of 0 disables drift-driven restarts entirely: reconcileScan will
 // still observe drift and rescue the cache (emitting IncReconcileRescue),
 // but the watcher is NOT torn down. The default is 2 × reconcileInterval,
 // floored at 60s. If reconcileInterval is 0 (reconciler disabled), drift
@@ -200,6 +227,28 @@ type ClaimBasedResolver struct {
 	// Reconcile configuration.
 	reconcileInterval time.Duration
 
+	// Scan-gate state for the periodic reconciler. Owned exclusively by
+	// the reconcileLoop goroutine — never touched by the watcher,
+	// supervisor, or ForceRefreshPartition. A gated tick proves via two
+	// stream-position probes (gateConfirmGap apart) that the bucket is
+	// byte-identical to what the last clean full pass observed, and
+	// skips the Keys()+Get walk entirely; any probe error or unsafe
+	// bucket config fails open into a full pass.
+	gateLatchValid     bool
+	gateLatch          natsutil.KVStreamPos
+	gateSkipsSinceFull int
+	gateConfigGuard    natsutil.ScanGateConfigGuard
+	// gateConfirmGap is the double-probe confirmation wait; tests
+	// shorten it. Production value is natsutil.ScanGateDefaultConfirmGap.
+	gateConfirmGap time.Duration
+	// streamPos probes the position of the bucket's backing stream.
+	// nil means no probe seam is configured and the gate is inert
+	// (every tick runs the full scan — pre-gate behavior). Set by
+	// WithStreamPosProbe over a DEDICATED probe handle, or injected
+	// directly by unit tests (jetstream.KeyValueBucketStatus cannot be
+	// fabricated outside nats.go).
+	streamPos func(ctx context.Context) (natsutil.KVStreamPos, error)
+
 	// Drift-driven watcher restart configuration. The reconciler signals
 	// the supervisor to tear down the current watcher when drift is
 	// observed; the supervisor's existing restart path then re-establishes
@@ -294,6 +343,7 @@ func NewClaimBasedResolver(
 		lastRefresh:       make(map[string]time.Time),
 		refreshCooldown:   1 * time.Second,
 		reconcileInterval: defaultReconcileInterval,
+		gateConfirmGap:    natsutil.ScanGateDefaultConfirmGap,
 		// Allocate lifecycle channels eagerly so Stop is safe before Start.
 		stopCh: make(chan struct{}),
 		doneCh: make(chan struct{}),
@@ -936,10 +986,12 @@ func (r *ClaimBasedResolver) reconcileLoop(ctx context.Context) {
 	}
 }
 
-// reconcileOnce performs a single reconcile pass: re-list the bucket, build a
-// pending-batch of upserts and tombstones for entries that disagree with the
-// cache, and apply through the shared revision-aware apply path. A no-op when
-// the cache is already in sync with KV.
+// reconcileScan is the full reconcile pass body (list + per-key read +
+// tombstone synthesis + apply). It reports whether the pass was CLEAN —
+// the list succeeded (the "no keys found" empty-bucket normalization
+// counts as success) and every listed key was readable — which is the
+// gate's precondition for latching a bucket position. Cleanliness is
+// about read health, not about whether the pass applied changes.
 //
 // Tombstone semantics: when a key is absent from KV but present (non-deleted)
 // in the cache, we stamp the tombstone with the cache's current revision + 1.
@@ -952,7 +1004,7 @@ func (r *ClaimBasedResolver) reconcileLoop(ctx context.Context) {
 //
 // This is the same revision-aware tombstone shape used by the watcher
 // at applyPendingBatch.
-func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
+func (r *ClaimBasedResolver) reconcileScan(ctx context.Context) bool {
 	// Snapshot the cache BEFORE walking KV Keys(). Any cache entry
 	// added by the watcher concurrently with Keys()/Get() will not appear in
 	// `snap` and therefore cannot be synthesized into a tombstone by the
@@ -967,7 +1019,7 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 	// We pick this "snapshot first" form over a CAS-style atomic check
 	// inside applyPendingBatch because it is the minimum change to close
 	// the race and keeps the tombstone-or-skip decision local to
-	// reconcileOnce.
+	// reconcileScan.
 	cur := r.cache.Load()
 	snap := map[string]claimEntry{}
 	if cur != nil {
@@ -980,7 +1032,7 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 			if r.logger != nil {
 				r.logger.Debug("claim resolver reconcile: list keys failed", "error", err)
 			}
-			return
+			return false
 		}
 		keys = nil
 	}
@@ -1070,7 +1122,7 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 	}
 
 	if len(pendingByPID) == 0 {
-		return
+		return len(unreadable) == 0
 	}
 	// Emit the rescue metric BEFORE applying so the event is observable
 	// even if applyPendingBatch were ever to panic.
@@ -1086,9 +1138,109 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 	// path will re-establish via WatchAll and re-deliver historical state
 	// through the initial replay. Rate-limited by driftRestartCooldown.
 	r.requestWatcherRestartFromReconcile()
+
+	return len(unreadable) == 0
 }
 
-// requestWatcherRestartFromReconcile is called by reconcileOnce when it has
+// gateProbe takes one stream-position probe and applies the fail-open
+// and config-validation rules: any probe error or unsafe bucket config
+// invalidates the latch, so no skip can happen until a clean full pass
+// re-latches. Returns the probe result, whether it is usable for
+// gating/latching, and the full-pass reason label when it is not.
+func (r *ClaimBasedResolver) gateProbe(ctx context.Context) (natsutil.KVStreamPos, bool, string) {
+	pos, err := r.streamPos(ctx)
+	if err != nil {
+		r.gateLatchValid = false
+		if r.logger != nil {
+			r.logger.Debug("claim resolver reconcile: stream position probe failed", "error", err)
+		}
+
+		return natsutil.KVStreamPos{}, false, "probe_error"
+	}
+	if !r.gateConfigGuard.Check(pos, r.logger) {
+		r.gateLatchValid = false
+
+		return pos, false, "unsafe_config"
+	}
+
+	return pos, true, ""
+}
+
+// reconcileOnce gates a reconcile tick behind a stream-position probe:
+// when two probes gateConfirmGap apart both equal the position latched
+// by the last clean full pass, the bucket is provably byte-identical to
+// what that pass observed and the tick is skipped (no snapshot, no
+// Keys(), no Gets, no apply, no drift signal). Anything else — probe
+// error, unsafe config, position mismatch, unlatched state, or the
+// forced-pass budget running out — runs the full reconcileScan.
+func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
+	if r.streamPos == nil {
+		// No probe seam configured (no dedicated probe handle was
+		// supplied): the gate is inert. Today's behavior, byte-for-byte
+		// — no probes, no gate bookkeeping, no gate logging.
+		_ = r.reconcileScan(ctx)
+
+		return
+	}
+
+	pos, ok, reason := r.gateProbe(ctx)
+	if ok && r.gateLatchValid && pos.Same(r.gateLatch) {
+		if r.gateSkipsSinceFull >= natsutil.ScanGateMaxSkippedPasses {
+			reason = "forced"
+		} else {
+			// Double-probe confirmation (stop/ctx-aware wait; on stop,
+			// end the pass without scanning or latching).
+			if !r.sleepWithStop(ctx, r.gateConfirmGap) {
+				return
+			}
+			pos2, ok2, reason2 := r.gateProbe(ctx)
+			if ok2 && pos2.Same(r.gateLatch) {
+				r.gateSkipsSinceFull++
+				if r.gateSkipsSinceFull == 1 && r.logger != nil {
+					r.logger.Debug("claim resolver reconcile gate engaged")
+				}
+
+				return
+			}
+			// Confirmation failed: fall through to the full pass. The
+			// freshest usable probe (if any) becomes the latch candidate.
+			pos, ok = pos2, ok2
+			reason = reason2
+			if reason == "" {
+				reason = "mismatch"
+			}
+		}
+	} else if ok && reason == "" {
+		if r.gateLatchValid {
+			reason = "mismatch"
+		} else {
+			reason = "unlatched"
+		}
+	}
+
+	clean := r.reconcileScan(ctx)
+
+	if ok && clean {
+		// Latch the pre-scan probe. Conservative by construction: any
+		// mutation landing between this probe and the scan's reads makes
+		// the NEXT probe differ from the latch, forcing a full pass —
+		// the scan may observe newer state than the latch claims, never
+		// older.
+		r.gateLatch = pos
+		r.gateLatchValid = true
+	} else {
+		r.gateLatchValid = false
+	}
+	if r.logger != nil {
+		r.logger.Debug("claim resolver reconcile full pass",
+			"gated_skips_since_last_full", r.gateSkipsSinceFull,
+			"reason", reason,
+		)
+	}
+	r.gateSkipsSinceFull = 0
+}
+
+// requestWatcherRestartFromReconcile is called by reconcileScan when it has
 // applied any change to the cache. The reconciler engaging means the watcher
 // missed events — likely a silent stall (the nats.go KV watcher does not
 // surface server restarts as Updates() channel close). The supervisor's

--- a/internal/durable/claim_resolver_gate_live_test.go
+++ b/internal/durable/claim_resolver_gate_live_test.go
@@ -1,0 +1,143 @@
+package durable
+
+// In-package live-NATS proof that the reconciler's watcher-recovery
+// contract survives with the scan gate active (spec §9 integration item
+// 3). In-package so the watcher seams (watcherMu/currentWatcher,
+// gateConfirmGap) are reachable — the same live pattern as
+// claim_resolver_test.go:576 (TestClaimResolver_ReconcileRescueIncrementsMetric).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGateLive_ReconcileRecoveryWithGateActive is the live proof of
+// ProbeKVStreamPos's success path on a real *jetstream.KeyValueBucketStatus,
+// combined with the pre-existing watcher-recovery contract: even with the
+// scan gate latched (real double-probe confirmation, shortened here via
+// r.gateConfirmGap so the test does not have to wait out the 2s
+// production default), a silently-stalled watcher must still be rescued by
+// the periodic reconciler within one interval once the bucket position
+// advances.
+//
+// The gate's own unit suite (claim_resolver_gate_test.go) proves this
+// against a fake KV and a fake probe; this test proves it against a real
+// embedded NATS server and the real streamPos probe wired via
+// WithStreamPosProbe, so ProbeKVStreamPos's *jetstream.KeyValueBucketStatus
+// type assertion and field mapping are exercised for real, not simulated.
+func TestGateLive_ReconcileRecoveryWithGateActive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := "gate-live-recovery"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	seed := handoff.NewInitialClaim("pA", "w1", time.Now(), time.Minute)
+	seedBytes, err := seed.Marshal()
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "claims/pA", seedBytes)
+	require.NoError(t, err)
+
+	// Dedicated probe handle — never shared with kv, the production
+	// handle, per the WithStreamPosProbe handle-ownership contract.
+	probeKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+
+	cl := &captureLogger{}
+	r := NewClaimBasedResolver(kv, "claims/", cl,
+		WithReconcileInterval(300*time.Millisecond),
+		WithStreamPosProbe(probeKV),
+	)
+	// Shorten the confirm gap so the gate latches on a test timescale; this
+	// is the in-package seam the interface-only integration tests cannot
+	// reach.
+	r.gateConfirmGap = 20 * time.Millisecond
+	t.Cleanup(r.Stop)
+
+	require.NoError(t, r.Start(ctx))
+
+	require.Eventually(t, func() bool {
+		owner, _, _, ok := r.GetOwner("pA")
+
+		return ok && owner == "w1"
+	}, 3*time.Second, 20*time.Millisecond, "resolver did not resolve pA at startup")
+
+	// Let the gate latch across several gated reconcile ticks (300ms
+	// interval + 20ms confirm gap each ⇒ several cycles in 1.5s).
+	time.Sleep(1500 * time.Millisecond)
+
+	// Status resolves through stream.Info and mutates the handle's cached
+	// stream state, so even this sanity check needs its own handle — the
+	// production handle is live inside the resolver.
+	sanityKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	status, err := sanityKV.Status(ctx)
+	require.NoError(t, err)
+	require.Positive(t, status.Values(), "sanity: bucket must still carry the seeded entry")
+
+	owner, _, _, ok := r.GetOwner("pA")
+	require.True(t, ok)
+	require.Equal(t, "w1", owner, "resolver must keep resolving while the gate is latched")
+
+	// Assert the gate actually engaged BEFORE the recovery write below —
+	// proving it was active when recovery happens, not permanently
+	// failed-open (which would make this pin vacuous).
+	require.True(t, cl.has("claim resolver reconcile gate engaged"),
+		"the scan gate must have engaged (Debug line) during the latch-settling window, "+
+			"before the watcher-kill + recovery write")
+
+	// Kill the watcher out-of-band, simulating a silent stall (the nats.go
+	// KV watcher does not surface NATS server restarts as a channel
+	// close). If the supervisor races ahead and re-establishes the watcher
+	// first, that is also fine — the point under test is convergence
+	// within one reconcile interval regardless of which path delivers it.
+	r.watcherMu.Lock()
+	w := r.currentWatcher
+	r.watcherMu.Unlock()
+	_ = w.Stop()
+
+	// Immediately write a new claim body for pA directly via kv.Put — the
+	// watcher (stopped) cannot see this; only the gated reconciler (or a
+	// supervisor-restarted watcher's replay) can deliver it.
+	next := handoff.Claim{
+		PartitionID: "pA",
+		Owner:       "w2",
+		State:       handoff.ClaimStateStable,
+		Epoch:       seed.Epoch + 1,
+		LastUpdated: time.Now().UTC(),
+		TTLSeconds:  seed.TTLSeconds,
+	}
+	nextBytes, err := next.Marshal()
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "claims/pA", nextBytes)
+	require.NoError(t, err)
+
+	// Three seconds is several 300ms reconcile intervals: the gate must
+	// unlatch on the LastSeq advance (a mismatching probe skips the
+	// confirm-gap wait and runs a full pass immediately) and the
+	// reconciler must apply the new claim body.
+	require.Eventually(t, func() bool {
+		owner, _, _, ok := r.GetOwner("pA")
+
+		return ok && owner == "w2"
+	}, 3*time.Second, 10*time.Millisecond,
+		"reconciler did not recover pA to w2 within the bound; the gate must not "+
+			"suppress recovery once the bucket position advances")
+}

--- a/internal/durable/claim_resolver_gate_test.go
+++ b/internal/durable/claim_resolver_gate_test.go
@@ -1,0 +1,453 @@
+package durable
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProbe is a scriptable stream-position probe. If script is
+// non-empty, calls pop results from it in order; once exhausted (or if
+// empty), calls return the steady pos/err.
+type fakeProbe struct {
+	mu     sync.Mutex
+	pos    natsutil.KVStreamPos
+	err    error
+	calls  int
+	script []probeResult
+}
+
+type probeResult struct {
+	pos natsutil.KVStreamPos
+	err error
+}
+
+func (f *fakeProbe) probe(context.Context) (natsutil.KVStreamPos, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if len(f.script) > 0 {
+		r := f.script[0]
+		f.script = f.script[1:]
+
+		return r.pos, r.err
+	}
+
+	return f.pos, f.err
+}
+
+func (f *fakeProbe) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.calls
+}
+
+func (f *fakeProbe) set(pos natsutil.KVStreamPos) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pos = pos
+}
+
+func (f *fakeProbe) push(results ...probeResult) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.script = append(f.script, results...)
+}
+
+func gatePos(seq, msgs uint64) natsutil.KVStreamPos {
+	return natsutil.KVStreamPos{Created: time.Unix(1000, 0), LastSeq: seq, Msgs: msgs}
+}
+
+// newGateResolver wires a resolver over kv with an injected probe, a
+// short confirm gap, and manual reconcile driving (interval 0 disables
+// the loop; tests call reconcileOnce directly).
+func newGateResolver(kv jetstream.KeyValue, p *fakeProbe, logger *captureLogger) *ClaimBasedResolver {
+	r := NewClaimBasedResolver(kv, "claims/", nil, WithReconcileInterval(0))
+	if logger != nil {
+		r.logger = logger
+	}
+	r.streamPos = p.probe
+	r.gateConfirmGap = time.Millisecond
+
+	return r
+}
+
+func TestGateSkipsWhenPosUnchanged(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // full pass: lists, latches
+	require.EqualValues(t, 1, kv.keysCalls.Load())
+
+	for i := 0; i < 5; i++ {
+		r.reconcileOnce(ctx)
+	}
+	require.EqualValues(t, 1, kv.keysCalls.Load(), "gated ticks must not list")
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, quorumTestOwner, owner)
+}
+
+func TestGateFullScanOnSeqAdvance(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // latch
+	r.reconcileOnce(ctx) // skip
+	require.EqualValues(t, 1, kv.keysCalls.Load())
+
+	// A mutation: new claim body at revision 6, LastSeq advances.
+	kv.store[quorumTestFullKey] = marshalClaim(t, handoff.Claim{
+		PartitionID: quorumTestPID,
+		Owner:       "worker-B",
+		State:       handoff.ClaimStateStable,
+		Epoch:       2,
+	})
+	kv.revision = 6
+	p.set(gatePos(6, 1))
+
+	r.reconcileOnce(ctx) // mismatch: full pass, re-latch
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, "worker-B", owner)
+
+	r.reconcileOnce(ctx) // skip again at the new latch
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+}
+
+func TestGateFullScanOnMsgsDrop(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // latch with the claim present
+
+	// Invisible removal: same Created and LastSeq, Msgs drops, key gone.
+	delete(kv.store, quorumTestFullKey)
+	p.set(gatePos(5, 0))
+
+	r.reconcileOnce(ctx)
+	require.EqualValues(t, 2, kv.keysCalls.Load(), "Msgs drop must force a full pass")
+	_, _, _, ok := r.GetOwner(quorumTestPID)
+	require.False(t, ok, "vanished key must be tombstoned")
+}
+
+func TestGateFullScanOnCreatedChange(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // latch
+
+	recreated := gatePos(5, 1)
+	recreated.Created = time.Unix(2000, 0)
+	p.set(recreated)
+
+	r.reconcileOnce(ctx)
+	require.EqualValues(t, 2, kv.keysCalls.Load(), "bucket recreate must force a full pass")
+}
+
+func TestGateDisabledOnUnsafeConfig(t *testing.T) {
+	t.Parallel()
+
+	for name, mutate := range map[string]func(*natsutil.KVStreamPos){
+		"max_age":       func(p *natsutil.KVStreamPos) { p.MaxAge = time.Hour },
+		"allow_msg_ttl": func(p *natsutil.KVStreamPos) { p.AllowMsgTTL = true },
+		"marker_ttl":    func(p *natsutil.KVStreamPos) { p.SubjectDeleteMarkerTTL = time.Minute },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			kv := newHealthyKV(t)
+			unsafePos := gatePos(5, 1)
+			mutate(&unsafePos)
+			p := &fakeProbe{pos: unsafePos}
+			cl := &captureLogger{}
+			r := newGateResolver(kv, p, cl)
+			ctx := context.Background()
+
+			for i := 0; i < 3; i++ {
+				r.reconcileOnce(ctx)
+			}
+			require.EqualValues(t, 3, kv.keysCalls.Load(), "unsafe config must full-pass every tick")
+			// "gate disabled" appears only in the Warn line, not in the
+			// per-tick Debug line, so this pins edge-triggering.
+			require.Equal(t, 1, cl.count("gate disabled"),
+				"exactly one Warn on the safe→unsafe transition")
+
+			// Config restored: one Info, then latching resumes.
+			p.set(gatePos(5, 1))
+			r.reconcileOnce(ctx) // clean full pass, latches
+			require.True(t, cl.has("config restored"))
+			r.reconcileOnce(ctx) // skip
+			require.EqualValues(t, 4, kv.keysCalls.Load())
+		})
+	}
+}
+
+func TestGateFailsOpenOnProbeError(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // latch
+	p.mu.Lock()
+	p.err = context.DeadlineExceeded
+	p.mu.Unlock()
+
+	r.reconcileOnce(ctx)
+	r.reconcileOnce(ctx)
+	require.EqualValues(t, 3, kv.keysCalls.Load(), "probe errors must full-pass every tick")
+
+	// Probe recovers at the latched position: the error invalidated the
+	// latch, so the next tick must still be a full pass (one clean pass
+	// before skipping resumes).
+	p.mu.Lock()
+	p.err = nil
+	p.mu.Unlock()
+	r.reconcileOnce(ctx) // full pass, re-latches
+	require.EqualValues(t, 4, kv.keysCalls.Load())
+	r.reconcileOnce(ctx) // skip
+	require.EqualValues(t, 4, kv.keysCalls.Load())
+}
+
+func TestGateDoesNotLatchOnUnreadableKeys(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	kv.getErrByKey = map[string]error{quorumTestFullKey: context.DeadlineExceeded}
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // unclean: unreadable key, must not latch
+	r.reconcileOnce(ctx) // pos unchanged, but unlatched ⇒ full pass
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+
+	kv.getErrByKey = nil
+	r.reconcileOnce(ctx) // clean full pass, latches
+	r.reconcileOnce(ctx) // skip
+	require.EqualValues(t, 3, kv.keysCalls.Load())
+}
+
+func TestGateForcedFullPassAfterMaxSkips(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	// Tick 1 latches (full). Ticks 2..20 skip (19 skips). Tick 21 is
+	// forced full. Then the budget renews.
+	for i := 0; i < 21; i++ {
+		r.reconcileOnce(ctx)
+	}
+	require.EqualValues(t, 2, kv.keysCalls.Load(), "exactly one forced full pass per 20 gated ticks")
+	for i := 0; i < 19; i++ {
+		r.reconcileOnce(ctx)
+	}
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+	r.reconcileOnce(ctx)
+	require.EqualValues(t, 3, kv.keysCalls.Load())
+}
+
+func TestGateSkipDoesNotEmitRescueOrDriftRestart(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ms := newMetricsSpy()
+	r.SetMetrics(ms)
+	r.driftRestartCooldown = time.Nanosecond // would fire if a rescue happened
+	seedResolverCache(r)                     // cache already in sync with KV
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // full pass over in-sync state: no rescue
+	for i := 0; i < 5; i++ {
+		r.reconcileOnce(ctx) // skips
+	}
+	require.Zero(t, ms.reconcileRescueCount())
+	require.Zero(t, r.lastDriftRestartNano.Load())
+}
+
+func TestGateRecoveryEquivalence(t *testing.T) {
+	t.Parallel()
+
+	// Silent watcher stall is the default in these tests: no watcher
+	// runs at all. A mutation + probe advance must converge on the next
+	// tick, exactly like an ungated reconciler.
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // latch
+	r.reconcileOnce(ctx) // skip
+
+	kv.store[quorumTestFullKey] = marshalClaim(t, handoff.Claim{
+		PartitionID: quorumTestPID,
+		Owner:       "worker-C",
+		State:       handoff.ClaimStateStable,
+		Epoch:       3,
+	})
+	kv.revision = 6
+	p.set(gatePos(6, 1))
+
+	r.reconcileOnce(ctx) // the very next tick converges
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, "worker-C", owner)
+}
+
+func TestGateDoubleProbeConfirms(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // full pass: exactly 1 probe
+	require.Equal(t, 1, p.callCount())
+
+	r.reconcileOnce(ctx) // gated tick: first probe + confirm probe
+	require.Equal(t, 3, p.callCount(), "a skip requires two probes")
+	require.EqualValues(t, 1, kv.keysCalls.Load())
+}
+
+func TestGateSecondProbeMismatchRunsFull(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(6, 1)} // steady = truth after the mutation
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	// Pass 1 latches the OLD state at seq 5.
+	p.push(probeResult{pos: gatePos(5, 1)})
+	r.reconcileOnce(ctx)
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, quorumTestOwner, owner, "cache must hold the pre-mutation owner")
+
+	// The hidden mutation lands AFTER the latch (watcher stalled: the
+	// cache does not see it).
+	kv.store[quorumTestFullKey] = marshalClaim(t, handoff.Claim{
+		PartitionID: quorumTestPID,
+		Owner:       "worker-B",
+		State:       handoff.ClaimStateStable,
+		Epoch:       2,
+	})
+	kv.revision = 6
+
+	// Deposed-leader race: first probe answers the stale latched pos,
+	// the confirm probe (post step-down) answers the truth.
+	p.push(probeResult{pos: gatePos(5, 1)}, probeResult{pos: gatePos(6, 1)})
+	r.reconcileOnce(ctx) // confirm mismatch ⇒ full pass converges NOW
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+	owner, _, _, ok = r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, "worker-B", owner, "the mismatching confirm probe must rescue the stale cache")
+
+	r.reconcileOnce(ctx) // steady pos (6): skip resumes at the new latch
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+}
+
+func TestGateStaleProbeBoundedByOneInterval(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(6, 1)} // steady = truth after the mutation
+	r := newGateResolver(kv, p, nil)
+	ctx := context.Background()
+
+	// Pass 1 latches the OLD state at seq 5.
+	p.push(probeResult{pos: gatePos(5, 1)})
+	r.reconcileOnce(ctx)
+	owner, _, _, ok := r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, quorumTestOwner, owner)
+
+	// Hidden mutation AFTER the latch (watcher stalled).
+	kv.store[quorumTestFullKey] = marshalClaim(t, handoff.Claim{
+		PartitionID: quorumTestPID,
+		Owner:       "worker-B",
+		State:       handoff.ClaimStateStable,
+		Epoch:       2,
+	})
+	kv.revision = 6
+
+	// Worst-case triple-fault corner: BOTH probes of the next tick
+	// answer the stale latched pos (double race loss). That tick
+	// wrongly skips — the documented residual — and the cache REALLY IS
+	// stale across it.
+	p.push(probeResult{pos: gatePos(5, 1)}, probeResult{pos: gatePos(5, 1)})
+	r.reconcileOnce(ctx)
+	require.EqualValues(t, 1, kv.keysCalls.Load(), "the corner tick skips")
+	owner, _, _, ok = r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, quorumTestOwner, owner, "suppression is real: the cache is stale for this one interval")
+
+	// The NEXT tick's probe answers the truth ⇒ full pass, converge.
+	// Suppression bounded to exactly one interval.
+	r.reconcileOnce(ctx)
+	require.EqualValues(t, 2, kv.keysCalls.Load())
+	owner, _, _, ok = r.GetOwner(quorumTestPID)
+	require.True(t, ok)
+	require.Equal(t, "worker-B", owner)
+}
+
+func TestGateConfirmWaitAbortsOnStop(t *testing.T) {
+	t.Parallel()
+
+	kv := newHealthyKV(t)
+	p := &fakeProbe{pos: gatePos(5, 1)}
+	r := newGateResolver(kv, p, nil)
+	r.gateConfirmGap = 30 * time.Second // Stop must not wait this out
+	ctx := context.Background()
+
+	r.reconcileOnce(ctx) // latch
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.reconcileOnce(ctx) // enters the confirm gap
+	}()
+	require.Eventually(t, func() bool { return p.callCount() >= 2 },
+		2*time.Second, time.Millisecond, "tick must take its first probe")
+	r.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconcile pass did not abort promptly on Stop")
+	}
+	require.EqualValues(t, 1, kv.keysCalls.Load(), "aborted pass must not scan")
+}

--- a/internal/durable/claim_resolver_test.go
+++ b/internal/durable/claim_resolver_test.go
@@ -1665,6 +1665,10 @@ type mockKVForReconcile struct {
 	store     map[string][]byte
 	revision  uint64
 	afterKeys func()
+	// keysCalls counts Keys() invocations so gate tests can assert a
+	// gated tick performs zero list scans. Incremented by both this
+	// type's Keys and the mockKVWithKeyErr override.
+	keysCalls atomic.Int32
 }
 
 func newMockKVForReconcile(store map[string][]byte, revision uint64) *mockKVForReconcile {
@@ -1675,6 +1679,7 @@ func newMockKVForReconcile(store map[string][]byte, revision uint64) *mockKVForR
 }
 
 func (m *mockKVForReconcile) Keys(ctx context.Context, _ ...jetstream.WatchOpt) ([]string, error) {
+	m.keysCalls.Add(1)
 	defer func() {
 		if m.afterKeys != nil {
 			m.afterKeys()
@@ -1758,6 +1763,7 @@ func newMockKVWithKeyErr(store map[string][]byte, revision uint64) *mockKVWithKe
 // The afterKeys hook is still honoured.
 func (m *mockKVWithKeyErr) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
 	if m.keysErr != nil {
+		m.keysCalls.Add(1)
 		return nil, m.keysErr
 	}
 	return m.mockKVForReconcile.Keys(ctx, opts...)
@@ -2602,6 +2608,19 @@ func (c *captureLogger) has(substr string) bool {
 	}
 
 	return false
+}
+
+func (c *captureLogger) count(substr string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, m := range c.msgs {
+		if strings.Contains(m, substr) {
+			n++
+		}
+	}
+
+	return n
 }
 
 // TestReconcile_LogsUnreadableKeys pins F-D2c: a reconcile pass that lists keys

--- a/internal/durable/resolver_metrics.go
+++ b/internal/durable/resolver_metrics.go
@@ -30,7 +30,7 @@ type ResolverMetrics interface {
 	// Reasons: "channel_closed", "drift_detected", "establish_failed".
 	IncWatcherRestart(reason string)
 
-	// IncReconcileRescue increments when reconcileOnce applies any
+	// IncReconcileRescue increments when reconcileScan applies any
 	// change to the cache — i.e., the reconciler observed drift between
 	// KV and the in-memory cache and rescued the cache. Persistent
 	// non-zero values are strong evidence the KV watcher is silently

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -591,11 +591,26 @@ func (wc *WorkerConsumer) ensureGateResolver(ctx context.Context) error {
 	// so the value is always positive here. The resolver-package contract
 	// is preserved: direct callers of NewClaimBasedResolver who pass 0 via
 	// WithReconcileInterval still get polling disabled.
+
+	// Dedicated probe handle for the reconcile scan gate. The gate must
+	// never probe through the resolver's production handle (kv.Status
+	// mutates shared *stream state under concurrent Get/Watch — the
+	// epoch-monitor race class); a missing probe handle just leaves
+	// reconcile ungated, the pre-gate behavior.
+	resolverOpts := make([]ResolverOption, 0, 2)
+	resolverOpts = append(resolverOpts, WithReconcileInterval(wc.config.Resolver.ReconcileInterval))
+	probeKV, perr := wc.js.KeyValue(ctx, wc.config.Resolver.HandoffBucketName)
+	if perr != nil {
+		wc.logger.Debug("reconcile scan gate disabled: probe handle unavailable", "error", perr)
+	}
+	// WithStreamPosProbe is a no-op on a nil handle, so an unavailable
+	// probe leaves the gate inert (full scans, the pre-gate behavior).
+	resolverOpts = append(resolverOpts, WithStreamPosProbe(probeKV))
 	resolver := NewClaimBasedResolver(
 		kv,
 		wc.config.Resolver.HandoffClaimsPrefix,
 		wc.logger,
-		WithReconcileInterval(wc.config.Resolver.ReconcileInterval),
+		resolverOpts...,
 	)
 	resolver.SetBatching(wc.config.Resolver.BatchWindow, wc.config.Resolver.BatchMaxItems)
 	if wc.resolverMetrics != nil {

--- a/internal/natsutil/kvstreampos.go
+++ b/internal/natsutil/kvstreampos.go
@@ -1,0 +1,104 @@
+package natsutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Sentinel errors returned by ProbeKVStreamPos. Callers treat ANY error
+// as "cannot prove the bucket is idle" and run their full scan (fail
+// open); the sentinels exist so tests can pin the classification.
+var (
+	// ErrNotJetStreamBucket reports that kv.Status returned something
+	// other than a NATS-backed *jetstream.KeyValueBucketStatus (e.g. a
+	// test fake), so no stream position is available.
+	ErrNotJetStreamBucket = errors.New("kv status is not a JetStream-backed bucket status")
+	// ErrNoStreamInfo reports a NATS-backed status that carries no
+	// stream info (defensive; not observed in practice).
+	ErrNoStreamInfo = errors.New("kv bucket status carries no stream info")
+)
+
+// KVStreamPos is a point-in-time position + contract snapshot of the
+// stream backing a KV bucket, obtained from one read-only
+// $JS.API.STREAM.INFO request (no consumer, no Raft proposal, no write).
+//
+// The position triple (Created, LastSeq, Msgs) proves bucket idleness:
+// every KV mutation appends a sequence-consuming message (advancing
+// LastSeq), and every message removal (stream purge, MaxAge expiry,
+// per-message TTL) decrements Msgs without changing LastSeq. An
+// unchanged triple within one stream generation (Created unchanged)
+// therefore means the bucket's message set is byte-identical to what a
+// prior observer saw.
+type KVStreamPos struct {
+	Created time.Time // stream generation (changes on delete+recreate)
+	LastSeq uint64    // highest sequence ever assigned
+	Msgs    uint64    // current message count (removals decrement this)
+
+	// Contract-validation fields: config that would permit message
+	// removals invisible to LastSeq. See UnsafeConfig.
+	MaxAge                 time.Duration
+	AllowMsgTTL            bool
+	SubjectDeleteMarkerTTL time.Duration
+}
+
+// Same reports whether two probes prove an unchanged message set within
+// one stream generation. It is equality on Created (time.Time.Equal),
+// LastSeq, AND Msgs — never an ordering comparison: a regressed LastSeq
+// (e.g. file-store truncation after an unclean shutdown) must unlatch a
+// scan gate, not satisfy it. Config fields do not participate.
+func (p KVStreamPos) Same(o KVStreamPos) bool {
+	return p.Created.Equal(o.Created) && p.LastSeq == o.LastSeq && p.Msgs == o.Msgs
+}
+
+// UnsafeConfig reports whether the stream's live config permits
+// invisible removals (MaxAge / per-message-TTL machinery). Gates must
+// treat an unsafe config as "cannot latch": run the full pass and stay
+// disabled until the config is clean again. Servers predating the
+// message-TTL feature decode these fields as zero values, so the check
+// passes there.
+func (p KVStreamPos) UnsafeConfig() bool {
+	return p.MaxAge != 0 || p.AllowMsgTTL || p.SubjectDeleteMarkerTTL != 0
+}
+
+// ProbeKVStreamPos fetches the bucket's stream position via kv.Status —
+// one read-only STREAM.INFO request. It returns an error when the
+// Status call fails (bucket deleted, timeout, no quorum), when the
+// status is not backed by NATS JetStream (test fakes), or when the
+// returned status carries no stream info. Callers MUST treat any error
+// as "cannot prove idle" and run their full pass (fail open).
+//
+// Handle-ownership contract: kv MUST be a handle dedicated to the
+// probing goroutine. kv.Status resolves through stream.Info, which
+// mutates the handle's cached *stream state and races concurrent
+// Get/Put/Watch/Keys issued on the same handle (the race class fixed
+// for the manager's epoch monitor by a dedicated probe handle; see
+// test/integration/manager/manager_epoch_monitor_concurrency_test.go).
+// Open a separate js.KeyValue handle for probing — never pass a handle
+// production paths also use.
+func ProbeKVStreamPos(ctx context.Context, kv jetstream.KeyValue) (KVStreamPos, error) {
+	status, err := kv.Status(ctx)
+	if err != nil {
+		return KVStreamPos{}, fmt.Errorf("kv status: %w", err)
+	}
+	bucket, ok := status.(*jetstream.KeyValueBucketStatus)
+	if !ok {
+		return KVStreamPos{}, ErrNotJetStreamBucket
+	}
+	info := bucket.StreamInfo()
+	if info == nil {
+		return KVStreamPos{}, ErrNoStreamInfo
+	}
+
+	return KVStreamPos{
+		Created:                info.Created,
+		LastSeq:                info.State.LastSeq,
+		Msgs:                   info.State.Msgs,
+		MaxAge:                 info.Config.MaxAge,
+		AllowMsgTTL:            info.Config.AllowMsgTTL,
+		SubjectDeleteMarkerTTL: info.Config.SubjectDeleteMarkerTTL,
+	}, nil
+}

--- a/internal/natsutil/kvstreampos_test.go
+++ b/internal/natsutil/kvstreampos_test.go
@@ -1,0 +1,109 @@
+package natsutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func basePos() KVStreamPos {
+	return KVStreamPos{
+		Created: time.Unix(1000, 0),
+		LastSeq: 42,
+		Msgs:    7,
+	}
+}
+
+func TestKVStreamPos_Same(t *testing.T) {
+	t.Parallel()
+
+	p := basePos()
+	require.True(t, p.Same(basePos()))
+
+	seq := basePos()
+	seq.LastSeq++
+	require.False(t, p.Same(seq), "LastSeq change must break equality")
+
+	msgs := basePos()
+	msgs.Msgs--
+	require.False(t, p.Same(msgs), "Msgs change must break equality")
+
+	created := basePos()
+	created.Created = created.Created.Add(time.Second)
+	require.False(t, p.Same(created), "Created change must break equality")
+
+	// Same must be pure equality, never an ordering comparison: a
+	// REGRESSED LastSeq (file-store truncation) must also mismatch.
+	regressed := basePos()
+	regressed.LastSeq--
+	require.False(t, p.Same(regressed))
+
+	// Config fields do not participate in position equality (they are
+	// validated separately via UnsafeConfig).
+	cfg := basePos()
+	cfg.MaxAge = time.Minute
+	require.True(t, p.Same(cfg))
+
+	// Created comparison uses time.Time.Equal semantics, so a
+	// wall-clock-identical instant in a different location still matches.
+	loc := basePos()
+	loc.Created = loc.Created.In(time.FixedZone("X", 3600))
+	require.True(t, p.Same(loc))
+}
+
+func TestKVStreamPos_UnsafeConfig(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, basePos().UnsafeConfig())
+
+	maxAge := basePos()
+	maxAge.MaxAge = time.Hour
+	require.True(t, maxAge.UnsafeConfig())
+
+	ttl := basePos()
+	ttl.AllowMsgTTL = true
+	require.True(t, ttl.UnsafeConfig())
+
+	marker := basePos()
+	marker.SubjectDeleteMarkerTTL = time.Minute
+	require.True(t, marker.UnsafeConfig())
+}
+
+// fakeStatusKV lets us drive the two statically-testable failure paths of
+// ProbeKVStreamPos. The success path requires a *jetstream.
+// KeyValueBucketStatus, which has unexported fields and cannot be
+// fabricated outside nats.go — it is exercised against real NATS by the
+// integration suite (handoff scan-gate tests).
+type fakeStatusKV struct {
+	jetstream.KeyValue
+	status jetstream.KeyValueStatus
+	err    error
+}
+
+func (f *fakeStatusKV) Status(ctx context.Context) (jetstream.KeyValueStatus, error) {
+	return f.status, f.err
+}
+
+// fakeStatus is a non-NATS KeyValueStatus (what a test double would
+// return); the probe must reject it with ErrNotJetStreamBucket.
+type fakeStatus struct{ jetstream.KeyValueStatus }
+
+func TestProbeKVStreamPos_StatusError(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+	_, err := ProbeKVStreamPos(context.Background(), &fakeStatusKV{err: boom})
+	require.Error(t, err)
+	require.ErrorIs(t, err, boom)
+}
+
+func TestProbeKVStreamPos_NotJetStreamBucket(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProbeKVStreamPos(context.Background(), &fakeStatusKV{status: &fakeStatus{}})
+	require.ErrorIs(t, err, ErrNotJetStreamBucket)
+}

--- a/internal/natsutil/scangate.go
+++ b/internal/natsutil/scangate.go
@@ -1,0 +1,69 @@
+package natsutil
+
+import (
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// Scan-gate tuning shared by the durable reconcile gate and the handoff
+// sweep gate. Both gates skip their full KV walk when two stream-position
+// probes prove the bucket byte-identical to what the last clean full pass
+// observed.
+const (
+	// ScanGateMaxSkippedPasses bounds consecutive gated skips: a full
+	// pass runs at least every ScanGateMaxSkippedPasses+1 ticks
+	// regardless of what the probes report — the unknown-unknown backstop
+	// (10 min at the default 30s interval).
+	ScanGateMaxSkippedPasses = 19
+
+	// ScanGateDefaultConfirmGap is the double-probe confirmation wait. It
+	// spans ~2 raft heartbeat intervals so a deposed-but-not-yet-stepped-
+	// down stream leader cannot easily answer both probes of one tick with
+	// stale state. Tests shorten each gate's own copy of this value.
+	ScanGateDefaultConfirmGap = 2 * time.Second
+)
+
+// ScanGateConfigGuard drives the unsafe-config edge machine shared by the
+// reconcile and sweep scan gates: it emits exactly one Warn on entry into
+// an unsafe bucket config, a Debug while the config stays unsafe, and one
+// Info when the config is restored. The zero value is ready to use. It
+// must be accessed under the same single-goroutine discipline as the gate
+// state it guards.
+type ScanGateConfigGuard struct {
+	unsafeSeen bool
+}
+
+// Check reports whether pos's live bucket config is safe for scan gating.
+// On the transition into an unsafe config it Warns once (with the
+// offending config fields); while the config stays unsafe it Debugs; on
+// the transition back to a safe config it Infos once. It returns true iff
+// the config is safe. A nil logger suppresses all logging. Check never
+// touches the caller's latch/cache state — the caller invalidates that on
+// a false return.
+func (g *ScanGateConfigGuard) Check(pos KVStreamPos, logger types.Logger) bool {
+	if pos.UnsafeConfig() {
+		if !g.unsafeSeen {
+			g.unsafeSeen = true
+			if logger != nil {
+				logger.Warn("handoff bucket config violates the scan-gate contract; gate disabled",
+					"max_age", pos.MaxAge,
+					"allow_msg_ttl", pos.AllowMsgTTL,
+					"subject_delete_marker_ttl", pos.SubjectDeleteMarkerTTL,
+				)
+			}
+		} else if logger != nil {
+			logger.Debug("handoff bucket config still violates the scan-gate contract")
+		}
+
+		return false
+	}
+	if g.unsafeSeen {
+		g.unsafeSeen = false
+		if logger != nil {
+			logger.Info("handoff bucket config restored; scan gate re-enabled")
+		}
+	}
+
+	return true
+}

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -201,7 +201,20 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 		return rErr
 	}
 
-	store := handoff.NewNATSClaimStore(handoffKV, "claims/")
+	// Dedicated probe handle for the sweep scan gate: probing must not
+	// share the production handle (kv.Status mutates cached *stream
+	// state under concurrent claim reads/writes — the epoch-monitor
+	// race class). On failure the store just stays ungated (full
+	// sweeps, the pre-gate behavior).
+	pctx, pcancel := context.WithTimeout(startupCtx, m.cfg.OperationTimeout)
+	probeKV, perr := js.KeyValue(pctx, m.cfg.KVBuckets.HandoffBucket)
+	pcancel()
+	if perr != nil {
+		m.logger.Debug("handoff sweep scan gate disabled: probe handle unavailable", "error", perr)
+	}
+	// A nil probeKV (probe handle unavailable) yields the same ungated
+	// store as the plain constructor.
+	store := handoff.NewNATSClaimStoreWithProbe(handoffKV, probeKV, "claims/")
 	m.handoffStore = store
 	// Build the per-worker claim-write limiter once and share it across the
 	// coordinator (site 1) and the startup hygiene/resume loops (sites 2-3) so

--- a/test/integration/failure/resolver_readfault_test.go
+++ b/test/integration/failure/resolver_readfault_test.go
@@ -379,6 +379,24 @@ func TestResolverReadFault_ConsumerSurvivesQuorumLossWindow(t *testing.T) {
 	// stays committed at R.
 	fc.ArmReads()
 
+	// (3b) Nudge the bucket position so the reconcile scan gate cannot keep
+	// skipping passes. Reconcile ticks are gated behind a stream-position
+	// probe (Status passes through the fault wrapper, so the probe stays
+	// healthy), and over a byte-idle bucket every tick provably no-ops and
+	// skips — the faulted claim-key Get below would then never fire. One
+	// write OUTSIDE the claims/ prefix advances the bucket position without
+	// touching any claim: the next tick mismatches the latch and runs a
+	// full pass, and that pass's faulted Get is unclean, so no pass can
+	// re-latch until reads recover — every subsequent tick stays a full
+	// pass for the rest of the fault window. This is the gate's designed
+	// contract (skips only when the bucket is provably unchanged), and it
+	// is exactly the shape observation-style reconcile tests must use in
+	// the gated world.
+	nudgeKV, err := realJS.KeyValue(ctx, rfHandoffBucket)
+	require.NoError(t, err)
+	_, err = nudgeKV.Put(ctx, "rf-gate-nudge", []byte("x"))
+	require.NoError(t, err)
+
 	// (4) Force at least one reconcileOnce pass under the fault: wait until a
 	// claim-key Get has actually faulted at least twice (proves a reconcile
 	// cycle observed the Keys-ok/Get-fail window — the exact condition that

--- a/test/integration/handoff/handoff_scan_gate_concurrency_test.go
+++ b/test/integration/handoff/handoff_scan_gate_concurrency_test.go
@@ -1,0 +1,222 @@
+package handoff_test
+
+// Concurrency stress test for the scan gate's ticker goroutines, per the
+// AGENTS.md "monitor goroutine on a ticker" rule: aggressive cadence,
+// concurrent production KV traffic, and the race detector as the primary
+// oracle. Patterned on
+// test/integration/manager/manager_epoch_monitor_concurrency_test.go.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandoffScanGate_ConcurrentTrafficStress races the scan gate's probes
+// against production KV traffic on the SAME bucket: gated ticker sweeps
+// (coordinator) and gated ticker reconciles (resolver) running at an
+// aggressive 20ms cadence — shorter than the components' own (unexported,
+// still-2s-default) confirm gap, itself a valid stress shape — against
+// concurrent PutIfEpoch writers, Apply-origin sweeps, and GetOwner/
+// ForceRefreshPartition readers.
+//
+// Every component keeps the same per-component handle discipline as the
+// flatness test: a dedicated production handle and a dedicated probe
+// handle, each its own js.KeyValue(ctx, bucket) call — the same discipline
+// that fixed the epoch-monitor race class this test's template pins.
+//
+// The primary oracle is the race detector (run this file under -race); the
+// secondary oracle is a final convergence check that each written claim's
+// owner resolves via a fresh Get once the stress traffic stops.
+func TestHandoffScanGate_ConcurrentTrafficStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: short mode")
+	}
+
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	bucket := fmt.Sprintf("itest-handoff-scan-gate-stress-%d", time.Now().UnixNano())
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	const numWorkers = 3
+	const cadence = 20 * time.Millisecond
+	components := make([]scanGateComponent, numWorkers)
+	for i := range components {
+		components[i] = newScanGateComponent(t, ctx, js, bucket, cadence)
+	}
+
+	pids := make([]string, numWorkers)
+	for i := range pids {
+		pid := fmt.Sprintf("cx-p%d", i)
+		pids[i] = pid
+		_, err := components[i].store.PutIfEpoch(ctx, pid, 0,
+			handoff.NewInitialClaim(pid, fmt.Sprintf("w%d-0", i), time.Now(), time.Minute))
+		require.NoError(t, err)
+	}
+
+	for i := range components {
+		components[i].coord.Start(ctx)
+		require.NoError(t, components[i].resolver.Start(ctx))
+	}
+	t.Cleanup(func() {
+		for i := range components {
+			components[i].resolver.Stop()
+		}
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// One goroutine per worker writes/updates claims through
+	// ClaimStore.PutIfEpoch at ~10ms cadence.
+	for i := range numWorkers {
+		wg.Go(func() {
+			runClaimWriter(ctx, stop, components[i].store, pids[i], i)
+		})
+	}
+
+	// One goroutine per worker calls coordinator.Apply with a small,
+	// unchanging assignment at ~50ms cadence — exercising Apply-origin
+	// sweeps racing gated ticker sweeps on sweepMu.
+	for i := range numWorkers {
+		wg.Go(func() {
+			runApplyLoop(ctx, stop, components[i].coord, pids[i], i)
+		})
+	}
+
+	// One goroutine per resolver calls GetOwner + ForceRefreshPartition at
+	// ~10ms cadence.
+	for i := range numWorkers {
+		wg.Go(func() {
+			runResolverReader(ctx, stop, components[i].resolver, pids[i])
+		})
+	}
+
+	time.Sleep(5 * time.Second)
+	close(stop)
+	wg.Wait()
+
+	// The concurrent soak's oracle is the race detector: no soak goroutine
+	// asserts on t, so a data race surfaces only as the -race binary's
+	// non-zero exit (check stderr for WARNING: DATA RACE blocks). The
+	// convergence check below is the functional oracle.
+
+	// Final convergence: each written claim's owner resolves via a fresh
+	// Get, while the resolvers' background loops are still running (their
+	// ticker/watcher must catch up to the last write within a handful of
+	// cadences).
+	for i, pid := range pids {
+		want, _, err := components[i].store.Get(ctx, pid)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			owner, _, _, ok := components[i].resolver.GetOwner(pid)
+
+			return ok && owner == want.Owner
+		}, 5*time.Second, 25*time.Millisecond,
+			"resolver %d did not converge to the final claim owner for %s", i, pid)
+	}
+}
+
+// runClaimWriter drives ~10ms-cadence PutIfEpoch churn against pid until
+// stop closes. It tracks the epoch it last wrote so successive CAS calls
+// keep succeeding against its own writes (no other writer touches this
+// pid); a defensive re-read on CAS failure keeps the loop alive if it ever
+// does lose a race.
+func runClaimWriter(ctx context.Context, stop <-chan struct{}, store handoff.ClaimStore, pid string, workerIdx int) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	epoch := int64(1)
+	for i := 0; ; i++ {
+		select {
+		case <-stop:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		next := handoff.Claim{
+			PartitionID: pid,
+			Owner:       fmt.Sprintf("w%d-%d", workerIdx, i),
+			State:       handoff.ClaimStateStable,
+			Epoch:       epoch + 1,
+			LastUpdated: time.Now().UTC(),
+			TTLSeconds:  int64(time.Minute.Seconds()),
+		}
+		if _, err := store.PutIfEpoch(ctx, pid, epoch, next); err != nil {
+			if cur, _, gerr := store.Get(ctx, pid); gerr == nil {
+				epoch = cur.Epoch
+			}
+
+			continue
+		}
+		epoch = next.Epoch
+	}
+}
+
+// runApplyLoop calls coord.Apply with an unchanging small assignment
+// (identical previous/next, so no prepare/commit/stabilize churn) at
+// ~50ms cadence until stop closes. Apply runs an opportunistic
+// Apply-origin sweep unconditionally at its top — never scan-gated — so
+// this races the gated ticker sweep on the coordinator's sweepMu exactly
+// as production does when Apply and the sweep ticker fire concurrently.
+func runApplyLoop(ctx context.Context, stop <-chan struct{}, coord handoff.Coordinator, pid string, workerIdx int) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	assignment := types.Assignment{
+		Version:    1,
+		Partitions: []types.Partition{{Keys: []string{pid}}},
+	}
+	workerID := fmt.Sprintf("w%d", workerIdx)
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		_ = coord.Apply(ctx, workerID, assignment, assignment)
+	}
+}
+
+// runResolverReader calls GetOwner + ForceRefreshPartition at ~10ms
+// cadence until stop closes, exercising the resolver's read paths
+// concurrently with its own gated reconciler goroutine.
+func runResolverReader(ctx context.Context, stop <-chan struct{}, resolver *durable.ClaimBasedResolver, pid string) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		resolver.GetOwner(pid)
+		_ = resolver.ForceRefreshPartition(ctx, pid)
+	}
+}

--- a/test/integration/handoff/handoff_scan_gate_test.go
+++ b/test/integration/handoff/handoff_scan_gate_test.go
@@ -1,0 +1,278 @@
+package handoff_test
+
+// Live-NATS contracts for the reconcile/sweep scan gate (spec §9 integration
+// items 1 and 2): an idle handoff bucket must stay consumer-flat under the
+// gate, scans must resume promptly on real activity, and a rebalance must
+// still converge end-to-end with two-phase handoff enabled.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/durable"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// scanGateComponent bundles one simulated worker's gated pair: a two-phase
+// coordinator over a probed ClaimStore, and a ClaimBasedResolver with its own
+// probed reconciler. Both halves are wired with the handle discipline the
+// scan gate requires in production: a DEDICATED production handle and a
+// DEDICATED probe handle per component, each obtained via its own
+// js.KeyValue(ctx, bucket) call. Sharing a handle between production
+// reads/writes and the gate's probe would race the cached *stream state
+// (the epoch-monitor race class); newScanGateComponent never does that.
+type scanGateComponent struct {
+	store    handoff.ClaimStore
+	coord    handoff.Coordinator
+	resolver *durable.ClaimBasedResolver
+}
+
+// newScanGateComponent opens four separate KV handles on bucket (store,
+// store-probe, resolver, resolver-probe) and builds one simulated worker's
+// gated pair at cadence. The unexported confirm-gap fields on both the
+// coordinator and the resolver are not reachable from this package and stay
+// at their 2s production defaults; cadence only controls how often each
+// component's ticker fires, which the scan-gate budget math accounts for.
+func newScanGateComponent(t *testing.T, ctx context.Context, js jetstream.JetStream, bucket string, cadence time.Duration) scanGateComponent {
+	t.Helper()
+
+	storeKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	storeProbeKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	resKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	resProbeKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+
+	store := handoff.NewNATSClaimStoreWithProbe(storeKV, storeProbeKV, "claims/")
+	coord := handoff.New(handoff.Config{
+		Store:         store,
+		SweepInterval: cadence,
+		TTL:           time.Minute,
+		Now:           time.Now,
+	}, true)
+	resolver := durable.NewClaimBasedResolver(resKV, "claims/", nil,
+		durable.WithReconcileInterval(cadence),
+		durable.WithStreamPosProbe(resProbeKV),
+	)
+
+	return scanGateComponent{store: store, coord: coord, resolver: resolver}
+}
+
+// TestHandoffScanGate_IdleBucketConsumerFlatness pins the flatness contract
+// (spec §9 integration item 1) end-to-end against real embedded NATS: it
+// drives the two REAL gated components (ClaimBasedResolver +
+// twoPhaseCoordinator over natsClaimStore) directly, rather than a full
+// FDC-shaped manager+consumer cluster. This exercises the exact production
+// code paths (default streamPos/BucketPos probe, real kv.Status, real
+// Keys()/ListKeys() consumers) with deterministic budget math; the
+// full-stack path is separately covered by
+// TestHandoffScanGate_RebalanceConvergence below.
+//
+// Non-vacuity: nats.go's kv.Keys() creates a throwaway ephemeral ordered
+// consumer PER CALL (see the reference cited in AGENTS.md's KV-watcher
+// churn note); kv.Status() (the gate's probe) does not. A full
+// reconcile/sweep pass calls Keys() exactly once; a gated skip calls neither
+// Keys() nor Get() — only Status(). Counting
+// $JS.EVENT.ADVISORY.CONSUMER.CREATED.KV_<bucket>.> messages is therefore a
+// direct, non-vacuous proxy for "did a full scan run".
+func TestHandoffScanGate_IdleBucketConsumerFlatness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := fmt.Sprintf("itest-handoff-scan-gate-%d", time.Now().UnixNano())
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	// Dedicated connection for the advisory subscriber: it must never share
+	// a handle with any production or probe KV operation.
+	advNC, err := nats.Connect(nc.ConnectedUrl(), nats.Timeout(2*time.Second))
+	require.NoError(t, err)
+	t.Cleanup(advNC.Close)
+
+	var created atomic.Int64
+	advSubject := fmt.Sprintf("$JS.EVENT.ADVISORY.CONSUMER.CREATED.KV_%s.>", bucket)
+	sub, err := advNC.Subscribe(advSubject, func(*nats.Msg) { created.Add(1) })
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	require.NoError(t, advNC.Flush())
+
+	// Three simulated workers (FDC-shaped, scaled down): each gets its own
+	// coordinator + resolver pair at an aggressive 500ms cadence, all four
+	// handles per component freshly opened.
+	const numWorkers = 3
+	const cadence = 500 * time.Millisecond
+	components := make([]scanGateComponent, numWorkers)
+	for i := range components {
+		components[i] = newScanGateComponent(t, ctx, js, bucket, cadence)
+	}
+
+	// Seed 20 stable claims (owner "w1") via one store before starting
+	// anything — plain KV Puts, not Keys()/Watch() calls, so seeding does
+	// not disturb the advisory counter.
+	const numClaims = 20
+	seedPIDs := make([]string, numClaims)
+	for j := range seedPIDs {
+		pid := fmt.Sprintf("gate-flat-p%d", j)
+		seedPIDs[j] = pid
+		_, err := components[0].store.PutIfEpoch(ctx, pid, 0,
+			handoff.NewInitialClaim(pid, "w1", time.Now(), time.Minute))
+		require.NoError(t, err)
+	}
+
+	for i := range components {
+		components[i].coord.Start(ctx)
+		require.NoError(t, components[i].resolver.Start(ctx))
+		t.Cleanup(components[i].resolver.Stop)
+	}
+
+	// Active window: several passes at 500ms cadence before the gate
+	// latches. Non-vacuity check — the advisory counter must have observed
+	// at least one KV_<bucket> consumer creation (each resolver's Start
+	// alone issues a warm() Keys() call and a WatchAll() watcher, both
+	// ephemeral consumers; each component's first reconcile/sweep tick adds
+	// one more).
+	time.Sleep(3 * time.Second)
+	active := created.Load()
+	require.GreaterOrEqual(t, active, int64(1),
+		"advisory counter must observe at least one KV_<bucket> consumer creation "+
+			"during the active window (harness non-vacuity: the counter must actually count)")
+
+	// Idle window: 10s soak, no writes anywhere. Ungated, 6 components
+	// (3 resolvers + 3 coordinators) ticking every 500ms would create
+	// ~120 consumers in this window (6 * 10s / 500ms = 120) — one Keys()
+	// call per tick. Gated, each tick that finds the bucket unchanged pays
+	// the (unexported, still-2s-default) confirm gap INSIDE the pass before
+	// it can skip, so a component completes at most ~5 gated cycles in 10s
+	// — and none of those cycles calls Keys() at all. The only Keys() calls
+	// expected in this window are the tail of the initial latch-settling
+	// from the active window and any CI-load jitter, which is why the
+	// budget below is a 10x-reduction floor (12, not 0) rather than an
+	// exact zero.
+	time.Sleep(10 * time.Second)
+	idle := created.Load() - active
+	const idleBudget = 12
+	require.LessOrEqual(t, idle, int64(idleBudget),
+		"idle handoff bucket must stay near consumer-flat under the scan gate "+
+			"(observed %d full-scan consumer creations across 6 components over 10s; "+
+			"ungated baseline for this shape is ~120; deleting the gate code must make "+
+			"this assertion fail by an order of magnitude)", idle)
+	t.Logf("idle-window consumer creations: %d (budget %d, ungated baseline ~120)", idle, idleBudget)
+
+	// Re-engage proof: one claim update via the store advances the bucket
+	// position. The first mismatching probe on either the resolver or the
+	// coordinator runs its full pass IMMEDIATELY (no confirm-gap wait on
+	// the mismatch path), so scans must resume well within one cadence +
+	// one confirm gap.
+	baseline := created.Load()
+	updated := handoff.Claim{
+		PartitionID: seedPIDs[0],
+		Owner:       "w2",
+		State:       handoff.ClaimStateStable,
+		Epoch:       2,
+		LastUpdated: time.Now().UTC(),
+		TTLSeconds:  int64(time.Minute.Seconds()),
+	}
+	_, err = components[0].store.PutIfEpoch(ctx, seedPIDs[0], 1, updated)
+	require.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
+	require.Greater(t, created.Load(), baseline,
+		"a claim write must re-engage scans (the mismatching probe runs a full pass "+
+			"with no confirm-gap wait) — the gate must not have failed permanently latched")
+}
+
+// TestHandoffScanGate_RebalanceConvergence pins spec §9 integration item 2:
+// a real manager cluster with EnableTwoPhaseHandoff must still converge
+// assignments and claims end-to-end through join and leave, with the scan
+// gate active on both the coordinator's sweep and every worker's resolver.
+// Unlike the flatness test above, this does not count advisories — it pins
+// that scans engage on real cluster activity through the full manager
+// stack, complementing the component-level flatness/re-engage proof.
+func TestHandoffScanGate_RebalanceConvergence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.EnableTwoPhaseHandoff = true
+	cfg.KVBuckets.HandoffBucket = fmt.Sprintf("itest-handoff-scan-gate-rebalance-%d", time.Now().UnixNano())
+
+	const numPartitions = 30
+	src := source.NewStatic(testutil.CreateTestPartitions(numPartitions))
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	defer cluster.StopWorkers()
+
+	for range 3 {
+		mgr := cluster.AddWorker(ctx)
+		require.NoError(t, mgr.Start(ctx))
+	}
+	cluster.WaitForStableState(20 * time.Second)
+	cluster.WaitForPartitionCoverage(numPartitions, 15*time.Second)
+	requireAllClaimsStable(t, ctx, cluster.JS, cfg.KVBuckets.HandoffBucket, numPartitions)
+
+	// Add a worker mid-soak: assignments must rebalance and every claim
+	// must converge back to stable.
+	newWorker := cluster.AddWorker(ctx)
+	require.NoError(t, newWorker.Start(ctx))
+	cluster.WaitForStableState(20 * time.Second)
+	cluster.WaitForPartitionCoverage(numPartitions, 15*time.Second)
+	requireAllClaimsStable(t, ctx, cluster.JS, cfg.KVBuckets.HandoffBucket, numPartitions)
+
+	// Remove it again: re-convergence.
+	cluster.RemoveWorker(3)
+	cluster.WaitForStableState(20 * time.Second)
+	cluster.WaitForPartitionCoverage(numPartitions, 15*time.Second)
+	requireAllClaimsStable(t, ctx, cluster.JS, cfg.KVBuckets.HandoffBucket, numPartitions)
+}
+
+// requireAllClaimsStable polls InspectHandoffClaims until at least
+// minClaims claims exist and every one of them has converged to Stable, or
+// fails the test after the timeout. Used to pin end-to-end convergence
+// after a rebalance without depending on which internal path (watcher or
+// gated reconciler/sweep) delivered it.
+func requireAllClaimsStable(t *testing.T, ctx context.Context, js jetstream.JetStream, bucket string, minClaims int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		claims, err := parti.InspectHandoffClaims(ctx, js, bucket)
+		if err != nil || len(claims) < minClaims {
+			return false
+		}
+		for _, c := range claims {
+			if c.State != parti.HandoffClaimStable {
+				return false
+			}
+		}
+
+		return true
+	}, 20*time.Second, 200*time.Millisecond,
+		"handoff claims did not converge to stable after rebalance")
+}


### PR DESCRIPTION

## Problem

Every handoff-bucket maintenance tick pays full scan cost even when the bucket has not changed:

- The claim resolver's periodic reconcile runs `Keys()` — which nats.go serves by creating and tearing down a throwaway ordered consumer per call — plus a `Get` per claim key.
- The two-phase sweep ticker runs `ListKeys()` plus a `Get` per key on every pass.

At 10 workers / 2,000 claims with default intervals this is ~40 ephemeral consumer creations/min and ~80k reads/min at idle across the two scan sites; both scale linearly with partition count and fleet size (at 10k partitions the idle floor is untenable, and each throwaway consumer is a JetStream meta-layer Raft proposal).

## Change

Both scan sites now probe the bucket's backing stream position first — one read-only `STREAM.INFO` request through a **dedicated** `js.KeyValue` handle (never the production handle; `kv.Status → stream.Info` mutates cached handle state and would race concurrent use — the same race class previously fixed for the epoch monitor):

- An unchanged `(Created, LastSeq, Msgs)` triple, confirmed by a second probe 2s later, proves the bucket byte-identical since the last full pass.
- The resolver then skips its key walk entirely; the sweeper runs **all** of its per-tick decision arms (expiry reset, commit finalization, orphan reaping) from a latched claim cache with a fresh live set — never skipping maintenance, only the redundant reads.
- `Apply`-path sweeps are completely unaffected.

Safety posture:

- **Fail-open everywhere.** Any probe error, unsafe bucket config (TTL-based expiry), or missing probe handle falls back to today's full-scan behavior. An edge-triggered warning fires if the bucket config is changed to permit server-side expiry.
- **Bounded staleness.** An unconditional full pass runs at least every 20th gated pass; a stale probe answer can suppress at most one interval.
- **No API change.** Observability is log-only; recovery semantics and all public surfaces are unchanged.

## Validation

- Unit suites for both gate sites (`-race`), including fail-open, double-probe confirm, forced-pass budget, staleness-bound, and no-probe-handle contracts.
- New integration contracts: idle-bucket consumer-creation flatness (0 observed vs ≤12 budget vs ~120 ungated baseline), rebalance convergence with the gate active, a 20ms-cadence concurrency stress under `-race`, and a live gate-active recovery test.
- `make pre-pr` (lint → unit `-race` → integration `-race`) green on the final tree, zero failures, no flake re-runs.

## Release

Carries the `v2.8.2` changelog cut covering both this PR and #60 (heartbeat
scan suppression, already merged). Tag + GitHub release follow this merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPUoEnYzc6dSE5TurTMhG
