### PR TITLE
fix(simulation): tolerate bounded post-shutdown drain in the claim-loss ordering oracle

### DIFF
--- a/test/simulation/internal/coordinator/claim_loss_ordering_oracle_test.go
+++ b/test/simulation/internal/coordinator/claim_loss_ordering_oracle_test.go
@@ -164,8 +164,9 @@ func TestClaimLossOrderingOracle_RevokeStableThenRealShutdownThenMessage_Violati
 	o.RecordAssignment("worker-0", []int{1, 2, 3})
 	tShut := t0.Add(1 * time.Second)
 	o.ObserveShutdown("worker-0", "freeze-victim-1", tShut)
-	// Post-shutdown message for an owned partition → violation.
-	o.ObserveMessage("worker-0", 2, tShut.Add(100*time.Millisecond))
+	// Message beyond the drain tolerance window for an owned partition →
+	// violation (the worker kept consuming well past the stop boundary).
+	o.ObserveMessage("worker-0", 2, tShut.Add(claimLossDrainToleranceWindow+100*time.Millisecond))
 	if got := o.Violations(); got != 1 {
 		t.Fatalf("real shutdown then post-shutdown message: expected 1 violation, got %d", got)
 	}
@@ -191,8 +192,10 @@ func TestClaimLossOrderingOracle_RevokeTimestampBeforeShutdown_Violation(t *test
 }
 
 // TestClaimLossOrderingOracle_PostShutdownMessage_Violation verifies that
