### PR TITLE
test: prove scan-gate backstops and guard heartbeat scan rate in CI

### DIFF
--- a/.github/workflows/simulation-stress.yml
+++ b/.github/workflows/simulation-stress.yml
@@ -414,8 +414,9 @@ jobs:
 
   sim-storage-residuals:
     runs-on: ubuntu-latest
-    # 3 scenarios: ~60s each ≈ 4m + setup ≈ 5m; 9m gives headroom.
-    timeout-minutes: 9
+    # 4 scenarios: three ~60s + heartbeat_scan_flatness ~285s ≈ 9m + setup;
+    # 16m gives headroom.
+    timeout-minutes: 16
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -428,9 +429,10 @@ jobs:
       - name: Run Storage & Burst Scenarios
         # Phase 8 (Gaps 9, 13) — manager create-time StorageType assertion,
         # operator-precreated replicas, burst-after-quiet KV-op ceiling.
+        # heartbeat_scan_flatness (FM7/FM3) — leader heartbeat scan-rate floor.
         run: |
           set -e
-          for scn in storage_assertion storage_replicas_operator burst_after_quiet; do
+          for scn in storage_assertion storage_replicas_operator burst_after_quiet heartbeat_scan_flatness; do
             echo "::group::${scn}"
             ./tmp/simulation \
               --config "test/simulation/configs/${scn}.yaml" \
@@ -447,3 +449,4 @@ jobs:
             failure_report.json
             tmp/storage_*.log
             tmp/burst_*.log
+            tmp/heartbeat_scan_flatness.log

--- a/.github/workflows/simulation-stress.yml
+++ b/.github/workflows/simulation-stress.yml
@@ -245,7 +245,7 @@ jobs:
         # boundary (peer-takeover vs whole-bucket-loss) plus the
         # bucket-recreate epoch fence.
         run: |
-          set -e
+          set -eo pipefail
           for scn in chaos_bucket_delete chaos_bucket_recreate chaos_bucket_peer_takeover chaos_kv_unavailable; do
             echo "::group::${scn}"
             ./tmp/simulation \
@@ -282,7 +282,7 @@ jobs:
         # recovery path in internal/source/nats_kv.go and the composed
         # bucket-delete error surface.
         run: |
-          set -e
+          set -eo pipefail
           for scn in chaos_natskv_source chaos_natskv_source_bucket_delete; do
             echo "::group::${scn}"
             ./tmp/simulation \
@@ -318,7 +318,7 @@ jobs:
         # reassignment, direct stable-ID claim steal, tiny-pool stale
         # takeover, and MaxAge-expiry returning-worker self-stop.
         run: |
-          set -e
+          set -eo pipefail
           for scn in chaos_network_disconnect_long chaos_stableid_claim_steal chaos_stableid_tiny_pool chaos_stableid_maxage_expiry; do
             echo "::group::${scn}"
             ./tmp/simulation \
@@ -355,7 +355,7 @@ jobs:
         # assignment-commit CAS storm, handoff bucket MaxAge contract,
         # orphan stable-claim drift, and handoff claim write-fault recovery.
         run: |
-          set -e
+          set -eo pipefail
           for scn in chaos_producer_disconnect chaos_assignment_cas_storm handoff_precreate_maxage handoff_orphan_stable_claim chaos_handoff_startup_write_fault chaos_handoff_version_write_fault; do
             echo "::group::${scn}"
             ./tmp/simulation \
@@ -393,7 +393,7 @@ jobs:
         # Phase 7 (Gaps 8b, 8c, 8a-OS) — process-mode IPC smoke +
         # SIGSTOP claim-loss takeover with same-pool replacement.
         run: |
-          set -e
+          set -eo pipefail
           for scn in process_smoke chaos_process_sigstop_long; do
             echo "::group::${scn}"
             ./tmp/simulation \
@@ -431,7 +431,7 @@ jobs:
         # operator-precreated replicas, burst-after-quiet KV-op ceiling.
         # heartbeat_scan_flatness (FM7/FM3) — leader heartbeat scan-rate floor.
         run: |
-          set -e
+          set -eo pipefail
           for scn in storage_assertion storage_replicas_operator burst_after_quiet heartbeat_scan_flatness; do
             echo "::group::${scn}"
             ./tmp/simulation \

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -198,6 +198,7 @@ func New(cfg Config, enableTwoPhase bool) Coordinator {
 			cfg:               cfg,
 			orphanAbsentSince: make(map[string]time.Time),
 			sweepConfirmGap:   natsutil.ScanGateDefaultConfirmGap,
+			sweepMaxSkips:     natsutil.ScanGateMaxSkippedPasses,
 		}
 		// Optional store capability: probing the backing stream position
 		// lets ticker sweeps skip provably-no-op ListKeys+Get storms.