-// a ReceivedMessage arriving strictly after Shutdown, for a partition
-// the SAME sim worker was last known to own, is flagged.
+// a ReceivedMessage arriving MORE THAN the drain tolerance window after
+// Shutdown, for a partition the SAME sim worker was last known to own, is
+// flagged — this is the "worker kept consuming past the stop boundary"
+// signal the oracle exists to catch.
 func TestClaimLossOrderingOracle_PostShutdownMessage_Violation(t *testing.T) {
 	o := NewClaimLossOrderingOracle()
 	o.RegisterStableID("worker-0", "freeze-victim-1")
@@ -200,16 +203,42 @@ func TestClaimLossOrderingOracle_PostShutdownMessage_Violation(t *testing.T) {
 
 	t0 := time.Now()
 	o.ObserveShutdown("worker-0", "freeze-victim-1", t0)
-	// Message for an owned partition arrives AFTER shutdown.
-	o.ObserveMessage("worker-0", 2, t0.Add(100*time.Millisecond))
+	// Message for an owned partition arrives well beyond the drain window.
+	o.ObserveMessage("worker-0", 2, t0.Add(claimLossDrainToleranceWindow+100*time.Millisecond))
 	if got := o.Violations(); got != 1 {
 		t.Fatalf("expected 1 violation, got %d", got)
 	}
 
 	// A message for a partition the worker did NOT own → no violation.
-	o.ObserveMessage("worker-0", 99, t0.Add(200*time.Millisecond))
+	o.ObserveMessage("worker-0", 99, t0.Add(claimLossDrainToleranceWindow+200*time.Millisecond))
 	if got := o.Violations(); got != 1 {
 		t.Fatalf("expected violations unchanged, got %d", got)
+	}
+}
+
+// TestClaimLossOrderingOracle_PostShutdownMessage_WithinDrainWindow_NoViolation
+// is the regression guard for the drain false positive that failed CI on
+// chaos_stableid_claim_steal / chaos_bucket_peer_takeover: parti transitions
+// to StateShutdown before revoking the worker consumer, and WithDrainOnRemove
+// lets an in-flight handler complete. A message for a previously-owned
+// partition arriving inside the drain tolerance window is CORRECT behavior and
+// MUST NOT be flagged.
+func TestClaimLossOrderingOracle_PostShutdownMessage_WithinDrainWindow_NoViolation(t *testing.T) {
+	o := NewClaimLossOrderingOracle()
+	o.RegisterStableID("worker-0", "freeze-victim-1")
+	o.RecordAssignment("worker-0", []int{1, 2, 3})
+
+	t0 := time.Now()
+	o.ObserveShutdown("worker-0", "freeze-victim-1", t0)
+	// A single drained frame lands shortly after the observed shutdown,
+	// still inside the drain window — the empirically observed CI gap was
+	// ~170ms. No violation.
+	o.ObserveMessage("worker-0", 2, t0.Add(claimLossDrainToleranceWindow-100*time.Millisecond))
+	// A frame exactly at the window boundary is still tolerated (strictly
+	// greater-than is required to flag).
+	o.ObserveMessage("worker-0", 2, t0.Add(claimLossDrainToleranceWindow))
+	if got := o.Violations(); got != 0 {
+		t.Fatalf("in-window drain: expected 0 violations, got %d", got)
 	}
 }
 

--- a/test/simulation/internal/coordinator/oracles.go
+++ b/test/simulation/internal/coordinator/oracles.go
@@ -731,7 +731,14 @@ func matchesAnySubstring(s string, subs []string) bool {
 //   - claim_loss_stop_ordering_violations: A RevocationReport for worker W
 //     arrived BEFORE the watcher observed W's StateShutdown transition; OR a
 //     ReceivedMessage for one of W's last-known-assigned partitions arrived
-//     STRICTLY AFTER the observed StateShutdown timestamp.
+//     MORE THAN claimLossDrainToleranceWindow after the observed StateShutdown
+//     timestamp. parti transitions to StateShutdown FIRST and revokes the
+//     worker consumer asynchronously afterwards, and WithDrainOnRemove lets an
+//     already-in-flight handler run to completion ("not a zero-overlap
+//     guarantee") — so a bounded burst of messages during that Stop→revoke→
+//     drain window is CORRECT, not a violation. Only traffic that persists
+//     beyond the drain window demonstrates a worker that never stopped
+//     consuming after losing its claim (see ObserveMessage).
 //
 // The oracle uses the StableWorkerID as the join key because that's what the
 // claim-lost ObserveClaimLostShutdown path reports. Assignment snapshots are
@@ -747,6 +754,21 @@ func matchesAnySubstring(s string, subs []string) bool {
 // state right now?" — yes → backfill (the watcher was just late), no →
 // violation.
 type WorkerStateSampler func(simWorkerID string) (state int, known bool)
+
+// claimLossDrainToleranceWindow bounds the legitimate post-shutdown consumer
+// drain when checking for post_shutdown_message violations. parti provides no
+// zero-overlap guarantee at StateShutdown: claimLostShutdown transitions to
+// Shutdown via Manager.Stop FIRST, then revokes the worker consumer
+// asynchronously, and consumer.WithDrainOnRemove permits an already-in-flight
+// handler to run to completion. A message for a previously-owned partition
+// therefore legitimately lands shortly after the observed shutdown. Empirically
+// these drain messages arrive within ~170ms of the (poll-lagged) observed
+// shutdown; a stuck worker that keeps consuming instead produces messages
+// continuously at the partition message rate for the rest of the run. Two
+// seconds sits far above the drain and far below the sustained-traffic regime,
+// so it eliminates the drain false positive while still catching a worker that
+// never stops.
+const claimLossDrainToleranceWindow = 2 * time.Second
 
 type ClaimLossOrderingOracle struct {
 	mu sync.Mutex
@@ -999,11 +1021,22 @@ func (o *ClaimLossOrderingOracle) ObserveRevocation(simWorkerID, stableID string
 
 // ObserveMessage is called from the ReceivedMessage path. The contract is
 // "no ReceivedMessage with worker=W for one of W's previously-assigned
-// partitions arrived AFTER the watcher observed W's StateShutdown". Both
-// the assignment snapshot AND the message attribution are keyed by
-// simWorkerID — a different sim worker that takes over the same stable
-// ID via stale-takeover is GOOD behavior, not a violation, so the lookup
-// MUST NOT cross sim-worker boundaries.
+// partitions arrived MORE THAN claimLossDrainToleranceWindow after the watcher
+// observed W's StateShutdown". Both the assignment snapshot AND the message
+// attribution are keyed by simWorkerID — a different sim worker that takes over
+// the same stable ID via stale-takeover is GOOD behavior, not a violation, so
+// the lookup MUST NOT cross sim-worker boundaries.
+//
+// The tolerance window absorbs the legitimate post-shutdown consumer drain:
+// parti reaches StateShutdown before the worker consumer is revoked, and
+// WithDrainOnRemove lets an in-flight handler complete (no zero-overlap
+// guarantee). A single message reported during that window is correct
+// behavior. Only a message arriving beyond the window — which requires the
+// worker to have kept pulling new frames long after it lost its claim —
+// counts as a violation. The at value is stamped at coordinator drain time,
+// so it already includes handler + queueing latency; the observed shutdown
+// lags the real transition by up to the watcher poll interval, which only
+// shrinks the measured gap, so the window need not compensate for it.
 func (o *ClaimLossOrderingOracle) ObserveMessage(simWorkerID string, partition int, at time.Time) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -1021,8 +1054,18 @@ func (o *ClaimLossOrderingOracle) ObserveMessage(simWorkerID string, partition i
 	if _, owned := parts[partition]; !owned {
 		return
 	}
-	log.Printf("[ClaimLossOrderingOracle] VIOLATION post_shutdown_message worker=%s partition=%d msg_at=%v shutdown_at=%v",
-		simWorkerID, partition, at.Format(time.RFC3339Nano), tShutdown.Format(time.RFC3339Nano))
+	if !at.After(tShutdown.Add(claimLossDrainToleranceWindow)) {
+		// Audit-only: a previously-owned partition's frame landed inside
+		// the tolerated Stop→revoke→drain window. Correct behavior; logged
+		// so runs demonstrate the oracle observed (not merely missed) the
+		// drain.
+		log.Printf("[ClaimLossOrderingOracle] post_shutdown_drain_tolerated worker=%s partition=%d msg_at=%v shutdown_at=%v gap=%v",
+			simWorkerID, partition, at.Format(time.RFC3339Nano), tShutdown.Format(time.RFC3339Nano), at.Sub(tShutdown))
+
+		return
+	}
+	log.Printf("[ClaimLossOrderingOracle] VIOLATION post_shutdown_message worker=%s partition=%d msg_at=%v shutdown_at=%v tolerance=%v",
+		simWorkerID, partition, at.Format(time.RFC3339Nano), tShutdown.Format(time.RFC3339Nano), claimLossDrainToleranceWindow)
 	o.violations.Add(1)
 }
 


### PR DESCRIPTION
## Problem

`claim_loss_stop_ordering_violations` fires intermittently in `sim-claim-loss-coverage` and `sim-bucket-lifecycle` (~2/6 runs). It was invisible until the recent CI exit-code fix un-masked it — the failure predates it: the identical counter appears non-zero in earlier "green" job logs, and the reproducer brackets to well before the v2.8.2 scan work (byte-identical oracle since the original Phase 4 oracle round).

## Root cause — sim oracle over-strictness, not a product bug

The oracle flagged ANY message arriving after a claim-lost worker's observed `StateShutdown`. But parti's documented contract transitions to Shutdown *before* the async consumer revoke, and `WithDrainOnRemove` explicitly does not promise zero overlap — so the 1-2 in-flight frames drained 18-170ms post-shutdown are correct behavior. The oracle asserted a guarantee the product never made. In every failing run the real Stop-before-revoke ordering held (revoke-ordering counter 0 throughout); the flagged traffic was always a bounded batch drain, never sustained consumption. This is the "Residual #2" case documented and deferred in the prior sim-oracle fix round.

## Fix

A 2s drain-tolerance window in the oracle's `ObserveMessage`, with audit-only logging of tolerated drain frames; violation tests updated to drive messages beyond the window (still detected), plus a within-window/at-boundary no-violation regression guard.

## Validation

- Post-fix: 8/8 consecutive clean runs across both implicated scenarios; the drain actually fired and was tolerated in 5/8 (positive-space proof).
- Detection power preserved: with the revoke dropped in a throwaway build, the oracle reports 135 violations, first at +2.3s — sustained consumption is still caught. Sabotage fully reverted.
- `make lint` 0 issues; `go vet` clean; sim test packages green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULPUoEnYzc6dSE5TurTMhG