--- a/internal/assignment/handoff/sweep_gate_reap_live_test.go
+++ b/internal/assignment/handoff/sweep_gate_reap_live_test.go
@@ -1,0 +1,230 @@
+package handoff
+
+// In-package live-NATS proof of the handoff sweep gate's two longest-horizon
+// backstops, neither of which any CI run otherwise reaches (~10 minutes at
+// production defaults):
+//
+//  1. the forced full pass every sweepMaxSkips+1 gated (cached) ticks, even
+//     while the bucket stays byte-idle; and
+//  2. orphan-claim reaping after OrphanGrace elapses WHILE the scan gate is
+//     actively latched — the cached/gated ticker pass is a legitimate
+//     finalizer of the clock-driven reap arm.
+//
+// sweepMaxSkips is a per-instance seam defaulting to
+// natsutil.ScanGateMaxSkippedPasses (19); only in-package tests shorten it.
+// OrphanGrace is already a settable Config field (production wires the 10m
+// const), so no seam is needed there — the test just configures it short.
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// sweepArgLogger records each message together with its structured args so
+// a test can count full passes carrying a specific reason (the plain
+// sweepCaptureLogger keeps only the message). Safe for the sweep goroutine
+// to write while the test goroutine reads.
+type sweepArgLogger struct {
+	mu      sync.Mutex
+	entries []sweepArgEntry
+}
+
+type sweepArgEntry struct {
+	msg string
+	kv  []any
+}
+
+var _ types.Logger = (*sweepArgLogger)(nil)
+
+func (l *sweepArgLogger) log(msg string, kv ...any) {
+	l.mu.Lock()
+	l.entries = append(l.entries, sweepArgEntry{msg: msg, kv: kv})
+	l.mu.Unlock()
+}
+
+func (l *sweepArgLogger) Debug(msg string, kv ...any) { l.log(msg, kv...) }
+func (l *sweepArgLogger) Info(msg string, kv ...any)  { l.log(msg, kv...) }
+func (l *sweepArgLogger) Warn(msg string, kv ...any)  { l.log(msg, kv...) }
+func (l *sweepArgLogger) Error(msg string, kv ...any) { l.log(msg, kv...) }
+func (l *sweepArgLogger) Fatal(msg string, kv ...any) { l.log(msg, kv...) }
+
+func (l *sweepArgLogger) countMsg(msg string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, e := range l.entries {
+		if e.msg == msg {
+			n++
+		}
+	}
+
+	return n
+}
+
+func (l *sweepArgLogger) countReason(msg, reason string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, e := range l.entries {
+		if e.msg != msg {
+			continue
+		}
+		for i := 0; i+1 < len(e.kv); i += 2 {
+			k, kok := e.kv[i].(string)
+			v, vok := e.kv[i+1].(string)
+			if kok && vok && k == "reason" && v == reason {
+				n++
+			}
+		}
+	}
+
+	return n
+}
+
+// TestSweepGateLive_ForcedPassAndOrphanReap proves both sweep-gate
+// backstops against a real embedded NATS server. A reap-eligible orphan
+// (stable claim whose partition is absent from the vouched live set) and a
+// live stable claim are seeded; the bucket then stays byte-idle so the gate
+// latches. The test asserts (i) forced full passes fire on schedule while
+// idle and (ii) the orphan is reaped once OrphanGrace elapses despite the
+// gate being actively latched, while the live claim survives untouched.
+func TestSweepGateLive_ForcedPassAndOrphanReap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	// partitest (not internal/testutil) is used to start embedded NATS: an
+	// in-package handoff test cannot import internal/testutil, which pulls
+	// in the root parti package that itself imports this package (cycle).
+	// partitest depends only on the leaf types package.
+	srv, nc := partitest.StartEmbeddedNATS(t)
+	defer func() {
+		nc.Close()
+		srv.Shutdown()
+		srv.WaitForShutdown()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := "sweep-gate-live-reap"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	// Dedicated probe handle for the sweep gate — never the handle the
+	// coordinator's store reads/writes through (kv.Status mutates shared
+	// *stream state under concurrent ops; the epoch-monitor race class).
+	probeKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+
+	store := NewNATSClaimStoreWithProbe(kv, probeKV, "claims/")
+
+	// Dedicated sanity handle for the test's own reads (ListKeys spins up a
+	// throwaway ordered consumer that mutates its handle's stream state), so
+	// it is never a handle a live component owns.
+	sanityKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	sanityStore := NewNATSClaimStore(sanityKV, "claims/")
+
+	const (
+		livePID   = "pLive"
+		orphanPID = "pOrphan"
+	)
+
+	now := time.Now()
+	_, err = store.PutIfEpoch(ctx, livePID, 0, NewInitialClaim(livePID, "worker-live", now, time.Minute))
+	require.NoError(t, err)
+	_, err = store.PutIfEpoch(ctx, orphanPID, 0, NewInitialClaim(orphanPID, "worker-gone", now, time.Minute))
+	require.NoError(t, err)
+
+	// Confirm both claims exist before starting — so a later "orphan gone"
+	// is a genuine reap, not a claim that was never written.
+	keys, err := sanityStore.ListKeys(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{livePID, orphanPID}, keys)
+
+	log := &sweepArgLogger{}
+	// vouchedLive answers ok=true with only livePID present, so orphanPID is
+	// continuously absent from the vouched set and thus reap-eligible.
+	vouchedLive := func(ctx context.Context) (map[string]struct{}, bool) {
+		return map[string]struct{}{livePID: {}}, true
+	}
+
+	coord, ok := New(Config{
+		Store:          store,
+		Logger:         log,
+		TTL:            time.Minute,
+		SweepInterval:  100 * time.Millisecond,
+		OrphanGrace:    1 * time.Second,
+		LivePartitions: vouchedLive,
+		// Now defaults to time.Now — the grace clock advances on the real
+		// clock, so the reap can only fire after ~1s of real sweeps.
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+
+	// In-package seams: shorten the confirm gap so the gate latches on a
+	// test timescale, and shrink the skip budget so the forced-pass backstop
+	// fires within a couple of seconds instead of ~10 minutes.
+	coord.sweepConfirmGap = 20 * time.Millisecond
+	coord.sweepMaxSkips = 4
+
+	coord.Start(ctx)
+
+	const (
+		fullPassMsg = "handoff sweep full pass"
+		engagedMsg  = "handoff sweep gate engaged"
+		reapMsg     = "reaped orphan claim"
+	)
+
+	// (ii) The orphan must be reaped once OrphanGrace elapses, even though
+	// the gate is actively latched over the idle bucket. Poll a dedicated
+	// handle for the orphan key disappearing.
+	require.Eventually(t, func() bool {
+		ks, lerr := sanityStore.ListKeys(ctx)
+		if lerr != nil {
+			return false
+		}
+
+		return !slices.Contains(ks, orphanPID)
+	}, 8*time.Second, 100*time.Millisecond,
+		"the orphan claim must be reaped after OrphanGrace under an active gate")
+
+	// The live claim must survive: reaping only ever touches the absent
+	// partition's claim.
+	survivors, err := sanityStore.ListKeys(ctx)
+	require.NoError(t, err)
+	require.Contains(t, survivors, livePID, "the live claim must survive the sweep")
+	require.NotContains(t, survivors, orphanPID, "the orphan claim must be gone")
+
+	// The reap must have been logged (the Info line), confirming it went
+	// through the reaper rather than some other deletion.
+	require.GreaterOrEqual(t, log.countMsg(reapMsg), 1, "the reaper must log the orphan reap")
+
+	// (i) Forced full passes must fire on schedule while the bucket is idle.
+	// With sweepMaxSkips=4 a forced pass fires every 5th cached tick; after
+	// the reap the bucket is idle again and the gate re-latches, so forced
+	// passes keep accruing. Two is well within a few seconds.
+	require.Eventually(t, func() bool {
+		return log.countReason(fullPassMsg, "forced") >= 2
+	}, 8*time.Second, 100*time.Millisecond,
+		"the forced-pass backstop must fire at least twice over the idle window")
+
+	require.GreaterOrEqual(t, log.countReason(fullPassMsg, "forced"), 2,
+		"expected >=2 forced full passes across the idle window")
+
+	// The gate must genuinely latch (engage) rather than fail open every
+	// tick — this is what makes the reap-under-active-gate claim non-vacuous.
+	require.GreaterOrEqual(t, log.countMsg(engagedMsg), 2,
+		"the sweep gate must engage (latch) repeatedly, not fail open every tick")
+}

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -53,7 +53,13 @@ type twoPhaseCoordinator struct {
 	sweepCachePos       natsutil.KVStreamPos
 	sweepCache          map[string]cachedClaim
 	sweepSkipsSinceFull int
-	sweepConfigGuard    natsutil.ScanGateConfigGuard
+	// sweepMaxSkips bounds consecutive gated (cached) passes before a
+	// full pass is forced regardless of the probes. Initialized to
+	// natsutil.ScanGateMaxSkippedPasses by New; only in-package tests
+	// shorten it to reach the forced-pass backstop on a test timescale.
+	// Production behavior is byte-identical to reading the constant.
+	sweepMaxSkips    int
+	sweepConfigGuard natsutil.ScanGateConfigGuard
 	// sweepConfirmGap is the double-probe confirmation wait; tests
 	// shorten it. Set by New to natsutil.ScanGateDefaultConfirmGap.
 	sweepConfirmGap time.Duration
@@ -572,7 +578,7 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 
 	pos, ok, reason := t.sweepProbe(ctx)
 	if ok && t.sweepCacheValid && pos.Same(t.sweepCachePos) {
-		if t.sweepSkipsSinceFull >= natsutil.ScanGateMaxSkippedPasses {
+		if t.sweepSkipsSinceFull >= t.sweepMaxSkips {
 			reason = "forced"
 		} else {
 			// Double-probe confirmation. The wait holds sweepMu on the

--- a/internal/durable/claim_resolver.go
+++ b/internal/durable/claim_resolver.go
@@ -237,7 +237,14 @@ type ClaimBasedResolver struct {
 	gateLatchValid     bool
 	gateLatch          natsutil.KVStreamPos
 	gateSkipsSinceFull int
-	gateConfigGuard    natsutil.ScanGateConfigGuard
+	// gateMaxSkips bounds consecutive gated skips before a full pass is
+	// forced regardless of the probes. Initialized to
+	// natsutil.ScanGateMaxSkippedPasses by NewClaimBasedResolver;
+	// only in-package tests shorten it to reach the forced-pass backstop
+	// on a test timescale. Production behavior is byte-identical to
+	// reading the constant directly.
+	gateMaxSkips    int
+	gateConfigGuard natsutil.ScanGateConfigGuard
 	// gateConfirmGap is the double-probe confirmation wait; tests
 	// shorten it. Production value is natsutil.ScanGateDefaultConfirmGap.
 	gateConfirmGap time.Duration
@@ -344,6 +351,7 @@ func NewClaimBasedResolver(
 		refreshCooldown:   1 * time.Second,
 		reconcileInterval: defaultReconcileInterval,
 		gateConfirmGap:    natsutil.ScanGateDefaultConfirmGap,
+		gateMaxSkips:      natsutil.ScanGateMaxSkippedPasses,
 		// Allocate lifecycle channels eagerly so Stop is safe before Start.
 		stopCh: make(chan struct{}),
 		doneCh: make(chan struct{}),
@@ -1185,7 +1193,7 @@ func (r *ClaimBasedResolver) reconcileOnce(ctx context.Context) {
 
 	pos, ok, reason := r.gateProbe(ctx)
 	if ok && r.gateLatchValid && pos.Same(r.gateLatch) {
-		if r.gateSkipsSinceFull >= natsutil.ScanGateMaxSkippedPasses {
+		if r.gateSkipsSinceFull >= r.gateMaxSkips {
 			reason = "forced"
 		} else {
 			// Double-probe confirmation (stop/ctx-aware wait; on stop,

--- a/internal/durable/claim_resolver_gate_forcedpass_live_test.go
+++ b/internal/durable/claim_resolver_gate_forcedpass_live_test.go
@@ -1,0 +1,187 @@
+package durable
+
+// In-package live-NATS proof of the reconcile scan gate's longest-horizon
+// backstop: a full pass is FORCED at least every gateMaxSkips+1 gated ticks
+// even while the bucket stays byte-idle, so a mis-latched gate can never
+// suppress the reconciler indefinitely. The gate's unit suite proves this
+// with a fake probe and a scripted counter; this test proves it against a
+// real embedded NATS server and the real streamPos probe.
+//
+// gateMaxSkips is a per-instance seam defaulting to
+// natsutil.ScanGateMaxSkippedPasses (19). Only in-package tests shorten it
+// (here to 4) so the forced-pass backstop is reachable on a test timescale
+// rather than the ~10 minutes a production budget would take.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// argLogger is a types.Logger that records each message together with its
+// structured key/value args, so a test can count full passes carrying a
+// specific reason (the plain captureLogger keeps only the message and
+// cannot distinguish reason="forced" from reason="mismatch"). Safe for the
+// reconciler goroutine to write while the test goroutine reads.
+type argLogger struct {
+	mu      sync.Mutex
+	entries []argEntry
+}
+
+type argEntry struct {
+	msg string
+	kv  []any
+}
+
+var _ types.Logger = (*argLogger)(nil)
+
+func (l *argLogger) log(msg string, kv ...any) {
+	l.mu.Lock()
+	l.entries = append(l.entries, argEntry{msg: msg, kv: kv})
+	l.mu.Unlock()
+}
+
+func (l *argLogger) Debug(msg string, kv ...any) { l.log(msg, kv...) }
+func (l *argLogger) Info(msg string, kv ...any)  { l.log(msg, kv...) }
+func (l *argLogger) Warn(msg string, kv ...any)  { l.log(msg, kv...) }
+func (l *argLogger) Error(msg string, kv ...any) { l.log(msg, kv...) }
+func (l *argLogger) Fatal(msg string, kv ...any) { l.log(msg, kv...) }
+
+// countMsg counts recorded entries whose message equals msg.
+func (l *argLogger) countMsg(msg string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, e := range l.entries {
+		if e.msg == msg {
+			n++
+		}
+	}
+
+	return n
+}
+
+// countReason counts recorded entries whose message equals msg and whose
+// args carry the pair "reason" == reason.
+func (l *argLogger) countReason(msg, reason string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, e := range l.entries {
+		if e.msg != msg {
+			continue
+		}
+		for i := 0; i+1 < len(e.kv); i += 2 {
+			k, kok := e.kv[i].(string)
+			v, vok := e.kv[i+1].(string)
+			if kok && vok && k == "reason" && v == reason {
+				n++
+			}
+		}
+	}
+
+	return n
+}
+
+// TestGateLive_ForcedFullPassBackstop proves the reconcile gate's
+// forced-full-pass backstop end-to-end. With a shortened skip budget the
+// resolver, faced with a perfectly byte-idle bucket (no writes after the
+// seed), must still run a full pass on schedule: at least once every
+// gateMaxSkips+1 gated ticks, with the gate re-engaging between forced
+// passes. This is the longest-horizon guarantee of the scan gate that no
+// CI run otherwise reaches (~10 minutes at production defaults).
+func TestGateLive_ForcedFullPassBackstop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	bucket := "gate-live-forcedpass"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	// Seed one claim, then never touch the bucket again — this is what
+	// keeps the backing stream position byte-identical so the gate latches
+	// and stays latched until the forced-pass budget trips it.
+	seed := handoff.NewInitialClaim("pA", "w1", time.Now(), time.Minute)
+	seedBytes, err := seed.Marshal()
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "claims/pA", seedBytes)
+	require.NoError(t, err)
+
+	// Dedicated probe handle — never shared with the resolver's live kv
+	// handle, per the WithStreamPosProbe handle-ownership contract.
+	probeKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+
+	cl := &argLogger{}
+	r := NewClaimBasedResolver(kv, "claims/", cl,
+		WithReconcileInterval(100*time.Millisecond),
+		WithStreamPosProbe(probeKV),
+	)
+	// In-package seams: shorten the confirm gap so the gate latches on a
+	// test timescale, and shrink the skip budget so the forced-pass
+	// backstop fires within a couple of seconds instead of ~10 minutes.
+	r.gateConfirmGap = 20 * time.Millisecond
+	r.gateMaxSkips = 4
+	t.Cleanup(r.Stop)
+
+	require.NoError(t, r.Start(ctx))
+
+	require.Eventually(t, func() bool {
+		owner, _, _, ok := r.GetOwner("pA")
+
+		return ok && owner == "w1"
+	}, 3*time.Second, 20*time.Millisecond, "resolver did not resolve pA at startup")
+
+	const fullPassMsg = "claim resolver reconcile full pass"
+	const engagedMsg = "claim resolver reconcile gate engaged"
+
+	// With gateMaxSkips=4 a forced full pass fires every 5th gated tick
+	// (~500ms). Wait for at least two forced passes; the bucket is idle,
+	// so the ONLY thing that can produce these full passes is the
+	// forced-pass budget tripping — a mismatch is impossible when nothing
+	// writes to the bucket.
+	require.Eventually(t, func() bool {
+		return cl.countReason(fullPassMsg, "forced") >= 2
+	}, 10*time.Second, 50*time.Millisecond,
+		"the forced-pass backstop must fire at least twice over an idle window")
+
+	forced := cl.countReason(fullPassMsg, "forced")
+	require.GreaterOrEqual(t, forced, 2,
+		"expected >=2 forced full passes across the idle window")
+
+	// The gate must re-engage between forced passes: each forced pass
+	// resets the skip counter, and the next gated skip logs "gate engaged"
+	// again. At least two engagements proves the gate genuinely latched
+	// repeatedly rather than failing open into a full pass every tick.
+	require.GreaterOrEqual(t, cl.countMsg(engagedMsg), 2,
+		"the gate must re-engage between forced passes (not permanently failed open)")
+
+	// The bucket never changed, so every full pass after the first latch is
+	// a FORCED pass — there must be no mismatch-driven pass to explain them
+	// away.
+	require.Zero(t, cl.countReason(fullPassMsg, "mismatch"),
+		"an idle bucket must never produce a mismatch-driven full pass")
+
+	// The resolver keeps serving the seeded owner throughout — the forced
+	// passes reconcile the same idle state without dropping ownership.
+	owner, _, _, ok := r.GetOwner("pA")
+	require.True(t, ok)
+	require.Equal(t, "w1", owner)
+}

--- a/test/simulation/cmd/simulation/heartbeat_scan_chaos.go
+++ b/test/simulation/cmd/simulation/heartbeat_scan_chaos.go
@@ -1,0 +1,147 @@
+// Heartbeat scan-flatness oracle (FM7 / FM3).
+//
+// The sole purpose of the leader WorkerMonitor's heartbeat-refresh suppression
+// (internal/assignment/worker_monitor.go) is to cut the leader's Keys() scan
+// rate on parti-heartbeat: without it, every routine heartbeat refresh (each
+// worker PUTs its key every HeartbeatInterval) forces a full Keys() scan, and
+// each Keys() spins up a throwaway ordered consumer. A regression that keeps
+// the suppression holiday open, forces a check per watcher event, or otherwise
+// re-scans on every refresh is CORRECTNESS-INVISIBLE — reassignment still
+// works, ownership/gap oracles stay green — yet it silently deletes the whole
+// benefit of the feature.
+//
+// This oracle makes that regression observable. A sampler snapshots the
+// cumulative parti-heartbeat scan count (Keys + ListKeys, counted in the KV
+// fault seam, kv_fault_chaos.go) at four phase boundaries; the final gate then
+// computes the scan count over two quiet windows and fails the run if either
+// exceeds a documented floor budget derived from the polling cadence:
+//
+//	Poll cadence   = HeartbeatTTL / 2 = 15s / 2 = 7.5s   (worker_monitor.go:307)
+//	Scans per poll = 1  (pollForChanges -> observeAndDecide -> GetActiveWorkers
+//	                     -> one Keys() scan; calculator.go)
+//	Only the leader runs the monitor (Calculator.Start is leader-only), so the
+//	across-all-workers sum equals the single current leader's count in a quiet
+//	window.
+//	Polling-only lower bound = 30 / 7.5 = 4 scans per 30s window
+//	Measured quiet floor     = 6 scans per 30s window (polling 4 + ~2 residual
+//	                           from watcher-session initial-replay reclassify)
+//	FloorBudget = measured_floor × 2 (CI headroom) — configured in the YAML.
+//
+// The suppressed path (heartbeat refreshes) contributes ~0 scans in a warm
+// quiet window, so the sabotage — force a scan per watcher event, or keep the
+// holiday permanently re-stamped — lifts the window count to
+// ~workers/HeartbeatInterval × 30s (dozens of scans), far above the budget.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync/atomic"
+	"time"
+
+	parti "github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/test/simulation/internal/config"
+)
+
+// Phase-boundary snapshots of the cumulative parti-heartbeat scan count and the
+// count of snapshots that actually fired (expected hbScanExpectedSnaps).
+// hbScanFloorViolations is the fatal counter surfaced by the final gate.
+var (
+	hbScanPhaseAStartSnap atomic.Int64
+	hbScanPhaseAEndSnap   atomic.Int64
+	hbScanPhaseCStartSnap atomic.Int64
+	hbScanPhaseCEndSnap   atomic.Int64
+	hbScanSnapsFired      atomic.Int64
+	hbScanFloorViolations atomic.Int64
+)
+
+// hbScanExpectedSnaps is the number of phase-boundary snapshots the sampler
+// must capture (phaseA start/end, phaseC start/end) before the floor check is
+// conclusive.
+const hbScanExpectedSnaps = 4
+
+// heartbeatScanBucket resolves the heartbeat bucket name from the parti
+// defaults the sim workers use (they construct parti.DefaultConfig()), so the
+// oracle tracks the exact bucket the leader WorkerMonitor scans.
+func heartbeatScanBucket() string {
+	return parti.DefaultConfig().KVBuckets.HeartbeatBucket
+}
+
+// startHeartbeatScanFlatnessOracle arms the phase-boundary sampler when the
+// scenario enables it. Snapshots are one-shot goroutines fired at fixed offsets
+// from simulation start (mirroring scheduled_events), all well before shutdown.
+func startHeartbeatScanFlatnessOracle(ctx context.Context, fc *simKVFaultController, cfg *config.Config) {
+	hs := cfg.Chaos.HeartbeatScan
+	if !hs.Enabled || fc == nil {
+		return
+	}
+
+	bucket := heartbeatScanBucket()
+	log.Printf("[HBScan] flatness oracle armed: bucket=%s floor_budget=%d phaseA_tail=[+%v,+%v] phaseC_tail=[+%v,+%v]",
+		bucket, hs.FloorBudget, hs.PhaseATailStart, hs.PhaseATailEnd, hs.PhaseCTailStart, hs.PhaseCTailEnd)
+
+	snapshot := func(at time.Duration, dst *atomic.Int64, label string) {
+		if at <= 0 {
+			return
+		}
+		time.AfterFunc(at, func() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			v := fc.scanCount(bucket)
+			dst.Store(v)
+			hbScanSnapsFired.Add(1)
+			log.Printf("[HBScan] snapshot %s at +%v: cumulative heartbeat scans=%d", label, at, v)
+		})
+	}
+
+	snapshot(hs.PhaseATailStart, &hbScanPhaseAStartSnap, "phaseA_tail_start")
+	snapshot(hs.PhaseATailEnd, &hbScanPhaseAEndSnap, "phaseA_tail_end")
+	snapshot(hs.PhaseCTailStart, &hbScanPhaseCStartSnap, "phaseC_tail_start")
+	snapshot(hs.PhaseCTailEnd, &hbScanPhaseCEndSnap, "phaseC_tail_end")
+}
+
+// checkHeartbeatScanFloor is the final-gate assertion for the scan-flatness
+// scenario. It is a self-contained return path (mirroring the unresolved-gaps
+// gate at main.go) rather than a new disjunct in the invariants OR: that block
+// is duplicated and any new counter must be threaded through BOTH copies plus
+// three fmt strings, so a standalone gate is materially less error-prone.
+//
+// It computes two quiet-window scan deltas from the sampler snapshots:
+//
+//	phaseA_tail = scans@phaseA_tail_end - scans@phaseA_tail_start
+//	phaseC_tail = scans@phaseC_tail_end - scans@phaseC_tail_start
+//
+// Both windows close at fixed pre-shutdown offsets (phaseC_tail_end lands a few
+// seconds before duration) so ordered-shutdown teardown scans never leak in. It
+// fails if either window exceeds FloorBudget, or if the sampler did not capture
+// all four snapshots (an aborted run must not silently pass).
+func checkHeartbeatScanFloor(fc *simKVFaultController, cfg *config.Config) error {
+	hs := cfg.Chaos.HeartbeatScan
+	if !hs.Enabled || fc == nil {
+		return nil
+	}
+
+	bucket := heartbeatScanBucket()
+	finalCumulative := fc.scanCount(bucket)
+	phaseATail := hbScanPhaseAEndSnap.Load() - hbScanPhaseAStartSnap.Load()
+	phaseCTail := hbScanPhaseCEndSnap.Load() - hbScanPhaseCStartSnap.Load()
+
+	log.Printf("[HBScan] heartbeat scan floor check: phaseA_tail=%d phaseC_tail=%d floor_budget=%d final_cumulative=%d (polling floor = 1 scan / (hbTTL/2=7.5s) ⇒ ≈4 scans per 30s quiet window)",
+		phaseATail, phaseCTail, hs.FloorBudget, finalCumulative)
+
+	if fired := hbScanSnapsFired.Load(); fired < hbScanExpectedSnaps {
+		hbScanFloorViolations.Add(1)
+		return fmt.Errorf("heartbeat scan floor inconclusive: only %d/%d phase snapshots fired (phaseA_tail=%d phaseC_tail=%d) — the sampler did not capture both quiet windows", fired, hbScanExpectedSnaps, phaseATail, phaseCTail)
+	}
+	if phaseATail > hs.FloorBudget || phaseCTail > hs.FloorBudget {
+		hbScanFloorViolations.Add(1)
+		return fmt.Errorf("heartbeat scan floor exceeded: phaseA_tail=%d phaseC_tail=%d floor_budget=%d — suppression is not holding the leader's parti-heartbeat scan rate at the polling floor (stuck-open holiday or per-watcher-event forced check)", phaseATail, phaseCTail, hs.FloorBudget)
+	}
+
+	return nil
+}

--- a/test/simulation/cmd/simulation/kv_fault_chaos.go
+++ b/test/simulation/cmd/simulation/kv_fault_chaos.go
@@ -29,12 +29,51 @@ type simKVFaultController struct {
 
 	kvUnavailableInjected     atomic.Int64
 	handoffClaimWriteInjected atomic.Int64
+
+	// scanMu guards scanCalls, a per-bucket count of key-enumeration scans
+	// (Keys + ListKeys) issued through this wrapper. Each Keys()/ListKeys()
+	// spins up a throwaway ordered consumer on the bucket's stream, so this
+	// counter is a faithful proxy for the leader WorkerMonitor's scan cost.
+	// Read by the heartbeat scan-flatness oracle (heartbeat_scan_chaos.go).
+	scanMu    sync.Mutex
+	scanCalls map[string]*atomic.Int64
 }
 
 func newSimKVFaultController() *simKVFaultController {
 	return &simKVFaultController{
 		kvUnavailableBuckets: make(map[string]struct{}),
+		scanCalls:            make(map[string]*atomic.Int64),
 	}
+}
+
+// recordScan counts one key-enumeration scan (Keys or ListKeys) against the
+// bucket. Both nats.go key-listing entry points funnel here so the oracle sees
+// the true scan rate regardless of which API the caller used. Counting happens
+// at call entry (before any fault check) because a scan attempt is a scan
+// attempt whether or not it is subsequently faulted.
+func (fc *simKVFaultController) recordScan(bucket string) {
+	fc.scanMu.Lock()
+	counter, ok := fc.scanCalls[bucket]
+	if !ok {
+		counter = &atomic.Int64{}
+		fc.scanCalls[bucket] = counter
+	}
+	fc.scanMu.Unlock()
+
+	counter.Add(1)
+}
+
+// scanCount returns the cumulative Keys+ListKeys scan count for the bucket, or
+// 0 if the bucket has never been scanned through the wrapper.
+func (fc *simKVFaultController) scanCount(bucket string) int64 {
+	fc.scanMu.Lock()
+	counter, ok := fc.scanCalls[bucket]
+	fc.scanMu.Unlock()
+	if !ok {
+		return 0
+	}
+
+	return counter.Load()
 }
 
 func (fc *simKVFaultController) armKVUnavailable(buckets []string) uint64 {
@@ -282,11 +321,26 @@ func (kv *simKVFaultKeyValue) WatchFiltered(ctx context.Context, keys []string, 
 }
 
 func (kv *simKVFaultKeyValue) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	kv.fc.recordScan(kv.bucket)
 	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
 		return nil, context.DeadlineExceeded
 	}
 
 	return kv.KeyValue.Keys(ctx, opts...)
+}
+
+// ListKeys mirrors Keys for the streaming key-lister API. nats.go's concrete
+// Keys() is built on WatchAll (not ListKeys), so this override only fires when
+// a caller invokes ListKeys directly on the wrapped handle — the embedded
+// Keys() never re-enters this method, so there is no double counting. Counted
+// so the heartbeat scan-flatness oracle observes every key-enumeration path.
+func (kv *simKVFaultKeyValue) ListKeys(ctx context.Context, opts ...jetstream.WatchOpt) (jetstream.KeyLister, error) {
+	kv.fc.recordScan(kv.bucket)
+	if kv.fc.shouldFaultKVUnavailable(kv.bucket) {
+		return nil, context.DeadlineExceeded
+	}
+
+	return kv.KeyValue.ListKeys(ctx, opts...)
 }
 
 func (kv *simKVFaultKeyValue) History(ctx context.Context, key string, opts ...jetstream.WatchOpt) ([]jetstream.KeyValueEntry, error) {

--- a/test/simulation/cmd/simulation/main.go
+++ b/test/simulation/cmd/simulation/main.go
@@ -3158,9 +3158,48 @@ func handleLeaderGoroutineNetworkDisconnect(
 	})
 }
 
+// longDisconnectDetectionFactor mirrors the suppressionHolidayFactor const
+// in internal/assignment/worker_monitor.go (unexported there, so it cannot
+// be imported directly from sim code; duplicated here as a literal). See
+// that file's doc comment (worker_monitor.go:24-45) for the full worst-case
+// single-serialization derivation this bounds: firstSeen -> debounce ->
+// pollMu wait -> own scan -> EmergencyGracePeriod -> confirming entry, all
+// of which collapses to < 3×HeartbeatTTL under warm suppression.
+const longDisconnectDetectionFactor = 3
+
+// longDisconnectCISlack is generous fixed headroom added on top of the
+// analytically-derived detection bound to absorb CI scheduler jitter.
+const longDisconnectCISlack = 15 * time.Second
+
+// pickLowestID returns the candidate with the lexicographically smallest
+// ID, giving deterministic target selection across repeated runs against
+// the same worker set (rather than a clock-seeded random pick).
+func pickLowestID(candidates []*coordinator.GoroutineInfo) *coordinator.GoroutineInfo {
+	best := candidates[0]
+	for _, c := range candidates[1:] {
+		if c.ID < best.ID {
+			best = c
+		}
+	}
+
+	return best
+}
+
 // handleLongGoroutineNetworkDisconnect implements the long-disconnect chaos
-// variant (Gap 12): pick a random worker, register a reassignment expectation,
-// suppress its slow-start assertion, disconnect it for 60–180s, then reconnect.
+// variant (Gap 12): pick a non-leader worker that currently owns at least
+// one partition, register a reassignment expectation bounded by the
+// heartbeat-suppression worst-case detection latency, suppress its
+// slow-start assertion, disconnect it for 60–180s, then reconnect.
+//
+// Target selection is a warm-suppression latency guard: excluding the
+// leader matters because a disconnected LEADER forces a fresh election and
+// a COLD monitor (lastSeen freshly replayed on the new leader) to notice
+// the departure, which is a materially easier detection path than a WARM
+// leader's suppression-holiday sweep noticing a silent expiry from a
+// follower it has been steadily tracking. Pinning the target to a
+// non-leader owner makes this scenario the sole sim detector of that
+// production-critical warm case. Selection is deterministic (see
+// pickLowestID) so the same worker set always yields the same target.
 //
 // Sequence (must be respected — advisor note, point 5):
 //  1. Register slow-start suppression BEFORE disconnect (coord.SuspendSlowStartAssertions).
@@ -3182,7 +3221,7 @@ func handleLongGoroutineNetworkDisconnect(
 	}
 	// Phase 4b: allow scenario to pin an explicit target_worker (e.g.
 	// "worker-0") so the disconnect lands on the worker with the tiny-
-	// pool stable-ID. Empty / "random" falls back to random selection.
+	// pool stable-ID. Empty / "random" falls back to selection below.
 	var target *coordinator.GoroutineInfo
 	if explicit, _ := params["target_worker"].(string); explicit != "" && explicit != "random" {
 		for i := range workers {
@@ -3192,29 +3231,40 @@ func handleLongGoroutineNetworkDisconnect(
 			}
 		}
 		if target == nil {
-			log.Printf("[Chaos] long_disconnect: target_worker=%s not found; falling back to non-empty random", explicit)
+			log.Printf("[Chaos] long_disconnect: target_worker=%s not found; falling back to selection", explicit)
 		}
 	}
 	if target == nil {
-		// Prefer workers with a non-empty current assignment so the
-		// reassignment-observed invariant (Phase 3 INV1) can actually
-		// fire. Random pick among workers with len(owned)>0; fall back
-		// to plain random (with a loud warning) only when no worker
-		// owns any partitions, which means the owner snapshot has not
-		// initialized yet — proceeding would yield an inconclusive
-		// expectation.
-		var nonEmpty []*coordinator.GoroutineInfo
+		// Prefer a NON-LEADER worker with a non-empty current assignment
+		// (see the function doc for why). Fall back to any owner
+		// (possibly the leader) only when no follower currently owns
+		// anything; skip the firing entirely when no worker owns
+		// anything, exactly as before.
+		var nonLeaderOwned []*coordinator.GoroutineInfo
+		var anyOwned []*coordinator.GoroutineInfo
 		if aioCoord != nil {
 			for i := range workers {
-				if owned := aioCoord.PartitionsOwnedBy(workers[i].ID); len(owned) > 0 {
-					nonEmpty = append(nonEmpty, workers[i])
+				if len(aioCoord.PartitionsOwnedBy(workers[i].ID)) == 0 {
+					continue
+				}
+				anyOwned = append(anyOwned, workers[i])
+				isLeader := false
+				if wk, ok := workers[i].Obj.(*worker.Worker); ok {
+					isLeader = wk.IsLeader()
+				}
+				if !isLeader {
+					nonLeaderOwned = append(nonLeaderOwned, workers[i])
 				}
 			}
 		}
 		switch {
-		case len(nonEmpty) > 0:
-			target = nonEmpty[time.Now().UnixNano()%int64(len(nonEmpty))]
-			log.Printf("[Chaos] long_disconnect: selected target=%s (had non-empty owner snapshot)", target.ID)
+		case len(nonLeaderOwned) > 0:
+			target = pickLowestID(nonLeaderOwned)
+			log.Printf("[Chaos] long_disconnect: selected non-leader target=%s (owns partitions; warm leader monitor is the sole detector)", target.ID)
+		case len(anyOwned) > 0:
+			target = pickLowestID(anyOwned)
+			log.Printf("[Chaos] long_disconnect: WARN no non-leader worker owns any partitions; falling back to target=%s "+
+				"(may be the leader, degrading warm-suppression coverage for this firing)", target.ID)
 		default:
 			log.Printf("[Chaos] long_disconnect: WARN no worker currently owns any partitions in the owner snapshot; " +
 				"skipping this chaos firing — the reassignment expectation would be vacuous (empty→empty). " +
@@ -3237,10 +3287,30 @@ func handleLongGoroutineNetworkDisconnect(
 		return
 	}
 
-	// T_reassign = ElectionTimeout (default 10s) + OperationTimeout (default 5s) + buffer.
-	// Use dur + 30s as the reassignment deadline: the partitions must migrate
-	// before the disconnect window closes (dur) plus a generous scheduling buffer.
-	tReassign := dur + 30*time.Second
+	// Reassignment deadline: bounds the worst-case latency for a WARM
+	// leader's WorkerMonitor to detect the target's silent heartbeat-key
+	// expiry and reassign its partitions — NOT the disconnect window
+	// itself. `dur` is otherwise irrelevant to detection latency: the key
+	// silently expires within one HeartbeatTTL of the last successful
+	// renewal regardless of how long the disconnect subsequently lasts
+	// (network_disconnect_long's contract guarantees dur > 2×HeartbeatTTL,
+	// so the key always has time to expire). Derivation, mirroring
+	// bucket_chaos.go:66's parti.DefaultConfig() pattern for reading
+	// HeartbeatTTL (the coordinator has no direct handle on it):
+	//   key-expiry:      up to 1×HeartbeatTTL for the last heartbeat PUT
+	//                    to silently lapse once the connection is severed.
+	//   detection bound: longDisconnectDetectionFactor(=3)×HeartbeatTTL,
+	//                    the worst-case single-serialization detection
+	//                    chain under warm suppression (see
+	//                    internal/assignment/worker_monitor.go:24-45, the
+	//                    suppressionHolidayFactor doc comment this mirrors).
+	//   CI slack:        longDisconnectCISlack, fixed headroom for
+	//                    scheduler jitter.
+	// Total = 4×HeartbeatTTL + slack (75s at the 15s default) — tighter
+	// than the previous dur+30s (~90s for this scenario's 60s override)
+	// and, unlike that bound, immune to the disconnect-duration override.
+	hbTTL := parti.DefaultConfig().HeartbeatTTL
+	tReassign := hbTTL + longDisconnectDetectionFactor*hbTTL + longDisconnectCISlack
 
 	// 1. Suppress slow-start assertion for this worker (per-worker scope).
 	// Window = dur + recovery headroom.

--- a/test/simulation/cmd/simulation/main.go
+++ b/test/simulation/cmd/simulation/main.go
@@ -809,6 +809,13 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 		startStorageTypeOracle(ctx, goroutineRegistry)
 	}
 
+	// Heartbeat scan-flatness oracle (heartbeat_scan_flatness scenario):
+	// snapshot the leader WorkerMonitor's parti-heartbeat scan count at the
+	// phase-A/phase-C quiet-window boundaries so the final gate can assert
+	// suppression holds the scan rate at the polling floor. Started here
+	// (before workers emit traffic) so the phase-A baseline snapshot lands.
+	startHeartbeatScanFlatnessOracle(ctx, kvFaults, cfg)
+
 	// Phase 8 / Gap 9b: fire the election-replicas oracle once all
 	// workers reach StateStable (election_replicas_override mode only).
 	if cfg.Chaos.Storage.ElectionReplicasOverride > 0 {
@@ -1226,6 +1233,17 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 
 					return invariantsErr
 				}
+			}
+
+			// Heartbeat scan-flatness gate (heartbeat_scan_flatness scenario):
+			// a separate return path — like the unresolved-gaps gate above —
+			// so the new counter need not be threaded through the duplicated
+			// invariants OR + its three fmt strings. No-op unless the scenario
+			// enables chaos.heartbeat_scan.
+			if hbErr := checkHeartbeatScanFloor(kvFaults, cfg); hbErr != nil {
+				coord.TriggerFailure("Heartbeat scan floor exceeded at shutdown", hbErr)
+
+				return hbErr
 			}
 
 			return nil

--- a/test/simulation/configs/chaos_network_disconnect_long.yaml
+++ b/test/simulation/configs/chaos_network_disconnect_long.yaml
@@ -1,5 +1,6 @@
 # Phase 3 — Long network disconnect (Gap 12): lease expiry → reassignment →
-# post-recovery convergence.
+# post-recovery convergence. Doubles as a warm-suppression detection-latency
+# guard for the heartbeat silent-expiry sweep (internal/assignment/worker_monitor.go).
 #
 # Setup:
 #   - 5 workers, static partition source.
@@ -7,6 +8,10 @@
 #     HeartbeatTTL default = 15s; disconnect (60s) > HeartbeatTTL × 2 (30s),
 #     so the disconnected worker's lease expires and remaining workers must
 #     claim its partitions before reconnection.
+#   - Target selection prefers a NON-LEADER worker that currently owns
+#     partitions (cmd/simulation/main.go handleLongGoroutineNetworkDisconnect),
+#     so the warm leader's suppression-holiday sweep is the sole detector —
+#     not a cold post-election monitor.
 #   - cooldown=120s stops chaos at T+60s, ensuring exactly one disconnect
 #     event fires before chaos halts.
 #   - Total runtime 3 minutes: covers disconnect (60s) + recovery (~30s)
@@ -15,7 +20,11 @@
 # Invariants asserted:
 #   - INV1 (Gap 12): long_disconnect_reassignment_observed >= 1.
 #     The disconnected worker's partitions migrate to remaining workers within
-#     T_reassign = disconnect_duration + 30s.
+#     T_reassign = HeartbeatTTL + 3×HeartbeatTTL (suppression-holiday
+#     detection bound, worker_monitor.go:24-45) + 15s CI slack = 75s at the
+#     15s default — independent of the disconnect duration itself, since
+#     detection only requires the heartbeat key to have already silently
+#     expired.
 #   - INV2: post-recovery assignment is gap-free (unassigned=0, no snapshot
 #     overlap violations, zero double-leader observations).
 #   - INV3: slow-start assertions are suppressed for the disconnect-target

--- a/test/simulation/configs/heartbeat_scan_flatness.yaml
+++ b/test/simulation/configs/heartbeat_scan_flatness.yaml
@@ -1,0 +1,135 @@
+# Heartbeat scan-rate flatness (FM7 / FM3) — suppression-benefit guard.
+#
+# WHY: the sole purpose of the leader WorkerMonitor's heartbeat-refresh
+# suppression (internal/assignment/worker_monitor.go) is to keep the leader's
+# parti-heartbeat Keys() scan rate at the polling floor. Each Keys() spins up a
+# throwaway ordered consumer, so without suppression every routine heartbeat
+# refresh (each worker PUTs its key every HeartbeatInterval=5s) would force a
+# full scan. A regression that keeps the suppression holiday permanently open,
+# forces a check per watcher event, or otherwise re-scans per refresh is
+# CORRECTNESS-INVISIBLE — reassignment still fires, ownership/gap oracles stay
+# green — yet it deletes the whole benefit of the feature. No ownership/gap
+# oracle can see it; only a direct scan-rate assertion can.
+#
+# SHAPE: all-in-one, 8 workers, static source, 10 partitions, low message rate.
+#   Phase A  0–90s   quiet  — leader suppression goes fully warm (no chaos).
+#   Phase B  90–210s chaos  — 2 leader_failure + 1 network_disconnect_long +
+#                             one scale_up + one scale_down (scheduled, so the
+#                             timing is deterministic).
+#   Phase C  210–285s quiet — chaos has stopped; after one full suppression
+#                             holiday (3×HeartbeatTTL=45s) the scan rate MUST
+#                             return to the polling floor.
+#
+# ASSERTION (heartbeat_scan_chaos.go, separate return path):
+#   heartbeat-bucket Keys+ListKeys scan count, summed across all workers, in
+#   each 30s quiet window must stay ≤ floor_budget.
+#     phaseA_tail window = [60s, 90s]    (quiet baseline)
+#     phaseC_tail window = [253s, 283s]  (final 30s, ending 2s before shutdown;
+#                                         73s past the last chaos event @180s and
+#                                         the disconnect reconnect ~180s — one
+#                                         suppression holiday, 45s, plus margin)
+#
+# FLOOR BUDGET DERIVATION (documented arithmetic + ×2 CI headroom):
+#   HeartbeatTTL default        = 15s      (parti.DefaultConfig, config.go:415)
+#   Polling ticker cadence       = hbTTL/2 = 7.5s   (worker_monitor.go:307)
+#   Scans per poll               = 1        (pollForChanges → observeAndDecide →
+#                                            GetActiveWorkers → one Keys() scan)
+#   Monitor runs on the LEADER ONLY (Calculator.Start is leader-only), so the
+#   across-all-workers sum equals the single current leader's count in a quiet
+#   window; suppressed refreshes add ~0 scans.
+#   Polling-only lower bound     = 30 / 7.5 = 4 scans/window
+#   Measured quiet floor         = 6 scans/window (both phaseA and phaseC tail,
+#                                  empirically stable) — polling 4 plus ~2
+#                                  residual scans from watcher-session initial-
+#                                  replay re-classification.
+#   floor_budget = measured_floor 6 × 2 (CI headroom) = 12
+#
+# DETECTION: a scan-per-watcher-event regression (stuck-open holiday or per-event
+#   forced check) lifts the window count to ~workers / HeartbeatInterval × 30s ≈
+#   8/5 × 30 ≈ 48 scans — ~8× the floor, far above the budget of 12.
+
+simulation:
+  duration: 285s
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 10
+  message_rate_per_partition: 1
+  distribution: uniform
+
+producers:
+  count: 1
+
+workers:
+  count: 8
+  # RoundRobin (not WeightedConsistentHash) so all 8 initial-cohort workers get
+  # >=1 partition at cold start: 10 partitions spread [2,2,1,1,1,1,1,1]. Under
+  # WCH, hash imbalance can leave a worker with 0 partitions, so its first-
+  # assignment latency runs until a later chaos rebalance and trips the initial
+  # slow-start SLO (25s budget) — an incidental cross-cutting invariant flake
+  # unrelated to scan rate. Even distribution removes that flake; the heartbeat
+  # scan floor is strategy-independent.
+  assignment_strategy: RoundRobin
+  processing_delay:
+    min: 1ms
+    max: 5ms
+
+chaos:
+  # enabled=true is required for the scheduled_events dispatcher to run; the
+  # random ticker never fires (events list empty, interval far in the future).
+  enabled: true
+  interval: "3600s-3601s"
+  events: []
+  # scale_up goes 8→9 (needs max ≥ 9); scale_down goes 9→8 (needs min ≤ 8).
+  min_workers: 6
+  max_workers: 10
+  # network_disconnect_long defaults to a 60s disconnect (< WorkerIDTTL 75s, so
+  # the stable-ID claim survives and no claimLostShutdown fires). The handler
+  # pins a NON-LEADER partition owner so the warm leader's suppression-holiday
+  # sweep is the sole detector of the silent heartbeat-key expiry.
+  scheduled_events:
+    - at: 100s
+      event: leader_failure
+    - at: 120s
+      event: network_disconnect_long
+    - at: 135s
+      event: scale_up
+      params:
+        count: 1
+    - at: 160s
+      event: leader_failure
+    - at: 180s
+      event: scale_down
+      params:
+        count: 1
+  heartbeat_scan:
+    enabled: true
+    # Quiet baseline window (last 30s of phase A).
+    phase_a_tail_start: 60s
+    phase_a_tail_end: 90s
+    # Post-chaos quiet window: [253s, 283s] = 30s. Starts 73s after the last
+    # chaos event (scale_down @180s) — well past one suppression holiday
+    # (3×HeartbeatTTL=45s). Ends 2s before duration (285s) so the snapshot is
+    # captured before ordered shutdown (worker heartbeat DELETEs during teardown
+    # would otherwise trigger a burst of leader scans into the window).
+    phase_c_tail_start: 253s
+    phase_c_tail_end: 283s
+    # 2 × measured quiet floor (6 scans/30s); ~4× below the ~48-scan sabotage.
+    floor_budget: 12
+
+coordinator:
+  # gap_aging must exceed the 60s disconnect window + reassignment/recovery so a
+  # transient gap during phase B chaos does not escalate falsely.
+  gap_aging: 120s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 60s
+    catch_up_percent: 99
+    absence_threshold: 20s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/heartbeat_scan_flatness.yaml
+++ b/test/simulation/configs/heartbeat_scan_flatness.yaml
@@ -30,7 +30,7 @@
 #                                         suppression holiday, 45s, plus margin)
 #
 # FLOOR BUDGET DERIVATION (documented arithmetic + ×2 CI headroom):
-#   HeartbeatTTL default        = 15s      (parti.DefaultConfig, config.go:415)
+#   HeartbeatTTL default        = 15s      (parti.DefaultConfig, config.go:418)
 #   Polling ticker cadence       = hbTTL/2 = 7.5s   (worker_monitor.go:307)
 #   Scans per poll               = 1        (pollForChanges → observeAndDecide →
 #                                            GetActiveWorkers → one Keys() scan)

--- a/test/simulation/internal/config/config.go
+++ b/test/simulation/internal/config/config.go
@@ -309,6 +309,13 @@ type ChaosConfig struct {
 	// burst-after-quiet (Gap 13) scenario knobs.
 	Storage StorageChaosConfig `yaml:"storage"`
 
+	// HeartbeatScan carries the heartbeat scan-flatness oracle knobs
+	// (heartbeat_scan_flatness scenario). When enabled a sampler snapshots
+	// the leader WorkerMonitor's parti-heartbeat Keys+ListKeys scan count at
+	// phase boundaries and the final gate asserts the quiet-window scan rate
+	// stays at the polling floor.
+	HeartbeatScan HeartbeatScanConfig `yaml:"heartbeat_scan"`
+
 	// Faults carries startup-armed fault injection knobs. Scheduled chaos
 	// events are usually preferred; this is only for faults that must be
 	// active before the initial worker Start path.
@@ -382,6 +389,43 @@ type StorageChaosConfig struct {
 	// A value of 1.5 is the tight bound; 5.0 is the conservative first-
 	// run default.
 	KvOpRateCeilingMultiplier float64 `yaml:"kv_op_rate_ceiling_multiplier"`
+}
+
+// HeartbeatScanConfig configures the heartbeat scan-flatness oracle. It guards
+// the benefit of the leader WorkerMonitor's heartbeat-refresh suppression
+// (internal/assignment/worker_monitor.go): in a quiet window only the hbTTL/2
+// polling ticker should scan parti-heartbeat; routine heartbeat refreshes must
+// be suppressed (no Keys() scan). A stuck-open suppression holiday or a
+// per-watcher-event forced check reverts to a scan-per-refresh storm — a pure
+// performance regression that no ownership/gap oracle can see — which this
+// oracle catches as a scan count above the polling floor.
+type HeartbeatScanConfig struct {
+	// Enabled turns on the scan-flatness sampler and the final-gate floor
+	// assertion.
+	Enabled bool `yaml:"enabled"`
+
+	// PhaseATailStart / PhaseATailEnd bound the quiet baseline window (the
+	// last 30s of phase A, before any chaos). The oracle asserts the
+	// heartbeat scan count over this window stays at/below FloorBudget.
+	PhaseATailStart time.Duration `yaml:"phase_a_tail_start"`
+	PhaseATailEnd   time.Duration `yaml:"phase_a_tail_end"`
+
+	// PhaseCTailStart / PhaseCTailEnd bound the post-chaos quiet window (the
+	// final ~30s). PhaseCTailStart MUST begin at least one full suppression
+	// holiday (3×HeartbeatTTL = 45s at the 15s default) after the last chaos
+	// event so a correct holiday has already closed and scans returned to the
+	// floor. PhaseCTailEnd MUST land a few seconds before simulation.duration
+	// so the snapshot is captured before ordered shutdown — worker heartbeat
+	// DELETEs during teardown would otherwise trigger a burst of leader scans
+	// and contaminate the window.
+	PhaseCTailStart time.Duration `yaml:"phase_c_tail_start"`
+	PhaseCTailEnd   time.Duration `yaml:"phase_c_tail_end"`
+
+	// FloorBudget is the maximum heartbeat Keys+ListKeys scan count allowed
+	// in each quiet window, summed across all workers. Derive it from the
+	// WorkerMonitor polling cadence (1 scan per hbTTL/2) with CI headroom;
+	// see the scenario YAML for the arithmetic.
+	FloorBudget int64 `yaml:"floor_budget"`
 }
 
 // ScheduledChaosEvent is a one-shot scenario-scheduled chaos event.


### PR DESCRIPTION
## What

Test-hardening follow-up to v2.8.2's scan-cost work — proves the mechanisms' long-horizon guarantees end-to-end and guards their benefit in CI:

- **Live backstop tests** (internal budget seams defaulting to the shared constants — zero public API, byte-identical production behavior): the forced full pass fires on schedule over a genuinely idle bucket, and orphan reaping completes under an active gate, on real embedded NATS. Sabotage-verified (huge budget / neutered reap arm → tests fail).
- **Sharpened long-disconnect guard**: deterministic non-leader-owner target and a derived 75s detection deadline (expiry + suppression-holiday bound + slack) replacing the loose ~90s one.
- **Heartbeat scan-rate floor scenario**: per-bucket Keys/ListKeys counting in the KV fault seam (ListKeys was previously unwrapped — it silently bypassed fault injection everywhere) plus a quiet→chaos→quiet run asserting the leader's heartbeat scans stay at the polling floor (budget 12 vs measured floor 6; a stuck-open suppression holiday reads ~36 and fails the gate). Sabotage-verified.
- **CI pipefail fix**: all six per-pillar scenario loops piped the sim binary through `tee` under plain `set -e`, masking non-zero exits — a pre-existing bug exposed by review; in-binary assertion failures now actually fail CI.

## Deliberately not shipped

A fourth proposed scenario (gate-latched idle→rebalance convergence) was **refuted by experiment**: with both gate sites fully defeated on every worker, the sim still converged perfectly — the resolver watcher and ungated Apply-path sweep are the load-bearing primaries, so healthy-primary convergence oracles are structurally blind to safety-net defeat. The gate's correct coverage boundary is the integration layer (read-fault pin + the live backstops above). Evidence retained in the review dossier.

## Validation

`make pre-pr` (lint → unit `-race` → integration `-race`) green; each new/changed scenario 2× green locally via the CI-equivalent invocation; every detector proven non-vacuous by a failing sabotage run; external post-impl review clean after the pipefail fix (its one P1).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPUoEnYzc6dSE5TurTMhG
