### PR TITLE
feat: label-based partition assignment (v2.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.9.0] - 2026-07-08
+
+Label-based partition assignment: pin a subset of partitions to a dedicated
+worker pool (a "VIP" tier, a latency-sensitive tenant, a GPU-backed task
+class) inside the same management plane — one heartbeat/election/assignment
+bucket set, one partition list, one leader — instead of running a second
+deployment of Parti. Fully additive: with zero labels anywhere in the fleet,
+assignment output is unchanged from every prior release. Promote or demote a
+partition at runtime by rewriting the partition list; no worker restart
+required.
+
+### Added
+
+- **`types.Partition.Label`** — one optional string label per partition. A
+  routing hint, not identity: excluded from `CanonicalID`, `HashID`,
+  `Compare`, and `PartitionSetDigest`, so relabeling a partition that is
+  already on a matching worker moves no ownership.
+- **`types.Heartbeat.Labels`** — a worker's label set, fixed for the process
+  lifetime and published on every heartbeat.
+- **`Config.WorkerLabels`** (yaml `workerLabels`) and **`parti.WithWorkerLabels(labels...)`**
+  — configure a worker's label set; the option overrides the config field
+  when both are set. Validated, sorted, and deduplicated at construction
+  time (charset rules matching partition keys, 64-byte cap, 16 labels max).
+- **`Config.UnlabeledPartitionPolicy`** (yaml `unlabeledPartitionPolicy`,
+  default `"dedicated"`) — `"dedicated"` routes unlabeled partitions to
+  unlabeled workers only (falling back to all workers when none are live);
+  `"shared"` routes them to any worker. Leader-side; must be fleet-uniform,
+  same contract as the `AssignmentStrategy` choice.
+- **`Config.LabelSpillGrace`** (yaml `labelSpillGrace`, default `60s`) — how
+  long a label's worker pool must be continuously empty before its
+  partitions spill to the fallback ladder (unlabeled workers, or — only in
+  an all-labeled fleet — any worker). A partition parked during the grace
+  window is deliberately unassigned and durably accounted for in the
+  assignment commit (`AssignmentCommit.ParkedCount` / `ParkedDigest`); it is
+  never silently dropped from coverage.
+- **`types.LabelMetrics`** — optional extension interface a
+  `MetricsCollector` may also implement for per-label pool-size and
+  parked-count gauges plus spill/label-change/incarnation-reject/fallback
+  counters. Existing collectors that don't implement it are unaffected;
+  label mode runs without them.
+- **`AssignmentPayload.WorkerLabels` / `WorkerLabelsKnown`** and
+  **`AssignmentCommit.ParkedCount` / `ParkedDigest`** — wire additions
+  carrying labels-of-record and parked-partition accounting through both the
+  commit path and the legacy alias path. A worker whose configured labels
+  don't match its payload's labels-of-record rejects the assignment outright
+  (no consumer attach/detach, no ack) instead of misapplying a payload
+  computed for a different process incarnation behind the same stable ID —
+  the guard that makes stable-ID takeover across a relabel safe.
+- **`provision`**: partition records carry `label` alongside `keys` and
+  `weight`; `partictl partitions plan`/`apply` report label-only edits as a
+  change (`PartitionWeightChange.OldLabel` / `NewLabel`), never as a
+  no-op.
+- See [Label-Based Partition Assignment](docs/LABELS.md) for the full
+  operator guide: the worker/partition match rule, the park-then-spill
+  grace window and its worst-case-stall formula, the stale-incarnation
+  guard, and the recommended one-`WorkerIDPrefix`-per-deployment pattern.
+
+### Compatibility and rollout
+
+Two rollout-ordering rules apply before adopting labels on an existing
+fleet; skipping either produces a silent failure mode, not an error:
+
+1. **Upgrade every deployment to a label-aware version before labeling any
+   partition.** Any worker can win leader election — a mixed fleet flips
+   between labeled and legacy (label-blind) assignment on every failover
+   until every deployment is upgraded.
+2. **Upgrade every writer of the partition list first, including the
+   `provision` CLI.** An old writer's full-list rewrite silently strips the
+   `Label` field, and the new label-aware change detection faithfully
+   propagates that stripped list as a real edit — demoting every labeled
+   partition, not leaving them untouched.
+
+On the first commit published by an upgraded leader, every worker's payload
+is re-hashed once (the new labels-of-record presence bit enters the
+canonical payload bytes even for unlabeled workers), so the fleet runs one
+apply+ack cycle with no ownership movement — the same benign shape as a
+label-only edit.
+
 ## [v2.8.2] - 2026-07-03
 
 Scalability release: Parti's coordination buckets no longer pay steady-state

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Use it for stream processors, job queues, sharded caches, or any system where a 
 - **Processing Gate**: Per-message admission control based on assignment status, NAKing deliveries for revoked partitions.
 - **Cache Affinity**: Preserves >80% partition locality during rebalancing using consistent hashing.
 - **Weighted Assignment**: Supports partition weights for uneven workload distribution.
+- **Label-Based Routing**: Pins labeled partitions to matching worker pools (e.g., a dedicated "VIP" tier) with runtime promotion/demotion, an empty-pool park-then-spill grace window, and a stale-incarnation guard for stable-ID takeover. See [Label-Based Partition Assignment](docs/LABELS.md).
 
 ### Consumer Auto-Recovery
 
@@ -191,6 +192,7 @@ func main() {
 - **Features**
     - [Consumer Helpers](docs/CONSUMERS.md): JetStream consumer management.
     - [Static Partitioning](docs/STATIC_PARTITIONING.md): Deterministic partitioning without coordination.
+    - [Label-Based Partition Assignment](docs/LABELS.md): Dedicated worker pools for partition classes (VIP routing).
 - **Reference**
     - [API Reference](docs/API_REFERENCE.md): Detailed API documentation.
     - [Reference](docs/REFERENCE.md): Hooks, error codes, and glossary.

--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package parti
 import (
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/arloliu/fuda"
@@ -384,6 +386,26 @@ type Config struct {
 	// WorkerIDPrefix is the prefix for worker IDs (e.g., "worker" produces "worker-0", "worker-1").
 	WorkerIDPrefix string `yaml:"workerIdPrefix" default:"worker" validate:"required"`
 
+	// WorkerLabels is this worker's label set, fixed at process startup.
+	// Labeled partitions (Partition.Label) are assigned only to workers
+	// whose set contains the partition's label. Validated with
+	// partition-key charset rules; sorted and deduplicated. At most 16
+	// labels, each at most 64 bytes. Empty = unlabeled worker.
+	// WithWorkerLabels overrides this field when both are set.
+	WorkerLabels []string `yaml:"workerLabels"`
+
+	// UnlabeledPartitionPolicy controls which workers receive unlabeled
+	// partitions. "dedicated" (default): unlabeled workers only, falling
+	// back to all workers when no unlabeled worker is live. "shared":
+	// all workers. Leader-side; MUST be identical across every manager
+	// in the fleet (same contract as the AssignmentStrategy choice).
+	UnlabeledPartitionPolicy string `yaml:"unlabeledPartitionPolicy" default:"dedicated" validate:"oneof=dedicated shared"`
+
+	// LabelSpillGrace is how long a label's worker pool must be
+	// continuously empty before its partitions spill to the fallback
+	// ladder. 0 spills immediately. Leader-side; MUST be fleet-uniform.
+	LabelSpillGrace time.Duration `yaml:"labelSpillGrace" default:"60s" validate:"gte=0"`
+
 	// WorkerIDMin is the minimum stable ID number (inclusive).
 	// Set to 0 for most use cases.
 	WorkerIDMin int `yaml:"workerIdMin" default:"0" validate:"gte=0"`
@@ -604,6 +626,42 @@ func SetDefaults(cfg *Config) error {
 	return nil
 }
 
+// normalizeWorkerLabels validates, sorts, and deduplicates a worker label
+// set. Rules mirror Partition.Validate's label rules: non-empty, no dots,
+// no whitespace, at most 64 bytes each, at most 16 labels total.
+func normalizeWorkerLabels(labels []string) ([]string, error) {
+	if len(labels) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		if l == "" {
+			return nil, errors.New("worker label cannot be empty")
+		}
+		if len(l) > 64 {
+			return nil, fmt.Errorf("worker label exceeds 64 bytes: %q", l)
+		}
+		if strings.Contains(l, ".") {
+			return nil, fmt.Errorf("worker label contains invalid character '.': %q", l)
+		}
+		if strings.ContainsAny(l, " \t\n\r") {
+			return nil, fmt.Errorf("worker label contains whitespace: %q", l)
+		}
+		if _, dup := seen[l]; dup {
+			continue
+		}
+		seen[l] = struct{}{}
+		out = append(out, l)
+	}
+	slices.Sort(out)
+	if len(out) > 16 {
+		return nil, fmt.Errorf("too many worker labels: %d (max 16)", len(out))
+	}
+
+	return out, nil
+}
+
 // TTL Configuration Guide
 // =======================
 //
@@ -734,6 +792,15 @@ func (cfg *Config) Validate() error {
 	if cfg.AssignmentWatcherDebounce > 1*time.Second {
 		return errors.New("AssignmentWatcherDebounce must be <= 1s")
 	}
+
+	// Rule 13: Normalize the worker label set (validate charset/count, sort,
+	// dedupe) and store the canonical form back so downstream consumers
+	// (heartbeat publisher, calculator) see it in its resolved shape.
+	normalizedLabels, err := normalizeWorkerLabels(cfg.WorkerLabels)
+	if err != nil {
+		return fmt.Errorf("invalid WorkerLabels: %w", err)
+	}
+	cfg.WorkerLabels = normalizedLabels
 
 	return nil
 }

--- a/config_labels_test.go
+++ b/config_labels_test.go
@@ -1,0 +1,46 @@
+package parti
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_WorkerLabelsNormalization(t *testing.T) {
+	t.Parallel()
+
+	got, err := normalizeWorkerLabels([]string{"vip", "batch", "vip"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"batch", "vip"}, got, "sorted + deduped")
+
+	_, err = normalizeWorkerLabels([]string{"bad label"})
+	require.Error(t, err, "whitespace rejected")
+	_, err = normalizeWorkerLabels([]string{"dotted.label"})
+	require.Error(t, err, "dots rejected")
+	_, err = normalizeWorkerLabels([]string{""})
+	require.Error(t, err, "empty label rejected")
+
+	seventeen := make([]string, 17)
+	for i := range seventeen {
+		seventeen[i] = string(rune('a' + i))
+	}
+	_, err = normalizeWorkerLabels(seventeen)
+	require.Error(t, err, "more than 16 labels rejected")
+}
+
+func TestConfig_LabelPolicyDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{}
+	require.NoError(t, SetDefaults(&cfg))
+	require.Equal(t, "dedicated", cfg.UnlabeledPartitionPolicy)
+	require.Equal(t, 60*time.Second, cfg.LabelSpillGrace)
+
+	cfg.UnlabeledPartitionPolicy = "invalid"
+	require.Error(t, cfg.Validate())
+
+	cfg.UnlabeledPartitionPolicy = "shared"
+	cfg.LabelSpillGrace = -time.Second
+	require.Error(t, cfg.Validate())
+}

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -1,0 +1,422 @@
+# Label-Based Partition Assignment
+
+> Route specific partitions to specific worker pools — dedicated capacity for
+> a task class, without a second management plane.
+
+**Related Documentation:**
+- [Docs README](README.md) - Documentation map
+- [Strategies & Sources](STRATEGIES.md) - Assignment strategies (labels route *into* a strategy, not around it)
+- [Configuration Guide](CONFIGURATION.md) - Configuration options
+- [Lifecycle](LIFECYCLE.md) - Worker states, handoff, degraded mode
+- [Operations Guide](OPERATIONS.md) - Metrics, troubleshooting
+- [Kubernetes Guide](KUBERNETES.md) - Deployment patterns (one Deployment per label pool)
+- [Provision Guide](PROVISION.md) - `partitions:` records, including labels
+
+---
+
+## Table of Contents
+
+- [Label-Based Partition Assignment](#label-based-partition-assignment)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [The model](#the-model)
+  - [Configuring labels](#configuring-labels)
+    - [Worker labels](#worker-labels)
+    - [Assignment policy (fleet-uniform)](#assignment-policy-fleet-uniform)
+  - [The VIP promotion workflow](#the-vip-promotion-workflow)
+  - [Parking and spill](#parking-and-spill)
+    - [Worst-case stall](#worst-case-stall)
+    - [Grace clocks reset on leader failover](#grace-clocks-reset-on-leader-failover)
+  - [The stale-incarnation guard](#the-stale-incarnation-guard)
+  - [Rollout rules](#rollout-rules)
+  - [Recommended pattern: one `WorkerIDPrefix` per deployment](#recommended-pattern-one-workeridprefix-per-deployment)
+  - [What operators see](#what-operators-see)
+  - [Gotchas](#gotchas)
+
+---
+
+## Overview
+
+Weighted assignment (`Partition.Weight`, see [Strategies](STRATEGIES.md)) balances
+*expected* cost across a single worker pool, but it can't stop one long task
+from occupying a worker while shorter, unrelated work queues up behind it on
+the same box. When a subset of partitions needs their own dedicated capacity
+— a "VIP" tier, a latency-sensitive tenant, a GPU-backed task class — labels
+let you segregate them onto a separate worker pool inside the *same* Parti
+management plane: one heartbeat/election/assignment bucket set, one partition
+list, one leader, but two (or more) isolation domains.
+
+The common deployment shape is multiple Kubernetes Deployments — say `general`
+and `vip` — each running the same binary with a different `WorkerLabels`
+value baked into its pod config. The VIP set is not static: operators promote
+and demote partitions between pools at runtime by rewriting the partition
+list, without redeploying or restarting any worker.
+
+## The model
+
+Two independent, deliberately simple primitives:
+
+- **`types.Partition.Label`** — one *optional* string label per partition.
+  Empty means unlabeled.
+- **`types.Heartbeat.Labels`** — a worker's label *set*, published on every
+  heartbeat. Fixed for the lifetime of the process: labels are read from
+  config at startup, never mutated at runtime. Changing a worker's labels
+  means changing its config and restarting it — which already triggers the
+  normal join/leave rebalance machinery.
+
+The match rule is a single membership test: **a labeled partition is
+eligible for a worker only if the partition's label is a member of the
+worker's label set.** There is no key=value selector language, no
+expressions — one flat string per partition, one flat string set per worker.
+
+`Label` is a **routing hint, not identity**. It is deliberately excluded from
+`Partition.CanonicalID()`, `HashID()`, `Compare()`, and
+`PartitionSetDigest()`. Two partitions with the same keys and different
+labels are the *same* partition with a new routing hint — which is exactly
+the VIP-promotion operation. The practical consequence: **relabeling a
+partition that is already sitting on a worker that matches its new label
+moves no ownership.** No consumer detaches, no consumer attaches — the
+partition's identity never changed, so the handoff machinery (which diffs by
+key/`HashID`) sees nothing to hand off. The worker does run one apply+ack
+cycle for the updated payload bytes, but it is a no-op at the consumer layer.
+
+Unlabeled partitions default to unlabeled workers only (see
+[Assignment policy](#assignment-policy-fleet-uniform) below) — labeling a
+pool of workers reserves them for their class even before any partition
+carries that label.
+
+## Configuring labels
+
+### Worker labels
+
+Set a worker's label set once, at construction:
+
+```go
+cfg := parti.DefaultConfig()
+cfg.WorkerLabels = []string{"vip"}
+mgr, _ := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash())
+```
+
+or, when several workers share one `Config` value (a common pattern in test
+harnesses or when building N managers from one template) and need distinct
+labels:
+
+```go
+mgr, _ := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(),
+    parti.WithWorkerLabels("vip"),
+)
+```
+
+`WithWorkerLabels` overrides `Config.WorkerLabels` when both are set.
+`NewManager` validates, sorts, and deduplicates the set: each label follows
+the same charset rules as a partition key (non-empty, no dots, no
+whitespace), capped at 64 bytes; at most 16 labels per worker. An invalid set
+makes `NewManager` return an error at construction time, not at some later
+runtime surprise.
+
+Labeling partitions uses the same `Partition.Label` field you already know
+from `types.Partition`:
+
+```go
+partitions := []types.Partition{
+    {Keys: []string{"tenant-acme"}, Label: "vip"},
+    {Keys: []string{"tenant-widgets"}}, // unlabeled — general pool
+}
+```
+
+`Partition.Validate()` applies the identical charset and length rules to
+`Label`.
+
+### Assignment policy (fleet-uniform)
+
+Two `Config` knobs govern *how* the leader routes labeled and unlabeled
+work. Both are **leader-side and must be identical across every manager in
+the fleet** — exactly the same contract that already applies to the
+configured `AssignmentStrategy`. Worker *labels* are meant to differ per
+deployment; assignment *policy* is not.
+
+| Field | Default | Description |
+|---|---|---|
+| `UnlabeledPartitionPolicy` | `"dedicated"` | `"dedicated"`: unlabeled partitions go to unlabeled workers only, falling back to all workers when no unlabeled worker is live. `"shared"`: unlabeled partitions go to any worker, labeled or not. |
+| `LabelSpillGrace` | `60s` | How long a label's worker pool must be continuously empty before its partitions spill to the fallback ladder. `0` spills immediately. |
+
+```yaml
+unlabeledPartitionPolicy: dedicated
+labelSpillGrace: 60s
+```
+
+With zero labels anywhere in the fleet (no labeled partitions, no labeled
+workers), the whole pipeline degenerates to today's single
+`Strategy.Assign(allWorkers, allPartitions)` call — every partition lands on
+the same worker it would have landed on in a pre-label deployment. Enabling
+labels never moves an unlabeled deployment's work. (The first commit an
+upgraded leader publishes does re-encode payloads once with the new label
+fields — a benign re-apply with no ownership movement; see
+[Rollout rules](#rollout-rules).)
+
+## The VIP promotion workflow
+
+In production the partition list normally lives in the `source.NatsKV`
+source (see [Strategies & Sources](STRATEGIES.md#natskv-source)). Promoting
+or demoting a partition is a **full-list rewrite** through the existing
+update path — there is no targeted "patch one partition's label" API.
+`source.NatsKV.Modify` does a CAS-fenced read-modify-write, which is the
+natural fit:
+
+```go
+// kv obtained as in the NatsKV Source guide (docs/STRATEGIES.md).
+src := source.NewNatsKV(kv, "partitions", logger)
+
+// Promote "tenant-acme" to the vip pool.
+err := src.Modify(ctx, func(partitions []types.Partition) []types.Partition {
+    for i := range partitions {
+        if partitions[i].ID() == "tenant-acme" {
+            partitions[i].Label = "vip"
+        }
+    }
+    return partitions
+})
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+The same rewrite works through the `provision` SDK/CLI's `partitions:`
+records (`partictl partitions plan` / `apply`) — each record has an optional
+`label:` field alongside `keys:` and `weight:`:
+
+```yaml
+partitionSource:
+  bucket: parti-partitions
+  key: partitions/v1
+  partitions:
+    - keys: ["tenant-acme"]
+      label: vip
+    - keys: ["tenant-widgets"]
+```
+
+`partictl partitions plan` reports label-only edits as a change (alongside
+weight changes) — a relabel is never a silent no-op in plan output.
+
+The leader detects a label-only rewrite as a real change (it is not
+collapsed into "nothing changed" just because the partition's keys and
+weight are untouched) and fires a rebalance. If the target pool has an
+eligible worker, the promoted partition moves there on the next assignment;
+if it doesn't, it parks — see below.
+
+## Parking and spill
+
+A **parked** partition is deliberately unassigned: no worker owns it, no
+consumer attaches to it, and any messages published for it queue durably in
+JetStream until assignment resumes. Parking is the leader's response to a
+labeled partition whose pool has gone completely empty — every worker that
+carries that label has left the fleet (scaled to zero, crashed, or simply
+never existed yet).
+
+Concretely: a `vip`-labeled partition whose only `vip` worker is drained
+during a deploy does **not** immediately fall back to the general pool.
+Instead the leader parks it — leaving it unowned rather than handing VIP work
+to a general-purpose worker — for up to `LabelSpillGrace` (default 60s). If a
+`vip` worker rejoins within that window, the partition is assigned to it with
+no spill ever having happened. If the grace window fully elapses with the
+pool still empty, the partition spills to the fallback ladder: it goes to an
+unlabeled worker if one exists, or — only in an all-labeled fleet — to any
+worker. A parked or spilled partition is never silently dropped from
+accounting: the assignment commit records how many partitions were parked
+and a digest of exactly which ones, so every batch is fully accounted for
+(assigned ∪ parked always equals the source set).
+
+Two properties worth calling out:
+
+- **Routine rolling updates don't park.** As long as Kubernetes'
+  `maxUnavailable` keeps at least one pod of the label alive during a
+  rollout, the survivors absorb the label's partitions immediately — no
+  grace delay, no parking.
+- **A single bad observation never parks or spills anything.** Before the
+  leader acts on "this pool just went empty" (or "this worker's labels are
+  unreadable"), it requires the same signal on two consecutive rebalance
+  passes. One transient blip is deferred and re-checked automatically within
+  a few seconds — it does not extend the effective grace window — and a
+  second, contrary observation cancels the deferral entirely. This exists
+  specifically so a one-off heartbeat read glitch can't revoke a live
+  worker's VIP partitions or trigger a spill that shouldn't happen.
+
+### Worst-case stall
+
+For a *total* outage of a label's pool (every worker carrying that label is
+gone), the worst-case time before a labeled partition either resumes on a
+replacement worker or spills to the fallback ladder is bounded by:
+
+```
+heartbeat-TTL detection  +  confirmation  +  LabelSpillGrace  +  rebalance / handoff
+```
+
+- **Heartbeat-TTL detection** — the leader must first notice the workers are
+  gone, bounded by `Config.HeartbeatTTL`.
+- **Confirmation** — the automatic two-observation check described above; a
+  small, fixed, non-configurable delay (typically the next rebalance cycle —
+  sub-second — with a bounded few-second retry if the leader happens to be
+  mid-rebalance already).
+- **`LabelSpillGrace`** — the configured grace window itself.
+- **Rebalance / handoff** — the normal debounce and two-phase handoff or
+  processing-gate latency any reassignment already pays.
+
+Size `LabelSpillGrace` well below the affected class's latency SLO. The 60s
+default is chosen to comfortably cover a pod reschedule or a leader failover
+blip without spilling VIP work prematurely.
+
+### Grace clocks reset on leader failover
+
+The "how long has this pool been empty" clock lives in the leader's memory,
+not in durable KV. A leader failover starts every grace clock fresh. In the
+rare case where a pool outage straddles *K* consecutive leader failovers, the
+worst-case stall extends to roughly `(K+1) × LabelSpillGrace` plus detection
+and handoff overhead. This is a deliberate trade: persisting grace clocks
+across failovers buys little in practice (failovers are rare and grace
+windows are short) at the cost of a new durable write path. Size
+`LabelSpillGrace` with this in mind if your fleet expects frequent leadership
+churn.
+
+## The stale-incarnation guard
+
+Stable worker IDs (`worker-0`, `worker-1`, …) are claimed from a pool that
+can outlive any single process — and, if two deployments share a
+`WorkerIDPrefix`, a pool that can be claimed by a *different deployment's*
+pod after a restart. Leader-side pool matching alone cannot prevent a
+mislabeled apply in that scenario: if a `vip` pod holding `worker-0` is
+replaced by a `general` pod that reclaims the same ID before the leader
+notices any membership change, the general pod would otherwise apply the
+stale VIP assignment it inherited and start processing VIP work on the wrong
+class of machine — worse than a transient misroute, because nothing about
+the worker *set* changed, so no rebalance would ever fire to correct it.
+
+Every worker therefore checks, on every assignment apply, whether the
+payload's labels-of-record (the label set the leader believed this worker
+had when it computed the assignment) match the worker's own configured
+labels:
+
+- Labels match → apply normally.
+- Labels are known and **don't** match → **reject** the payload outright: no
+  consumer attaches or detaches, the worker does not acknowledge the
+  assignment, and it keeps heartbeating (with its true labels) on its
+  current assignment. This is a first-class, expected outcome, not an error
+  to retry — retrying the same payload would be futile, since it can never
+  become applicable to this incarnation.
+- Labels are unknown (the payload came from a pre-label leader) → apply, for
+  backward compatibility during a rolling upgrade.
+
+Convergence after a rejection doesn't wait for a full audit cycle: the
+leader's heartbeat watcher already sees every heartbeat's contents on every
+publish, and a worker whose observed labels differ from what it last
+published for that same worker ID triggers an immediate targeted rebalance,
+independent of whether the *set* of live worker IDs changed at all. During
+the (bounded) rejection window the partition's messages simply queue
+durably — strictly preferable to a wrong-class worker processing them.
+
+You do not need to configure or invoke this guard; it runs unconditionally
+whenever any worker in the fleet carries labels. See
+[What operators see](#what-operators-see) for the log line and metric it
+emits, and the recommended pattern below for shrinking how often it can ever
+fire.
+
+## Rollout rules
+
+Labels are additive and JSON-compatible in both directions — an old leader
+ignores labels entirely (legacy assignment, no parking), and a new leader
+treats old, label-less workers as unlabeled. That compatibility does **not**
+extend to the two rules below; skipping either produces a silent failure
+mode, not a loud error.
+
+1. **Upgrade every deployment to a label-aware version before labeling any
+   partition.** Any worker can win leader election. If even one deployment
+   in the fleet is still running a pre-label version, a leadership handoff
+   to that version flips the whole fleet back to legacy, label-blind
+   assignment — with no warning — until leadership returns to a label-aware
+   worker.
+2. **Upgrade every writer of the partition list before relying on labels —
+   including the `provision` CLI.** A writer built against an old
+   `types.Partition` (or an old `provision` binary) drops the `Label` field
+   on a full-list rewrite. Because label-aware leaders correctly detect this
+   as a real change, the effect is not "no-op" but **active, silent
+   demotion**: every VIP partition loses its label on the very next write
+   from the stale tool, and the leader dutifully reassigns them to the
+   general pool.
+
+Both rules apply the same "fleet-uniform" discipline already documented for
+the assignment-strategy choice: get every process onto compatible code
+first, *then* turn the feature on operationally.
+
+On the very first commit published by an upgraded leader, every worker's
+payload gets one benign re-hash: the labels-of-record presence bit enters the
+canonical payload bytes for the first time, which changes `PayloadHash` even
+though no partition moved. Every worker runs one apply+ack cycle with no
+ownership change as a result — expected, and harmless.
+
+## Recommended pattern: one `WorkerIDPrefix` per deployment
+
+Give each Deployment its own `WorkerIDPrefix` (e.g. `vip-0`, `vip-1`, … vs.
+`worker-0`, `worker-1`, …) instead of sharing one prefix across deployments
+with different label sets.
+
+This makes cross-deployment stable-ID takeover **structurally impossible** —
+a `general` pod can never claim an ID from the `vip` pool, because the pools
+don't overlap. That shrinks the [stale-incarnation guard](#the-stale-incarnation-guard)'s
+job down to the one residual case it exists to cover: a *single* deployment
+relabeling itself across a rollout while keeping its own prefix. As a bonus,
+worker IDs become self-describing in logs and metrics: `vip-3` identifies its
+pool at a glance, where `worker-17` requires a lookup.
+
+## What operators see
+
+Label-aware observability is opt-in via `types.LabelMetrics`, an optional
+extension interface. If your `MetricsCollector` also implements
+`LabelMetrics`, the manager and calculator type-assert it and start
+recording; if not, label mode still runs, it just isn't instrumented. All
+methods are recomputed every rebalance, and a label that drops out of the
+current partition/worker snapshot has its gauges explicitly zeroed rather
+than left stale:
+
+| Method | Kind | Meaning |
+|---|---|---|
+| `RecordLabelPoolSize(label, workers)` | gauge | Workers currently eligible for `label`. |
+| `RecordParkedPartitions(label, count)` | gauge | Partitions of `label` currently parked. |
+| `IncrementLabelSpill(label)` | counter | A partition of `label` spilled to the fallback ladder. |
+| `IncrementLabelChangeTrigger()` | counter | A rebalance was triggered by a detected worker-label change (the incarnation-guard convergence path). |
+| `IncrementLabelIncarnationReject()` | counter | A worker rejected an assignment payload computed for a different incarnation of its ID. |
+| `IncrementUnlabeledFallback()` | counter | Under `dedicated` policy: an unlabeled partition had to be served by a labeled worker because the unlabeled pool was empty. Under `shared` policy this counter stays at zero in normal operation (unlabeled work landing on labeled workers is routine there, not a fallback) — it fires only in the degenerate case of no live workers at all. |
+
+The gauges are leader-scoped: a leader that steps down zeroes every per-label
+gauge it was reporting, so a deposed leader's metrics export doesn't freeze
+at a stale non-zero reading.
+
+Grep for these log lines when diagnosing a labeled deployment:
+
+| Log line | Level | Where |
+|---|---|---|
+| `resolved worker labels` | Info | Once at manager startup, labeled workers only — confirms the label set this process actually applied (`WithWorkerLabels` vs. `Config.WorkerLabels`). Unlabeled workers do not emit it. |
+| `worker label change detected` | Info | The leader's heartbeat watcher saw a worker publish a different label set under a worker ID it had seen before — the stale-incarnation trigger firing. |
+| `rejecting assignment computed for a different incarnation of this worker ID` | Warn | The stale-incarnation guard fired on this worker. Logged with `payload_labels` and `worker_labels` so you can see the mismatch directly. |
+| `startup: current commit is for a different incarnation; waiting for a label-correct commit` | Warn | Same guard, at startup, on the commit path. |
+| `startup: current alias assignment is for a different incarnation; waiting for a label-correct assignment` | Warn | Same guard, at startup, on the legacy-alias path. |
+| `initial assignment deferred pending label observation confirmation` | Info | The leader's first rebalance after startup saw a disruptive label observation and is waiting for the automatic second (confirming) observation before acting. |
+| `label recheck requested` | Debug | The leader's label re-check timer or a label-change signal woke the rebalance path (with a `reason` field). Useful for confirming the grace-expiry or confirmation timers are actually firing. |
+
+## Gotchas
+
+- **Reserved-but-idle is by design.** Under the default `dedicated` policy,
+  labeling a set of workers before labeling any partitions leaves those
+  workers idle — they're reserved for their class, not folded back into
+  general work. Use `shared` if you'd rather let idle labeled capacity absorb
+  unlabeled work.
+- **A spilled partition never invades a different label's pool.** The spill
+  ladder always prefers unlabeled workers; it only reaches into "any worker"
+  when the fleet has no unlabeled workers at all. A `vip` pool outage cannot
+  spill into a separate `gpu` pool's dedicated capacity.
+- **Custom `AssignmentStrategy` implementations need no changes.** Labels are
+  handled entirely above the strategy interface — see
+  [Strategies & Sources](STRATEGIES.md#assignment-strategies) for why. Your
+  strategy still just receives a worker list and a partition list; it simply
+  gets called once per label pool instead of once for the whole fleet.
+- **`Partition.Weight` still balances *within* a pool.** Cross-pool weight
+  balancing is not a goal — pools are isolation domains, not shared capacity
+  to be split by weight.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ mgr.Start(context.Background())
 | [Strategies & Sources](STRATEGIES.md)         | Assignment strategies, partition sources                    |
 | [Static Partitioning](STATIC_PARTITIONING.md) | Key-based routing plus static partition publisher/subscriber helpers |
 | [Scaling](SCALING.md)                         | Bounded-cost partitioning: NATS `partition()` + `Dynamic` over a fixed K |
+| [Labels](LABELS.md)                           | Dedicated worker pools for partition classes (VIP routing), park/spill, rollout rules |
 
 ### Reference
 

--- a/docs/STRATEGIES.md
+++ b/docs/STRATEGIES.md
@@ -21,6 +21,7 @@
     - [WeightedConsistentHash](#weightedconsistenthash)
     - [RoundRobin](#roundrobin)
     - [Custom Strategies](#custom-strategies)
+    - [Label Routing](#label-routing)
   - [Partition Sources](#partition-sources)
     - [Import](#import-1)
     - [Source Interface](#source-interface)
@@ -288,6 +289,30 @@ func (s *AffinityStrategy) Assign(
     return result, nil
 }
 ```
+
+---
+
+### Label Routing
+
+Label-based partition assignment (`Partition.Label` / `Config.WorkerLabels`)
+sits **above** this layer, not inside it. Labels partition the worker set and
+the partition set into pools first (a "vip" pool, a "general" pool, and so
+on); the configured `AssignmentStrategy` then runs once per pool, unmodified,
+exactly as it would for a single unlabeled fleet.
+
+Concretely, `AssignmentStrategy` stays the two-method interface shown above —
+it never receives label information and never needs to. A custom strategy
+you've already written keeps working with **no changes** once labels are
+enabled; it simply gets called once per eligible pool instead of once for the
+whole fleet, and its own load-balancing behavior (including
+`Partition.Weight` handling) applies *within* each pool. Balancing capacity
+*across* pools is deliberately not a strategy concern — pools are isolation
+domains, not shared capacity.
+
+See [Label-Based Partition Assignment](LABELS.md) for the full model: the
+worker/partition label match rule, the `dedicated`/`shared` unlabeled policy,
+the park-then-spill grace window for an empty pool, and the rollout rules for
+upgrading a fleet safely.
 
 ---
 

--- a/docs/plans/label-assignment/00-design-spec.md
+++ b/docs/plans/label-assignment/00-design-spec.md
@@ -1,0 +1,889 @@
+# Label-Based Partition Assignment — Design Spec
+
+- **Status**: v5 — external review clean (5 rounds; round 5 verdict
+  "ready to implement", no findings; reports at
+  `tmp/label-assignment_v1_review.md` … `tmp/label-assignment_v5_review.md`)
+- **Date**: 2026-07-07
+- **Target version**: v2.9.0 (additive minor)
+- **Packages touched**: `types/`, `source/`, `provision/`,
+  `internal/assignment/`, root (`config.go`, manager wiring, apply path),
+  `internal/heartbeat/`, docs
+
+## 1. Motivation
+
+Weighted partitioning balances *expected* cost across workers, but a single
+long-running task still occupies its worker serially and blocks the shorter
+work queued behind it. Operators need to segregate task *classes* onto
+dedicated worker pools.
+
+Primary use case ("VIP partitions"): a subset of partitions must be served by
+dedicated workers. The VIP set changes **at runtime** — operators rewrite the
+partition list in the NATS KV source to promote/demote partitions, without
+redeploying workers.
+
+Typical deployment: multiple Kubernetes Deployments, each with its own label
+set baked into pod config. All pods share one parti management plane (one
+heartbeat/election/assignment bucket set, one partition list, one leader).
+
+## 2. Requirements (decided)
+
+| # | Decision |
+|---|----------|
+| R1 | Worker carries a **set** of labels; partition carries **one optional** label. Match rule: partition label ∈ worker's label set. |
+| R2 | Worker labels are **fixed at process startup** (from config). Label changes happen via pod restart, which already triggers join/leave rebalances. |
+| R3 | Empty-pool fallback: **spill after a grace window**. A labeled partition whose pool has no live worker is *parked* (deliberately unassigned) until the pool has been empty for a configurable grace duration, then spills to the fallback ladder. Grace `0` = spill immediately. |
+| R4 | Unlabeled partitions go to **unlabeled workers only** by default (`dedicated` policy); configurable to **all workers** (`shared` policy). |
+| R5 | Production partition list source is the **NATS KV source**; label edits arrive as full-list rewrites through the existing update path. No targeted label-patch API. |
+| R6 | Assignment-policy configuration (grace, unlabeled policy) is **leader-side and must be fleet-uniform**, same contract as the existing `AssignmentStrategy` choice. Worker *labels* differ per deployment by design; assignment *policy* must not. |
+
+## 3. Non-goals
+
+- Key=value label selectors or expression matching (k8s-style). One flat
+  string label per partition; flat string set per worker.
+- Runtime mutation of a worker's label set (`Manager.SetLabels`).
+- Cross-pool load balancing. Pools are isolation domains; balance within a
+  pool is the configured strategy's job.
+- Per-label or per-partition grace overrides. One global grace duration.
+- A targeted "patch one partition's label" write API (R5).
+- Persisting grace clocks across leader failover (see §8.4).
+
+## 4. Data model changes
+
+### 4.1 `types.Partition` (`types/partition.go`)
+
+```go
+// Label optionally pins this partition to workers that carry the same
+// label (see Heartbeat.Labels). Empty means unlabeled: the partition is
+// assigned according to the unlabeled-partition policy. Label is a
+// routing hint, NOT part of partition identity: it does not participate
+// in CanonicalID, HashID, Compare, or PartitionSetDigest.
+Label string `json:"label,omitempty" yaml:"label,omitempty"`
+```
+
+- `Partition.Validate()` additionally validates a non-empty `Label` with the
+  same charset rules as keys (non-empty, no dots, no whitespace), plus a
+  length cap of 64 bytes (labels become metric label values; see §13). Empty
+  label is valid (= unlabeled).
+- **Copy/transform-path audit (load-bearing).** Several production paths
+  reconstruct `types.Partition` field-by-field and would silently strip
+  `Label`, breaking the VIP flow before `partitionsEqual` ever runs. Every
+  one of these MUST preserve `Label`, each pinned by a label round-trip test:
+  - `source/nats_kv.go:1274` `deepCopyPartitions` — builds
+    `types.Partition{Weight: p.Weight}` + copied keys. Without the fix, a
+    decoded labeled list is stripped before storage/comparison, so the
+    calculator never sees labels at all.
+  - `source/nats_kv.go:1327` `validateAndDedupe` — same construction; strips
+    labels from every `Update`/`Modify`/`AddPartitions` write path.
+  - `provision/partition_records.go:223` `clonePartition` (and via it
+    `clonePartitions`, `diffPartitions`) — the in-repo provisioning writer
+    would erase labels on any plan/apply round trip.
+  - `provision/partition_records.go` `diffPartitions` — treats only `Weight`
+    differences as "changed"; a label-only edit must surface as a change in
+    plan output (exact change-record shape is an implementation-plan detail,
+    but label changes MUST be visible in plans, not dropped).
+  - `provision/apply_partitions.go:322` `partitionTablesEqual` — Weight-only
+    equality; a label-only apply would be skipped as a no-op.
+
+  Implementation rule: any code that copies a `Partition` must copy the
+  struct value (`cp := p` then re-allocate `Keys`) rather than enumerating
+  fields, so future field additions cannot regress this class again. A
+  repo-wide `types.Partition{` sweep at implementation time confirms no
+  other production copy sites exist (audit as of this spec: the five above;
+  strategy/partcodec paths copy whole values or pass through JSON and are
+  safe).
+- **Identity is unchanged.** `CanonicalID`, `HashID`, `Compare`, and
+  `PartitionSetDigest` deliberately exclude `Label`:
+  - Same keys + different label = the *same* partition with a new routing
+    hint, which is exactly the VIP-promotion semantics.
+  - If a label edit does not change where a partition lands (it was already
+    on a matching worker), **no ownership movement** occurs: identity digests
+    stay equal, handoff diffing (key/HashID-based) sees no acquire/revoke,
+    and no consumer detaches or attaches. Note the weaker-than-"no churn"
+    phrasing: assignment payloads carry `Label` (uniform copy rule below),
+    so a label-only edit still changes the worker's canonical payload bytes
+    and `PayloadHash`, and the worker runs one apply+ack cycle that is a
+    no-op at the consumer layer. A test pins "no consumer detach/attach on
+    label-only promotion of an already-matching partition".
+  - Dedup in `source.validateAndDedupe` (by `CanonicalID`) still rejects two
+    entries with the same keys, regardless of labels — correct, since they
+    would be one partition with two contradictory hints.
+
+### 4.2 `types.Heartbeat` (`types/heartbeat.go`)
+
+```go
+// Labels is the worker's label set, fixed for the process lifetime.
+// Sorted and deduplicated at publish time. Empty for unlabeled workers
+// and for pre-label workers (additive JSON field).
+Labels []string `json:"labels,omitempty"`
+```
+
+- Published on every beat by `internal/heartbeat/publisher.go`.
+- `SchemaVersion` stays 1: the field is additive JSON; old leaders ignore it,
+  old workers omit it (decodes as nil = unlabeled). No capability bit — this
+  is routing data, not a safety mechanism the audit path must gate on.
+- **No new KV bucket.** Labels ride the existing heartbeat channel and
+  inherit its liveness semantics: a label set is only ever read from a live
+  heartbeat.
+- Why not attach labels to the stable ID claim: stable IDs (`worker-0`, …)
+  are claimed from a pool **shared across deployments**, so a given ID can
+  belong to a "vip" pod today and a general pod after restart/takeover.
+  Labels keyed to the stable ID would go stale; labels in the live heartbeat
+  are correct by construction.
+
+### 4.3 Wire additions: labels-of-record and parked metadata
+
+`WorkerLabels` records the label set the leader read from this worker's
+heartbeat when computing the assignment. It powers the worker-side
+stale-incarnation guard (§9): a worker whose own labels differ from the
+labels-of-record knows the payload was computed for a different process
+incarnation behind the same stable ID.
+
+It must live on the object commit-path workers actually fetch. Commits point
+workers at content-addressed `AssignmentPayload`s (`types/assignment_commit.go:25-34`,
+currently `SchemaVersion` + `Partitions` only); `buildAssignmentFromCommit`
+synthesizes the runtime `Assignment` from `payload.Partitions` plus commit
+metadata (`manager_assignment.go:1212-1220`). A field on `types.Assignment`
+alone would therefore never reach commit-path workers. So:
+
+```go
+// AssignmentPayload gains:
+// WorkerLabels      []string `json:"worker_labels,omitempty"`       // labels-of-record
+// WorkerLabelsKnown bool     `json:"worker_labels_known,omitempty"` // presence bit
+```
+
+- **`WorkerLabelsKnown` is required because `omitempty` alone cannot
+  distinguish "computed for an unlabeled worker" from "computed by a
+  pre-label leader"** — an empty `[]string` marshals as absent, so a labeled
+  pod taking over an unlabeled worker's ID would see the absent field and
+  compat-apply a payload computed for a different label set (violating
+  I11). Label-aware leaders ALWAYS set `WorkerLabelsKnown=true`, including
+  for unlabeled workers (labels empty). Guard rule: `Known && !setEqual` →
+  reject; `Known && setEqual` → apply; `!Known` → pre-label compat apply.
+  This mirrors the existing `SourceRevisionKnown` presence-bit precedent
+  (`types/partition.go` Assignment / `types/assignment_commit.go`).
+- Both fields are part of the canonical payload bytes and therefore of
+  `PayloadHash` (content identity) — two workers with identical partition
+  sets but different labels-of-record are different payloads, which is
+  correct. `AssignmentPayloadRef.SetDigest` stays partition-only.
+  Compat note: the first commit published by an upgraded leader re-hashes
+  every worker's payload (the presence bit enters the canonical bytes), so
+  the fleet runs one apply+ack cycle with no ownership movement — same
+  benign shape as a label-only edit (§4.1).
+- `buildAssignmentFromCommit` copies `payload.WorkerLabels` and
+  `payload.WorkerLabelsKnown` into the runtime `types.Assignment` (which
+  gains the same fields for in-process use), and `buildLegacyAlias`
+  (`assignment_publisher.go:1327-1341`) copies both onto the legacy alias
+  envelope, so the guard sees labels-of-record with presence on **both**
+  wire paths.
+- The commit record gains parked-partition metadata (`ParkedCount`,
+  `ParkedDigest` — §8.2).
+
+All fields are additive JSON; old readers ignore them. Payload content-key
+reuse across commits is preserved whenever partition set AND labels-of-record
+are unchanged.
+
+## 5. Configuration surface
+
+New `Config` fields (`config.go`), following existing yaml/default/validate
+conventions:
+
+```go
+// WorkerLabels is this worker's label set (R1/R2). Fixed at startup.
+// Validated with partition-key charset rules; deduplicated and sorted.
+// Caps: at most 16 labels per worker, each at most 64 bytes — bounds
+// heartbeat payload growth and metric cardinality (§13).
+WorkerLabels []string `yaml:"workerLabels" validate:"max=16,dive,max=64"`
+
+// UnlabeledPartitionPolicy controls which workers receive unlabeled
+// partitions (R4). "dedicated" (default): unlabeled workers only,
+// falling back to all workers when no unlabeled worker is live.
+// "shared": all workers. Leader-side; must be fleet-uniform (R6).
+UnlabeledPartitionPolicy string `yaml:"unlabeledPartitionPolicy" default:"dedicated" validate:"oneof=dedicated shared"`
+
+// LabelSpillGrace is how long a label's pool must be continuously empty
+// before its partitions spill to the fallback ladder (R3). 0 spills
+// immediately. Leader-side; must be fleet-uniform (R6).
+LabelSpillGrace time.Duration `yaml:"labelSpillGrace" default:"60s" validate:"gte=0"`
+```
+
+Defaults preserve legacy behavior for unlabeled fleets (see invariant I1).
+
+## 6. Leader-side label discovery
+
+At each rebalance, after `getActiveWorkersFiltered` produces the active
+worker-ID list, the calculator fetches the current heartbeat **values** for
+exactly those IDs to learn label sets. Mechanism: a new
+`WorkerMonitor.GetHeartbeatsFor(ctx, workerIDs)` that performs one bounded KV
+`Get` per listed worker — unlike the existing `GetHeartbeats`
+(`internal/assignment/worker_monitor.go:240`), it does not re-run the
+`Keys()` scan the caller just performed.
+
+- **Freshness over caching.** Labels are read fresh every rebalance. A
+  long-lived `workerID → labels` cache is rejected: a stable-ID takeover can
+  swap the process behind an ID without the heartbeat key ever expiring, so
+  cached labels can be wrong within a TTL window. Rebalances are infrequent
+  (join/leave/source-change/audit-driven), so N `Get`s per rebalance is
+  acceptable.
+- **Failure taxonomy first: `unknown` is only for isolated per-worker
+  failures.** Broad failures must never be laundered into label decisions:
+  if the heartbeat `Keys()` enumeration fails, or per-worker `Get` failures
+  are classified connectivity/degrading-JetStream (`natsutil`), or more
+  than max(1, 10% of the active set) of the `Get`s fail, the rebalance
+  aborts and the error routes through the existing KV-error/degraded
+  machinery (`recordKVError` → `KVErrorThreshold` → Degraded) — preserving
+  the whole-bucket-loss contract (AGENTS.md cross-feature contract 1).
+  Without this split, a heartbeat-bucket outage with a still-writable
+  assignment bucket would read as "every worker's labels unknown" and,
+  after confirmation, publish explicit empty assignments for the entire
+  fleet — a mass revocation caused by unreadable labels, not by absent
+  workers. At small fleet sizes the threshold degenerates soundly:
+  max(1, 10%) = 1 for N ≤ 10, so one unreadable worker is isolated
+  (unknown-label handling) and two of three is a broad failure (abort +
+  KV-error path); tests pin both sides (§14).
+- **Unreadable labels are `unknown`, never guessed.** If an isolated
+  worker's heartbeat `Get` (after one bounded inline retry) still fails,
+  its label set is *unknown* — NOT "unlabeled" and NOT its labels from a
+  previous read. Both guesses misroute: a stale-ID takeover can change the
+  labels behind a worker ID at any time, so a previous read may describe a
+  dead process; and "unlabeled" would hand general work to what may be a
+  dedicated worker under the `dedicated` policy. Unknown-label handling
+  follows the defer-once-then-act rule (§8.5): the first rebalance
+  observing an unknown-label worker defers (dedicated sentinel + label
+  re-check timer, §8.3); if the read still fails on the re-check, the
+  worker is excluded from every pool and receives an explicit empty
+  assignment entry (I8 — no stale KV leak), with a warning log and metric.
+  Its partitions redistribute; a later successful read re-homes them.
+  Correctness over churn.
+- Legacy workers (SchemaVersion 0 or a decoded heartbeat without the field)
+  are unlabeled — that is a *successful* read of an empty set, distinct from
+  unknown.
+
+## 7. Assignment pipeline
+
+The single strategy call at `internal/assignment/calculator.go:1707`
+(`c.Strategy.Assign(workers, partitions)`) is replaced by a grouping layer.
+The `types.AssignmentStrategy` interface is **unchanged**; the configured
+strategy runs once per pool. (Alternatives rejected: extending the strategy
+interface with worker metadata forces every custom strategy — see
+`docs/STRATEGIES.md` — to reimplement label routing, and parking/grace is
+stateful, which contradicts the stateless-strategy contract; a wrapper
+strategy with an injected label lookup hides KV reads inside `Assign` and
+breaks its determinism contract.)
+
+```
+inputs:  workers      []string            (active set, post-filter)
+         labelsOf     map[string][]string  (from §6)
+         partitions   []types.Partition    (source snapshot)
+         policy       dedicated | shared
+         grace        time.Duration
+
+pools:
+  workers with unknown labels (§6) are excluded from every pool below and
+  receive explicit empty entries in the merge step (I8)
+  for each label L: pool[L] = workers whose set contains L   (may overlap)
+  unlabeledWorkers  = workers with empty label set
+  generalPool       = policy==dedicated ? unlabeledWorkers : all workers
+  fallbackPool      = unlabeledWorkers if non-empty, else all workers
+
+groups:
+  group[L]  = partitions with Label == L
+  group[""] = unlabeled partitions
+
+assign:
+  group[""]:
+    target = generalPool if non-empty, else all workers
+    merge(Strategy.Assign(target, group[""]))
+  for each label L in sorted order:
+    if pool[L] non-empty:
+        clear emptySince[L]
+        merge(Strategy.Assign(pool[L], group[L]))
+    else:   // empty-pool transition must first be CONFIRMED (§8.5)
+        if emptySince[L] unset: emptySince[L] = now
+        if now - emptySince[L] < grace:
+            park group[L]                       // deliberately unassigned
+        else:
+            merge(Strategy.Assign(fallbackPool, group[L]))   // spill
+
+merge contract (I8):
+  result keys == active worker set, exactly — every worker gets an entry,
+  empty slice when it received nothing. Overlapping pools concatenate.
+
+prune:
+  drop emptySince entries for labels absent from the current snapshot
+  (a demoted/removed label must not leak a stale clock)
+```
+
+Notes:
+
+- **Spill ladder prefers unlabeled workers** so a `vip` outage never invades
+  a *different* label's dedicated pool. In an all-labeled fleet the ladder
+  degenerates to "all workers".
+- **Strategies must never see an empty worker list** (`ErrNoWorkers`,
+  `strategy/round_robin.go:55`). Every `Assign` call above is guarded: pools
+  are non-empty by branch condition; `generalPool`/`fallbackPool` fall back
+  to all workers; the `len(workers) == 0` case exits the rebalance earlier
+  (existing behavior at `calculator.go:1657`).
+- **I8 is load-bearing**: the publisher updates only workers present in the
+  assignments map and deletes only workers in `WorkersToRemove` — a live
+  worker missing from the map would keep a stale assignment in KV
+  indefinitely. Existing strategies already emit empty entries for all
+  workers they were given (`round_robin.go:68`); the merge step guarantees
+  it across pools, including labeled workers whose label has no partitions
+  (reserved capacity, intentionally idle under `dedicated`).
+- **Determinism**: pools and groups are built from sorted inputs, labels are
+  processed in sorted order, and strategies sort internally. Same inputs
+  (including clock-derived park decisions) → same output.
+- **Dedicated reserves capacity even with zero labeled partitions.** With
+  labeled workers and no labeled partitions, `dedicated` keeps the labeled
+  workers idle by design (they are reserved for their class); `shared` uses
+  them for general work. Operators who label workers before labeling
+  partitions should expect this.
+- Cross-pool weight balancing is out of scope (§3); `Partition.Weight`
+  continues to balance *within* each pool, which satisfies the "N matched
+  workers → split equally or by weight" requirement.
+
+## 8. Parking and the grace window
+
+### 8.1 Semantics
+
+A parked partition is deliberately unassigned: no worker owns it, no consumer
+attaches, and messages published to it queue durably in JetStream until
+assignment resumes. Worst-case processing stall for a total pool outage:
+
+```
+heartbeat-TTL detection + LabelSpillGrace + rebalance debounce + handoff/attach
+```
+
+Parking only occurs when a label's pool is **completely empty**. Routine
+rolling updates never park (k8s `maxUnavailable` keeps pods alive; survivors
+absorb the label's partitions with no grace delay).
+
+### 8.2 Coverage accounting and durable parked metadata
+
+The assignment publisher enforces strict set-equality between assigned
+partitions and the source set it is given, aborting the batch on mismatch
+(`internal/assignment/assignment_publisher.go:337`, `ErrCoverageMismatch`).
+Parking must be **explicit in that contract**, not smuggled in by shrinking
+the source input: `PublishInput.SourcePartitions` keeps its documented
+meaning ("pass exactly what was returned from the source snapshot",
+`assignment_publisher.go:280-284`), and the calculator additionally passes
+`ParkedPartitions`. The coverage check becomes:
+
+```
+assigned ∪ parked == source   AND   assigned ∩ parked == ∅
+```
+
+with any violation still aborting the batch. Rationale: the earlier draft
+passed `eligible = snapshot − parked` as the source input, which silently
+changed the durable meaning of `AssignmentCommit.BatchDigest` — documented
+as matching *the source partition set's* digest at publish time
+(`types/assignment_commit.go:111-114`, computed from the source input at
+`assignment_publisher.go:406`) — so a crash after commit would leave no
+durable record of which partitions were intentionally parked versus lost.
+
+Instead, `BatchDigest` keeps its exact current semantics (full source set),
+and the commit record gains additive fields:
+
+```go
+// ParkedCount is the number of partitions intentionally left unassigned
+// (label pool empty, spill grace not yet expired) in this batch.
+ParkedCount int `json:"parked_count,omitempty"`
+// ParkedDigest is xxh3 over the sorted CanonicalIDs of the parked set
+// (types.PartitionSetDigest). Zero when nothing is parked.
+ParkedDigest uint64 `json:"parked_digest,omitempty"`
+```
+
+Every batch identity question is then answerable from the durable commit
+alone: full source (BatchDigest), who got what (Payloads), what was parked
+and how much (ParkedDigest/ParkedCount). The ack-audit path
+(`calculator_audit.go`) is untouched — it classifies only `commit.Workers`
+against payload refs and heartbeat digests, and parked partitions belong to
+no worker.
+
+The existing orphaned-partitions gauge (`calculator.go:1717-1725`) keeps its
+meaning "accidentally unassigned": it compares assigned count against
+`len(source) − len(parked)`, while parked counts are reported separately. An
+accidental orphan is a bug signal; a parked partition is a policy outcome.
+
+### 8.3 The label re-check timer (grace expiry AND deferral re-arm)
+
+No existing event fires when a grace window lapses: if a pool empties and no
+worker ever joins again, nothing else would ever re-run the rebalance, and
+parked partitions would wait forever instead of spilling. The same holds for
+§8.5 deferrals: the existing suspicious-observation sentinels are swallowed
+as benign no-ops with no label-aware re-arm — `handleRebalance` treats both
+sentinels as "keep cached assignment" no-ops (`calculator.go:1511-1524`),
+the partition-lifecycle path re-arms only the *partition* sentinel and
+explicitly relies on the worker-monitor poll to re-fire for worker-shape
+issues (`calculator.go:779-797`), and that poll short-circuits when the
+worker set is unchanged. A label-only source edit that creates an
+empty-pool group would be deferred once and then **never re-observed** —
+no worker topology change, no source change, nothing pending.
+
+Therefore the calculator owns a **leader-only one-shot label re-check
+timer**, armed whenever a rebalance ends with any of:
+
+1. parked groups → delay = minimum remaining grace across parked labels;
+2. a §8.5 deferral (first adverse observation: pool-empty transition or
+   unknown-label worker) → delay = a short fixed re-check interval
+   (implementation constant, ~5s) so the confirming observation is
+   guaranteed to happen without any external event.
+
+The deferral abort uses a dedicated sentinel (`errLabelObservationDeferred`,
+same benign-no-op handling shape as the existing suspicious sentinels) so it
+is never conflated with them and never depends on their re-arm behavior.
+
+**Delivery path**: the timer does not call `rebalance` directly and does not
+ride the worker-set change-check (which no-ops on an unchanged set,
+`calculator.go:1052`). It funnels into the same `requestLabelRecheck`
+entrypoint as the watcher label-change signal (§9): a sticky
+`pendingLabelRecheck` flag plus a `TryClaimRebalancing("label_change")`
+attempt, with the partition-lifecycle pending-retry semantics
+(`calculator.go:823-846`, `882-932`). If the claim loses to a busy state
+machine, a recovery-grace window, or cooldown, the flag persists and is
+re-attempted on the existing drain tick and on the next timer fire; it is
+cleared only when a rebalance actually completes. Consequently a
+defer→confirm or park→spill transition cannot be lost to a one-shot timer
+firing at the wrong moment. The timer is disarmed on leadership loss, on
+calculator stop, and whenever a rebalance completes with nothing parked and
+nothing deferred (the sticky flag, if set, still guarantees one more
+recheck).
+
+Per the repository's monitor-goroutine rule, this new timer path gets a
+live-cluster concurrency stress test (see §14).
+
+### 8.4 Grace clocks are per-leader-term
+
+`emptySince` lives in calculator memory. On leader failover the new leader
+starts fresh clocks, so a pool outage that straddles K failovers can stall up
+to `(K+1) × grace` plus detection/handoff overhead. Accepted: persisting
+clocks to KV buys little (failovers are rare, grace is short) and adds a
+write path. Documented in operator docs with the sizing guidance: set grace
+well below the affected class's latency SLO; 60s default covers pod
+reschedule and leader failover blips.
+
+### 8.5 Adverse-observation confirmation (defer once, then act)
+
+The F10-A worker-shrink floor is **total-count** based
+(`calculator.go:1240-1264`): losing 1 worker out of 11 is not suspicious
+fleet-wide, yet it can be 100% of a label's pool. A transient heartbeat
+`Keys()` omission of the only `vip` worker would otherwise park (and after
+grace, spill) VIP partitions — revoking them from a still-alive worker —
+without any of the existing shrink defenses engaging. The same shape applies
+to a transiently unreadable heartbeat value (§6): acting on one bad
+observation converts a read blip into churn.
+
+Rule: **a disruptive label observation must be confirmed by two consecutive
+rebalance-time observations before the calculator acts on it.** Two
+triggers share the mechanism:
+
+1. A label pool that was non-empty in the previous committed rebalance is
+   observed empty.
+2. A worker's labels are unknown after the bounded inline retry (§6).
+
+On the first such observation the rebalance aborts with the dedicated
+`errLabelObservationDeferred` sentinel and arms the label re-check timer
+(§8.3), which guarantees the confirming observation without any external
+event — the existing suspicious-observation machinery must NOT be reused
+for re-arming, because it is swallowed without label-aware retry (see §8.3
+citations). On the second consecutive observation the calculator proceeds
+(park the pool / empty-assign the worker). A successful contrary
+observation resets the counter. `emptySince[L]` starts at the *first* empty
+observation, so confirmation does not extend the effective grace window.
+
+Honest scoping: a single-worker phantom scan-loss already causes
+reassignment on main today (only sharp fleet-level shrink is floored); this
+gate does not fix that pre-existing exposure. What it guards is the *new*
+label behaviors — parking (a service stop, worse than today's
+reassign-and-keep-serving) and spill — from firing on one bad read.
+
+## 9. Worker-side stale-incarnation guard
+
+Leader-side grouping alone cannot enforce the match rule: the worker
+startup/apply path applies whatever the current commit assigns to its worker
+ID, with no label awareness. `applyInitialAssignment` reads the existing
+commit and applies the payload for `m.WorkerID()` (`manager.go:693-716` →
+`buildAssignmentFromCommit`), and stable IDs are claimed from a pool shared
+across deployments. Failure case: `worker-0` was a `vip` pod with a
+committed VIP assignment; a general pod later claims `worker-0`; it applies
+the old payload and attaches to VIP partitions. Worse than a transient: in a
+tight takeover the heartbeat key never lapses (the new process starts
+beating before the old key's TTL expires), the leader observes **no
+membership change, so no rebalance ever fires** — the misroute is unbounded,
+not a window.
+
+Guard: on every apply (initial and watcher-driven, commit path and legacy
+alias path), the worker compares the payload's labels-of-record
+(`AssignmentPayload.WorkerLabels`, propagated per §4.3) against its own
+configured label set (sorted-set equality):
+
+- **`WorkerLabelsKnown` && set-equal** → apply normally.
+- **`WorkerLabelsKnown` && mismatch** → reject the payload: log at Warn with
+  both label sets, skip the apply entirely (no consumer attach or detach),
+  do not ack. The worker keeps heartbeating (its heartbeat carries its true
+  labels) and stays on its current (empty, at startup) assignment.
+- **`!WorkerLabelsKnown`** (payload from a pre-label leader) → apply, for
+  compatibility. Label-aware leaders always set the presence bit — including
+  for unlabeled workers (§4.3) — so this branch fires only for genuinely
+  pre-label payloads, and under the documented rollout ordering (§11) those
+  carry no labeled partitions.
+
+**Rejection is a first-class outcome, not a failure.** The current control
+flow would otherwise defeat the guard or spin: `applyInitialAssignment`
+treats `buildAssignmentFromCommit` `ok=false` as "payload unverifiable" and
+falls back to the legacy alias (`manager.go:706-727`) — and a pre-label
+alias would compat-apply, bypassing the guard through the back door; a
+returned apply error feeds the apply-retry machinery, which would retry a
+payload that can never become applicable. So the spec requires a distinct
+rejected outcome (e.g. `errLabelIncarnationRejected` / a third result
+state) with exactly these semantics, on both the initial-apply and
+watcher-driven paths:
+
+- NO legacy-alias fallback (the alias carries the same labels-of-record per
+  §4.3 and would be rejected identically; falling back to a *pre-label*
+  alias would bypass the guard).
+- NO `scheduleApplyRetry` — retrying the same commit is futile; convergence
+  arrives as a NEW commit via the label-change trigger below, delivered by
+  the existing assignment watcher.
+- NO snapshot/LSR/ack advancement; heartbeating continues; a Warn log and a
+  rejection metric fire.
+- At startup this reads as "no applicable assignment yet": the worker stays
+  in `WaitingAssignment` and the startup watchdog semantics below apply.
+
+The check is **incarnation identity, not partition-label matching**: it asks
+"was this payload computed for the process I am?", never "do these
+partitions match my labels?". Deliberate spill (R3) places labeled
+partitions on non-matching workers *with* correct labels-of-record, and the
+guard must not second-guess that placement — filtering partitions
+worker-side would break spill.
+
+Convergence after a reject — the **label-change trigger** (primary
+mechanism): the worker monitor's heartbeat watcher already receives the full
+KV entry, value included, on every heartbeat PUT
+(`worker_monitor.go:processWatcherEvents`, entries from `watcher.Updates()`).
+Today a PUT on a recently-seen key is suppressed as a refresh ("worker was
+continuously alive; skip the check") — which is precisely the tight-takeover
+hole: the new process beats the same key, so nothing ever fires. The fix:
+the watcher decodes each PUT's heartbeat and keeps a per-key label
+fingerprint alongside its existing `lastSeen` session state; a PUT whose
+labels differ from the fingerprint signals a label change.
+
+**The signal must NOT ride the existing worker-set change-check.** The
+watcher's debounced callback lands in `pollForChanges` → `observeAndDecide`,
+which short-circuits to a no-op when the worker-ID set is unchanged
+(`calculator.go:1052` `if !changed { return pollActionNone, nil }`) — and in
+a tight takeover the set IS unchanged, so the edge would be swallowed.
+Instead the monitor exposes a separate label-change notification (new
+callback), and the calculator routes it — together with the §8.3 re-check
+timer — through one entrypoint:
+
+```
+requestLabelRecheck(reason):
+  set sticky pendingLabelRecheck flag (with reason)
+  attempt TryClaimRebalancing("label_change")   // partition-lifecycle style
+  if the state machine is busy / in recovery grace / cooling down:
+      flag persists; re-attempted by the existing drain tick and by the
+      §8.3 timer — cleared ONLY when a rebalance actually completes
+```
+
+This reuses the pending-retry semantics the partition-lifecycle path already
+has (`calculator.go:823-846`, `882-932`) rather than the worker-set path, so
+a label recheck can never be lost to the unchanged-set short-circuit or to
+an inopportune busy state. The claimed rebalance is a full standard
+rebalance: fresh worker enumeration, fresh label reads (§6), republish with
+correct labels-of-record — which the rejecting worker then applies.
+Properties:
+
+- Zero extra IO (values already arrive on the watch); cost is one small-JSON
+  decode per heartbeat PUT.
+- Independent of apply mode, capability bits, and audit configuration.
+- **Fingerprint state survives watcher restarts** (level-triggered, not
+  edge-triggered). Session-local state — like the existing `lastSeen` map,
+  rebuilt from each session's initial replay
+  (`worker_monitor.go:381-396`) — would lose the only label-change edge if
+  the takeover PUT lands while the watch is closed/backing off
+  (`worker_monitor.go:328-360`): the new session would seed its
+  fingerprints from the already-new values and no subsequent beat would
+  differ. So the fingerprint map is owned by the monitor for the leader's
+  lifetime, and on every session (re)establishment the initial replay is
+  **compared against the retained fingerprints** — any label difference
+  fires `requestLabelRecheck("watcher_restart")`. Keys first seen in a
+  replay (no retained fingerprint) seed silently: a genuinely new worker is
+  a join, already covered by the worker-change path. The map is cleared on
+  leadership loss. (The simpler alternative — an unconditional
+  `requestLabelRecheck` after every watcher re-establishment — is correct
+  but fires full rebalances exactly when NATS is flaky and watchers churn;
+  the comparison variant is precise for the same guarantee.)
+- The leader-failover race is covered independently: a newly-elected
+  leader's calculator always performs an immediate initial assignment
+  (`calculator.go:346-351`, `cold_start_immediate`/`takeover_immediate`),
+  which reads labels fresh.
+
+The ack-audit is explicitly **not** relied on: in direct mode (the default,
+`config.go:502` `EnableTwoPhaseHandoff=false`) audit escalation is Warn-only
+(`calculator_audit.go` direct-mode branch), and even in two-phase mode
+escalation is gated on worker capability bits and an eligible target set. A
+rejecting worker also never acks, so where audit-repair IS enabled it acts
+as a supplementary net; the spec's convergence bound comes from the
+label-change trigger (watcher debounce + rebalance latency), not from audit
+cadence.
+
+During the reject window the partitions are unserved (messages queue
+durably) — strictly preferable to running VIP work on a wrong-class pod,
+where the processing gate would let a long task pin the partition for its
+full duration. If the window exceeds `StartupTimeout` the startup watchdog
+fires Degraded(`startup-timeout`), which is a correct, observable signal,
+not a defect.
+
+Operational complement: `WorkerIDPrefix` is already per-manager config
+(`config.go:384`). Giving each deployment a distinct prefix (e.g. `vip`,
+`worker`) makes cross-deployment stable-ID takeover structurally impossible
+and is the **recommended deployment pattern** in the docs. The guard remains
+required for the residual case (a deployment's labels changed across a
+rollout while keeping its prefix) and as defense in depth.
+
+## 10. Change propagation (load-bearing for the VIP flow)
+
+`source/nats_kv.go`'s `partitionsEqual` (line 1285) decides whether an
+applied KV entry changed the partition state and therefore whether watchers
+are notified. It currently compares **Keys and Weight only**. Without a fix,
+a label-only rewrite — the primary VIP promotion operation — would decode,
+compare "equal", set `changed=false`, and **never notify the leader**: the
+promotion would be silently swallowed until an unrelated event rebalanced.
+
+Fix: `partitionsEqual` also compares `Label` (same pattern as the existing
+`Weight` comparison). This covers both the watch path and the reconcile
+path, since both funnel through `applyLocalLocked`. **Necessary but not
+sufficient**: `applyLocalLocked` deep-copies through `deepCopyPartitions`
+before comparing/storing, so without the §4.1 copy-path fixes both sides of
+the comparison are already label-stripped and the label-aware comparison
+sees nothing. The regression test must therefore exercise the full path:
+label-only KV update → decode → store → change notification fires → leader
+rebalances (§14), not `partitionsEqual` in isolation.
+
+The static source (`source/static.go`) carries `[]types.Partition` verbatim
+and needs no change beyond the shared `Validate()` update.
+
+## 11. Compatibility and rollout
+
+Additive minor (v2.9.0). JSON compatibility in both directions:
+
+| Fleet state | Behavior |
+|---|---|
+| Old leader, any workers/partitions | Labels ignored entirely; legacy assignment (label-blind, no parking). |
+| New leader, old (label-less) workers | Workers treated as unlabeled; correct per R1. |
+| New leader, labeled partitions, no labeled workers | Park → grace → spill ladder; degenerates to legacy placement after grace. |
+| No labels anywhere | Invariant I1: pipeline degenerates to a single `Assign(all, all)` — assignment output identical to today. |
+
+Two **documented rollout-ordering rules** (operator docs + CHANGELOG):
+
+1. **Upgrade every deployment before labeling anything.** Any pod can win
+   leadership; a mixed fleet flips between labeled and legacy assignment on
+   failover.
+2. **Upgrade every partition-list writer first.** A writer built against the
+   old `types.Partition` drops the `Label` field on a full-list rewrite,
+   silently demoting all VIP partitions (the new label-aware
+   `partitionsEqual` will faithfully propagate that stripped list as a real
+   change). This explicitly includes the in-repo `provision` SDK/CLI, whose
+   clone/diff/equality paths are part of the §4.1 fix list — an old provision
+   binary is a label-stripping writer.
+
+Policy uniformity (R6) is documented alongside the existing "all managers
+must configure the same strategy" contract.
+
+Recommended (not required) deployment pattern: give each Deployment a
+distinct `WorkerIDPrefix` (`config.go:384`). This makes cross-deployment
+stable-ID takeover structurally impossible, shrinking the incarnation
+guard's job (§9) to the rare same-deployment relabel case, and makes worker
+IDs self-describing in logs and metrics (`vip-3` vs `worker-3`).
+
+## 12. Invariants
+
+| # | Invariant |
+|---|---|
+| I1 | With zero labels (no labeled partitions, no labeled workers), assignment output is identical to the pre-feature pipeline for the same inputs. |
+| I2 | Every source partition is either assigned to exactly one worker or explicitly parked; parked requires: its label's pool is confirmed empty (§8.5) AND grace has not expired. The publisher enforces `assigned ∪ parked == source` and `assigned ∩ parked == ∅` per batch, and the commit durably records the parked set (`ParkedDigest`/`ParkedCount`). |
+| I3 | `Label` never affects partition identity: `CanonicalID`, `HashID`, `Compare`, `PartitionSetDigest` are label-blind. |
+| I4 | A label-only change to the source list fires a change notification (new `partitionsEqual`). |
+| I5 | Spilled partitions land on unlabeled workers whenever any exist; they never land on a different label's dedicated workers while an unlabeled worker is live. |
+| I6 | When anything is parked, a leader-local timer guarantees a rebalance re-check no later than grace expiry (modulo debounce), without external events. |
+| I7 | A worker's label set is immutable for its process lifetime and is only ever read from its live heartbeat. |
+| I8 | Merged assignment map keys == active worker set, exactly (merge contract in §7 — no stale-assignment leaks, no phantom workers). |
+| I9 | Each partition appears in exactly one label group, so per-pool strategy outputs merge without duplication and set-equality coverage holds. |
+| I10 | `Label` survives every production copy/transform path (source deep-copy, validate/dedupe, provision clone/diff/equality — §4.1 audit list), each pinned by a round-trip test. |
+| I11 | A worker never applies an assignment payload with `WorkerLabelsKnown=true` whose labels-of-record differ from its own configured label set — commit path AND legacy alias path (§9). Rejection triggers no alias fallback, no apply retry, and no ack; label-aware leaders always set the presence bit, so the compat branch fires only for pre-label payloads. |
+| I12 | The calculator acts on a disruptive label observation (previously non-empty pool reads empty; worker labels unreadable) only after two consecutive rebalance-time observations (§8.5). |
+| I13 | A change in the labels behind a live worker ID (stale-ID takeover) is detected from heartbeat PUTs by the leader's worker monitor — **including changes that land while the watch session is closed or restarting** (retained fingerprints vs initial replay) — and triggers a rebalance via `requestLabelRecheck`, a path that bypasses the unchanged-worker-set short-circuit and survives busy states via the sticky pending flag, independent of apply mode, capability bits, and audit configuration (§9). |
+
+## 13. Observability
+
+New metrics via an **optional extension interface** (type-asserted, so
+existing `types.MetricsCollector` implementors don't break):
+
+- parked partition count, per label (gauge)
+- label pool size (workers per label, gauge)
+- spill activations (counter, per label) and park→spill transitions
+- unlabeled-policy fallback activations (unlabeled group served by all
+  workers because no unlabeled worker was live)
+- label-change triggers (counter: worker monitor observed a label change
+  behind a live worker ID, §9) and incarnation-guard rejections (counter,
+  worker-side)
+
+Log lines at state transitions: pool empty (grace start), park, spill, pool
+recovered (partitions re-homed), payload rejected by incarnation guard (§9),
+worker labels unreadable (§6). Exact interface shape and metric names are an
+implementation-plan decision, but **lifecycle semantics are part of this
+spec**:
+
+- Per-label gauges are recomputed and re-published on every completed
+  rebalance; a label absent from the current source snapshot has its gauges
+  explicitly zeroed/deleted in the same pass (no stale `vip` parked-count
+  after the last `vip` partition is demoted — pairs with the `emptySince`
+  prune step in §7).
+- Metric label values are the validated label strings; cardinality is
+  bounded by validation (§4.1 charset + 64-byte cap, §5 per-worker count
+  cap) and by the operator-controlled label vocabulary. No derived or
+  synthesized label values.
+- Counters (spill activations, guard rejections) are monotonic per process;
+  gauges are absolute per rebalance.
+
+## 14. Testing plan
+
+Unit (`internal/assignment/`, `types/`, `source/`):
+
+- Pool/group construction; `dedicated` vs `shared` policy branches; spill
+  ladder including the no-unlabeled-workers degenerate case; grace
+  park→spill transitions with an injected clock; `emptySince` pruning for
+  labels that disappear from the snapshot (§7 prune step); merge contract I8
+  (workers in no pool get empty entries); determinism (repeated runs, same
+  inputs → same map); I1 golden test (label-free inputs produce output
+  identical to a direct `Strategy.Assign` call).
+- `Partition.Validate` label rules; heartbeat encode/decode with labels
+  (including legacy payloads).
+- **Label round-trip regressions for every §4.1 copy path**:
+  `deepCopyPartitions`, `validateAndDedupe`, provision
+  `clonePartition`/`diffPartitions`/`partitionTablesEqual` (label-only edits
+  must appear in plans and not be skipped as no-ops).
+- **Label-only change propagation, full path** (§10): label-only KV update →
+  decode → store → `changed` → notification observed. Both watch and
+  reconcile paths (a `partitionsEqual`-only unit test cannot catch the
+  deep-copy strip).
+- Publisher-facing: `assigned ∪ parked == source` and disjointness
+  enforcement (violation aborts with `ErrCoverageMismatch`); commit carries
+  `ParkedDigest`/`ParkedCount`; a partition omitted from BOTH assignment and
+  parked set fails coverage; orphan gauge vs parked accounting.
+- Incarnation guard (§9) unit tests: `Known` + mismatch → reject + no ack;
+  `Known` + set-equal → apply; `!Known` (pre-label payload) → compat apply;
+  reject leaves prior state untouched. Exercised on BOTH wire paths: commit
+  payload fetch (`AssignmentPayload.WorkerLabels`/`WorkerLabelsKnown`) and
+  legacy alias envelope.
+- Label-change trigger (§9): heartbeat PUT with changed labels on a
+  recently-refreshed key escapes refresh suppression and reaches
+  `requestLabelRecheck` — proven to force a rebalance **despite an unchanged
+  worker-ID set** (the `calculator.go:1052` short-circuit must not swallow
+  it); unchanged labels stay suppressed (scan-skip behavior preserved).
+- Watcher-restart edge loss (§9): labels change while the heartbeat watch
+  session is closed/restarting (heartbeat key never lapses, no source
+  change, default direct mode); the retained-fingerprint vs initial-replay
+  comparison fires `requestLabelRecheck` exactly once and the fleet
+  converges without audit. Unit-level: replay with unchanged labels fires
+  nothing; replay with a first-seen key seeds silently.
+- Presence bit (§4.3): a new-leader payload for an unlabeled worker carries
+  `WorkerLabelsKnown=true` and is rejected by a labeled reclaiming pod; a
+  genuinely pre-label payload (bit absent) compat-applies; payload-hash
+  change from the presence bit causes one no-op apply cycle and no ownership
+  movement.
+- Rejection control flow (§9): guard reject on the commit path does NOT fall
+  back to a present legacy alias; does NOT schedule apply retries; worker
+  stays unacked and applies the next label-correct commit.
+- Label re-check under busy state (§8.3): timer fires while the calculator
+  is Scaling/Rebalancing or in recovery grace; the sticky flag survives and
+  the recheck eventually runs (defer→confirm and park→spill both complete).
+- Payload identity: label-only edit changes `PayloadHash` (worker applies)
+  but causes no consumer detach/attach for an already-matching worker
+  (§4.1 no-ownership-movement claim).
+- Heartbeat failure taxonomy (§6): whole-bucket loss / connectivity-classed
+  failures abort the rebalance and route through the KV-error path (never
+  publish empty assignments); an isolated single-worker Get failure defers,
+  then empty-assigns only that worker. Small-fleet pins: 1-of-2 and 1-of-3
+  Get failures are isolated unknowns; 2-of-3 is a broad failure that aborts
+  and degrades.
+- Defer-once-then-act (§8.5): first empty-pool observation defers, second
+  consecutive parks; contrary observation resets; same for unknown-label
+  workers; `emptySince` starts at first observation (confirmation does not
+  extend grace). **No-external-event progression**: a label-only source
+  edit creating an empty-pool group (label typo; no worker ever carries
+  it) must progress defer → confirm → park → grace-expire → spill purely
+  on the label re-check timer (§8.3), with no worker or source event.
+- I3 label-blindness unit tests: `CanonicalID`, `HashID`, `Compare`,
+  `PartitionSetDigest` each proven equal across differing labels; I7
+  normalization test (labels sorted/deduped once at startup, read only
+  from live heartbeats).
+
+Integration (`test/integration/`, live NATS, `-race`):
+
+- Runtime VIP promotion: rewrite KV list adding a label → partition moves to
+  the labeled worker; demote → moves back.
+- Pool outage lifecycle: stop all labeled workers → partitions park within
+  detection window (no consumer attached, messages queue) → spill after
+  grace → labeled worker returns → partitions re-home.
+- Mixed fleet under both policies, including labeled-workers-idle
+  reservation under `dedicated`.
+- **Stale-incarnation takeover** (default config: direct mode, audit
+  repair inert): the same stable ID is reclaimed by a worker with different
+  labels while the old commit still assigns labeled partitions, with the
+  heartbeat key never lapsing (tight takeover, no membership event). Assert
+  the new worker never attaches those partitions (guard reject, no alias
+  fallback, no apply-retry spin), and that the **label-change trigger**
+  converges the fleet: fingerprint edge → `requestLabelRecheck` → rebalance
+  → new commit → worker applies. A separate test proves audit escalation
+  acts as a supplementary net when two-phase mode and worker capabilities
+  are present.
+- Mixed-version leader bouncing: old (label-blind) and new leaders alternate
+  via failover with labeled partitions present; assignment flips between
+  legacy and labeled placement but never loses coverage and never wedges.
+- Source purge/delete while partitions are parked: partition-shrink guard
+  behavior, `emptySince` pruning, parked gauges zeroed.
+- Partial batch crash with parked partitions present: kill the leader
+  between payload writes and commit; restart/audit must converge without
+  treating parked partitions as lost.
+- **Grace-timer concurrency stress test** per the repository
+  monitor-goroutine rule (aggressive cadence, concurrent KV traffic, `-race`;
+  template: `test/integration/manager/epoch_monitor_concurrency_test.go`).
+- Every invariant I1-I13 maps to at least one named test; the implementation
+  plan carries the explicit invariant→test matrix (the I3/I7 encodings above
+  are already fixed by this spec).
+
+Gates:
+
+- This feature touches `internal/assignment/` and `source/` → `make pre-pr`
+  (lint + unit `-race` + integration `-race`) before PR.
+- The four cross-feature contracts in `AGENTS.md` are not intentionally
+  touched (no error classification/routing changes), but their pinned tests
+  run as part of the integration suite regardless.
+
+## 15. Documentation
+
+- New operator-facing section (README pointer + `docs/` page or STRATEGIES.md
+  section): label model, VIP workflow, policy/grace tuning, rollout-ordering
+  rules, worst-case-stall formula (§8.1), fleet-uniform-policy contract.
+- Godoc for all new exported fields/config.
+- CHANGELOG entry under v2.9.0.
+
+## 16. Open items deferred to the implementation plan
+
+1. Final metrics extension-interface shape and metric names (§13).
+2. `GetHeartbeatsFor` exact signature and whether the audit path should share
+   it; whether the watcher's per-PUT decode (§9) can feed the rebalance-time
+   label read as a freshness hint (optimization only — correctness must not
+   depend on it).
+3. Whether config validation warns when `WorkerLabels` is set but the
+   feature is otherwise unused (parallel to the existing inert-config
+   startup WARN precedent).
+4. Docs placement (new page vs STRATEGIES.md extension).
+5. Provision plan/apply change-record shape for label edits (must be
+   visible; exact type is plan detail — §4.1).
+6. Whether the §8.5 confirmation counter needs its own config knob or a
+   fixed value of 2 suffices (spec default: fixed 2).
+7. The §8.3 deferral re-check interval constant (spec default: ~5s;
+   bounded below by the rebalance debounce).

--- a/docs/plans/label-assignment/01-implementation-plan.md
+++ b/docs/plans/label-assignment/01-implementation-plan.md
@@ -1,0 +1,3458 @@
+# Label-Based Partition Assignment — Implementation Plan
+
+> **For agentic workers:** Execute task-by-task with a fresh review between
+> tasks. Steps use checkbox (`- [ ]`) syntax for tracking. Every task ends
+> with passing tests and a commit.
+
+**Spec:** `docs/plans/label-assignment/00-design-spec.md` (v5, external
+review clean — 5 rounds). Section references (§N) below point into that spec.
+
+**Plan review status:** clean after 3 external review rounds
+(`tmp/label-assignment_implplan_v{1..3}_review.md`; round-3 verdict "ready
+to execute" conditional on the nil-guard fix in the
+`recordLabelReadFailure` adapter, which is applied in Task 4).
+
+**Goal:** Partitions carry an optional label; workers carry a label set;
+the leader assigns labeled partitions only to matching workers, with
+park-then-spill fallback — VIP partitions promoted/demoted at runtime via
+the NATS KV source.
+
+**Architecture:** A grouping layer above the unchanged `AssignmentStrategy`
+interface (pools per label, configured strategy runs per pool, merged).
+Labels ride existing channels: heartbeats (worker→leader), assignment
+payloads (leader→worker, with presence bit), the KV partition list
+(operator→leader). Three new leader-side mechanisms: parked-partition
+accounting in the publisher contract, a label re-check timer, and a
+label-change trigger in the worker monitor. One worker-side mechanism: the
+stale-incarnation guard.
+
+**Tech stack:** Go 1.24+, NATS JetStream KV (nats.go), testify, embedded
+NATS for tests (`internal/testutil`, `partitest`).
+
+## Global Constraints
+
+- Target version **v2.9.0**, additive only: no breaking change to any
+  exported API, wire format, or default behavior (spec I1: zero labels ⇒
+  assignment output identical to today).
+- **Copy rule (spec §4.1)**: any code copying a `types.Partition` copies
+  the struct value (`cp := p`) then re-allocates `Keys` — never enumerate
+  fields.
+- `Label` is NEVER part of partition identity: `CanonicalID`, `HashID`,
+  `Compare`, `PartitionSetDigest` stay label-blind (spec I3).
+- Label validation: partition-key charset (non-empty, no dots, no
+  whitespace), max 64 bytes. Worker label sets: ≤ 16 labels, sorted,
+  deduplicated.
+- New config defaults: `UnlabeledPartitionPolicy="dedicated"`,
+  `LabelSpillGrace=60s`. Grace `0` = spill immediately.
+- Commit messages: no attribution trailers, no plan jargon (no "Task N",
+  "§", "P0", reviewer names). Run `make lint` before every commit.
+- Tests in `internal/assignment` and `source` follow existing package
+  conventions (`partitest.StartEmbeddedNATS(t)` for real-KV unit tests).
+  Integration tests live in `test/integration/<pkg>/` and are guarded by
+  `testing.Short()`.
+- Final gate: `make pre-pr` (lint + `make test` `-race` + `make
+  test-integration` `-race`) — this feature touches `internal/assignment/`
+  and `source/`, so the gate is mandatory (AGENTS.md).
+
+## File Map
+
+| File | Change |
+|---|---|
+| `types/partition.go` | `Partition.Label` field + validation; `Assignment.WorkerLabels`/`WorkerLabelsKnown` (runtime + legacy alias wire) |
+| `types/heartbeat.go` | `Heartbeat.Labels` |
+| `types/assignment_commit.go` | `AssignmentPayload.WorkerLabels`/`WorkerLabelsKnown`; `AssignmentCommit.ParkedCount`/`ParkedDigest` |
+| `types/metrics_collector.go` | optional `LabelMetrics` extension interface |
+| `source/nats_kv.go` | label-preserving `deepCopyPartitions`/`validateAndDedupe`; label-aware `partitionsEqual` |
+| `provision/partition_records.go` | label-preserving `clonePartition`; `diffPartitions` label changes |
+| `provision/apply_partitions.go` | label-aware `partitionTablesEqual` |
+| `provision/plan.go` (or wherever `PartitionWeightChange` renders) | label-change plan rendering |
+| `config.go` | `WorkerLabels`, `UnlabeledPartitionPolicy`, `LabelSpillGrace` + validation/normalization |
+| `options.go` | `WithWorkerLabels` |
+| `internal/heartbeat/publisher.go` | `SetLabels` + emit in `build()` |
+| `internal/assignment/worker_monitor.go` | `GetHeartbeatsFor`; label fingerprints; `SetOnLabelChange` |
+| `internal/assignment/labels.go` (new) | pool/group topology + merged assignment computation (pure) |
+| `internal/assignment/labels_state.go` (new) | emptySince, defer-once confirmation, re-check timer, `requestLabelRecheck` |
+| `internal/assignment/calculator.go` | label read + taxonomy; pipeline wiring in `rebalance`; orphan gauge vs eligible |
+| `internal/assignment/config.go` | `UnlabeledPartitionPolicy`, `LabelSpillGrace` |
+| `internal/assignment/assignment_publisher.go` | `PublishInput.ParkedPartitions`/`WorkerLabels`; coverage v2; commit parked fields; payload fields; legacy alias copy |
+| `manager_assignment.go` | guard in `buildAssignmentFromCommit` callers; reject plumbing |
+| `manager.go` | `applyInitialAssignment` reject handling (no alias fallback) |
+| `test/integration/assignment/label_*.go` (new) | E2E label suites |
+| `docs/`, `README.md`, `CHANGELOG.md` | operator docs + release notes |
+
+Interface names locked for cross-task consistency:
+
+```go
+// types
+Partition.Label                     string
+Heartbeat.Labels                    []string
+AssignmentPayload.WorkerLabels      []string
+AssignmentPayload.WorkerLabelsKnown bool
+Assignment.WorkerLabels             []string
+Assignment.WorkerLabelsKnown       bool
+AssignmentCommit.ParkedCount        int
+AssignmentCommit.ParkedDigest       uint64
+
+// public config (config.go / options.go)
+Config.WorkerLabels             []string
+Config.UnlabeledPartitionPolicy string   // "dedicated" | "shared"
+Config.LabelSpillGrace          time.Duration
+func WithWorkerLabels(labels ...string) Option
+
+// internal/assignment
+Config.UnlabeledPartitionPolicy string
+Config.LabelSpillGrace          time.Duration
+func (m *WorkerMonitor) GetHeartbeatsFor(ctx context.Context, workerIDs []string) (map[string]types.Heartbeat, map[string]error, error)
+func (m *WorkerMonitor) SetOnLabelChange(fn func())
+func buildLabelTopology(in topologyInput) labelTopology
+func computeLabelAssignments(strategy types.AssignmentStrategy, topo labelTopology, actions map[string]emptyPoolAction) (map[string][]types.Partition, []types.Partition, error)
+func (c *Calculator) requestLabelRecheck(reason string)
+var errLabelObservationDeferred error
+var errLabelReadBroadFailure error
+
+// internal/heartbeat
+func (p *Publisher) SetLabels(labels []string)
+
+// root package
+var errLabelIncarnationRejected error   // manager-internal sentinel
+
+// types (metrics extension, type-asserted)
+type LabelMetrics interface {
+    RecordLabelPoolSize(label string, workers int)
+    RecordParkedPartitions(label string, count int)
+    IncrementLabelSpill(label string)
+    IncrementLabelChangeTrigger()
+    IncrementLabelIncarnationReject()
+    IncrementUnlabeledFallback()
+}
+```
+
+---
+
+### Task 1: `Partition.Label` — field, validation, identity blindness
+
+**Files:**
+- Modify: `types/partition.go` (struct at :16-26, `Validate` at :34-52)
+- Test: `types/partition_label_test.go` (new)
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `types.Partition.Label string` — every later task relies on
+  this field existing with `json:"label,omitempty" yaml:"label,omitempty"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// types/partition_label_test.go
+package types_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionLabel_IdentityBlind(t *testing.T) {
+	t.Parallel()
+
+	plain := types.Partition{Keys: []string{"topic", "42"}, Weight: 3}
+	vip := types.Partition{Keys: []string{"topic", "42"}, Weight: 3, Label: "vip"}
+
+	require.Equal(t, plain.CanonicalID(), vip.CanonicalID(), "CanonicalID must be label-blind")
+	require.Equal(t, plain.HashID(), vip.HashID(), "HashID must be label-blind")
+	require.Equal(t, plain.HashIDSeed(7), vip.HashIDSeed(7), "HashIDSeed must be label-blind")
+	require.Zero(t, plain.Compare(vip), "Compare must be label-blind")
+	require.Equal(t,
+		types.PartitionSetDigest([]types.Partition{plain}),
+		types.PartitionSetDigest([]types.Partition{vip}),
+		"PartitionSetDigest must be label-blind")
+}
+
+func TestPartitionLabel_Validate(t *testing.T) {
+	t.Parallel()
+
+	valid := func(label string) error {
+		return types.Partition{Keys: []string{"k"}, Label: label}.Validate()
+	}
+
+	require.NoError(t, valid(""), "empty label = unlabeled, valid")
+	require.NoError(t, valid("vip"))
+	require.NoError(t, valid("gpu-batch_2"))
+
+	require.Error(t, valid("has space"))
+	require.Error(t, valid("has\ttab"))
+	require.Error(t, valid("dotted.label"))
+	require.Error(t, valid(strings.Repeat("x", 65)), "over 64-byte cap")
+	require.NoError(t, valid(strings.Repeat("x", 64)), "exactly 64 bytes ok")
+}
+
+func TestPartitionLabel_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	p := types.Partition{Keys: []string{"a"}, Weight: 2, Label: "vip"}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"label":"vip"`)
+
+	var back types.Partition
+	require.NoError(t, json.Unmarshal(b, &back))
+	require.Equal(t, p, back)
+
+	// omitempty: unlabeled partitions marshal without the field, so the
+	// wire bytes of existing label-free lists are unchanged.
+	b2, err := json.Marshal(types.Partition{Keys: []string{"a"}})
+	require.NoError(t, err)
+	require.NotContains(t, string(b2), "label")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./types/ -run 'TestPartitionLabel' -v`
+Expected: compile error — `unknown field Label in struct literal`.
+
+- [ ] **Step 3: Implement**
+
+In `types/partition.go`, extend the struct (after `Weight`):
+
+```go
+	// Label optionally pins this partition to workers that carry the same
+	// label (see Heartbeat.Labels). Empty means unlabeled: the partition
+	// is assigned according to the unlabeled-partition policy. Label is a
+	// routing hint, NOT part of partition identity: it does not
+	// participate in CanonicalID, HashID, Compare, or PartitionSetDigest.
+	Label string `json:"label,omitempty" yaml:"label,omitempty"`
+```
+
+Extend `Validate()` (after the Keys loop, before `return nil`):
+
+```go
+	if p.Label != "" {
+		if len(p.Label) > 64 {
+			return fmt.Errorf("partition label exceeds 64 bytes: %q", p.Label)
+		}
+		if strings.Contains(p.Label, ".") {
+			return fmt.Errorf("partition label contains invalid character '.': %q", p.Label)
+		}
+		if strings.ContainsAny(p.Label, " \t\n\r") {
+			return fmt.Errorf("partition label contains whitespace: %q", p.Label)
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./types/ -run 'TestPartitionLabel' -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full types package + lint, commit**
+
+Run: `go test ./types/ && make lint`
+Expected: all green (identity funcs untouched, so existing digest tests
+still pass).
+
+```bash
+git add types/partition.go types/partition_label_test.go
+git commit -m "feat(types): add optional routing label to Partition"
+```
+
+---
+
+### Task 2: Source label preservation + label-aware change detection
+
+The load-bearing task for the VIP flow (spec §4.1 audit + §10). Both copy
+paths currently strip unknown fields, and `partitionsEqual` is
+Keys+Weight-only — a label-only rewrite would be silently swallowed
+**before and at** the comparison.
+
+**Files:**
+- Modify: `source/nats_kv.go` — `deepCopyPartitions` (:1271-1281),
+  `validateAndDedupe` (:1314-1334), `partitionsEqual` (:1285-1304)
+- Test: `source/nats_kv_label_test.go` (new)
+
+**Interfaces:**
+- Consumes: `types.Partition.Label` (Task 1).
+- Produces: a `source.NatsKV` whose `Snapshot` returns labels intact and
+  whose `Watch` channel fires on label-only edits. Tasks 8/13/14 rely on
+  both behaviors.
+
+- [ ] **Step 1: Write the failing unit tests (copy paths + equality)**
+
+```go
+// source/nats_kv_label_test.go
+package source
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepCopyPartitions_PreservesLabel(t *testing.T) {
+	t.Parallel()
+
+	in := []types.Partition{{Keys: []string{"a"}, Weight: 2, Label: "vip"}}
+	out := deepCopyPartitions(in)
+
+	require.Equal(t, in, out)
+	// Still a deep copy: mutating the copy's Keys must not alias the input.
+	out[0].Keys[0] = "mutated"
+	require.Equal(t, "a", in[0].Keys[0])
+}
+
+func TestValidateAndDedupe_PreservesLabel(t *testing.T) {
+	t.Parallel()
+
+	in := []types.Partition{{Keys: []string{"a"}, Weight: 2, Label: "vip"}}
+	out, err := validateAndDedupe(in)
+	require.NoError(t, err)
+	require.Equal(t, "vip", out[0].Label)
+
+	// Same keys + different labels = duplicate identity → error (spec §4.1).
+	_, err = validateAndDedupe([]types.Partition{
+		{Keys: []string{"a"}, Label: "vip"},
+		{Keys: []string{"a"}, Label: "batch"},
+	})
+	require.Error(t, err)
+}
+
+func TestPartitionsEqual_LabelAware(t *testing.T) {
+	t.Parallel()
+
+	a := []types.Partition{{Keys: []string{"a"}, Weight: 1}}
+	b := []types.Partition{{Keys: []string{"a"}, Weight: 1, Label: "vip"}}
+
+	require.True(t, partitionsEqual(a, a))
+	require.False(t, partitionsEqual(a, b), "label-only difference must be a change")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./source/ -run 'TestDeepCopy|TestValidateAndDedupe_Preserves|TestPartitionsEqual_Label' -v`
+Expected: `TestDeepCopyPartitions_PreservesLabel` and
+`TestValidateAndDedupe_PreservesLabel` FAIL (label stripped);
+`TestPartitionsEqual_LabelAware` FAILS (labels compare equal).
+
+- [ ] **Step 3: Implement (struct-value copy rule)**
+
+`deepCopyPartitions` — replace the field-enumerating construction:
+
+```go
+func deepCopyPartitions(partitions []types.Partition) []types.Partition {
+	result := make([]types.Partition, len(partitions))
+	for i, p := range partitions {
+		cp := p // struct-value copy: all scalar fields (Weight, Label, future additions)
+		cp.Keys = make([]string, len(p.Keys))
+		copy(cp.Keys, p.Keys)
+		result[i] = cp
+	}
+
+	return result
+}
+```
+
+`validateAndDedupe` — same replacement inside the loop:
+
+```go
+		// Deep-copy Keys to protect the encode→write window against caller mutation.
+		cp := p // struct-value copy preserves Weight, Label, and future fields
+		cp.Keys = make([]string, len(p.Keys))
+		copy(cp.Keys, p.Keys)
+		result = append(result, cp)
+```
+
+`partitionsEqual` — add the label comparison next to Weight:
+
+```go
+	for i := range a {
+		if a[i].Weight != b[i].Weight {
+			return false
+		}
+		if a[i].Label != b[i].Label {
+			return false
+		}
+		...
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./source/ -run 'TestDeepCopy|TestValidateAndDedupe_Preserves|TestPartitionsEqual_Label' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing end-to-end propagation regression (real KV, watch + reconcile paths)**
+
+This is the regression the spec calls out explicitly (§10): a
+`partitionsEqual`-only unit test cannot catch the deep-copy strip, so the
+test must drive the full decode → store → notify path against a real
+bucket.
+
+```go
+// appended to source/nats_kv_label_test.go
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// newLabelTestSource creates a real KV bucket, seeds it with `initial`,
+// and returns a started NatsKV plus the raw KV handle for out-of-band
+// writes (simulating an external operator/writer process).
+func newLabelTestSource(t *testing.T, initial []types.Partition) (*NatsKV, jetstream.KeyValue, context.Context) {
+	t.Helper()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-src-test"})
+	require.NoError(t, err)
+
+	seed, err := partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", seed)
+	require.NoError(t, err)
+
+	src := NewNatsKV(kv, "partitions", nil) // nil logger is the package's test convention
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	return src, kv, ctx
+}
+
+// TestNatsKV_LabelOnlyEdit_WatchPathPropagates is the spec §10 regression:
+// a rewrite that changes ONLY a label (same keys, same weights) must fire
+// the Watch signal and the next Snapshot must carry the label.
+func TestNatsKV_LabelOnlyEdit_WatchPathPropagates(t *testing.T) {
+	t.Parallel()
+
+	initial := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1},
+		{Keys: []string{"p1"}, Weight: 1},
+	}
+	src, kv, ctx := newLabelTestSource(t, initial)
+
+	watchCh := src.Watch(ctx)
+
+	// Label-only rewrite via an out-of-band KV write (external writer).
+	promoted := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1, Label: "vip"}, // <- only delta
+		{Keys: []string{"p1"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	select {
+	case <-watchCh:
+		// change notification observed
+	case <-time.After(10 * time.Second):
+		t.Fatal("label-only edit did not fire the source Watch signal")
+	}
+
+	parts, _, _, err := src.Snapshot(ctx)
+	require.NoError(t, err)
+	byID := map[string]string{}
+	for _, p := range parts {
+		byID[p.CanonicalID()] = p.Label
+	}
+	require.Equal(t, "vip", byID[types.Partition{Keys: []string{"p0"}}.CanonicalID()],
+		"snapshot must carry the label through decode → deep-copy → store")
+}
+
+// TestNatsKV_LabelOnlyEdit_ReconcilePathPropagates drives the same edit
+// through the reconcile path: the watcher is starved by writing while the
+// source's watch is torn down, then the periodic reconcile must pick up
+// the label-only change and notify.
+func TestNatsKV_LabelOnlyEdit_ReconcilePathPropagates(t *testing.T) {
+	t.Parallel()
+
+	initial := []types.Partition{{Keys: []string{"p0"}, Weight: 1}}
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-src-reconcile"})
+	require.NoError(t, err)
+	seed, err := partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", seed)
+	require.NoError(t, err)
+
+	// Aggressive reconcile; leadership probe true = leader cadence. The
+	// watcher is FROZEN (a never-delivering injected watchFn, the same
+	// harness shape existing reconcile tests use — see the frozen-watcher
+	// pattern around source/nats_kv_test.go:446) so ONLY the reconcile
+	// loop can observe the direct KV write. Without freezing, the watch
+	// path could deliver first and this test would prove nothing about
+	// reconcile.
+	src := NewNatsKV(kv, "partitions", nil,
+		WithReconcileInterval(200*time.Millisecond),
+		WithLeadershipProbe(func() bool { return true }))
+	src.watchFn = frozenWatchFn(t) // reuse/adapt the existing test helper
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	watchCh := src.Watch(ctx)
+
+	promoted := []types.Partition{{Keys: []string{"p0"}, Weight: 1, Label: "vip"}}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	// With the watcher frozen, this notification can ONLY come from the
+	// reconcile loop — pinning that reconcile's skip-guard does not skip
+	// a label-only change (its identity check is revision-based and every
+	// KV Put advances the revision).
+	select {
+	case <-watchCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("label-only edit did not propagate via the reconcile path")
+	}
+
+	parts, _, _, err := src.Snapshot(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "vip", parts[0].Label)
+}
+```
+
+- [ ] **Step 6: Run the propagation tests**
+
+Run: `go test ./source/ -run 'TestNatsKV_LabelOnlyEdit' -v -race`
+Expected: PASS — they should pass immediately given Step 3; if either
+fails, a copy/notify path was missed. Do not proceed until green.
+
+Note: if `partitest.StartEmbeddedNATS` differs from the helper the
+`source` package's existing tests use, match whatever
+`source/nats_kv_test.go` already uses — the assertions, not the harness,
+are the contract.
+
+- [ ] **Step 7: Full package + lint + commit**
+
+Run: `go test ./source/ -race && make lint`
+
+```bash
+git add source/nats_kv.go source/nats_kv_label_test.go
+git commit -m "fix(source): preserve partition labels through copy paths and detect label-only changes"
+```
+
+---
+
+### Task 3: Provision writer label support
+
+The in-repo provisioning SDK/CLI is a partition-list writer; without this
+task an operator using `provision` erases labels on every plan/apply
+round trip (spec §4.1, §11 rollout rule 2).
+
+**Files:**
+- Modify: `provision/partition_records.go` — `clonePartition` (:221-234),
+  `diffPartitions` (:168-210 including Godoc)
+- Modify: `provision/types.go` — `PartitionWeightChange` (:343-352)
+- Modify: `provision/apply_partitions.go` — `partitionTablesEqual` (:317-339)
+- Test: `provision/partition_label_test.go` (new)
+
+**Interfaces:**
+- Consumes: `types.Partition.Label` (Task 1).
+- Produces: label-preserving provision round trips; `PartitionWeightChange`
+  gains `OldLabel`/`NewLabel` (name kept for API compatibility — Godoc
+  widened to "weight or label change").
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// provision/partition_label_test.go
+package provision
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClonePartition_PreservesLabel(t *testing.T) {
+	t.Parallel()
+
+	p := types.Partition{Keys: []string{"a"}, Weight: 2, Label: "vip"}
+	got := clonePartition(p)
+	require.Equal(t, p, got)
+}
+
+func TestDiffPartitions_LabelOnlyChangeIsVisible(t *testing.T) {
+	t.Parallel()
+
+	live := []types.Partition{{Keys: []string{"a"}, Weight: 1}}
+	desired := []types.Partition{{Keys: []string{"a"}, Weight: 1, Label: "vip"}}
+
+	added, removed, changed := diffPartitions(live, desired)
+	require.Empty(t, added)
+	require.Empty(t, removed)
+	require.Len(t, changed, 1, "label-only edit must surface as a change in plan output")
+	require.Equal(t, "", changed[0].OldLabel)
+	require.Equal(t, "vip", changed[0].NewLabel)
+	require.Equal(t, int64(1), changed[0].OldWeight)
+	require.Equal(t, int64(1), changed[0].NewWeight)
+}
+
+func TestPartitionTablesEqual_LabelAware(t *testing.T) {
+	t.Parallel()
+
+	a := []types.Partition{{Keys: []string{"a"}, Weight: 1}}
+	b := []types.Partition{{Keys: []string{"a"}, Weight: 1, Label: "vip"}}
+
+	require.True(t, partitionTablesEqual(a, a))
+	require.False(t, partitionTablesEqual(a, b),
+		"label-only apply must not be skipped as a no-op")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./provision/ -run 'TestClonePartition_Preserves|TestDiffPartitions_LabelOnly|TestPartitionTablesEqual_Label' -v`
+Expected: compile error on `OldLabel` (field missing), then value
+mismatches after adding the field.
+
+- [ ] **Step 3: Implement**
+
+`provision/types.go` — extend the change record (keep the exported name):
+
+```go
+// PartitionWeightChange records a partition present in both the live and
+// declared tables whose Weight or Label differs. Keys identifies the
+// partition (it is unchanged — a different key set is a different
+// partition, i.e. an add plus a remove, not a change). The name predates
+// label support and is kept for API compatibility.
+type PartitionWeightChange struct {
+	Keys      []string `json:"keys"`
+	OldWeight int64    `json:"oldWeight"`
+	NewWeight int64    `json:"newWeight"`
+	OldLabel  string   `json:"oldLabel,omitempty"`
+	NewLabel  string   `json:"newLabel,omitempty"`
+}
+```
+
+`provision/partition_records.go`:
+
+```go
+// clonePartition deep-copies a partition, reallocating its Keys slice.
+func clonePartition(p types.Partition) types.Partition {
+	cp := p // struct-value copy: Weight, Label, and future fields
+	cp.Keys = slices.Clone(p.Keys)
+
+	return cp
+}
+```
+
+In `diffPartitions`, replace the weight-only change detection:
+
+```go
+	for id, d := range desiredByID {
+		live, ok := liveByID[id]
+		if !ok {
+			added = append(added, clonePartition(d))
+			continue
+		}
+		if live.Weight != d.Weight || live.Label != d.Label {
+			changed = append(changed, PartitionWeightChange{
+				Keys:      slices.Clone(d.Keys),
+				OldWeight: live.Weight,
+				NewWeight: d.Weight,
+				OldLabel:  live.Label,
+				NewLabel:  d.Label,
+			})
+		}
+	}
+```
+
+Also update the function Godoc line `changed — records present in both
+whose Weight differs` to `changed — records present in both whose Weight
+or Label differs`.
+
+`provision/apply_partitions.go` — make equality label-aware. The current
+implementation maps CanonicalID → Weight; widen the value:
+
+```go
+// partitionTablesEqual reports whether a and b describe the same partition
+// table: the same set of CanonicalIDs with the same per-record Weight and
+// Label, order independent. Both inputs are duplicate-free (partcodec.Decode
+// and ValidatePartitionSet reject duplicate CanonicalIDs), so an equal
+// length plus a matching lookup is a bijection.
+func partitionTablesEqual(a, b []types.Partition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	type wl struct {
+		w int64
+		l string
+	}
+	byID := make(map[string]wl, len(a))
+	for _, p := range a {
+		byID[p.CanonicalID()] = wl{w: p.Weight, l: p.Label}
+	}
+	for _, p := range b {
+		v, ok := byID[p.CanonicalID()]
+		if !ok || v.w != p.Weight || v.l != p.Label {
+			return false
+		}
+	}
+
+	return true
+}
+```
+
+- [ ] **Step 4: Run tests + full provision package**
+
+Run: `go test ./provision/ -race`
+Expected: PASS, including existing plan/apply tests (label fields are
+omitempty so existing golden JSON stays byte-identical for label-free
+tables).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make lint
+git add provision/
+git commit -m "fix(provision): preserve and diff partition labels in plan and apply paths"
+```
+
+---
+
+### Task 4: Config surface + heartbeat labels
+
+**Files:**
+- Modify: `config.go` — new fields near `WorkerIDPrefix` (:384), defaults,
+  `Validate`
+- Modify: `options.go` — `WithWorkerLabels`
+- Modify: `types/heartbeat.go` — `Labels` field
+- Modify: `internal/heartbeat/publisher.go` — `SetLabels` + emit in
+  `build()` (:379-404)
+- Modify: `manager.go` / `manager_election.go` — resolve labels at
+  construction; wire into the heartbeat publisher in `startHeartbeat`
+  (manager_election.go:414)
+- Modify: `internal/assignment/config.go` — `UnlabeledPartitionPolicy`,
+  `LabelSpillGrace` (consumed by Task 8); thread from
+  `startCalculator` (manager_assignment.go:116)
+- Test: `config_labels_test.go`, `types/heartbeat_test.go` (extend),
+  `internal/heartbeat/publisher_test.go` (extend)
+
+**Interfaces:**
+- Consumes: Task 1.
+- Produces (locked):
+  - `Config.WorkerLabels []string` `yaml:"workerLabels"`
+  - `Config.UnlabeledPartitionPolicy string` `yaml:"unlabeledPartitionPolicy" default:"dedicated" validate:"oneof=dedicated shared"`
+  - `Config.LabelSpillGrace time.Duration` `yaml:"labelSpillGrace" default:"60s" validate:"gte=0"`
+  - `func WithWorkerLabels(labels ...string) Option` — overrides
+    `Config.WorkerLabels` (option wins; needed because test clusters share
+    one Config across workers)
+  - `types.Heartbeat.Labels []string` `json:"labels,omitempty"`
+  - `func (p *heartbeat.Publisher) SetLabels(labels []string)` — call
+    before `Start`, stores a sorted/deduped copy
+  - `assignment.Config.UnlabeledPartitionPolicy string`,
+    `assignment.Config.LabelSpillGrace time.Duration`
+  - normalization helper `normalizeWorkerLabels(labels []string) ([]string, error)`
+    in `config.go`: sort, dedupe, validate each label with the same rule
+    as `Partition.Validate` (≤64 bytes, no dots/whitespace, non-empty),
+    cap 16 labels.
+
+- [ ] **Step 1: Write the failing config tests**
+
+```go
+// config_labels_test.go
+package parti
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_WorkerLabelsNormalization(t *testing.T) {
+	t.Parallel()
+
+	got, err := normalizeWorkerLabels([]string{"vip", "batch", "vip"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"batch", "vip"}, got, "sorted + deduped")
+
+	_, err = normalizeWorkerLabels([]string{"bad label"})
+	require.Error(t, err, "whitespace rejected")
+	_, err = normalizeWorkerLabels([]string{"dotted.label"})
+	require.Error(t, err, "dots rejected")
+	_, err = normalizeWorkerLabels([]string{""})
+	require.Error(t, err, "empty label rejected")
+
+	seventeen := make([]string, 17)
+	for i := range seventeen {
+		seventeen[i] = string(rune('a' + i))
+	}
+	_, err = normalizeWorkerLabels(seventeen)
+	require.Error(t, err, "more than 16 labels rejected")
+}
+
+func TestConfig_LabelPolicyDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{}
+	require.NoError(t, SetDefaults(&cfg))
+	require.Equal(t, "dedicated", cfg.UnlabeledPartitionPolicy)
+	require.Equal(t, 60*time.Second, cfg.LabelSpillGrace)
+
+	cfg.UnlabeledPartitionPolicy = "invalid"
+	require.Error(t, cfg.Validate())
+
+	cfg.UnlabeledPartitionPolicy = "shared"
+	cfg.LabelSpillGrace = -time.Second
+	require.Error(t, cfg.Validate())
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test . -run 'TestConfig_WorkerLabels|TestConfig_LabelPolicy' -v`
+Expected: compile errors (missing fields / helper).
+
+- [ ] **Step 3: Implement config fields**
+
+In `config.go`, next to `WorkerIDPrefix`:
+
+```go
+	// WorkerLabels is this worker's label set, fixed at process startup.
+	// Labeled partitions (Partition.Label) are assigned only to workers
+	// whose set contains the partition's label. Validated with
+	// partition-key charset rules; sorted and deduplicated. At most 16
+	// labels, each at most 64 bytes. Empty = unlabeled worker.
+	// WithWorkerLabels overrides this field when both are set.
+	WorkerLabels []string `yaml:"workerLabels"`
+
+	// UnlabeledPartitionPolicy controls which workers receive unlabeled
+	// partitions. "dedicated" (default): unlabeled workers only, falling
+	// back to all workers when no unlabeled worker is live. "shared":
+	// all workers. Leader-side; MUST be identical across every manager
+	// in the fleet (same contract as the AssignmentStrategy choice).
+	UnlabeledPartitionPolicy string `yaml:"unlabeledPartitionPolicy" default:"dedicated" validate:"oneof=dedicated shared"`
+
+	// LabelSpillGrace is how long a label's worker pool must be
+	// continuously empty before its partitions spill to the fallback
+	// ladder. 0 spills immediately. Leader-side; MUST be fleet-uniform.
+	LabelSpillGrace time.Duration `yaml:"labelSpillGrace" default:"60s" validate:"gte=0"`
+```
+
+Add the normalization helper (near other config helpers):
+
+```go
+// normalizeWorkerLabels validates, sorts, and deduplicates a worker label
+// set. Rules mirror Partition.Validate's label rules: non-empty, no dots,
+// no whitespace, at most 64 bytes each, at most 16 labels total.
+func normalizeWorkerLabels(labels []string) ([]string, error) {
+	if len(labels) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		if l == "" {
+			return nil, errors.New("worker label cannot be empty")
+		}
+		if len(l) > 64 {
+			return nil, fmt.Errorf("worker label exceeds 64 bytes: %q", l)
+		}
+		if strings.Contains(l, ".") {
+			return nil, fmt.Errorf("worker label contains invalid character '.': %q", l)
+		}
+		if strings.ContainsAny(l, " \t\n\r") {
+			return nil, fmt.Errorf("worker label contains whitespace: %q", l)
+		}
+		if _, dup := seen[l]; dup {
+			continue
+		}
+		seen[l] = struct{}{}
+		out = append(out, l)
+	}
+	slices.Sort(out)
+	if len(out) > 16 {
+		return nil, fmt.Errorf("too many worker labels: %d (max 16)", len(out))
+	}
+
+	return out, nil
+}
+```
+
+Call it from `Config.Validate()` (store the normalized result back onto
+the field so downstream consumers see canonical form), and follow the
+existing pattern used by other validated fields in that function.
+
+Decision (closes spec §16 open item 3): NO inert-config startup warning
+for `WorkerLabels` set with no labeled partitions — unlike an inert rate
+limit, a labeled-but-idle worker is a *legitimate steady state* (reserved
+capacity awaiting VIP promotion, spec §7 "dedicated reserves capacity").
+Log the resolved label set once at Info and stop there.
+
+- [ ] **Step 4: `WithWorkerLabels` option**
+
+In `options.go` (mirror `WithLogger`'s shape; the manager keeps a
+`workerLabels []string` resolved at `NewManager` time):
+
+```go
+// WithWorkerLabels sets this worker's label set, overriding
+// Config.WorkerLabels. Labels are fixed for the manager's lifetime,
+// published in every heartbeat, and drive label-based partition
+// assignment. Invalid labels cause NewManager to return an error.
+//
+// Use this instead of Config.WorkerLabels when several workers share one
+// Config value (e.g. test clusters) but need distinct labels.
+func WithWorkerLabels(labels ...string) Option {
+	return func(m *Manager) error {
+		normalized, err := normalizeWorkerLabels(labels)
+		if err != nil {
+			return fmt.Errorf("WithWorkerLabels: %w", err)
+		}
+		m.workerLabels = normalized
+
+		return nil
+	}
+}
+```
+
+(Adapt the closure signature to the repo's actual `Option` type — check
+`options.go:32 WithElectionAgent` and copy its exact shape. If `Option`
+does not return error, validate lazily in `NewManager` after options run
+and return the error from there.)
+
+In `NewManager`, after options are applied: if `m.workerLabels == nil`,
+resolve from `cfg.WorkerLabels` via `normalizeWorkerLabels` (error out on
+invalid). Log the resolved set once at Info.
+
+- [ ] **Step 5: Heartbeat field + publisher**
+
+`types/heartbeat.go`, after `Capabilities`:
+
+```go
+	// Labels is the worker's label set, fixed for the process lifetime.
+	// Sorted and deduplicated at publish time. Empty for unlabeled
+	// workers and for pre-label workers (additive JSON field).
+	Labels []string `json:"labels,omitempty"`
+```
+
+`internal/heartbeat/publisher.go` — add field + setter, then emit:
+
+```go
+// SetLabels registers the worker's label set to include in every
+// heartbeat. Call before Start. The slice is stored as-is (the manager
+// passes an already-normalized copy) and must not be mutated afterwards.
+func (p *Publisher) SetLabels(labels []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.labels = labels
+}
+```
+
+In `build()` add `Labels: p.labels,` to the returned `types.Heartbeat`
+(read under the same lock discipline as `capsFn` — copy the slice header
+into a local before composing if `build` runs without `p.mu`).
+
+In `manager_election.go:startHeartbeat`, after the publisher is
+constructed and before `Start`: `pub.SetLabels(m.workerLabels)`.
+
+- [ ] **Step 6: Thread policy/grace into the calculator config**
+
+`internal/assignment/config.go` — add:
+
+```go
+	// UnlabeledPartitionPolicy: "dedicated" (default when empty) routes
+	// unlabeled partitions to unlabeled workers only (falling back to all
+	// workers when none are live); "shared" routes them to all workers.
+	UnlabeledPartitionPolicy string
+
+	// LabelSpillGrace is how long a label pool must be continuously empty
+	// before its partitions spill. 0 = immediate spill.
+	LabelSpillGrace time.Duration
+
+	// OnLabelReadBroadFailure, if set, is invoked when a rebalance aborts
+	// because worker label reads failed broadly (connectivity/degrading-
+	// JetStream class, or above the isolated-failure cap). The manager
+	// wires this to its KV-error recorder so sustained heartbeat-read
+	// trouble trips the degraded circuit (spec §6). Mirrors the
+	// OnEnumerationError seam. Must be safe for concurrent use.
+	OnLabelReadBroadFailure func(err error)
+```
+
+`manager_assignment.go:startCalculator` — add to the `assignment.Config`
+literal:
+
+```go
+		UnlabeledPartitionPolicy: m.cfg.UnlabeledPartitionPolicy,
+		LabelSpillGrace:          m.cfg.LabelSpillGrace,
+		OnLabelReadBroadFailure:  m.recordLabelReadFailure,
+```
+
+The adapter is NOT a bare pass-through — the routing subtlety lives here.
+`m.recordKVError` admits only whole-bucket-loss (connectivity/degrading)
+or `ErrKVUnavailable`-wrapped errors; everything else is dropped by
+`classifyKVError` (`kv_error_classify.go:56-69`,
+`manager_degraded.go:140-143`). A COUNT-based broad label-read failure
+(many unclassified per-worker Get failures) carries no admissible class,
+so passing it straight through would silently no-op — violating the spec
+§6 requirement that broad failures reach the KV-error/degraded machinery.
+`ErrKVUnavailable` lives in the root package (`manager_degraded.go:38`)
+and cannot be imported by `internal/assignment` (cycle), so the wrapping
+happens HERE, in the manager-side adapter:
+
+```go
+// recordLabelReadFailure routes a broad label-read failure from the
+// calculator into the degraded circuit. Classed causes (connectivity /
+// degrading JetStream) pass through and are admitted as whole-bucket
+// loss. Count-based broad failures (many unclassified per-worker Get
+// failures — a connected-but-KV-misbehaving shape) carry no admissible
+// class of their own, so wrap ErrKVUnavailable: they enter the window as
+// the F-D1 transient class (DegradeReasonKVUnavailable), which healthy
+// ops clear — sustained trouble degrades, a transient blip does not.
+func (m *Manager) recordLabelReadFailure(err error) {
+	if err == nil {
+		return // classifyKVError(nil) is also kvRouteDrop — without this
+		//        guard a nil input would be wrapped into a live window entry
+	}
+	if classifyKVError(err).route == kvRouteDrop {
+		err = fmt.Errorf("%w: broad worker label read failure: %w", ErrKVUnavailable, err)
+	}
+	m.recordKVError(err)
+}
+```
+
+Unit test for the adapter (root package, alongside the classifier tests):
+
+```go
+// TestRecordLabelReadFailure_Routing:
+//   connectivity-classed cause  → classifyKVError admits it, non-transient
+//     (whole-bucket-loss window entry)
+//   bare count-based error      → wrapped ErrKVUnavailable; assert
+//     classifyKVError(wrapped) == {route: kvRouteWindow, transient: true}
+//     and that repeated calls within KVErrorWindow trip the degraded
+//     circuit with DegradeReasonKVUnavailable (reuse the existing
+//     degraded-circuit test harness in manager_degraded's tests)
+//   nil → no-op (no window entry)
+```
+
+- [ ] **Step 7: Tests for heartbeat emission**
+
+Extend `types/heartbeat_test.go`: a v1 JSON heartbeat with
+`"labels":["vip"]` decodes to `Labels=[]string{"vip"}`; a legacy
+timestamp payload decodes to `Labels=nil`; a v1 payload without the field
+decodes to nil (distinct from error).
+
+Extend the publisher test (follow the existing test file's harness for
+`build()` or a real KV publish): after `SetLabels([]string{"vip"})`, the
+published JSON contains `"labels":["vip"]`; without SetLabels the field
+is absent (payload byte-compat for unlabeled fleets).
+
+- [ ] **Step 8: Run, lint, commit**
+
+Run: `go test . ./types/ ./internal/heartbeat/ ./internal/assignment/ -race && make lint`
+
+```bash
+git add config.go options.go config_labels_test.go types/heartbeat.go types/heartbeat_test.go internal/heartbeat/ internal/assignment/config.go manager.go manager_election.go manager_assignment.go
+git commit -m "feat: worker label configuration published via heartbeats"
+```
+
+---
+
+### Task 5: `WorkerMonitor.GetHeartbeatsFor`
+
+**Files:**
+- Modify: `internal/assignment/worker_monitor.go` (next to
+  `GetHeartbeats`, :240-275)
+- Test: `internal/assignment/worker_monitor_test.go` (extend; harness:
+  `partitest.StartEmbeddedNATS(t)` like the existing tests)
+
+**Interfaces:**
+- Consumes: `types.Heartbeat.Labels` (Task 4).
+- Produces:
+  `GetHeartbeatsFor(ctx, workerIDs []string) (map[string]types.Heartbeat, map[string]error, error)`
+  — one bounded `Get` per listed worker, **no** `Keys()` scan. A worker
+  whose Get or decode fails is absent from the heartbeat map and present
+  in the error map WITH ITS ORIGINAL ERROR — the caller (Task 8) needs
+  the error class (connectivity/degrading-JetStream vs not) to apply the
+  spec §6 taxonomy; swallowing the class into a bare omission would let a
+  connectivity failure masquerade as "unknown labels" (fatal in a
+  1-worker fleet, where max(1,10%) = 1 makes every failure "isolated" by
+  count). Final error non-nil only if ctx is done before completion.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestWorkerMonitor_GetHeartbeatsFor(t *testing.T) {
+	t.Parallel()
+
+	// Same harness as TestWorkerMonitor_GetHeartbeats_DualDecode: embedded
+	// NATS, heartbeat bucket, monitor with prefix "heartbeat".
+	_, nc := partitest.StartEmbeddedNATS(t)
+	// ... create js + KV bucket exactly as the sibling tests do ...
+
+	// Seed: worker-0 v1 JSON with labels, worker-1 v1 JSON without,
+	// worker-2 malformed payload.
+	putHeartbeat(t, kv, "heartbeat.worker-0", types.Heartbeat{
+		WorkerID: "worker-0", SchemaVersion: 1, Labels: []string{"vip"},
+		Timestamp: time.Now(),
+	})
+	putHeartbeat(t, kv, "heartbeat.worker-1", types.Heartbeat{
+		WorkerID: "worker-1", SchemaVersion: 1, Timestamp: time.Now(),
+	})
+	_, err := kv.Put(ctx, "heartbeat.worker-2", []byte("not-json-not-time"))
+	require.NoError(t, err)
+
+	m := NewWorkerMonitor(kv, "heartbeat", 5*time.Second, nil, logger)
+
+	got, errs, err := m.GetHeartbeatsFor(ctx, []string{"worker-0", "worker-1", "worker-2", "worker-9"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"vip"}, got["worker-0"].Labels)
+	require.Empty(t, got["worker-1"].Labels)
+	_, ok := got["worker-2"]
+	require.False(t, ok, "malformed payload omitted from heartbeats")
+	require.Error(t, errs["worker-2"], "…but its decode error is preserved for classification")
+	_, ok = got["worker-9"]
+	require.False(t, ok, "missing key omitted from heartbeats")
+	require.Error(t, errs["worker-9"], "…and its Get error is preserved (jetstream.ErrKeyNotFound)")
+	require.Len(t, errs, 2)
+}
+```
+
+(`putHeartbeat` = small helper marshaling the heartbeat to JSON and
+`kv.Put`-ing it; add it to the test file if the existing tests don't
+already have an equivalent.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/assignment/ -run 'TestWorkerMonitor_GetHeartbeatsFor' -v`
+Expected: compile error (method missing).
+
+- [ ] **Step 3: Implement**
+
+```go
+// GetHeartbeatsFor returns decoded heartbeats for exactly the given
+// worker IDs, keyed by worker ID. Unlike GetHeartbeats it does NOT run a
+// Keys() scan — callers that already hold the active worker list (the
+// rebalance path) use this to avoid a second stream-wide enumeration.
+//
+// Per-worker Get or decode failures omit that worker from the map (logged
+// at debug); the caller applies its own isolated-vs-broad failure policy.
+// The only non-nil error is context cancellation/deadline.
+func (m *WorkerMonitor) GetHeartbeatsFor(ctx context.Context, workerIDs []string) (map[string]types.Heartbeat, map[string]error, error) {
+	opCtx, cancel := m.boundedOpCtx(ctx)
+	defer cancel()
+
+	out := make(map[string]types.Heartbeat, len(workerIDs))
+	fails := make(map[string]error)
+	for _, workerID := range workerIDs {
+		if err := opCtx.Err(); err != nil {
+			return out, fails, fmt.Errorf("heartbeat fetch aborted: %w", err)
+		}
+		key := m.hbPrefix + "." + workerID
+		entry, gerr := m.heartbeatKV.Get(opCtx, key)
+		if gerr != nil {
+			m.logger.Debug("heartbeat get failed during targeted fetch", "key", key, "error", gerr)
+			fails[workerID] = gerr
+			continue
+		}
+		hb, derr := types.DecodeHeartbeat(entry.Value())
+		if derr != nil {
+			m.logger.Debug("heartbeat decode failed during targeted fetch", "key", key, "error", derr)
+			fails[workerID] = derr
+			continue
+		}
+		out[workerID] = hb
+	}
+
+	return out, fails, nil
+}
+```
+
+- [ ] **Step 4: Run tests, lint, commit**
+
+Run: `go test ./internal/assignment/ -run 'TestWorkerMonitor' -race && make lint`
+
+```bash
+git add internal/assignment/worker_monitor.go internal/assignment/worker_monitor_test.go
+git commit -m "feat(assignment): targeted heartbeat fetch for the rebalance path"
+```
+
+---
+
+### Task 6: Label topology + assignment computation (pure core)
+
+The grouping layer (spec §7). Pure functions, no calculator state — the
+park/spill/defer decisions arrive as inputs (Task 8 computes them), which
+keeps this exhaustively unit-testable.
+
+**Files:**
+- Create: `internal/assignment/labels.go`
+- Test: `internal/assignment/labels_test.go` (new)
+
+**Interfaces:**
+- Consumes: `types.AssignmentStrategy`, `types.Partition.Label`.
+- Produces (consumed by Task 8):
+
+```go
+type topologyInput struct {
+	Workers    []string            // active set, post-filter
+	Labels     map[string][]string // workerID → sorted label set (successful reads)
+	Unknown    map[string]bool     // workerID → labels unreadable (§6); disjoint from Labels
+	Partitions []types.Partition   // source snapshot
+	Policy     string              // "dedicated" | "shared" ("" = dedicated)
+}
+
+type labelTopology struct {
+	Pools        map[string][]string          // label → matching workers (sorted)
+	Groups       map[string][]types.Partition // label → partitions; "" key = unlabeled group
+	SortedLabels []string                     // sorted keys of Groups, excluding ""
+	EmptyLabels  []string                     // labels whose pool is empty (sorted)
+	GeneralPool  []string                     // per policy; empty ⇒ caller uses AllWorkers
+	FallbackPool []string                     // unlabeled workers; empty ⇒ caller uses AllWorkers
+	AllWorkers   []string                     // Workers minus Unknown (sorted)
+	UnknownSet   map[string]bool              // pass-through of in.Unknown
+}
+
+type emptyPoolAction int
+
+const (
+	emptyPoolPark emptyPoolAction = iota
+	emptyPoolSpill
+)
+
+func buildLabelTopology(in topologyInput) labelTopology
+func computeLabelAssignments(strategy types.AssignmentStrategy, topo labelTopology, actions map[string]emptyPoolAction) (map[string][]types.Partition, []types.Partition, error)
+```
+
+Contract highlights (each is a named test below):
+- merged map keys == `topo.AllWorkers ∪ topo.UnknownSet` exactly; unknown
+  workers and pool-less workers get explicit empty slices (spec I8);
+- each partition appears exactly once across merged ∪ parked (spec I9/I2);
+- unlabeled group → `GeneralPool`, or `AllWorkers` when the general pool
+  is empty; labeled group with empty pool → `actions[label]`: park
+  (returned in parked slice) or spill to `FallbackPool`/`AllWorkers`;
+- deterministic: sorted label iteration; strategies sort internally;
+- `Strategy.Assign` is never called with an empty worker list.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/assignment/labels_test.go
+package assignment
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func parts(labels ...string) []types.Partition {
+	out := make([]types.Partition, len(labels))
+	for i, l := range labels {
+		out[i] = types.Partition{Keys: []string{string(rune('a' + i))}, Label: l}
+	}
+	return out
+}
+
+func topo(workers []string, labels map[string][]string, partitions []types.Partition, policy string) labelTopology {
+	return buildLabelTopology(topologyInput{
+		Workers: workers, Labels: labels, Partitions: partitions, Policy: policy,
+	})
+}
+
+func TestBuildLabelTopology_PoolsAndGroups(t *testing.T) {
+	t.Parallel()
+
+	tp := topo(
+		[]string{"w0", "w1", "w2"},
+		map[string][]string{"w0": {"vip"}, "w1": {"batch", "vip"}, "w2": nil},
+		parts("vip", "", "batch", "ghost"),
+		"dedicated",
+	)
+
+	require.Equal(t, []string{"w0", "w1"}, tp.Pools["vip"])
+	require.Equal(t, []string{"w1"}, tp.Pools["batch"])
+	require.Equal(t, []string{"w2"}, tp.GeneralPool, "dedicated: unlabeled workers only")
+	require.Equal(t, []string{"w2"}, tp.FallbackPool)
+	require.Equal(t, []string{"ghost"}, tp.EmptyLabels, "label with no matching worker")
+	require.Len(t, tp.Groups[""], 1)
+	require.Len(t, tp.Groups["vip"], 1)
+}
+
+func TestBuildLabelTopology_SharedPolicy(t *testing.T) {
+	t.Parallel()
+
+	tp := topo(
+		[]string{"w0", "w1"},
+		map[string][]string{"w0": {"vip"}, "w1": nil},
+		parts(""),
+		"shared",
+	)
+	require.Equal(t, []string{"w0", "w1"}, tp.GeneralPool, "shared: all workers")
+}
+
+func TestComputeLabelAssignments_MergeContract(t *testing.T) {
+	t.Parallel()
+
+	// w0 vip-only; w1 unlabeled; w2 unknown labels; one vip partition,
+	// one unlabeled partition. Expect: w0 gets vip, w1 gets unlabeled,
+	// w2 present with EMPTY slice (I8 — no stale-assignment leak).
+	in := topologyInput{
+		Workers:    []string{"w0", "w1", "w2"},
+		Labels:     map[string][]string{"w0": {"vip"}, "w1": nil},
+		Unknown:    map[string]bool{"w2": true},
+		Partitions: parts("vip", ""),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	merged, parked, err := computeLabelAssignments(strategy.NewRoundRobin(), tp, nil)
+	require.NoError(t, err)
+	require.Empty(t, parked)
+
+	require.Len(t, merged, 3, "every active worker gets an entry")
+	require.NotNil(t, merged["w2"])
+	require.Empty(t, merged["w2"], "unknown-label worker: explicit empty entry")
+	require.Len(t, merged["w0"], 1)
+	require.Equal(t, "vip", merged["w0"][0].Label)
+	require.Len(t, merged["w1"], 1)
+
+	total := 0
+	for _, ps := range merged {
+		total += len(ps)
+	}
+	require.Equal(t, 2, total, "each partition exactly once (I9)")
+}
+
+func TestComputeLabelAssignments_ParkAndSpill(t *testing.T) {
+	t.Parallel()
+
+	in := topologyInput{
+		Workers:    []string{"w0"},
+		Labels:     map[string][]string{"w0": nil},
+		Partitions: parts("vip", ""),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	require.Equal(t, []string{"vip"}, tp.EmptyLabels)
+
+	// Park:
+	merged, parked, err := computeLabelAssignments(strategy.NewRoundRobin(), tp,
+		map[string]emptyPoolAction{"vip": emptyPoolPark})
+	require.NoError(t, err)
+	require.Len(t, parked, 1)
+	require.Equal(t, "vip", parked[0].Label)
+	require.Len(t, merged["w0"], 1, "unlabeled partition still assigned")
+
+	// Spill:
+	merged, parked, err = computeLabelAssignments(strategy.NewRoundRobin(), tp,
+		map[string]emptyPoolAction{"vip": emptyPoolSpill})
+	require.NoError(t, err)
+	require.Empty(t, parked)
+	require.Len(t, merged["w0"], 2, "spilled onto the fallback pool")
+}
+
+func TestComputeLabelAssignments_SpillPrefersUnlabeledWorkers(t *testing.T) {
+	t.Parallel()
+
+	// vip pool empty; batch pool exists; one unlabeled worker. Spilled
+	// vip partitions must land on the unlabeled worker, never invade the
+	// batch pool (spec I5).
+	in := topologyInput{
+		Workers:    []string{"batchw", "plainw"},
+		Labels:     map[string][]string{"batchw": {"batch"}, "plainw": nil},
+		Partitions: parts("vip"),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	merged, _, err := computeLabelAssignments(strategy.NewRoundRobin(), tp,
+		map[string]emptyPoolAction{"vip": emptyPoolSpill})
+	require.NoError(t, err)
+	require.Empty(t, merged["batchw"], "spill must not invade another label's pool")
+	require.Len(t, merged["plainw"], 1)
+}
+
+// TestComputeLabelAssignments_I1Golden: with zero labels anywhere the
+// pipeline output must be identical to a direct Strategy.Assign call.
+func TestComputeLabelAssignments_I1Golden(t *testing.T) {
+	t.Parallel()
+
+	workers := []string{"w0", "w1", "w2"}
+	partitions := make([]types.Partition, 10)
+	for i := range partitions {
+		partitions[i] = types.Partition{Keys: []string{"p", string(rune('0' + i))}, Weight: int64(i%3 + 1)}
+	}
+
+	for _, strat := range []types.AssignmentStrategy{
+		strategy.NewRoundRobin(),
+		strategy.NewConsistentHash(),
+	} {
+		direct, err := strat.Assign(workers, partitions)
+		require.NoError(t, err)
+
+		tp := buildLabelTopology(topologyInput{
+			Workers: workers,
+			Labels:  map[string][]string{"w0": nil, "w1": nil, "w2": nil},
+			Partitions: partitions,
+			Policy:     "dedicated",
+		})
+		merged, parked, err := computeLabelAssignments(strat, tp, nil)
+		require.NoError(t, err)
+		require.Empty(t, parked)
+		require.Equal(t, direct, merged, "label-free pipeline must equal direct Assign")
+	}
+}
+
+func TestComputeLabelAssignments_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	in := topologyInput{
+		Workers: []string{"w2", "w0", "w1"},
+		Labels:  map[string][]string{"w0": {"vip"}, "w1": {"batch"}, "w2": nil},
+		Partitions: parts("vip", "batch", "", "vip"),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	first, _, err := computeLabelAssignments(strategy.NewConsistentHash(), tp, nil)
+	require.NoError(t, err)
+	for range 20 {
+		tp2 := buildLabelTopology(in)
+		again, _, err := computeLabelAssignments(strategy.NewConsistentHash(), tp2, nil)
+		require.NoError(t, err)
+		require.Equal(t, first, again)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/assignment/ -run 'TestBuildLabelTopology|TestComputeLabelAssignments' -v`
+Expected: compile errors (file absent).
+
+- [ ] **Step 3: Implement `internal/assignment/labels.go`**
+
+```go
+package assignment
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// topologyInput / labelTopology / emptyPoolAction: see interface block in
+// the plan header (copy the type definitions verbatim).
+
+// buildLabelTopology partitions workers and partitions into label pools
+// and groups (spec §7). Pure and deterministic: all slices sorted.
+func buildLabelTopology(in topologyInput) labelTopology {
+	topo := labelTopology{
+		Pools:      map[string][]string{},
+		Groups:     map[string][]types.Partition{},
+		UnknownSet: in.Unknown,
+	}
+
+	// Active workers minus unknown-label workers, sorted.
+	for _, w := range in.Workers {
+		if in.Unknown[w] {
+			continue
+		}
+		topo.AllWorkers = append(topo.AllWorkers, w)
+		labels := in.Labels[w]
+		if len(labels) == 0 {
+			topo.FallbackPool = append(topo.FallbackPool, w)
+		}
+		for _, l := range labels {
+			topo.Pools[l] = append(topo.Pools[l], w)
+		}
+	}
+	slices.Sort(topo.AllWorkers)
+	slices.Sort(topo.FallbackPool)
+	for l := range topo.Pools {
+		slices.Sort(topo.Pools[l])
+	}
+
+	if in.Policy == "shared" {
+		topo.GeneralPool = topo.AllWorkers
+	} else { // "dedicated" and "" default
+		topo.GeneralPool = topo.FallbackPool
+	}
+
+	for _, p := range in.Partitions {
+		topo.Groups[p.Label] = append(topo.Groups[p.Label], p)
+	}
+	for l := range topo.Groups {
+		if l == "" {
+			continue
+		}
+		topo.SortedLabels = append(topo.SortedLabels, l)
+		if len(topo.Pools[l]) == 0 {
+			topo.EmptyLabels = append(topo.EmptyLabels, l)
+		}
+	}
+	slices.Sort(topo.SortedLabels)
+	slices.Sort(topo.EmptyLabels)
+
+	return topo
+}
+
+// computeLabelAssignments runs the configured strategy once per pool and
+// merges (spec §7). actions supplies the park/spill decision for each
+// empty-pool label (Task 8 computes them from grace state); a missing
+// entry defaults to park — the conservative choice, and unreachable in
+// production because the calculator always populates every EmptyLabels
+// entry.
+func computeLabelAssignments(
+	strategy types.AssignmentStrategy,
+	topo labelTopology,
+	actions map[string]emptyPoolAction,
+) (map[string][]types.Partition, []types.Partition, error) {
+	merged := make(map[string][]types.Partition, len(topo.AllWorkers)+len(topo.UnknownSet))
+	var parked []types.Partition
+
+	assignGroup := func(pool []string, group []types.Partition, what string) error {
+		if len(group) == 0 {
+			return nil
+		}
+		if len(pool) == 0 {
+			pool = topo.AllWorkers // guarded final rung; callers pre-check
+		}
+		if len(pool) == 0 {
+			return fmt.Errorf("label pipeline: no workers available for %s", what)
+		}
+		out, err := strategy.Assign(pool, group)
+		if err != nil {
+			return fmt.Errorf("label pipeline: %s: %w", what, err)
+		}
+		for w, ps := range out {
+			merged[w] = append(merged[w], ps...)
+		}
+
+		return nil
+	}
+
+	// Unlabeled group → general pool (ladder: general → all).
+	if err := assignGroup(topo.GeneralPool, topo.Groups[""], "unlabeled group"); err != nil {
+		return nil, nil, err
+	}
+
+	// Labeled groups in sorted order.
+	for _, l := range topo.SortedLabels {
+		pool := topo.Pools[l]
+		if len(pool) > 0 {
+			if err := assignGroup(pool, topo.Groups[l], "label "+l); err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+		switch actions[l] {
+		case emptyPoolSpill:
+			// Ladder: unlabeled workers first (never another label's
+			// dedicated pool), then all workers.
+			if err := assignGroup(topo.FallbackPool, topo.Groups[l], "spilled label "+l); err != nil {
+				return nil, nil, err
+			}
+		default: // emptyPoolPark
+			parked = append(parked, topo.Groups[l]...)
+		}
+	}
+
+	// I8: every active worker appears exactly once — explicit empty
+	// entries for workers in no pool and for unknown-label workers.
+	for _, w := range topo.AllWorkers {
+		if _, ok := merged[w]; !ok {
+			merged[w] = []types.Partition{}
+		}
+	}
+	for w := range topo.UnknownSet {
+		merged[w] = []types.Partition{}
+	}
+
+	return merged, parked, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/assignment/ -run 'TestBuildLabelTopology|TestComputeLabelAssignments' -v -race`
+Expected: PASS (7 tests).
+
+Watch one subtlety in the I1 golden test: strategies return entries for
+every worker they were given, so the merged result for the label-free
+case is exactly the strategy's own map — `require.Equal` on the full map
+is intentionally strict (nil-vs-empty slice differences will fail; make
+`assignGroup`'s merge preserve the strategy's slices untouched for this
+to hold).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make lint
+git add internal/assignment/labels.go internal/assignment/labels_test.go
+git commit -m "feat(assignment): label pool topology and per-pool assignment merge"
+```
+
+---
+
+### Task 7: Wire additions — payload labels-of-record + parked commit contract
+
+Everything the leader writes to KV (spec §4.3 + §8.2): labels-of-record on
+the per-worker payload (with presence bit), parked metadata on the commit,
+and the widened coverage check. No calculator behavior changes yet — the
+new inputs default to empty and preserve today's semantics bit-for-bit
+until Task 8 populates them.
+
+**Files:**
+- Modify: `types/assignment_commit.go` — `AssignmentPayload` (:25-34),
+  `AssignmentCommit` (add after `BatchDigest`, :111-114)
+- Modify: `types/partition.go` — `Assignment` struct (:218-255)
+- Modify: `internal/assignment/assignment_publisher.go` — `PublishInput`
+  (:271-310), `checkCoverage` (:521+), payload construction inside
+  `writePayloads`, commit literal (:405-418), `buildLegacyAlias`
+  (:1327-1341)
+- Test: `internal/assignment/assignment_publisher_labels_test.go` (new;
+  follow the harness of `assignment_publisher_test.go`)
+
+**Interfaces:**
+- Consumes: Task 1.
+- Produces (locked; Tasks 8/10/11 depend on exact names):
+
+```go
+// types/assignment_commit.go
+type AssignmentPayload struct {
+	SchemaVersion uint8             `json:"schema_version"`
+	Partitions    []Partition       `json:"partitions"`
+	// WorkerLabels is the labels-of-record: the label set the leader read
+	// from this worker's heartbeat when computing the assignment. Part of
+	// the canonical payload bytes (and therefore PayloadHash).
+	WorkerLabels []string `json:"worker_labels,omitempty"`
+	// WorkerLabelsKnown distinguishes "computed for an unlabeled worker"
+	// (true + empty WorkerLabels) from "computed by a pre-label leader"
+	// (false). Label-aware leaders ALWAYS set true. Mirrors the
+	// SourceRevisionKnown presence-bit precedent.
+	WorkerLabelsKnown bool `json:"worker_labels_known,omitempty"`
+}
+
+// types/assignment_commit.go — AssignmentCommit additions
+	// ParkedCount is the number of partitions intentionally left
+	// unassigned in this batch (label pool empty, spill grace not yet
+	// expired). Zero when nothing is parked.
+	ParkedCount int `json:"parked_count,omitempty"`
+	// ParkedDigest is types.PartitionSetDigest over the parked set.
+	// Zero when nothing is parked.
+	ParkedDigest uint64 `json:"parked_digest,omitempty"`
+
+// types/partition.go — Assignment additions (runtime + legacy alias wire)
+	// WorkerLabels / WorkerLabelsKnown mirror the fetched
+	// AssignmentPayload's labels-of-record so the worker-side
+	// stale-incarnation guard can compare against its own label set.
+	WorkerLabels      []string `json:"worker_labels,omitempty"`
+	WorkerLabelsKnown bool     `json:"worker_labels_known,omitempty"`
+
+// internal/assignment — PublishInput additions
+	// ParkedPartitions is the set deliberately left unassigned this batch.
+	// Coverage becomes: assigned ∪ parked == source AND assigned ∩ parked == ∅.
+	ParkedPartitions []types.Partition
+	// WorkerLabels maps workerID → labels-of-record for payload stamping.
+	// Workers absent from the map get WorkerLabels=nil (still Known=true).
+	WorkerLabels map[string][]string
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/assignment/assignment_publisher_labels_test.go
+package assignment
+
+// Harness note: copy the publisher construction from
+// assignment_publisher_test.go (embedded NATS KV + NewAssignmentPublisher
+// with test logger/metrics). The assertions below are the contract.
+
+func TestCheckCoverage_ParkedUnionAndDisjointness(t *testing.T) {
+	t.Parallel()
+	p := newTestPublisher(t) // existing helper or minimal local ctor
+
+	src := []types.Partition{
+		{Keys: []string{"a"}}, {Keys: []string{"b"}, Label: "vip"},
+	}
+	assignedOnly := map[string][]types.Partition{"w0": {src[0]}}
+
+	// (1) parked partition completes coverage:
+	require.NoError(t, p.checkCoverage(src, assignedOnly, []types.Partition{src[1]}))
+
+	// (2) partition missing from BOTH assignment and parked → error:
+	err := p.checkCoverage(src, assignedOnly, nil)
+	require.ErrorIs(t, err, types.ErrCoverageMismatch)
+
+	// (3) partition in BOTH assignment and parked → error:
+	both := map[string][]types.Partition{"w0": {src[0], src[1]}}
+	err = p.checkCoverage(src, both, []types.Partition{src[1]})
+	require.ErrorIs(t, err, types.ErrCoverageMismatch)
+
+	// (4) legacy shape (no parked) unchanged:
+	full := map[string][]types.Partition{"w0": {src[0]}, "w1": {src[1]}}
+	require.NoError(t, p.checkCoverage(src, full, nil))
+}
+
+func TestPublish_ParkedMetadataOnCommit(t *testing.T) {
+	t.Parallel()
+	// Publish with one parked partition; read back "assignment._commit";
+	// require commit.ParkedCount == 1 and commit.ParkedDigest ==
+	// types.PartitionSetDigest(parked). BatchDigest must still cover the
+	// FULL source set (compare against a second publish without parking).
+}
+
+func TestPublish_PayloadCarriesLabelsOfRecord(t *testing.T) {
+	t.Parallel()
+	// Publish with WorkerLabels{"w0": {"vip"}} and one with nil labels for
+	// w1. Fetch both payloads via their refs; require:
+	//   payload(w0).WorkerLabels == ["vip"], WorkerLabelsKnown == true
+	//   payload(w1).WorkerLabels == nil,     WorkerLabelsKnown == true
+	// And PayloadHash(w0-with-labels) != PayloadHash(w0-without-labels):
+	// labels-of-record are part of content identity.
+}
+
+func TestBuildLegacyAlias_CopiesLabelsOfRecord(t *testing.T) {
+	t.Parallel()
+	payload := types.AssignmentPayload{
+		SchemaVersion: 1,
+		Partitions:    []types.Partition{{Keys: []string{"a"}}},
+		WorkerLabels:  []string{"vip"},
+		WorkerLabelsKnown: true,
+	}
+	alias := buildLegacyAlias(payload, 7, 3, 0, "steady", 2)
+	require.Equal(t, []string{"vip"}, alias.WorkerLabels)
+	require.True(t, alias.WorkerLabelsKnown)
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/assignment/ -run 'TestCheckCoverage_Parked|TestPublish_Parked|TestPublish_Payload|TestBuildLegacyAlias_Copies' -v`
+Expected: compile errors (fields/params missing).
+
+- [ ] **Step 3: Implement**
+
+1. Add the three type extensions exactly as in the interface block.
+2. `checkCoverage(source []types.Partition, assignments map[string][]types.Partition, parked []types.Partition) error`:
+
+```go
+func (p *AssignmentPublisher) checkCoverage(source []types.Partition, assignments map[string][]types.Partition, parked []types.Partition) error {
+	union := unionPartitions(assignments)
+	assignedIDs := canonicalIDSet(union) // sorted, deduped
+	parkedIDs := canonicalIDSet(parked)
+	expected := canonicalIDSet(source)
+
+	// Disjointness: a partition may not be both assigned and parked.
+	overlap := intersectSortedIDs(assignedIDs, parkedIDs) // new tiny helper
+	// Union: assigned ∪ parked must equal source as a set, and the raw
+	// counts must match (multiset check catches duplicates).
+	got := mergeSortedIDs(assignedIDs, parkedIDs) // new tiny helper, dedupes
+	rawCount := len(union) + len(parked)
+	setOK := equalStringSlices(got, expected)
+	multisetOK := rawCount == len(expected)
+	if setOK && multisetOK && len(overlap) == 0 {
+		return nil
+	}
+	// ... keep the existing missing/extra/duplicates diagnostics, add
+	// "parked" and "overlap" counts to the log line and error, and return
+	// types.ErrCoverageMismatch as before.
+}
+```
+
+Update the single call site (`Publish` step 3) to
+`p.checkCoverage(in.SourcePartitions, in.Assignments, in.ParkedPartitions)`.
+
+3. Payload stamping: `writePayloads` gains the labels map. Change its
+   signature to accept `in PublishInput` (or add a
+   `labels map[string][]string` parameter — pick whichever matches the
+   existing style; there is exactly one caller). At the single site where
+   `types.AssignmentPayload{...}` is constructed for worker `w`, set:
+
+```go
+	WorkerLabels:      in.WorkerLabels[w],
+	WorkerLabelsKnown: true,
+```
+
+   Note `WorkerLabelsKnown: true` is UNCONDITIONAL — a label-aware leader
+   always records presence, including for unlabeled workers (spec §4.3).
+
+4. Commit literal (step 8 of `Publish`): add
+
+```go
+	ParkedCount:  len(in.ParkedPartitions),
+	ParkedDigest: types.PartitionSetDigest(in.ParkedPartitions),
+```
+
+5. `buildLegacyAlias`: add to the returned `types.Assignment`:
+
+```go
+	WorkerLabels:      payload.WorkerLabels,
+	WorkerLabelsKnown: payload.WorkerLabelsKnown,
+```
+
+- [ ] **Step 4: Run new + existing publisher tests**
+
+Run: `go test ./internal/assignment/ -run 'TestCheckCoverage|TestPublish|TestBuildLegacyAlias' -race`
+Expected: PASS. Existing coverage tests keep passing because a nil parked
+set degenerates to the old check exactly.
+
+One expected ripple: any existing publisher test asserting exact payload
+bytes/hashes now sees `worker_labels_known:true` in canonical bytes.
+Update those fixtures — this is the one-time fleet-wide payload re-hash
+the spec accepts (§4.3 compat note), not a regression.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make lint
+git add types/assignment_commit.go types/partition.go internal/assignment/assignment_publisher.go internal/assignment/assignment_publisher_labels_test.go
+git commit -m "feat(assignment): labels-of-record on payloads and parked-partition commit metadata"
+```
+
+---
+
+### Task 8: Calculator — label reads, confirmation state, pipeline wiring
+
+Replaces the single strategy call with the label pipeline (spec §6, §7,
+§8.5). After this task the leader assigns by label end-to-end.
+
+**Files:**
+- Create: `internal/assignment/labels_state.go`
+- Modify: `internal/assignment/calculator.go` — struct fields (near the
+  other mu-guarded maps), `rebalance` (:1646-1811: after `snapshotSource`,
+  replacing the `c.Strategy.Assign` call at :1707 and extending the
+  `PublishInput` literal at :1777), `handleRebalance` sentinel list
+  (:1505-1525)
+- Modify: `internal/assignment/calculator.go` — `NewCalculatorWithConfig`
+  defaults for the two new config fields
+- Test: `internal/assignment/labels_state_test.go` (new),
+  `internal/assignment/calculator_labels_test.go` (new)
+
+**Interfaces:**
+- Consumes: Tasks 5, 6, 7 (`GetHeartbeatsFor`, topology/compute, publisher
+  inputs), config fields (Task 4).
+- Produces:
+  - `errLabelObservationDeferred` — benign-abort sentinel
+  - `errLabelReadBroadFailure` — broad heartbeat-read failure abort
+  - `(c *Calculator) readWorkerLabels(ctx, workers []string) (labels map[string][]string, unknown map[string]bool, err error)`
+  - `(c *Calculator) decideEmptyPoolActions(topo labelTopology, unknown map[string]bool) (map[string]emptyPoolAction, error)`
+  - `(c *Calculator) commitLabelObservation(topo labelTopology, parkedCount int)` — post-publish state advance
+  - Task 9 consumes: `c.labelState` internals for timer arming.
+
+- [ ] **Step 1: Create the state container + decision logic (failing tests first)**
+
+```go
+// internal/assignment/labels_state_test.go — core state-machine tests,
+// all with an injected clock (Config.Now).
+package assignment
+
+func newLabelStateForTest(now func() time.Time, grace time.Duration) *labelState {
+	return newLabelState(grace, now)
+}
+
+func TestLabelState_DeferOnceThenPark(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	st := newLabelStateForTest(clock, time.Minute)
+
+	// First observation of an empty pool for "vip": defer (spec §8.5).
+	act, deferred := st.observeEmptyPools([]string{"vip"})
+	require.True(t, deferred)
+	require.Empty(t, act)
+
+	// Second consecutive observation: act — inside grace ⇒ park.
+	act, deferred = st.observeEmptyPools([]string{"vip"})
+	require.False(t, deferred)
+	require.Equal(t, emptyPoolPark, act["vip"])
+
+	// emptySince started at the FIRST observation: advancing the clock
+	// past grace-from-first flips to spill (confirmation does not extend
+	// the grace window).
+	now = now.Add(61 * time.Second)
+	act, deferred = st.observeEmptyPools([]string{"vip"})
+	require.False(t, deferred)
+	require.Equal(t, emptyPoolSpill, act["vip"])
+}
+
+func TestLabelState_NonEmptyResets(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	st := newLabelStateForTest(func() time.Time { return now }, time.Minute)
+
+	_, _ = st.observeEmptyPools([]string{"vip"})
+	st.observeNonEmpty([]string{"vip"}) // pool recovered
+	_, deferred := st.observeEmptyPools([]string{"vip"})
+	require.True(t, deferred, "recovery resets the confirmation streak AND emptySince")
+}
+
+func TestLabelState_PruneRemovedLabels(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	st := newLabelStateForTest(func() time.Time { return now }, time.Minute)
+	_, _ = st.observeEmptyPools([]string{"vip"})
+	st.prune(map[string]bool{}) // "vip" no longer in the snapshot
+	require.Empty(t, st.emptySince, "stale grace clocks must not leak")
+}
+
+func TestLabelState_ZeroGraceSpillsImmediatelyAfterConfirmation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	st := newLabelStateForTest(func() time.Time { return now }, 0)
+	_, deferred := st.observeEmptyPools([]string{"vip"})
+	require.True(t, deferred, "confirmation still applies at grace=0")
+	act, _ := st.observeEmptyPools([]string{"vip"})
+	require.Equal(t, emptyPoolSpill, act["vip"], "grace 0 = spill as soon as confirmed")
+}
+
+func TestLabelState_UnknownWorkerDeferThenAct(t *testing.T) {
+	t.Parallel()
+
+	st := newLabelStateForTest(time.Now, time.Minute)
+	require.True(t, st.observeUnknownWorkers([]string{"w2"}), "first: defer")
+	require.False(t, st.observeUnknownWorkers([]string{"w2"}), "second consecutive: act")
+	st.observeUnknownWorkers(nil) // successful read resets
+	require.True(t, st.observeUnknownWorkers([]string{"w2"}), "reset after recovery")
+}
+```
+
+- [ ] **Step 2: Implement `internal/assignment/labels_state.go`**
+
+```go
+package assignment
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// errLabelObservationDeferred is the benign-abort sentinel for the first
+// observation of a disruptive label condition (previously non-empty pool
+// reads empty; worker labels unreadable). Deliberately distinct from the
+// suspicious-observation sentinels: those are swallowed without
+// label-aware re-arm; this one arms the label re-check timer.
+var errLabelObservationDeferred = errors.New("label observation deferred pending confirmation")
+
+// errLabelReadBroadFailure aborts a rebalance whose heartbeat label reads
+// failed broadly (bucket/connectivity-class trouble or more than
+// max(1, 10%) of workers unreadable). Never converted into label
+// decisions: a broad failure must not empty-assign the fleet.
+var errLabelReadBroadFailure = errors.New("worker label read failed broadly")
+
+// labelState tracks per-label grace clocks and defer-once confirmation
+// streaks (spec §8.5). All methods are called from the rebalance path
+// (serialized by rebalanceMu) but the mutex keeps the timer path (Task 9)
+// safe when it inspects remaining grace.
+type labelState struct {
+	mu    sync.Mutex
+	grace time.Duration
+	now   func() time.Time
+
+	emptySince    map[string]time.Time // label → first empty observation
+	emptyStreak   map[string]int       // label → consecutive empty observations
+	unknownStreak map[string]int       // workerID → consecutive unreadable-label observations
+}
+
+func newLabelState(grace time.Duration, now func() time.Time) *labelState {
+	if now == nil {
+		now = time.Now
+	}
+	return &labelState{
+		grace:         grace,
+		now:           now,
+		emptySince:    map[string]time.Time{},
+		emptyStreak:   map[string]int{},
+		unknownStreak: map[string]int{},
+	}
+}
+
+// observeEmptyPools records this rebalance's empty-pool set and returns
+// the action per confirmed-empty label. deferred=true means at least one
+// label is on its FIRST empty observation — the caller aborts the
+// rebalance with errLabelObservationDeferred and arms the re-check timer.
+// emptySince always starts at the first observation so the deferral does
+// not extend the effective grace window.
+func (s *labelState) observeEmptyPools(empty []string) (map[string]emptyPoolAction, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	deferred := false
+	actions := make(map[string]emptyPoolAction, len(empty))
+	for _, l := range empty {
+		if _, ok := s.emptySince[l]; !ok {
+			s.emptySince[l] = now
+		}
+		s.emptyStreak[l]++
+		if s.emptyStreak[l] < 2 {
+			deferred = true
+			continue
+		}
+		if now.Sub(s.emptySince[l]) < s.grace {
+			actions[l] = emptyPoolPark
+		} else {
+			actions[l] = emptyPoolSpill
+		}
+	}
+
+	return actions, deferred
+}
+
+// observeNonEmpty resets streak and grace clock for recovered pools.
+func (s *labelState) observeNonEmpty(labels []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, l := range labels {
+		delete(s.emptySince, l)
+		delete(s.emptyStreak, l)
+	}
+}
+
+// observeUnknownWorkers implements defer-once for unreadable labels.
+// Returns true when at least one worker is on its first unreadable
+// observation (caller defers). Passing the empty set resets everything
+// (a fully successful read).
+func (s *labelState) observeUnknownWorkers(unknown []string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(unknown) == 0 {
+		clear(s.unknownStreak)
+		return false
+	}
+	current := make(map[string]bool, len(unknown))
+	deferred := false
+	for _, w := range unknown {
+		current[w] = true
+		s.unknownStreak[w]++
+		if s.unknownStreak[w] < 2 {
+			deferred = true
+		}
+	}
+	// Workers that recovered reset their streak.
+	for w := range s.unknownStreak {
+		if !current[w] {
+			delete(s.unknownStreak, w)
+		}
+	}
+
+	return deferred
+}
+
+// prune drops state for labels absent from the current snapshot.
+func (s *labelState) prune(currentLabels map[string]bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for l := range s.emptySince {
+		if !currentLabels[l] {
+			delete(s.emptySince, l)
+			delete(s.emptyStreak, l)
+		}
+	}
+}
+
+// minRemainingGrace returns the shortest time until an emptySince clock
+// crosses grace, and whether any clock is running. The re-check timer
+// (Task 9) arms with this value after a rebalance that parked anything.
+func (s *labelState) minRemainingGrace() (time.Duration, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	found := false
+	var minLeft time.Duration
+	now := s.now()
+	for _, since := range s.emptySince {
+		left := s.grace - now.Sub(since)
+		if left < 0 {
+			left = 0
+		}
+		if !found || left < minLeft {
+			minLeft, found = left, true
+		}
+	}
+
+	return minLeft, found
+}
+```
+
+- [ ] **Step 3: Run the state tests**
+
+Run: `go test ./internal/assignment/ -run 'TestLabelState' -v -race`
+Expected: PASS.
+
+- [ ] **Step 4: Wire into the rebalance path (failing test first)**
+
+Test (in `calculator_labels_test.go`, using the package's existing
+calculator test harness — embedded NATS, `NewCalculatorWithConfig`, fake
+heartbeats seeded into the heartbeat bucket as JSON):
+
+```go
+// TestRebalance_LabelRouting_EndToEnd: 2 workers (w0 labels=[vip],
+// w1 unlabeled) with live heartbeats, source = 1 vip + 1 plain partition.
+// Trigger a rebalance; read the published commit + payloads; assert:
+//   - w0's payload contains exactly the vip partition, WorkerLabels=[vip],
+//     WorkerLabelsKnown=true
+//   - w1's payload contains exactly the plain partition
+//   - commit.ParkedCount == 0
+//
+// TestRebalance_EmptyPool_DeferThenPark: source has a "ghost"-labeled
+// partition with no matching worker. First rebalance attempt returns
+// errLabelObservationDeferred (assert via handleRebalance treating it as
+// benign nil + no publish happened). Second attempt publishes with
+// commit.ParkedCount == 1 and the ghost partition in no payload.
+```
+
+- [ ] **Step 5: Implement the wiring**
+
+Calculator struct additions:
+
+```go
+	// labelState carries per-label grace clocks and defer-once streaks.
+	labelState *labelState
+```
+
+Init in `NewCalculatorWithConfig`:
+`c.labelState = newLabelState(cfg.LabelSpillGrace, cfg.Now)` (after the
+existing Now-defaulting; policy string defaulted to "dedicated" when
+empty).
+
+`readWorkerLabels` (in calculator.go, near getActiveWorkers):
+
+```go
+// readWorkerLabels fetches labels-of-record for the rebalance worker set
+// (spec §6). One bounded retry for missing workers; then the taxonomy:
+// more than max(1, 10%) unreadable ⇒ errLabelReadBroadFailure (broad
+// failures must never become label decisions). Legacy heartbeats decode
+// with nil labels — that is a SUCCESSFUL read of an empty set.
+func (c *Calculator) readWorkerLabels(ctx context.Context, workers []string) (map[string][]string, map[string]bool, error) {
+	hbs, fails, err := c.monitor.GetHeartbeatsFor(ctx, workers)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", errLabelReadBroadFailure, err)
+	}
+	missing := missingWorkers(workers, hbs)
+	if len(missing) > 0 { // one inline retry for the stragglers
+		retry, retryFails, rerr := c.monitor.GetHeartbeatsFor(ctx, missing)
+		if rerr == nil {
+			maps.Copy(hbs, retry)
+			fails = retryFails // post-retry classification uses the fresh errors
+		}
+		missing = missingWorkers(workers, hbs)
+	}
+
+	// Error-CLASS taxonomy first (spec §6): a connectivity or
+	// degrading-JetStream failure is broad by nature, regardless of how
+	// many workers it hit — in a 1-worker fleet a count-based rule alone
+	// would misclassify it as an isolated unknown and eventually
+	// empty-assign the whole fleet. The count rule below only governs
+	// UNCLASSIFIED failures (e.g. key-not-found on a live worker,
+	// malformed payloads).
+	for _, w := range missing {
+		ferr := fails[w]
+		if natsutil.IsConnectivityError(ferr) || natsutil.IsDegradingJetStreamError(ferr) {
+			return nil, nil, fmt.Errorf("%w: worker %s: %w", errLabelReadBroadFailure, w, ferr)
+		}
+	}
+
+	broadCap := max(1, len(workers)/10)
+	if len(missing) > broadCap {
+		return nil, nil, fmt.Errorf("%w: %d of %d workers unreadable", errLabelReadBroadFailure, len(missing), len(workers))
+	}
+
+	labels := make(map[string][]string, len(hbs))
+	for w, hb := range hbs {
+		labels[w] = hb.Labels
+	}
+	unknown := make(map[string]bool, len(missing))
+	for _, w := range missing {
+		unknown[w] = true
+	}
+
+	return labels, unknown, nil
+}
+
+// missingWorkers returns workers absent from the heartbeat map, sorted.
+func missingWorkers(workers []string, hbs map[string]types.Heartbeat) []string {
+	var out []string
+	for _, w := range workers {
+		if _, ok := hbs[w]; !ok {
+			out = append(out, w)
+		}
+	}
+	slices.Sort(out)
+
+	return out
+}
+```
+
+Compile-order note: this task calls `c.requestLabelRecheck(...)` and
+`c.armLabelRecheckAfterRebalance(...)`, both owned by Task 9. Define BOTH
+as logging no-op stubs in `labels_state.go` in THIS task so it compiles
+and tests standalone:
+
+```go
+// requestLabelRecheck is completed by the label re-check machinery; the
+// stub records intent so Task 8 is testable standalone.
+func (c *Calculator) requestLabelRecheck(reason string) {
+	c.Logger.Debug("label recheck requested", "reason", reason)
+}
+
+func (c *Calculator) armLabelRecheckAfterRebalance(parkedCount int) {}
+```
+
+(Task 9 replaces both bodies; its tests fail until it does.)
+
+In `rebalance` (calculator.go), replace the block at :1706-1711:
+
+```go
+	// --- label pipeline (spec §7) ---
+	labels, unknown, lerr := c.readWorkerLabels(ctx, workers)
+	if lerr != nil {
+		// Spec §6: broad label-read failures route to the manager's
+		// KV-error/degraded machinery — the OnEnumerationError precedent
+		// (config.go seam). Wire a new optional callback:
+		//   assignment.Config.OnLabelReadBroadFailure func(err error)
+		// which startCalculator (manager_assignment.go:116) connects to
+		// the manager's KV-error recorder (the same m.recordKVError
+		// routing heartbeat/election ops use — see kv_error_classify.go;
+		// match its exact signature at the call site). Nil-safe: skip
+		// when unwired (unit-test default).
+		if c.OnLabelReadBroadFailure != nil {
+			c.OnLabelReadBroadFailure(lerr)
+		}
+		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
+		return c.wrapStopErr(lerr)
+	}
+
+	unknownList := slices.Sorted(maps.Keys(unknown))
+	unknownDeferred := c.labelState.observeUnknownWorkers(unknownList)
+
+	topo := buildLabelTopology(topologyInput{
+		Workers:    workers,
+		Labels:     labels,
+		Unknown:    unknown,
+		Partitions: partitions,
+		Policy:     c.UnlabeledPartitionPolicy,
+	})
+
+	nonEmpty := make([]string, 0, len(topo.SortedLabels))
+	for _, l := range topo.SortedLabels {
+		if len(topo.Pools[l]) > 0 {
+			nonEmpty = append(nonEmpty, l)
+		}
+	}
+	c.labelState.observeNonEmpty(nonEmpty)
+	actions, emptyDeferred := c.labelState.observeEmptyPools(topo.EmptyLabels)
+
+	currentLabels := make(map[string]bool, len(topo.SortedLabels))
+	for _, l := range topo.SortedLabels {
+		currentLabels[l] = true
+	}
+	c.labelState.prune(currentLabels)
+
+	if unknownDeferred || emptyDeferred {
+		c.requestLabelRecheck("observation_deferred") // Task 9; arms timer + pending flag
+		c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
+		c.Metrics.RecordRebalanceAttempt(lifecycle, true)
+		return errLabelObservationDeferred
+	}
+
+	assignments, parked, err := computeLabelAssignments(c.Strategy, topo, actions)
+	if err != nil {
+		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
+		return c.wrapStopErr(fmt.Errorf("assignment calculation failed: %w", err))
+	}
+```
+
+Orphan gauge (the block currently at :1717-1725) compares against the
+ELIGIBLE count:
+
+```go
+	eligible := len(partitions) - len(parked)
+	if assignedCount != eligible {
+		c.Metrics.RecordOrphanedPartitions(eligible - assignedCount)
+	} else {
+		c.Metrics.RecordOrphanedPartitions(0)
+	}
+```
+
+`PublishInput` literal (:1777) gains:
+
+```go
+		ParkedPartitions:    parked,
+		WorkerLabels:        labels,
+```
+
+After the publish succeeds (next to the existing tracking-state update),
+arm/disarm the re-check timer for parked grace (Task 9 provides the
+function; until Task 9 lands, leave a call to a no-op
+`c.armLabelRecheckAfterRebalance(len(parked))` defined in
+labels_state.go as `func (c *Calculator) armLabelRecheckAfterRebalance(parkedCount int) {}`
+so this task compiles and Task 9 replaces the body).
+
+`handleRebalance` (:1505-1525) — add the benign case:
+
+```go
+	// A deferred label observation is an explicit "confirm before
+	// acting" decision; the label re-check timer re-fires it. Benign.
+	if errors.Is(err, errLabelObservationDeferred) {
+		return nil
+	}
+```
+
+Do the same in `triggerPartitionRebalance`'s error handling: treat
+`errLabelObservationDeferred` like the suppressed-observation case
+(re-arm `pendingPartitionUpdate` is NOT needed — the label re-check timer
+owns the retry; just convert to nil).
+
+- [ ] **Step 6: Taxonomy tests (spec §14 small-fleet pins)**
+
+Add to `calculator_labels_test.go`, using the real heartbeat bucket
+(stage failures by simply NOT writing heartbeat values for the targeted
+workers while keeping them in the `workers` argument):
+
+```go
+// TestReadWorkerLabels_SmallFleetTaxonomy:
+//   3 workers, heartbeat values present for w0,w1 only:
+//     → labels for w0,w1; unknown == {w2}; err == nil   (1-of-3 isolated)
+//   2 workers, value present for w0 only:
+//     → unknown == {w1}; err == nil                     (1-of-2 isolated: max(1,10%)=1)
+//   3 workers, values present for w0 only:
+//     → err wraps errLabelReadBroadFailure              (2-of-3 broad)
+//   1 worker whose Get fails with a CONNECTIVITY-classed error (stage via
+//   a canceled/closed connection or a fake KV returning nats.ErrTimeout):
+//     → err wraps errLabelReadBroadFailure              (class beats count:
+//       the 1-worker fleet must NOT treat this as isolated unknown)
+//   broad failure must abort BEFORE any label decision: assert no commit
+//   was published, labelState streaks were not advanced, and
+//   OnLabelReadBroadFailure fired exactly once with an error that the
+//   MANAGER-side adapter can route (the count-based case is admitted via
+//   the ErrKVUnavailable wrap — see the Task 4 adapter and
+//   TestRecordLabelReadFailure_Routing, which prove the degraded circuit
+//   observes it; this test only pins the calculator half).
+```
+
+- [ ] **Step 7: Run the calculator tests**
+
+Run: `go test ./internal/assignment/ -race`
+Expected: all green — including every pre-existing calculator test (the
+I1 golden path: no labels anywhere ⇒ identical assignments; any failure
+here means the pipeline broke legacy behavior — stop and fix).
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+make lint
+git add internal/assignment/
+git commit -m "feat(assignment): label-aware rebalance pipeline with park and spill"
+```
+
+---
+
+### Task 9: Label re-check timer + `requestLabelRecheck`
+
+The guaranteed second observation (spec §8.3): grace expiry and deferral
+confirmation must re-fire without any external event, surviving busy
+states.
+
+**Files:**
+- Modify: `internal/assignment/labels_state.go` (calculator-side methods)
+- Modify: `internal/assignment/calculator.go` — fields, `Start` (launch
+  the goroutine next to `monitorPartitions`), `Stop` path, lifecycle
+  constants next to `lifecyclePartitionUpdate` (:640-644)
+- Test: `internal/assignment/labels_recheck_test.go` (new)
+
+**Interfaces:**
+- Consumes: Task 8 state; `stateMach.TryClaimRebalancing` /
+  `RunClaimedRebalanceErr` (same primitives as `triggerPartitionRebalance`,
+  calculator.go:823-846); `ctxFromStopCh`.
+- Produces: `requestLabelRecheck(reason string)` — also consumed by the
+  worker monitor wiring (Task 11).
+
+Design (mirrors `monitorPartitions` exactly):
+
+```go
+const (
+	lifecycleLabelRecheck = "label_recheck"
+	lifecycleLabelChange  = "label_change"
+)
+
+// Calculator fields:
+	pendingLabelRecheck atomic.Bool
+	labelRecheckCh      chan struct{} // capacity 1; timer + external signals coalesce
+```
+
+- `requestLabelRecheck(reason)`: replace Task 8's stub — set
+  `pendingLabelRecheck=true`, log at Debug with reason, non-blocking send
+  on `labelRecheckCh`. (Task 8 left `requestLabelRecheck` and
+  `armLabelRecheckAfterRebalance` as no-op stubs; this task supplies the
+  real bodies.)
+- `armLabelRecheckAfterRebalance(parkedCount)`: replace Task 8's no-op —
+  if `parkedCount > 0`, compute `labelState.minRemainingGrace()` and
+  `time.AfterFunc(left+50ms, func() { c.requestLabelRecheck("grace_expiry") })`,
+  storing the timer so Stop and re-arm cancel the previous one; if
+  nothing parked and nothing pending, cancel any armed timer.
+- `monitorLabelRecheck(ctx)` goroutine (started unconditionally in the
+  same place `monitorPartitions` starts; guarded by `stopCh`):
+
+```go
+func (c *Calculator) monitorLabelRecheck(ctx context.Context) {
+	drainTick := time.NewTicker(c.RebalanceGraceDrainInterval)
+	defer drainTick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-c.labelRecheckCh:
+		case <-drainTick.C:
+		}
+		if !c.pendingLabelRecheck.CompareAndSwap(true, false) {
+			continue
+		}
+		if c.inRecoveryGrace() {
+			c.pendingLabelRecheck.Store(true) // retry next tick
+			continue
+		}
+		if !c.stateMach.TryClaimRebalancing(context.Background(), lifecycleLabelRecheck) {
+			c.pendingLabelRecheck.Store(true) // busy; sticky flag survives
+			// Short retry so a deferral raised INSIDE a running rebalance
+			// (claim still held when the wake arrives) confirms in ~2s
+			// rather than waiting a full drain tick (spec §16 item 7:
+			// re-check well under the drain cadence). Coalesced: the
+			// channel has capacity 1.
+			time.AfterFunc(2*time.Second, func() {
+				select {
+				case c.labelRecheckCh <- struct{}{}:
+				default:
+				}
+			})
+			continue
+		}
+		reqCtx, cancel := ctxFromStopCh(context.Background(), c.stopCh, partitionRebalanceRequestTimeout)
+		err := c.stateMach.RunClaimedRebalanceErr(reqCtx, lifecycleLabelRecheck)
+		cancel()
+		if errors.Is(err, errLabelObservationDeferred) {
+			// Deferral re-arms itself via requestLabelRecheck inside the
+			// rebalance; nothing extra to do (flag already set again).
+			continue
+		}
+		c.restorePendingOnGraceBail(errToPendingLabel(err, c))
+	}
+}
+```
+
+(`errToPendingLabel` = tiny adapter that restores
+`pendingLabelRecheck=true` when the error is the recovery-grace bail —
+reuse the `restorePendingOnGraceBail` pattern but for the label flag; a
+straight copy with the label flag is fine and clearer than
+generalizing.)
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/assignment/labels_recheck_test.go
+// Uses the package's existing calculator harness (embedded NATS).
+
+// TestLabelRecheck_GhostLabelProgressesWithoutExternalEvents: the spec §14
+// no-external-event progression pin. Source contains a "ghost"-labeled
+// partition, no worker ever carries the label, grace = 500ms,
+// RebalanceGraceDrainInterval = 200ms. Drive ONE partition-update
+// rebalance (the label edit). Then, with no further worker/source events:
+//   - within ~2s a commit appears with ParkedCount == 1  (defer → confirm → park)
+//   - within ~2s after grace expiry a commit appears with ParkedCount == 0
+//     and the ghost partition present in some worker's payload (spill)
+// Poll the commit key with require.Eventually; no manual TriggerRebalance
+// calls after the first.
+
+// TestLabelRecheck_StickyUnderBusyStateMachine: hold the rebalancing
+// claim (TryClaimRebalancing from the test), call requestLabelRecheck,
+// assert pendingLabelRecheck stays true and no rebalance ran; release the
+// claim; assert the drain tick picks it up (a rebalance runs within one
+// RebalanceGraceDrainInterval).
+
+// TestLabelRecheck_DisarmedOnStop: requestLabelRecheck, then Stop; no
+// goroutine leak (the package's leak detector / doneCh join covers this)
+// and no rebalance after Stop.
+```
+
+- [ ] **Step 2: Run to verify failure, then implement as designed above**
+
+Run: `go test ./internal/assignment/ -run 'TestLabelRecheck' -v`
+Expected: compile errors, then behavioral failures until the goroutine +
+flag land.
+
+- [ ] **Step 3: Full package + lint + commit**
+
+Run: `go test ./internal/assignment/ -race && make lint`
+
+```bash
+git add internal/assignment/
+git commit -m "feat(assignment): label re-check timer with sticky retry across busy states"
+```
+
+---
+
+### Task 10: Worker-side stale-incarnation guard
+
+Spec §9. A worker must never apply a payload whose labels-of-record
+mismatch its own labels; rejection is a first-class outcome — no legacy
+alias fallback, no apply retry, no ack.
+
+**Files:**
+- Modify: `manager_assignment.go` — `buildAssignmentFromCommit` return
+  literal (:1212-1220), `applyAssignmentWithPrev` (:1434, guard at top),
+  new sentinel + guard helper near it
+- Modify: `manager.go` — `applyInitialAssignment` (:716 and :780 call
+  sites convert the sentinel to success-without-apply)
+- Test: `manager_label_guard_test.go` (new; root package unit tests
+  following the style of `manager_apply_test.go`)
+
+**Interfaces:**
+- Consumes: `Assignment.WorkerLabels`/`WorkerLabelsKnown` (Task 7),
+  `m.workerLabels` (Task 4).
+- Produces: `errLabelIncarnationRejected` (manager-internal sentinel);
+  guard semantics for Task 14's integration tests.
+
+Key placement fact (verified): the apply paths converge on TWO sibling
+entrypoints, not one — `applyAssignmentWithPrev` (watcher-driven commit
+:1110 via applyAssignment :1274, legacy alias :663, both startup branches
+manager.go:716/:780) AND `applyAssignmentWithPrevSkipJitter`
+(:1454, used by the `scheduleApplyRetry` re-attempt path :1745), both of
+which call `applyAssignmentWithPrevCore` directly. The guard is a shared
+helper invoked at the head of BOTH wrappers, before either reaches Core
+and before any failure handler — keeping `scheduleApplyRetry` out of the
+reject path (retrying a payload that can never become applicable is the
+futile loop the spec forbids). The retry entrypoint is defense in depth:
+labels are immutable per process, so a stashed retry that matched at
+stash time still matches — but the guard there costs one comparison and
+makes the coverage claim true by construction.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// manager_label_guard_test.go
+package parti
+
+// Construct managers the way manager_apply_test.go does (test-constructed
+// Manager with workerLabels set directly; no NATS needed for the guard
+// unit tests).
+
+func TestLabelGuard_Matrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		workerLabels []string
+		asg          Assignment
+		rejected     bool
+	}{
+		{"known+equal applies", []string{"vip"},
+			Assignment{WorkerLabels: []string{"vip"}, WorkerLabelsKnown: true}, false},
+		{"known+mismatch rejects", nil,
+			Assignment{WorkerLabels: []string{"vip"}, WorkerLabelsKnown: true}, true},
+		{"known+empty vs labeled worker rejects", []string{"vip"},
+			Assignment{WorkerLabelsKnown: true}, true},
+		{"unknown (pre-label payload) applies", []string{"vip"},
+			Assignment{}, false},
+		{"known+empty vs unlabeled worker applies", nil,
+			Assignment{WorkerLabelsKnown: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{workerLabels: tc.workerLabels}
+			require.Equal(t, tc.rejected, m.labelIncarnationMismatch(tc.asg))
+		})
+	}
+}
+
+// TestLabelGuard_RejectIsTerminalNoRetryNoAck: build a minimal manager as
+// manager_apply_test.go does (with a stub handoff coordinator + heartbeat
+// snapshot recorder), feed a mismatched assignment through
+// applyAssignmentWithPrev, and assert:
+//   - the returned error Is errLabelIncarnationRejected
+//   - the handoff coordinator's Apply was NEVER invoked
+//   - the applied-snapshot (ack source) was NOT advanced
+//   - no apply-retry was scheduled (the retry stash stays empty)
+//
+// TestLabelGuard_BuildAssignmentCopiesLabels: a commit whose payload has
+// WorkerLabels=["vip"], WorkerLabelsKnown=true round-trips into the
+// Assignment returned by buildAssignmentFromCommit.
+//
+// TestLabelGuard_RetryEntrypointAlsoGuarded: feed a mismatched assignment
+// through applyAssignmentWithPrevSkipJitter (the scheduleApplyRetry
+// entrypoint, manager_assignment.go:1454) and assert the same terminal
+// reject: errLabelIncarnationRejected, no coordinator Apply, no ack, no
+// re-scheduled retry.
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test . -run 'TestLabelGuard' -v`
+Expected: compile errors (helper/sentinel missing).
+
+- [ ] **Step 3: Implement**
+
+Sentinel + guard (manager_assignment.go, near the apply pipeline):
+
+```go
+// errLabelIncarnationRejected marks an assignment payload computed for a
+// different process incarnation behind this worker's stable ID (the
+// labels-of-record mismatch this worker's configured labels). Rejection
+// is terminal for that payload: no alias fallback, no apply retry, no
+// ack — convergence arrives as the next label-correct commit via the
+// leader's label-change trigger.
+var errLabelIncarnationRejected = errors.New("assignment labels-of-record mismatch worker labels; payload from a different incarnation")
+
+// labelIncarnationMismatch implements the spec §9 guard matrix. Both
+// sides are sorted+deduplicated (normalizeWorkerLabels for the worker,
+// publisher-normalized labels-of-record for the payload), so slice
+// equality is set equality.
+func (m *Manager) labelIncarnationMismatch(a Assignment) bool {
+	if !a.WorkerLabelsKnown {
+		return false // pre-label payload: compat apply
+	}
+
+	return !slices.Equal(a.WorkerLabels, m.workerLabels)
+}
+```
+
+At the very top of BOTH `applyAssignmentWithPrev` AND
+`applyAssignmentWithPrevSkipJitter` (before jitter, before
+`applyAssignmentWithPrevCore`, before ANY side effect) — extract the
+block below into a shared `rejectIfStaleIncarnation(newAssignment) error`
+helper called from each:
+
+```go
+	if m.labelIncarnationMismatch(newAssignment) {
+		m.logger.Warn("rejecting assignment computed for a different incarnation of this worker ID",
+			"worker_id", m.WorkerID(),
+			"payload_labels", newAssignment.WorkerLabels,
+			"worker_labels", m.workerLabels,
+			"version", newAssignment.Version)
+		if lm, ok := m.metrics.(types.LabelMetrics); ok {
+			lm.IncrementLabelIncarnationReject()
+		}
+
+		return errLabelIncarnationRejected
+	}
+```
+
+`buildAssignmentFromCommit` return literal gains:
+
+```go
+		WorkerLabels:      payload.WorkerLabels,
+		WorkerLabelsKnown: payload.WorkerLabelsKnown,
+```
+
+`applyInitialAssignment` (manager.go): both apply branches convert the
+sentinel to success-without-apply — the worker stays in
+`WaitingAssignment` and the next label-correct commit (delivered by the
+existing watcher) applies normally:
+
+```go
+			if err := m.applyAssignmentWithPrev(Assignment{}, newAsg); err != nil {
+				if errors.Is(err, errLabelIncarnationRejected) {
+					m.logger.Warn("startup: current commit is for a different incarnation; waiting for a label-correct commit")
+					return nil
+				}
+				return err
+			}
+```
+
+and the same conversion around the alias-branch apply at manager.go:780.
+Critically, the commit-path reject must NOT fall through to the legacy
+alias branch: the guard returns from inside `applyAssignmentWithPrev`
+after `buildAssignmentFromCommit` succeeded (`ok==true`), so the existing
+`ok==false → alias fallback` route is untouched and never sees rejects.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test . -run 'TestLabelGuard|TestApply' -race`
+Expected: new tests PASS; every existing apply-path test still green
+(assignments without `WorkerLabelsKnown` hit the compat branch).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make lint
+git add manager_assignment.go manager.go manager_label_guard_test.go
+git commit -m "feat: reject assignments computed for a different worker incarnation"
+```
+
+---
+
+### Task 11: Label-change trigger — monitor fingerprints + calculator wiring
+
+Spec §9 convergence: detect label changes behind live worker IDs from
+heartbeat PUTs, level-triggered across watcher sessions, delivered via
+`requestLabelRecheck` (never the worker-set change path, which no-ops on
+an unchanged set at calculator.go:1052).
+
+**Files:**
+- Modify: `internal/assignment/worker_monitor.go` — monitor-lifetime
+  fingerprint map + `SetOnLabelChange`; PUT/DELETE handling inside
+  `processWatcherEvents` (:381-470)
+- Modify: `internal/assignment/calculator.go` — wire
+  `SetOnLabelChange` after the `NewWorkerMonitor` call (:269)
+- Test: `internal/assignment/worker_monitor_label_test.go` (new)
+
+**Interfaces:**
+- Consumes: `requestLabelRecheck` (Task 9), `types.DecodeHeartbeat`.
+- Produces: `SetOnLabelChange(fn func())` — invoked (coalesced by the
+  caller) whenever a heartbeat PUT's labels differ from the retained
+  fingerprint for that key.
+
+Design:
+
+```go
+// Monitor fields:
+	labelFPMu sync.Mutex
+	labelFP   map[string]uint64 // heartbeat key → fingerprint of sorted labels; MONITOR lifetime (survives watcher sessions)
+	onLabelChangeCb func()
+
+// labelFingerprint hashes a sorted label set; 0 is reserved for "no labels".
+func labelFingerprint(labels []string) uint64 {
+	if len(labels) == 0 {
+		return 0
+	}
+	var h xxh3.Hasher
+	for i, l := range labels {
+		if i > 0 {
+			_, _ = h.WriteString("\n")
+		}
+		_, _ = h.WriteString(l)
+	}
+	fp := h.Sum64()
+	if fp == 0 {
+		fp = 1
+	}
+	return fp
+}
+```
+
+In `processWatcherEvents`, inside the `jetstream.KeyValuePut` case (after
+the existing lastSeen bookkeeping, BEFORE the suppression decision is
+final):
+
+```go
+			// Label fingerprint: level-triggered across watcher sessions.
+			// The map deliberately outlives this session — a takeover PUT
+			// that lands while the watch is closed is caught when the next
+			// session's initial replay delivers the key's current value
+			// and it differs from the retained fingerprint.
+			if hb, derr := types.DecodeHeartbeat(entry.Value()); derr == nil {
+				fp := labelFingerprint(hb.Labels)
+				m.labelFPMu.Lock()
+				prev, seen := m.labelFP[key]
+				m.labelFP[key] = fp
+				m.labelFPMu.Unlock()
+				if seen && prev != fp {
+					m.logger.Info("worker label change detected", "key", key)
+					trigger = true // a label change is never a suppressible refresh
+					if m.onLabelChangeCb != nil {
+						m.onLabelChangeCb()
+					}
+				}
+			}
+```
+
+DELETE/PURGE case: also `delete(m.labelFP, entry.Key())` (a leave;
+rejoin-with-new-labels is a join covered by the worker-change path; a
+delete+rewrite missed entirely inside one watch gap replays as a PUT
+whose value differs from... nothing — first-seen seeds silently, and the
+join/leave key-set delta drives the worker-change rebalance instead).
+
+`SetOnLabelChange(fn func())` — plain setter (call before `Start`, like
+the constructor callback).
+
+Calculator wiring (calculator.go, immediately after `c.monitor =
+NewWorkerMonitor(...)` at :269):
+
+```go
+	c.monitor.SetOnLabelChange(func() {
+		if lm, ok := c.Metrics.(types.LabelMetrics); ok {
+			lm.IncrementLabelChangeTrigger()
+		}
+		c.requestLabelRecheck("label_change")
+	})
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/assignment/worker_monitor_label_test.go
+// Harness: embedded NATS heartbeat bucket like the sibling monitor tests.
+
+// TestWorkerMonitor_LabelChangeEscapesSuppression: start the monitor with
+// an onChange callback counter AND SetOnLabelChange counter. Publish
+// heartbeats for worker-0 with labels ["vip"] every 200ms (hbTTL 5s) —
+// after the first, refreshes are suppressed (assert onChange does not
+// grow). Then publish the SAME key with labels ["batch"]:
+//   - onLabelChange fires within the watcher latency (require.Eventually)
+//   - a subsequent identical-labels beat does NOT re-fire (fingerprint
+//     updated)
+//
+// TestWorkerMonitor_LabelChangeAcrossWatcherRestart: publish worker-0
+// with ["vip"]; wait for the fingerprint to seed (onLabelChange quiet).
+// Stop the watcher session (monitor test hook: kill the watcher via
+// m.stopWatcher(); the retry loop restarts it). While the watch is down,
+// publish worker-0 with ["batch"]. After the session re-establishes and
+// replays, onLabelChange must fire exactly once — the retained-
+// fingerprint-vs-replay comparison (spec §9, watcher-restart edge).
+//
+// TestWorkerMonitor_MalformedPayloadNoFingerprintChurn: a malformed
+// heartbeat PUT neither fires onLabelChange nor erases the retained
+// fingerprint (the next well-formed identical-labels beat stays quiet).
+//
+// TestWorkerMonitor_FirstSeenSeedsSilently: a brand-new worker key with
+// labels never fires onLabelChange (joins are the worker-change path's
+// job).
+```
+
+- [ ] **Step 2: Run to verify failure, implement per the design block, re-run**
+
+Run: `go test ./internal/assignment/ -run 'TestWorkerMonitor_Label' -v -race`
+Expected: fail (setter missing) → PASS after implementation.
+
+- [ ] **Step 3: End-to-end wiring test (calculator level)**
+
+Extend `calculator_labels_test.go`:
+
+```go
+// TestCalculator_TightTakeover_LabelChangeTriggersRebalance: real
+// calculator + heartbeat bucket. worker-0 heartbeats with ["vip"], one
+// vip partition assigned to it (initial rebalance). Now simulate a tight
+// takeover: keep the SAME heartbeat key alive but switch its payload to
+// labels [] (a different process incarnation; the key never lapses so
+// the worker SET never changes). Assert via require.Eventually that a
+// NEW commit is published in which the vip partition is NOT assigned to
+// worker-0 (parked or reassigned) — proving the label-change trigger
+// bypasses the unchanged-worker-set short-circuit end to end.
+```
+
+- [ ] **Step 4: Run full package, lint, commit**
+
+Run: `go test ./internal/assignment/ -race && make lint`
+
+```bash
+git add internal/assignment/
+git commit -m "feat(assignment): detect worker label changes from heartbeats and trigger rebalance"
+```
+
+---
+
+### Task 12: `LabelMetrics` extension interface + lifecycle
+
+Spec §13. Optional interface (type-asserted) so existing
+`MetricsCollector` implementors don't break.
+
+**Files:**
+- Modify: `types/metrics_collector.go` — add the interface (verbatim from
+  the plan header block) with Godoc stating lifecycle semantics
+- Modify: `internal/metrics/nop.go` — nop implements it
+- Modify: `internal/assignment/calculator.go` — record pool sizes /
+  parked counts / spill / fallback after each successful publish; zero
+  gauges for labels that left the snapshot
+- Test: `internal/assignment/calculator_label_metrics_test.go` (new)
+
+**Interfaces:**
+- Consumes: Tasks 8/9/10/11 record points (`IncrementLabelChangeTrigger`
+  and `IncrementLabelIncarnationReject` were wired there behind the same
+  type assertion).
+- Produces: `types.LabelMetrics` — documented contract: per-label gauges
+  recomputed on every completed rebalance; a label absent from the
+  current snapshot is explicitly zeroed in the same pass; counters
+  monotonic per process.
+
+- [ ] **Step 1: Failing test**
+
+```go
+// calculator_label_metrics_test.go — fakeLabelMetrics records calls.
+// Drive two rebalances through the calculator harness:
+//   1) source has vip partition + vip worker → RecordLabelPoolSize("vip",1),
+//      RecordParkedPartitions("vip",0)
+//   2) source rewritten WITHOUT any vip partition → the same pass emits
+//      RecordLabelPoolSize("vip",0) AND RecordParkedPartitions("vip",0)
+//      (zeroed, not leaked), and no further "vip" records afterwards.
+```
+
+- [ ] **Step 2: Implement**
+
+Calculator keeps `prevMetricLabels map[string]bool`; after each successful
+publish:
+
+```go
+	if lm, ok := c.Metrics.(types.LabelMetrics); ok {
+		current := map[string]bool{}
+		for _, l := range topo.SortedLabels {
+			current[l] = true
+			lm.RecordLabelPoolSize(l, len(topo.Pools[l]))
+			lm.RecordParkedPartitions(l, parkedCountByLabel[l])
+		}
+		for l := range c.prevMetricLabels {
+			if !current[l] {
+				lm.RecordLabelPoolSize(l, 0)
+				lm.RecordParkedPartitions(l, 0)
+			}
+		}
+		c.prevMetricLabels = current
+	}
+```
+
+(`parkedCountByLabel` is derived from the parked slice right here:
+`for _, p := range parked { parkedCountByLabel[p.Label]++ }` — parked
+partitions always carry their label. Spill actions call
+`lm.IncrementLabelSpill(l)` where the action map is applied; the
+unlabeled-group ladder falling through to AllWorkers calls
+`lm.IncrementUnlabeledFallback()`.)
+
+Nop implementation in `internal/metrics/nop.go` mirrors the existing nop
+method style.
+
+- [ ] **Step 3: Run, lint, commit**
+
+Run: `go test ./internal/assignment/ ./types/ ./internal/metrics/ -race && make lint`
+
+```bash
+git add types/metrics_collector.go internal/metrics/nop.go internal/assignment/
+git commit -m "feat(metrics): label assignment observability with per-label gauge lifecycle"
+```
+
+---
+
+### Task 13: Integration — label-only edit propagates end to end (priority)
+
+The user-priority scenario: a **label-only rewrite (same keys, same
+weights, new label) through the production update path** must flow KV
+source watch → leader rebalance → new assignments on live managers.
+Task 2 proved source-level propagation; this proves the whole system.
+
+**Files:**
+- Create: `test/integration/assignment/label_promotion_test.go`
+
+**Interfaces:**
+- Consumes: everything through Task 11; `testutil.WorkerCluster`,
+  `AddWorkerWithOptions`, `source.NewNatsKV`, `partcodec`.
+
+- [ ] **Step 1: Write the test**
+
+```go
+package assignment_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// partitionsOf returns the CanonicalID set of a manager's current assignment.
+func partitionsOf(m *parti.Manager) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range m.CurrentAssignment().Partitions {
+		out[p.CanonicalID()] = true
+	}
+	return out
+}
+
+func TestLabelPromotion_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	// Production-shaped source: partition list in a KV bucket.
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-e2e-partitions"})
+	require.NoError(t, err)
+	initial := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1},
+		{Keys: []string{"p1"}, Weight: 1},
+		{Keys: []string{"p2"}, Weight: 1},
+		{Keys: []string{"p3"}, Weight: 1},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, initial)) // seeds the bucket
+	require.NoError(t, src.Start(ctx))           // watch + reconcile loops
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.LabelSpillGrace = 5 * time.Second
+
+	// Same construction shape as manager_e2e_invariant_test.go (which
+	// uses testutil.NewWorkerClusterWithSource — prefer that helper if
+	// its config parameter fits; otherwise the literal below).
+	cluster := &testutil.WorkerCluster{
+		Config: cfg, Source: src, Strategy: strategy.NewConsistentHash(),
+		NC: nc, JS: js, T: t,
+	}
+	vipWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	plainWorker := cluster.AddWorkerWithOptions(ctx)
+	defer cluster.StopWorkers()
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	p0 := types.Partition{Keys: []string{"p0"}}.CanonicalID()
+
+	// Phase 0 — dedicated reservation: no labeled partitions yet, so the
+	// vip worker idles and the plain worker owns everything (spec §7).
+	require.Eventually(t, func() bool {
+		return len(partitionsOf(plainWorker)) == 4 && len(partitionsOf(vipWorker)) == 0
+	}, 20*time.Second, 200*time.Millisecond,
+		"dedicated policy must reserve the labeled worker")
+
+	// Phase 1 — PROMOTION: rewrite the full list with ONLY p0's label
+	// changed (same keys, same weights), OUT-OF-BAND via a raw KV write.
+	// CRITICAL: do NOT use src.Update here — NatsKV.Update refreshes its
+	// local cache and notifies its own listeners directly (without the
+	// KV watcher round trip), so a same-instance Update would let this
+	// test pass even with watch-path propagation broken. A raw kv.Put is
+	// exactly what an external operator/writer process does, and the
+	// manager-owned source can only learn about it through its WATCHER —
+	// which is the propagation path this test exists to pin.
+	promoted := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1, Label: "vip"}, // <- the only delta
+		{Keys: []string{"p1"}, Weight: 1},
+		{Keys: []string{"p2"}, Weight: 1},
+		{Keys: []string{"p3"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return partitionsOf(vipWorker)[p0] && !partitionsOf(plainWorker)[p0]
+	}, 30*time.Second, 200*time.Millisecond,
+		"label-only promotion must move p0 to the vip worker: KV watch → rebalance → assignment")
+
+	// Coverage invariant across the move: every partition owned exactly once.
+	require.Eventually(t, func() bool {
+		vip, plain := partitionsOf(vipWorker), partitionsOf(plainWorker)
+		if len(vip)+len(plain) != 4 {
+			return false
+		}
+		for id := range vip {
+			if plain[id] {
+				return false
+			}
+		}
+		return true
+	}, 20*time.Second, 200*time.Millisecond, "no orphan, no duplicate during promotion")
+
+	// Phase 2 — DEMOTION: label-only rewrite back, same out-of-band path.
+	// Under dedicated policy p0 must return to the plain worker and the
+	// vip worker must drain to empty (its KV assignment updated, not
+	// stale — see the stale check).
+	encoded, err = partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return !partitionsOf(vipWorker)[p0] && partitionsOf(plainWorker)[p0] &&
+			len(partitionsOf(vipWorker)) == 0
+	}, 30*time.Second, 200*time.Millisecond,
+		"label-only demotion must move p0 back and drain the reserved worker")
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `go test ./test/integration/assignment/ -run 'TestLabelPromotion_EndToEnd' -v -race -timeout 300s`
+Expected: PASS. If Phase 1 times out, debug order: (1) Task 2 source
+tests still green? (2) leader log shows "partition change detected"? (3)
+commit content via `nats kv get` — is the label present in the payload?
+
+- [ ] **Step 3: Commit**
+
+```bash
+make lint
+git add test/integration/assignment/label_promotion_test.go
+git commit -m "test(integration): runtime label promotion moves partitions across worker pools"
+```
+
+---
+
+### Task 14: Integration — orphan and stale-assignment regressions
+
+Three suites pinning spec I2/I8: nothing is ever silently unassigned, and
+no worker's KV assignment goes stale when its pool drains.
+
+**Files:**
+- Create: `test/integration/assignment/label_orphan_stale_test.go`
+
+- [ ] **Step 1: Write the stale-assignment (I8) test**
+
+```go
+// TestLabelDemotion_NoStaleAssignmentInKV: same 2-worker setup as Task 13
+// (vip + plain, dedicated). Promote p0 to vip; wait until the vip worker
+// owns it. Demote. Then assert against the ASSIGNMENT KV BUCKET directly
+// (not just CurrentAssignment): the commit's payload for the vip worker
+// exists and contains ZERO partitions — the merge contract publishes an
+// explicit empty entry rather than leaving the old vip payload dangling.
+//
+// Mechanics: read "assignment._commit" via kvutil.GetJSON[types.AssignmentCommit],
+// find commit.Payloads[vipWorkerID], fetch it with
+// assignment.FetchAndVerifyCommitPayload (exported helper used by the
+// manager), and require len(payload.Partitions) == 0 while
+// payload.WorkerLabelsKnown == true. Also require the vip worker's
+// heartbeat eventually acks the new version (Heartbeat.AppliedVersion ==
+// commit.Version) — the empty assignment was APPLIED, not ignored.
+```
+
+- [ ] **Step 2: Write the parked-coverage test**
+
+```go
+// TestGhostLabel_ParksThenSpills_NeverOrphans: 1 unlabeled worker,
+// LabelSpillGrace = 6s. Source: 3 plain partitions + 1 partition labeled
+// "ghost" (no worker will ever carry it).
+//
+// Phase park: require.Eventually a commit where ParkedCount == 1,
+// ParkedDigest == PartitionSetDigest({ghost}), and the union of all
+// payload partition sets == the 3 plain partitions (ghost in NO payload).
+// Invariant at every observation: assigned ∪ parked == source (fetch all
+// payloads, union with parked count, compare CanonicalID sets).
+//
+// Phase spill: after grace, require.Eventually a commit where
+// ParkedCount == 0 and the ghost partition IS in some payload. The
+// transition must happen with NO source/worker events — this pins the
+// label re-check timer end to end against a live cluster.
+//
+// Phase recover: add a "ghost"-labeled worker
+// (cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("ghost")) +
+// start). require.Eventually the ghost partition moves to it (re-home).
+```
+
+- [ ] **Step 3: Write the pool-outage lifecycle test**
+
+```go
+// TestLabelPoolOutage_ParkSpillRehome: 2 vip workers + 1 plain worker,
+// 2 vip partitions + 2 plain, LabelSpillGrace = 8s, dedicated policy.
+//
+//  1. Stable: vip partitions on vip workers only.
+//  2. Stop ONE vip worker: its vip partitions concentrate onto the
+//     surviving vip worker (no parking — the pool is non-empty; assert
+//     ParkedCount stays 0 through this transition).
+//  3. Stop the second vip worker: pool now empty. Within detection +
+//     confirmation, a commit parks BOTH vip partitions (ParkedCount == 2)
+//     and the plain worker does NOT receive them during grace.
+//  4. After grace: spill — vip partitions appear in the plain worker's
+//     payload, ParkedCount == 0.
+//  5. Restart a vip worker: partitions re-home (plain worker's payload
+//     sheds the vip partitions; ParkedCount stays 0).
+//
+// Every phase asserts the coverage invariant (assigned ∪ parked == source
+// by CanonicalID sets) so any orphan window fails loudly. Timing: use
+// require.Eventually with 30s windows; heartbeat TTL is 5s and detection
+// + defer-once confirmation adds up to ~2 poll cycles.
+```
+
+- [ ] **Step 3b: No-ownership-movement regression (spec §4.1 pin)**
+
+```go
+// TestLabelOnlyEdit_NoConsumerChurnWhenPlacementUnchanged: 1 worker
+// labeled "vip", shared policy (so it also serves unlabeled work).
+// Install a recording consumer updater on that worker:
+//   rec := &recordingUpdater{}   // implements parti.WorkerConsumerUpdater;
+//                                // records each UpdateWorkerConsumer call's
+//                                // partition CanonicalID set
+//   cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"),
+//       parti.WithWorkerConsumerUpdater(rec))
+// Steady state: worker owns p0 (unlabeled) among others. Now promote p0
+// to "vip" out-of-band (raw kv.Put, label-only edit): placement CANNOT
+// change — the only vip-capable worker already owns it.
+// Assert, via require.Eventually on the worker's acked version:
+//   - a NEW assignment version was applied (payload hash changed), AND
+//   - every UpdateWorkerConsumer call after the promotion carries the
+//     SAME CanonicalID set as before (no partition added/removed — no
+//     detach/attach at the ownership layer).
+```
+
+Partial-batch-crash note (spec §14 bullet, resolved by design rather
+than a new harness): parked metadata lives ONLY on the commit record,
+which is written by the publisher's single CAS — there is no
+payload-side parked state to tear. A leader crash between payload writes
+and the commit CAS leaves the previous commit (and its parked view)
+fully intact, which the existing partial-batch publisher tests already
+pin. The one new surface — parked fields round-tripping the CAS — is
+covered by `TestPublish_ParkedMetadataOnCommit` (Task 7).
+
+- [ ] **Step 4: Run, lint, commit**
+
+Run: `go test ./test/integration/assignment/ -run 'TestLabelDemotion_NoStale|TestGhostLabel_Parks|TestLabelPoolOutage|TestLabelOnlyEdit_NoConsumerChurn' -v -race -timeout 600s`
+Expected: PASS.
+
+```bash
+make lint
+git add test/integration/assignment/label_orphan_stale_test.go
+git commit -m "test(integration): parked-coverage and stale-assignment regressions for labels"
+```
+
+---
+
+### Task 15: Integration — incarnation guard + policy matrix
+
+**Files:**
+- Create: `test/integration/assignment/label_incarnation_test.go`
+- Create: `test/integration/assignment/label_policy_test.go`
+
+- [ ] **Step 1: Incarnation guard, ID-reuse takeover**
+
+```go
+// TestStableIDReuse_DifferentLabels_NoStaleExposureAndConverge: force stable-ID
+// reuse across label classes with a 1-slot ID window:
+//   cfg.WorkerIDMin = 0; cfg.WorkerIDMax = 0   // exactly one stable ID
+//   cfg.WorkerIDTTL = 3 * time.Second
+// Start manager A with WithWorkerLabels("vip") + a second config bucket
+// set... no: single-worker cluster. Source: 1 vip partition + 1 plain.
+//  1. A (labels=[vip]) claims worker-0, becomes leader, owns both
+//     partitions (vip pool = itself; plain spills to all = itself).
+//     Record commit version V1; its payload has WorkerLabels ["vip"].
+//  2. Stop A WITHOUT waiting for KV cleanup (hard stop; claim + commit
+//     remain until TTL).
+//  3. Start B UNLABELED, same config → after claim TTL it claims
+//     worker-0. The stale commit V1 still assigns worker-0 the vip
+//     partition with labels-of-record ["vip"] ≠ B's [].
+//  4. Assert (a) B NEVER applies V1: poll B.CurrentAssignment() —
+//     version stays 0 until a NEW commit (version > V1) appears; the
+//     guard log line ("different incarnation") is the observable, and
+//     B's heartbeat must never ack V1's digest.
+//  5. Assert (b) convergence WITHOUT audit repair (default direct mode):
+//     B becomes leader (single worker) and its startup initial rebalance
+//     publishes V2 with labels-of-record []; B applies V2; the vip
+//     partition parks (no vip worker) then spills after grace to B.
+//
+// The TIGHT-takeover variant (heartbeat key never lapses, leader
+// unchanged) cannot be staged with two real managers sharing one process
+// — it is pinned at the component level instead:
+// TestCalculator_TightTakeover_LabelChangeTriggersRebalance (calculator,
+// real KV) + TestWorkerMonitor_LabelChangeAcrossWatcherRestart (monitor).
+// This test pins the guard + convergence half with full managers.
+```
+
+- [ ] **Step 2: Pre-label compat + mixed-version scoping**
+
+```go
+// TestPreLabelCommit_CompatApplies: hand-write a commit + payload WITHOUT
+// the presence bit (SchemaVersion 1, no worker_labels_known — exactly what
+// a pre-label leader publishes) into the assignment bucket, then start a
+// labeled worker whose ID the commit targets. The worker must APPLY it
+// (compat branch: !WorkerLabelsKnown). This pins the worker-side half of
+// the mixed-version matrix (spec §11 row 1) without needing to run an old
+// library version in-process.
+```
+
+Scoping note (documented deviation from spec §14's "mixed-version leader
+bouncing" bullet): two library versions cannot run in one Go test binary.
+The mixed-version matrix is pinned piecewise instead — old-leader
+payloads via TestPreLabelCommit_CompatApplies (above), old-worker
+heartbeats via the legacy-decode tests (Task 4), and label-blind
+list-writers via the rollout-rule docs (Task 17). State this in the PR
+description.
+
+- [ ] **Step 3: Policy matrix**
+
+```go
+// TestUnlabeledPartitionPolicy_SharedVsDedicated:
+//   dedicated (default): labeled worker + plain worker, all partitions
+//     unlabeled → labeled worker owns NOTHING (reservation), plain owns all.
+//   shared: same fleet, cfg.UnlabeledPartitionPolicy = "shared" on BOTH
+//     workers → both workers own partitions (WaitForBalancedAssignments).
+//
+// TestAllWorkersLabeled_UnlabeledPartitionsFallBack: every worker labeled
+// (vip), partitions unlabeled, dedicated policy → generalPool is empty so
+// the ladder falls back to all workers; assert full coverage and
+// IncrementUnlabeledFallback observable via a fake metrics collector
+// installed with parti.WithMetrics.
+```
+
+- [ ] **Step 4: Run, lint, commit**
+
+Run: `go test ./test/integration/assignment/ -run 'TestStableIDReuse|TestPreLabelCommit|TestUnlabeledPartitionPolicy|TestAllWorkersLabeled' -v -race -timeout 600s`
+
+```bash
+make lint
+git add test/integration/assignment/label_incarnation_test.go test/integration/assignment/label_policy_test.go
+git commit -m "test(integration): incarnation guard on stable-id reuse and unlabeled-partition policies"
+```
+
+---
+
+### Task 16: Integration — label machinery concurrency stress test
+
+AGENTS.md rule: every new monitor goroutine on a ticker gets a
+live-cluster `-race` stress test. This feature adds two ticker/watcher
+paths: `monitorLabelRecheck` and the per-PUT fingerprint decode.
+
+**Files:**
+- Create: `test/integration/assignment/label_stress_test.go` (template:
+  `test/integration/manager/manager_epoch_monitor_concurrency_test.go`)
+
+- [ ] **Step 1: Write the test**
+
+```go
+// TestLabelMachinery_NoRaceUnderConcurrentTraffic:
+//   - 3 workers: labels [vip], [batch], [] — real cluster, embedded NATS
+//   - cfg.LabelSpillGrace = 300 * time.Millisecond (aggressive: park/spill
+//     transitions churn constantly)
+//   - NATS KV source with 12 partitions
+//   - For ~5 seconds, from 3 concurrent goroutines:
+//       g1: every 150ms rewrite the source flipping labels on a rotating
+//           subset (vip ↔ batch ↔ unlabeled) — label-only edits
+//       g2: every 200ms read the commit + all payloads and assert the
+//           coverage invariant assigned ∪ parked == source (hard fail on
+//           any orphan window)
+//       g3: stop the batch worker mid-soak and restart it 2s later —
+//           exercises pool-empty detection, defer/confirm, park, and
+//           re-home while g1's label churn is in flight
+//   - Liveness proxy: assignment version strictly increases during the
+//     soak (as in the epoch-monitor template)
+//   - Pass criterion: no race-detector trigger, no coverage violation,
+//     cluster returns to a stable full-coverage state within 20s after
+//     the churn stops.
+```
+
+- [ ] **Step 2: Run it under race**
+
+Run: `go test ./test/integration/assignment/ -run 'TestLabelMachinery_NoRace' -v -race -timeout 300s`
+Expected: PASS with zero `WARNING: DATA RACE` output. This is the test
+that historically catches what unit suites cannot (shared nats.go stream
+state between monitor and production goroutines).
+
+- [ ] **Step 3: Commit**
+
+```bash
+make lint
+git add test/integration/assignment/label_stress_test.go
+git commit -m "test(integration): label machinery stress under concurrent source churn"
+```
+
+---
+
+### Task 17: Documentation + CHANGELOG
+
+**Files:**
+- Create: `docs/LABELS.md`
+- Modify: `README.md` (feature bullet + link), `docs/STRATEGIES.md`
+  (pointer: label routing happens ABOVE strategies; custom strategies
+  need no changes), `CHANGELOG.md` (v2.9.0 section)
+- Godoc: already written per-symbol in earlier tasks; verify with
+  `go doc ./types Partition` etc.
+
+**`docs/LABELS.md` must cover** (source: spec §5, §8.1, §9, §11):
+- The model: worker label sets (fixed at startup), one optional partition
+  label, membership matching; VIP runtime promotion workflow via
+  full-list rewrite.
+- Policy knobs: `UnlabeledPartitionPolicy` (dedicated vs shared),
+  `LabelSpillGrace` — both **fleet-uniform** (leader-side; same contract
+  as the strategy choice).
+- Park/spill semantics + the worst-case stall formula:
+  detection (heartbeat TTL) + confirmation + `LabelSpillGrace` +
+  rebalance/handoff; grace clocks are per-leader-term (failover restarts
+  them).
+- **Rollout ordering rules** (both from spec §11, verbatim intent):
+  upgrade every deployment before labeling anything; upgrade every
+  partition-list writer first (including the provision CLI) — an old
+  writer's full-list rewrite silently strips labels.
+- Recommended pattern: distinct `WorkerIDPrefix` per deployment (makes
+  cross-deployment stable-ID takeover structurally impossible; the
+  incarnation guard covers the residual same-deployment relabel case).
+- What operators see: parked metrics/logs, label-change trigger logs,
+  incarnation-reject warnings.
+
+**CHANGELOG v2.9.0**: added (Partition.Label, Config.WorkerLabels /
+WithWorkerLabels, UnlabeledPartitionPolicy, LabelSpillGrace,
+LabelMetrics, payload labels-of-record + parked commit metadata), the
+one-time payload re-hash note (first commit from an upgraded leader
+re-applies with no ownership movement), and the two rollout rules.
+
+- [ ] Draft all docs, then run `/doc-sync` scoped to the new/edited pages
+  to catch signature drift, then:
+
+```bash
+make lint
+git add docs/ README.md CHANGELOG.md
+git commit -m "docs: label-based partition assignment guide and v2.9.0 changelog"
+```
+
+---
+
+### Task 18: Final gate — invariant matrix + pre-PR validation
+
+- [ ] **Step 1: Invariant → test matrix.** Verify each spec invariant has
+  a passing, named test; record the table in the PR description:
+
+| Invariant | Test |
+|---|---|
+| I1 zero-labels identical output | `TestComputeLabelAssignments_I1Golden` + full existing calculator suite green |
+| I2 assigned ∪ parked == source | `TestCheckCoverage_ParkedUnionAndDisjointness`, `TestGhostLabel_ParksThenSpills_NeverOrphans`, stress g2 assertions |
+| I3 label-blind identity | `TestPartitionLabel_IdentityBlind` |
+| I4 label-only change notifies | `TestPartitionsEqual_LabelAware`, `TestNatsKV_LabelOnlyEdit_{Watch,Reconcile}PathPropagates`, `TestLabelPromotion_EndToEnd` |
+| I5 spill never invades other pools | `TestComputeLabelAssignments_SpillPrefersUnlabeledWorkers` |
+| I6 recheck fires without events | `TestLabelRecheck_GhostLabelProgressesWithoutExternalEvents`, `TestGhostLabel_ParksThenSpills_NeverOrphans` |
+| I7 labels immutable per lifetime | `TestConfig_WorkerLabelsNormalization` + heartbeat emission tests |
+| I8 merged keys == active set | `TestComputeLabelAssignments_MergeContract`, `TestLabelDemotion_NoStaleAssignmentInKV` |
+| I9 one group per partition | `TestComputeLabelAssignments_MergeContract` (count assertion) |
+| I10 label survives copy paths | Task 2 + Task 3 round-trip tests |
+| I11 guard on both wire paths | `TestLabelGuard_Matrix`, `TestLabelGuard_RejectIsTerminalNoRetryNoAck`, `TestLabelGuard_RetryEntrypointAlsoGuarded`, `TestStableIDReuse_DifferentLabels_NoStaleExposureAndConverge` |
+| §4.1 no ownership movement on label-only edit | `TestLabelOnlyEdit_NoConsumerChurnWhenPlacementUnchanged` (+ `TestPublish_PayloadCarriesLabelsOfRecord` for the hash side) |
+| I12 defer-once confirmation | `TestLabelState_DeferOnceThenPark`, `TestLabelState_UnknownWorkerDeferThenAct` |
+| I13 label-change trigger | `TestWorkerMonitor_LabelChangeEscapesSuppression`, `TestWorkerMonitor_LabelChangeAcrossWatcherRestart`, `TestCalculator_TightTakeover_LabelChangeTriggersRebalance` |
+
+- [ ] **Step 2: Cross-feature contracts** (AGENTS.md): no error
+  classification or routing was changed, but run the pinned tests
+  explicitly: `TestManager_LiveNATSBucketLoss*`,
+  `TestStableID_StaleKeyTakeover_Reclaim`, `TestStart_*`.
+
+- [ ] **Step 3: The gate.**
+
+Run: `make pre-pr`
+Expected: lint clean, unit `-race` green, integration `-race` green.
+Known load-flakes that are NOT this feature: `TestLeaderElection_ColdStart`,
+`TestHandoffConflictStress` (re-run in isolation before blaming the
+change).
+
+- [ ] **Step 4: Post-implementation review loop** per project practice:
+  `/simplify`, then `/post-impl-review <phase> docs/plans/label-assignment/01-implementation-plan.md v1`,
+  iterate to merge-clean.

--- a/internal/assignment/assignment_publisher.go
+++ b/internal/assignment/assignment_publisher.go
@@ -302,6 +302,15 @@ type PublishInput struct {
 	// AssignmentCommit.Workers are implicitly revoked at the commit level;
 	// alias sweeping is rolling-upgrade hygiene only.
 	WorkersToRemove []string
+
+	// ParkedPartitions is the set deliberately left unassigned this batch.
+	// Coverage becomes: assigned ∪ parked == source AND assigned ∩ parked == ∅.
+	// Nil (the default) degenerates to the pre-label set-equality check.
+	ParkedPartitions []types.Partition
+
+	// WorkerLabels maps workerID → labels-of-record for payload stamping.
+	// Workers absent from the map get WorkerLabels=nil (still Known=true).
+	WorkerLabels map[string][]string
 }
 
 // Publish runs the 12-step refs-always commit flow described in §3.5 of the
@@ -335,7 +344,7 @@ func (p *AssignmentPublisher) Publish(ctx context.Context, in PublishInput) erro
 	}
 
 	// --- step 3 of §3.5: publish-time set-equality coverage check ---
-	if err := p.checkCoverage(in.SourcePartitions, in.Assignments); err != nil {
+	if err := p.checkCoverage(in.SourcePartitions, in.Assignments, in.ParkedPartitions); err != nil {
 		p.metrics.IncrementBatchAborted("coverage_mismatch")
 		return err
 	}
@@ -345,7 +354,7 @@ func (p *AssignmentPublisher) Publish(ctx context.Context, in PublishInput) erro
 	proposedVersion := p.currentVersion + 1
 
 	// --- step 4 of §3.5: write content-addressable payload keys ---
-	refs, payloadByWorker, err := p.writePayloads(ctx, in.Workers, in.Assignments)
+	refs, payloadByWorker, err := p.writePayloads(ctx, in.Workers, in.Assignments, in.WorkerLabels)
 	if err != nil {
 		// Coverage was fine but a payload write failed; classify as a generic
 		// abort. We do not increment IncrementBatchAborted with a specific
@@ -412,6 +421,8 @@ func (p *AssignmentPublisher) Publish(ctx context.Context, in PublishInput) erro
 		Workers:             sortedWorkers,
 		Payloads:            refs,
 		BatchDigest:         batchDigest,
+		ParkedCount:         len(in.ParkedPartitions),
+		ParkedDigest:        types.PartitionSetDigest(in.ParkedPartitions),
 		PrevCommitRev:       p.lastCommitRev,
 		Lifecycle:           in.Lifecycle,
 	}
@@ -515,17 +526,30 @@ func (p *AssignmentPublisher) Publish(ctx context.Context, in PublishInput) erro
 	return nil
 }
 
-// checkCoverage implements §3.8: strict set-equality of sorted CanonicalIDs
-// across the assignments union and the source snapshot. Catches duplicates
-// AND missing partitions, unlike the count-based check.
-func (p *AssignmentPublisher) checkCoverage(source []types.Partition, assignments map[string][]types.Partition) error {
+// checkCoverage implements §3.8 widened for parked partitions (spec §4.3):
+// assigned ∪ parked == source AND assigned ∩ parked == ∅. The union check is a
+// strict set-equality of sorted CanonicalIDs; a raw multiset count catches
+// duplicates (a partition assigned twice, or both assigned and parked), and the
+// overlap check catches a partition that is simultaneously assigned and parked.
+//
+// A nil parked set degenerates to the pre-label check exactly: got == the
+// assignment union, rawCount == len(union), and overlap is empty.
+func (p *AssignmentPublisher) checkCoverage(source []types.Partition, assignments map[string][]types.Partition, parked []types.Partition) error {
 	union := unionPartitions(assignments)
-	got := canonicalIDSet(union) // sorted, deduped
+	assignedIDs := canonicalIDSet(union) // sorted, deduped
+	parkedIDs := canonicalIDSet(parked)  // sorted, deduped
 	expected := canonicalIDSet(source)
-	rawCount := len(union)
+
+	// Disjointness: a partition may not be both assigned and parked.
+	overlap := intersectSortedIDs(assignedIDs, parkedIDs)
+	// Union: assigned ∪ parked must equal source as a set, and the raw counts
+	// must match (multiset check catches duplicates within either set and
+	// across the assigned/parked boundary).
+	got := mergeSortedIDs(assignedIDs, parkedIDs) // sorted, deduped union
+	rawCount := len(union) + len(parked)
 	setOK := equalStringSlices(got, expected)
 	multisetOK := rawCount == len(expected)
-	if setOK && multisetOK {
+	if setOK && multisetOK && len(overlap) == 0 {
 		return nil
 	}
 
@@ -553,15 +577,17 @@ func (p *AssignmentPublisher) checkCoverage(source []types.Partition, assignment
 	duplicates := rawCount - len(got)
 	p.logger.Error("publish coverage mismatch",
 		"source_partitions", len(expected),
-		"assigned_unique", len(got),
-		"assigned_raw", rawCount,
+		"covered_unique", len(got),
+		"covered_raw", rawCount,
+		"parked", len(parked),
+		"overlap", len(overlap),
 		"missing", missing,
 		"extra", extra,
 		"duplicates", duplicates,
 	)
 
-	return fmt.Errorf("%w: source=%d assigned_unique=%d assigned_raw=%d missing=%d extra=%d duplicates=%d",
-		types.ErrCoverageMismatch, len(expected), len(got), rawCount, missing, extra, duplicates)
+	return fmt.Errorf("%w: source=%d covered_unique=%d covered_raw=%d parked=%d overlap=%d missing=%d extra=%d duplicates=%d",
+		types.ErrCoverageMismatch, len(expected), len(got), rawCount, len(parked), len(overlap), missing, extra, duplicates)
 }
 
 // checkLeadership implements steps 5 and 7: invoke the live leader-check
@@ -590,6 +616,7 @@ func (p *AssignmentPublisher) writePayloads(
 	ctx context.Context,
 	workers []string,
 	assignments map[string][]types.Partition,
+	labels map[string][]string,
 ) (map[string]types.AssignmentPayloadRef, map[string]types.AssignmentPayload, error) {
 	refs := make(map[string]types.AssignmentPayloadRef, len(workers))
 	payloads := make(map[string]types.AssignmentPayload, len(workers))
@@ -609,6 +636,17 @@ func (p *AssignmentPublisher) writePayloads(
 		payload := types.AssignmentPayload{
 			SchemaVersion: types.AssignmentSchemaVersion,
 			Partitions:    canonical,
+			// Labels feed the same content-addressed sha256 as the partitions,
+			// so stamp a SORTED copy — identical label sets must hash
+			// identically regardless of caller order, exactly like the
+			// CanonicalID sort above. Never mutates the caller's slice.
+			WorkerLabels: sortedLabelsCopy(labels[w]),
+			// WorkerLabelsKnown is UNCONDITIONAL: a label-aware leader always
+			// records presence, including for unlabeled workers (spec §4.3).
+			// The presence bit distinguishes "computed for an unlabeled worker"
+			// (true + empty) from "computed by a pre-label leader" (false).
+			// Mirrors the SourceRevisionKnown precedent.
+			WorkerLabelsKnown: true,
 		}
 		canonicalBytes, err := json.Marshal(payload)
 		if err != nil {
@@ -730,7 +768,10 @@ func (p *AssignmentPublisher) runAliasBarrier(
 			// Worker is in the batch but has no assignment slice — degenerate;
 			// we still write an empty payload alias so old workers see the
 			// "you're revoked" signal at version V.
-			payload = types.AssignmentPayload{SchemaVersion: types.AssignmentSchemaVersion}
+			// WorkerLabelsKnown stays true: a label-aware leader always records
+			// presence, even on this (currently unreachable) revoke fallback —
+			// future routing changes must not emit Known=false aliases.
+			payload = types.AssignmentPayload{SchemaVersion: types.AssignmentSchemaVersion, WorkerLabelsKnown: true}
 		}
 		legacy := buildLegacyAlias(payload, proposedVersion, in.LeaderRevision, in.SourceRevision, in.Lifecycle, len(in.Workers))
 		if werr := p.writeLegacyAliasWithRetry(ctx, w, legacy); werr != nil {
@@ -1224,6 +1265,79 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
+// intersectSortedIDs returns the sorted intersection of two sorted, deduped
+// string slices (as produced by canonicalIDSet). Returns nil when the inputs
+// share no elements. Used by checkCoverage to detect assigned∩parked overlap.
+func intersectSortedIDs(a, b []string) []string {
+	var out []string
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			out = append(out, a[i])
+			i++
+			j++
+		case a[i] < b[j]:
+			i++
+		default:
+			j++
+		}
+	}
+
+	return out
+}
+
+// mergeSortedIDs returns the sorted, deduped union of two sorted, deduped
+// string slices (as produced by canonicalIDSet). Used by checkCoverage to
+// compare assigned∪parked against the source set.
+func mergeSortedIDs(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make([]string, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			out = append(out, a[i])
+			i++
+			j++
+		case a[i] < b[j]:
+			out = append(out, a[i])
+			i++
+		default:
+			out = append(out, b[j])
+			j++
+		}
+	}
+	out = append(out, a[i:]...)
+	out = append(out, b[j:]...)
+
+	return out
+}
+
+// sortedLabelsCopy returns a sorted, de-duplicated copy of the given label set
+// for payload stamping. Labels are part of the canonical payload bytes (and
+// therefore the content-addressed PayloadHash), so ordering must be
+// deterministic regardless of caller order — the "heartbeat labels arrive
+// pre-sorted and deduped" invariant is an unenforced cross-package assumption,
+// so this helper enforces it locally (sort + compact) to stay symmetric with
+// normalizeWorkerLabels. Returns nil for empty input and never mutates the
+// caller's slice.
+func sortedLabelsCopy(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, len(labels))
+	copy(out, labels)
+	slices.Sort(out)
+
+	return slices.Compact(out)
+}
+
 // computeSetDigest delegates to types.PartitionSetDigest so the publisher and
 // the manager-side apply ack share a single source of truth for the
 // SetDigest / AppliedDigest values. Kept as a thin local alias for readability
@@ -1333,10 +1447,12 @@ func buildLegacyAlias(
 	totalWorkers int,
 ) types.Assignment {
 	return types.Assignment{
-		Version:        version,
-		Lifecycle:      lifecycle,
-		Partitions:     payload.Partitions,
-		LeaderRevision: leaderRevision,
-		TotalWorkers:   totalWorkers,
+		Version:           version,
+		Lifecycle:         lifecycle,
+		Partitions:        payload.Partitions,
+		LeaderRevision:    leaderRevision,
+		TotalWorkers:      totalWorkers,
+		WorkerLabels:      payload.WorkerLabels,
+		WorkerLabelsKnown: payload.WorkerLabelsKnown,
 	}
 }

--- a/internal/assignment/assignment_publisher_labels_test.go
+++ b/internal/assignment/assignment_publisher_labels_test.go
@@ -1,0 +1,244 @@
+package assignment
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckCoverage_ParkedUnionAndDisjointness pins the widened coverage
+// contract: assigned ∪ parked == source AND assigned ∩ parked == ∅. A nil
+// parked set must degenerate to the pre-label set-equality check exactly.
+func TestCheckCoverage_ParkedUnionAndDisjointness(t *testing.T) {
+	t.Parallel()
+	// checkCoverage is a pure method (no KV access); a minimal publisher with a
+	// logger and metrics is sufficient.
+	p := NewAssignmentPublisher(PublisherConfig{
+		Logger:  logging.NewNop(),
+		Metrics: newCountingMetrics(),
+	})
+
+	src := []types.Partition{
+		{Keys: []string{"a"}}, {Keys: []string{"b"}, Label: "vip"},
+	}
+	assignedOnly := map[string][]types.Partition{"w0": {src[0]}}
+
+	// (1) parked partition completes coverage:
+	require.NoError(t, p.checkCoverage(src, assignedOnly, []types.Partition{src[1]}))
+
+	// (2) partition missing from BOTH assignment and parked → error:
+	err := p.checkCoverage(src, assignedOnly, nil)
+	require.ErrorIs(t, err, types.ErrCoverageMismatch)
+
+	// (3) partition in BOTH assignment and parked → error:
+	both := map[string][]types.Partition{"w0": {src[0], src[1]}}
+	err = p.checkCoverage(src, both, []types.Partition{src[1]})
+	require.ErrorIs(t, err, types.ErrCoverageMismatch)
+
+	// (4) legacy shape (no parked) unchanged:
+	full := map[string][]types.Partition{"w0": {src[0]}, "w1": {src[1]}}
+	require.NoError(t, p.checkCoverage(src, full, nil))
+}
+
+// TestPublish_ParkedMetadataOnCommit asserts the commit carries ParkedCount and
+// ParkedDigest over the parked set only, while BatchDigest still covers the full
+// source set.
+func TestPublish_ParkedMetadataOnCommit(t *testing.T) {
+	t.Parallel()
+	f := newPublisherFixture(t, "parked-commit-metadata")
+	ctx := context.Background()
+	f.putV1Heartbeat(t, ctx, "w0")
+
+	src := []types.Partition{ps("a"), {Keys: []string{"b"}, Label: "vip"}}
+	parked := []types.Partition{src[1]}
+
+	// Publish with one parked partition: w0 gets "a"; "b" is parked.
+	err := f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w0"},
+		Assignments:      map[string][]types.Partition{"w0": {src[0]}},
+		SourcePartitions: src,
+		ParkedPartitions: parked,
+		LeaderRevision:   1,
+	})
+	require.NoError(t, err)
+
+	commit := f.readCommit(t, ctx)
+	require.NotNil(t, commit)
+	require.Equal(t, 1, commit.ParkedCount)
+	require.Equal(t, types.PartitionSetDigest(parked), commit.ParkedDigest)
+	// BatchDigest covers the FULL source set, not just the assigned subset.
+	require.Equal(t, types.PartitionSetDigest(src), commit.BatchDigest)
+
+	// A second publish that parks nothing (full coverage) must produce the same
+	// BatchDigest and zero parked metadata.
+	f.putV1Heartbeat(t, ctx, "w1")
+	err = f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w0", "w1"},
+		Assignments:      map[string][]types.Partition{"w0": {src[0]}, "w1": {src[1]}},
+		SourcePartitions: src,
+		LeaderRevision:   1,
+	})
+	require.NoError(t, err)
+
+	commit2 := f.readCommit(t, ctx)
+	require.NotNil(t, commit2)
+	require.Equal(t, 0, commit2.ParkedCount)
+	require.Equal(t, uint64(0), commit2.ParkedDigest)
+	require.Equal(t, commit.BatchDigest, commit2.BatchDigest,
+		"BatchDigest must cover the full source set regardless of parking")
+}
+
+// TestPublish_PayloadCarriesLabelsOfRecord asserts the per-worker payload
+// carries labels-of-record with an unconditional presence bit, and that the
+// labels-of-record are part of the payload's content identity (hash).
+func TestPublish_PayloadCarriesLabelsOfRecord(t *testing.T) {
+	t.Parallel()
+	f := newPublisherFixture(t, "payload-labels-of-record")
+	ctx := context.Background()
+	f.putV1Heartbeat(t, ctx, "w0")
+	f.putV1Heartbeat(t, ctx, "w1")
+
+	src := []types.Partition{ps("a"), ps("b")}
+	err := f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w0", "w1"},
+		Assignments:      map[string][]types.Partition{"w0": {src[0]}, "w1": {src[1]}},
+		SourcePartitions: src,
+		// w0 has labels-of-record; w1 is absent from the map → nil labels but
+		// still Known=true.
+		WorkerLabels:   map[string][]string{"w0": {"vip"}},
+		LeaderRevision: 1,
+	})
+	require.NoError(t, err)
+
+	commit := f.readCommit(t, ctx)
+	require.NotNil(t, commit)
+
+	p0 := readPayload(t, ctx, f, commit.Payloads["w0"].Key)
+	require.Equal(t, []string{"vip"}, p0.WorkerLabels)
+	require.True(t, p0.WorkerLabelsKnown, "label-aware leader always records presence")
+
+	p1 := readPayload(t, ctx, f, commit.Payloads["w1"].Key)
+	require.Nil(t, p1.WorkerLabels, "unlabeled worker gets nil labels")
+	require.True(t, p1.WorkerLabelsKnown, "presence bit is unconditional, even for unlabeled workers")
+
+	// Labels-of-record are part of content identity: the hash of w0's payload
+	// WITH labels differs from the hash the same worker/partitions would produce
+	// WITHOUT labels (but still with the presence bit set).
+	withoutLabels := mustMarshalCanonicalPayload(t, types.AssignmentPayload{
+		SchemaVersion:     types.AssignmentSchemaVersion,
+		Partitions:        []types.Partition{src[0]},
+		WorkerLabelsKnown: true,
+	})
+	withoutHash := sha256.Sum256(withoutLabels)
+	require.NotEqual(t, hex.EncodeToString(withoutHash[:]), commit.Payloads["w0"].PayloadHash,
+		"labels-of-record must be part of the payload content address")
+}
+
+// TestPublish_LabelsOfRecordSortedForContentAddress asserts the publisher
+// stamps labels-of-record in sorted order regardless of caller order, so two
+// leaders observing the same label set produce the identical content-addressed
+// payload (mirrors the partition CanonicalID sort in the same function). The
+// caller's slice must not be mutated.
+func TestPublish_LabelsOfRecordSortedForContentAddress(t *testing.T) {
+	t.Parallel()
+	f := newPublisherFixture(t, "labels-sorted-content-address")
+	ctx := context.Background()
+	f.putV1Heartbeat(t, ctx, "w0")
+
+	src := []types.Partition{ps("a")}
+	unsorted := []string{"vip", "batch"} // deliberately unsorted
+	err := f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w0"},
+		Assignments:      map[string][]types.Partition{"w0": {src[0]}},
+		SourcePartitions: src,
+		WorkerLabels:     map[string][]string{"w0": unsorted},
+		LeaderRevision:   1,
+	})
+	require.NoError(t, err)
+
+	c1 := f.readCommit(t, ctx)
+	require.NotNil(t, c1)
+	p0 := readPayload(t, ctx, f, c1.Payloads["w0"].Key)
+	require.Equal(t, []string{"batch", "vip"}, p0.WorkerLabels,
+		"labels-of-record must be stamped in sorted order")
+	require.Equal(t, []string{"vip", "batch"}, unsorted,
+		"the caller's label slice must not be mutated")
+
+	// Cross-leader determinism: a second publish with PRE-SORTED labels must
+	// produce the identical content address (payload reuse fires).
+	reusedBefore := f.metrics.payloadsReused.Load()
+	err = f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w0"},
+		Assignments:      map[string][]types.Partition{"w0": {src[0]}},
+		SourcePartitions: src,
+		WorkerLabels:     map[string][]string{"w0": {"batch", "vip"}},
+		LeaderRevision:   1,
+	})
+	require.NoError(t, err)
+
+	c2 := f.readCommit(t, ctx)
+	require.NotNil(t, c2)
+	require.Equal(t, c1.Payloads["w0"].PayloadHash, c2.Payloads["w0"].PayloadHash,
+		"unsorted and pre-sorted label input must content-address identically")
+	require.Greater(t, f.metrics.payloadsReused.Load(), reusedBefore,
+		"the second publish must reuse the first publish's payload key")
+
+	// Duplicate labels in the input dedupe to the same stamp (symmetric with
+	// normalizeWorkerLabels: sort + compact), so a repeated label
+	// content-addresses identically to the deduped set and reuses the payload.
+	dupInput := []string{"vip", "batch", "vip"}
+	err = f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w0"},
+		Assignments:      map[string][]types.Partition{"w0": {src[0]}},
+		SourcePartitions: src,
+		WorkerLabels:     map[string][]string{"w0": dupInput},
+		LeaderRevision:   1,
+	})
+	require.NoError(t, err)
+
+	c3 := f.readCommit(t, ctx)
+	require.NotNil(t, c3)
+	p3 := readPayload(t, ctx, f, c3.Payloads["w0"].Key)
+	require.Equal(t, []string{"batch", "vip"}, p3.WorkerLabels,
+		"duplicate labels must dedupe in the stamped labels-of-record")
+	require.Equal(t, []string{"vip", "batch", "vip"}, dupInput,
+		"the caller's label slice must not be mutated")
+	require.Equal(t, c1.Payloads["w0"].PayloadHash, c3.Payloads["w0"].PayloadHash,
+		"duplicate and deduped label input must content-address identically")
+}
+
+// TestBuildLegacyAlias_CopiesLabelsOfRecord asserts the legacy alias envelope
+// mirrors the payload's labels-of-record so the worker-side stale-incarnation
+// guard can read them from the alias path too.
+func TestBuildLegacyAlias_CopiesLabelsOfRecord(t *testing.T) {
+	t.Parallel()
+	payload := types.AssignmentPayload{
+		SchemaVersion:     1,
+		Partitions:        []types.Partition{{Keys: []string{"a"}}},
+		WorkerLabels:      []string{"vip"},
+		WorkerLabelsKnown: true,
+	}
+	alias := buildLegacyAlias(payload, 7, 3, 0, "steady", 2)
+	require.Equal(t, []string{"vip"}, alias.WorkerLabels)
+	require.True(t, alias.WorkerLabelsKnown)
+}
+
+// readPayload fetches, decompresses, and decodes an AssignmentPayload from its
+// content-addressable KV key.
+func readPayload(t *testing.T, ctx context.Context, f *publisherFixture, key string) types.AssignmentPayload {
+	t.Helper()
+	entry, err := f.assignmentKV.Get(ctx, key)
+	require.NoError(t, err)
+	plain, err := gzipDecompress(entry.Value())
+	require.NoError(t, err)
+	var p types.AssignmentPayload
+	require.NoError(t, json.Unmarshal(plain, &p))
+
+	return p
+}

--- a/internal/assignment/assignment_publisher_test.go
+++ b/internal/assignment/assignment_publisher_test.go
@@ -185,6 +185,9 @@ func TestPublisher_Crash_BeforeCommit_PayloadsInert(t *testing.T) {
 	canonical := mustMarshalCanonicalPayload(t, types.AssignmentPayload{
 		SchemaVersion: types.AssignmentSchemaVersion,
 		Partitions:    []types.Partition{ps("p1")},
+		// Label-aware publisher stamps WorkerLabelsKnown=true on every payload
+		// (Task 7); mirror it here so the planted content-address matches.
+		WorkerLabelsKnown: true,
 	})
 	hash := sha256.Sum256(canonical)
 	orphanKey := "assignment._payload." + hex.EncodeToString(hash[:])
@@ -483,6 +486,9 @@ func TestPublisher_ErrKeyExists_VerifiedAndReused(t *testing.T) {
 	canonical := mustMarshalCanonicalPayload(t, types.AssignmentPayload{
 		SchemaVersion: types.AssignmentSchemaVersion,
 		Partitions:    []types.Partition{ps("p1")},
+		// Label-aware publisher stamps WorkerLabelsKnown=true on every payload
+		// (Task 7); mirror it here so the planted content-address matches.
+		WorkerLabelsKnown: true,
 	})
 	hash := sha256.Sum256(canonical)
 	key := "assignment._payload." + hex.EncodeToString(hash[:])
@@ -515,6 +521,9 @@ func TestPublisher_ErrKeyExists_HashMismatchSurfacesCollisionError(t *testing.T)
 	canonical := mustMarshalCanonicalPayload(t, types.AssignmentPayload{
 		SchemaVersion: types.AssignmentSchemaVersion,
 		Partitions:    []types.Partition{ps("p1")},
+		// Label-aware publisher stamps WorkerLabelsKnown=true on every payload
+		// (Task 7); mirror it here so the planted content-address matches.
+		WorkerLabelsKnown: true,
 	})
 	hash := sha256.Sum256(canonical)
 	key := "assignment._payload." + hex.EncodeToString(hash[:])
@@ -602,7 +611,7 @@ func TestPublisher_SetEqualityCoversAllPartitions(t *testing.T) {
 
 	// Also exercise the "duplicate" path: a strategy assigning p1 to two
 	// workers must fail the coverage check too. The publisher catches this
-	// via the multiset count check: assigned_raw=4 but source unique=3.
+	// via the multiset count check: covered_raw=4 but source unique=3.
 	f.putV1Heartbeat(t, ctx, "w2")
 	err = f.pub.Publish(ctx, PublishInput{
 		Workers: []string{"w1", "w2"},
@@ -1005,7 +1014,12 @@ func mustMarshalCanonicalPayload(t *testing.T, p types.AssignmentPayload) []byte
 			canonical[j-1], canonical[j] = canonical[j], canonical[j-1]
 		}
 	}
-	out := types.AssignmentPayload{SchemaVersion: p.SchemaVersion, Partitions: canonical}
+	out := types.AssignmentPayload{
+		SchemaVersion:     p.SchemaVersion,
+		Partitions:        canonical,
+		WorkerLabels:      p.WorkerLabels,
+		WorkerLabelsKnown: p.WorkerLabelsKnown,
+	}
 	b, err := json.Marshal(out)
 	require.NoError(t, err)
 

--- a/internal/assignment/calculator.go
+++ b/internal/assignment/calculator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -166,6 +168,54 @@ type Calculator struct {
 	// successful enumeration (nil-error GetActiveWorkers, before F10-A handling).
 	// Guarded by c.mu (same as workerShrunkObservations).
 	enumFailures int
+
+	// labelState carries per-label grace clocks and defer-once streaks
+	// (spec §8.5). Touched only on the rebalance path (serialized by
+	// rebalanceMu) and, once Task 9 lands, the label re-check timer; its
+	// own mutex fences the two.
+	labelState *labelState
+
+	// lastPublishedPartitions retains (a reference to) the source snapshot
+	// behind THIS calculator's most recent successful publish. The
+	// cached-observation replay proof compares the current snapshot against
+	// it by label-aware content (Keys + Weight + Label): the revision
+	// fast-path alone cannot prove "unchanged" for revision-blind sources,
+	// and PartitionSetDigest/BatchDigest are deliberately label-blind (a
+	// label-only edit slips through them). Holding a reference is safe:
+	// snapshot providers return a fresh slice per call (sources replace
+	// their backing slice rather than mutating it in place). Guarded by
+	// c.mu. Nil until the first successful publish by this instance.
+	lastPublishedPartitions []types.Partition
+
+	// Label re-check timer state (spec §8.3). The guaranteed second
+	// observation — grace expiry and deferral confirmation — must re-fire
+	// without any external event and survive busy states.
+	//
+	// pendingLabelRecheck is the sticky "a label re-check is owed" flag. Set
+	// by requestLabelRecheck (deferral / grace-expiry / non-fresh) and drained
+	// by monitorLabelRecheck under a CompareAndSwap; it survives a busy state
+	// machine because the monitor re-stores it when it cannot claim.
+	//
+	// labelRecheckCh (capacity 1) coalesces timer + external signals into a
+	// single monitor wake. A non-blocking send never blocks the rebalance path.
+	pendingLabelRecheck atomic.Bool
+	labelRecheckCh      chan struct{}
+
+	// labelRecheckTimer is the grace-expiry AfterFunc armed after a rebalance
+	// that parked anything (armLabelRecheckAfterRebalance). Guarded by
+	// labelRecheckTimerMu so Stop and re-arm can cancel the previous one.
+	labelRecheckTimer   *time.Timer
+	labelRecheckTimerMu sync.Mutex
+
+	// prevMetricLabels is the label set recorded by the last successful
+	// rebalance's LabelMetrics pass (spec §13 lifecycle: per-label gauges
+	// recomputed every rebalance; a label absent from the current snapshot
+	// is explicitly zeroed in the same pass rather than left at its last
+	// non-zero reading; a stopping leader zeroes and clears everything —
+	// the gauges are leader-scoped). Touched only inside recordLabelMetrics
+	// (called from rebalance under rebalanceMu) and zeroLabelGaugesOnStop
+	// (takes rebalanceMu itself) — no separate mutex needed.
+	prevMetricLabels map[string]bool
 }
 
 // cachedWorkerList bundles worker data with its timestamp for atomic operations.
@@ -223,10 +273,18 @@ func NewCalculator(cfg *Config) (*Calculator, error) {
 		stateProvider:       cfg.StateProvider, // Optional state provider for degraded mode checks
 		stopCh:              stopCh,
 		doneCh:              make(chan struct{}),
+		labelRecheckCh:      make(chan struct{}, 1), // capacity 1: timer + external signals coalesce
 	}
 
 	// Initialize emergency detector with configured grace period
 	c.emergencyDetector = NewEmergencyDetector(cfg.EmergencyGracePeriod)
+
+	// Label grace/confirmation state. cfg.Now is defaulted by SetDefaults
+	// above, so the injected clock (tests) or time.Now (production) is
+	// already resolved. UnlabeledPartitionPolicy is defaulted to
+	// "dedicated" by SetDefaults; the topology builder treats "" the same,
+	// so the default is belt-and-suspenders.
+	c.labelState = newLabelState(cfg.LabelSpillGrace, cfg.Now)
 
 	// Initialize components.
 	//
@@ -273,6 +331,19 @@ func NewCalculator(cfg *Config) (*Calculator, error) {
 		c.pollForChanges,
 		cfg.Logger,
 	)
+
+	// Route a detected worker-label change (a heartbeat PUT whose labels differ
+	// from the monitor's retained fingerprint — e.g. a stale-ID takeover behind
+	// a live worker ID) through the label re-check path. The worker-set change
+	// path no-ops on an unchanged set, so this is the only path that recomputes
+	// label-correct assignments when the fleet's labels shift without the set
+	// changing. The callback is coalesced by requestLabelRecheck.
+	c.monitor.SetOnLabelChange(func() {
+		if lm, ok := c.Metrics.(types.LabelMetrics); ok {
+			lm.IncrementLabelChangeTrigger()
+		}
+		c.requestLabelRecheck(lifecycleLabelChange)
+	})
 
 	return c, nil
 }
@@ -351,8 +422,23 @@ func (c *Calculator) Start(ctx context.Context) error {
 		initialReason = "takeover_immediate"
 	}
 	if err := c.rebalance(ctx, initialReason); err != nil {
-		c.started.Store(false)
-		return fmt.Errorf("immediate initial assignment failed: %w", err)
+		// A deferred label observation is benign HERE TOO (spec §8.5): a new
+		// leader's fresh per-term labelState (spec §8.4) defers its first
+		// adverse observation by design, and requestLabelRecheck (fired
+		// inside the rebalance) has already armed the confirming second
+		// observation. The incumbent commit stays valid meanwhile, so
+		// success-without-publish is safe. Failing Start instead would
+		// release leadership (releaseLeadershipAfterCalculatorFailure), hand
+		// the next leader another fresh labelState that defers again, and
+		// livelock the fleet in a leadership flap where the defer-once
+		// streak never reaches 2 and parked partitions are never committed
+		// (the Task 14 pool-outage reproducer, spec I2 violation).
+		if !errors.Is(err, errLabelObservationDeferred) {
+			c.started.Store(false)
+			return fmt.Errorf("immediate initial assignment failed: %w", err)
+		}
+		c.Logger.Info("initial assignment deferred pending label observation confirmation",
+			"reason", initialReason)
 	}
 
 	// Get worker count after immediate assignment and update lastWorkers
@@ -402,6 +488,14 @@ func (c *Calculator) Start(ctx context.Context) error {
 		})
 	}
 
+	// Start the label re-check monitor unconditionally (spec §8.3): grace
+	// expiry and deferral confirmation must re-fire without any external
+	// event, independent of whether the source is watchable. Joined on Stop
+	// via wg.Wait.
+	c.wg.Go(func() {
+		c.monitorLabelRecheck(ctx)
+	})
+
 	// Step 2: Enter stabilization window.
 	//   - Cold start: use the long ColdStartWindow so the initial fleet has
 	//     time to fully come online before the final rebalance fires.
@@ -449,6 +543,15 @@ func (c *Calculator) Stop(ctx context.Context) error {
 	c.stateMach.stopping.Store(true)
 	close(c.stopCh)
 
+	// Cancel any armed label re-check grace-expiry timer so a late AfterFunc
+	// cannot fire requestLabelRecheck after the monitor goroutine has joined.
+	c.labelRecheckTimerMu.Lock()
+	if c.labelRecheckTimer != nil {
+		c.labelRecheckTimer.Stop()
+		c.labelRecheckTimer = nil
+	}
+	c.labelRecheckTimerMu.Unlock()
+
 	// 2. Stop worker monitor (stops watcher and monitoring goroutines)
 	if err := c.monitor.Stop(); err != nil {
 		c.Logger.Error("failed to stop worker monitor", "error", err)
@@ -464,6 +567,13 @@ func (c *Calculator) Stop(ctx context.Context) error {
 
 	// 4. Wait for background goroutines (e.g., monitorPartitions)
 	c.wg.Wait()
+
+	// 5. Close out the leader-scoped label gauges (spec §13): zero every
+	// per-label gauge this leader last recorded so a deposed leader's
+	// metrics export doesn't freeze at stale non-zero readings. Placed
+	// after the joins above so no rebalance can record concurrently or
+	// after the zeroing pass.
+	c.zeroLabelGaugesOnStop()
 
 	return nil
 }
@@ -512,6 +622,17 @@ func (c *Calculator) TriggerRebalance(ctx context.Context) error {
 	c.Logger.Info("manual rebalance triggered")
 
 	if err := c.rebalance(ctx, "manual-refresh"); err != nil {
+		// A deferred label observation is benign everywhere (spec §8.5):
+		// success-without-publish. The re-check armed inside the rebalance
+		// owns the confirming retry; surfacing the internal sentinel to the
+		// manual-refresh API caller would report a designed no-op as a
+		// failure. lastWorkers is deliberately NOT updated on this path —
+		// mirroring handleRebalance's early sentinel return — so the next
+		// poll still observes any pending worker change.
+		if errors.Is(err, errLabelObservationDeferred) {
+			return nil
+		}
+
 		return err
 	}
 
@@ -640,9 +761,39 @@ const (
 	lifecyclePartitionUpdateDeferred = "partition_update_deferred"
 )
 
+// isPartitionLifecycle reports whether the lifecycle is one of the
+// monitor-claimed rebalances (monitorPartitions or monitorLabelRecheck) that
+// honor the in-rebalance recovery-grace re-check in shouldDeferForRecoveryGrace.
+// lifecycleLabelRecheck belongs here for the same reason as the partition
+// lifecycles: its monitor checks inRecoveryGrace before claiming, so a grace
+// flip between that pre-claim check and rebalanceMu acquisition must bail
+// (errShuttingDown) and be retried by the drain tick —
+// restorePendingLabelOnGraceBail restores the sticky flag on exactly that bail.
 func isPartitionLifecycle(lc string) bool {
-	return lc == lifecyclePartitionUpdate || lc == lifecyclePartitionUpdateDeferred
+	return lc == lifecyclePartitionUpdate || lc == lifecyclePartitionUpdateDeferred || lc == lifecycleLabelRecheck
 }
+
+// Label re-check lifecycle constants (spec §8.3). monitorLabelRecheck drives
+// its rebalances through the state-machine claim path under these reasons.
+const (
+	// lifecycleLabelRecheck drives a rebalance re-run owed to the label
+	// re-check timer / requestLabelRecheck (deferral confirmation, grace
+	// expiry, persistent-non-fresh convergence).
+	lifecycleLabelRecheck = "label_recheck"
+	// lifecycleLabelChange is the requestLabelRecheck reason fired when the
+	// worker monitor detects a heartbeat label change behind a live worker ID
+	// (SetOnLabelChange wiring in NewCalculator). It is distinct from
+	// reasonNonFreshObservation, so requestLabelRecheck wakes the monitor
+	// immediately for fast convergence.
+	lifecycleLabelChange = "label_change"
+)
+
+// reasonNonFreshObservation is the requestLabelRecheck reason fired from INSIDE
+// a rebalance when the worker observation degraded to the cached list (the
+// replay-skip / defer path). Defined as a constant so the call site and the
+// spin-guard comparison in requestLabelRecheck cannot drift: a non-fresh
+// re-check must NOT wake the monitor synchronously (see requestLabelRecheck).
+const reasonNonFreshObservation = "non_fresh_observation"
 
 // isStopping reports whether Stop has been called. Used as the
 // Publisher's IsShuttingDown gate.
@@ -662,9 +813,10 @@ func (c *Calculator) inRecoveryGrace() bool {
 
 // shouldDeferForRecoveryGrace reports whether a rebalance with the given
 // lifecycle should bail because the leader entered recovery grace between
-// the caller's check and rebalanceMu acquisition. Only partition-triggered
-// rebalances honor this re-check; worker-change / audit / emergency paths
-// have their own grace handling (checkForChanges, emergency bypass).
+// the caller's check and rebalanceMu acquisition. Only monitor-claimed
+// rebalances (partition-triggered and label re-check) honor this re-check;
+// worker-change / audit / emergency paths have their own grace handling
+// (checkForChanges, emergency bypass).
 func (c *Calculator) shouldDeferForRecoveryGrace(lifecycle string) bool {
 	if !isPartitionLifecycle(lifecycle) {
 		return false
@@ -845,6 +997,14 @@ func (c *Calculator) triggerPartitionRebalance(lifecycle string) error {
 		err = nil
 	}
 
+	// A deferred label observation is a benign "confirm before acting"
+	// decision. Unlike the suspicious-partition case above, do NOT re-arm
+	// pendingPartitionUpdate: the label re-check timer (Task 9) owns the
+	// retry, so re-arming here would double-drive the same rebalance.
+	if errors.Is(err, errLabelObservationDeferred) {
+		err = nil
+	}
+
 	// Tail-check on a FRESH stop-aware context: reqCtx may already be near or
 	// past its deadline; observeAndDecide exits fast on a cancelled context
 	// and would strand any emergency loser until the next poll tick.
@@ -931,6 +1091,81 @@ func (c *Calculator) monitorPartitions(ctx context.Context, source types.Watchab
 			err := c.triggerPartitionRebalance(lifecyclePartitionUpdate)
 			c.restorePendingOnGraceBail(err)
 		}
+	}
+}
+
+// restorePendingLabelOnGraceBail restores pendingLabelRecheck=true when the
+// rebalance returned errShuttingDown but stopCh is still open — the bail came
+// from an in-rebalance recovery-grace re-check (grace flipped between the
+// monitor's pre-claim check and rebalance entry), NOT from a real shutdown, so
+// the owed re-check should be retried on the next tick. Mirrors
+// restorePendingOnGraceBail for the label flag (a straight copy is clearer than
+// generalizing).
+func (c *Calculator) restorePendingLabelOnGraceBail(err error) {
+	if !errors.Is(err, errShuttingDown) {
+		return
+	}
+	select {
+	case <-c.stopCh:
+		// Real shutdown; nothing to restore.
+	default:
+		c.pendingLabelRecheck.Store(true)
+	}
+}
+
+// monitorLabelRecheck owns the guaranteed second observation (spec §8.3): it
+// re-runs a rebalance when a label re-check is owed (deferral confirmation,
+// grace expiry, persistent-non-fresh convergence) even if no external event
+// ever arrives. It mirrors monitorPartitions: a capacity-1 channel coalesces
+// signals, a drain ticker guarantees eventual service across busy/grace
+// states, and the pendingLabelRecheck flag is sticky so nothing is lost when
+// the state machine is busy. Started unconditionally by Start; joined on Stop
+// via wg.Wait (returns on stopCh close).
+func (c *Calculator) monitorLabelRecheck(ctx context.Context) {
+	drainTick := time.NewTicker(c.RebalanceGraceDrainInterval)
+	defer drainTick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-c.labelRecheckCh:
+		case <-drainTick.C:
+		}
+
+		if !c.pendingLabelRecheck.CompareAndSwap(true, false) {
+			continue
+		}
+		if c.inRecoveryGrace() {
+			c.pendingLabelRecheck.Store(true) // retry next tick
+			continue
+		}
+		if !c.stateMach.TryClaimRebalancing(context.Background(), lifecycleLabelRecheck) {
+			c.pendingLabelRecheck.Store(true) // busy; sticky flag survives
+			// Short retry so a deferral raised INSIDE a running rebalance
+			// (claim still held when the wake arrives) confirms in ~2s rather
+			// than waiting a full drain tick (spec §16 item 7: re-check well
+			// under the drain cadence). Coalesced: the channel has capacity 1.
+			time.AfterFunc(2*time.Second, func() {
+				select {
+				case c.labelRecheckCh <- struct{}{}:
+				default:
+				}
+			})
+
+			continue
+		}
+
+		reqCtx, cancel := ctxFromStopCh(context.Background(), c.stopCh, partitionRebalanceRequestTimeout)
+		err := c.stateMach.RunClaimedRebalanceErr(reqCtx, lifecycleLabelRecheck)
+		cancel()
+		if errors.Is(err, errLabelObservationDeferred) {
+			// The deferral re-arms itself via requestLabelRecheck inside the
+			// rebalance; nothing extra to do (the flag is already set again).
+			continue
+		}
+		c.restorePendingLabelOnGraceBail(err)
 	}
 }
 
@@ -1274,6 +1509,403 @@ func (c *Calculator) getActiveWorkers(ctx context.Context) ([]string, bool, erro
 	return workers, true, nil
 }
 
+// readWorkerLabels fetches labels-of-record for the rebalance worker set
+// (spec §6). One bounded retry for missing workers; then the taxonomy:
+// more than max(1, 10%) unreadable ⇒ errLabelReadBroadFailure (broad
+// failures must never become label decisions). Legacy heartbeats decode
+// with nil labels — that is a SUCCESSFUL read of an empty set.
+//
+// Unreadable means unreadable for ANY reason: an absent heartbeat key
+// (worker departed between the active-set scan and this read) and a
+// present-but-undecodeable payload both leave the worker UNKNOWN and both
+// count toward the cap. Spec §6 is explicit: unreadable labels are
+// unknown, never guessed — "unlabeled" would hand general work to what
+// may be a dedicated worker under the dedicated policy. A decoded legacy
+// timestamp heartbeat proves a well-formed pre-label worker; an
+// undecodeable payload proves nothing.
+//
+// Connectivity / degrading-JetStream errors on ANY worker are broad by
+// class regardless of count (the 1-worker-fleet trap) and short-circuit
+// before the count rule, which only governs UNCLASSIFIED failures (e.g.
+// key-not-found on a live worker, malformed payloads).
+func (c *Calculator) readWorkerLabels(ctx context.Context, workers []string) (map[string][]string, map[string]bool, error) {
+	hbs, fails, err := c.monitor.GetHeartbeatsFor(ctx, workers)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", errLabelReadBroadFailure, err)
+	}
+	missing := missingWorkers(workers, hbs)
+	if len(missing) > 0 { // one inline retry for the stragglers
+		retry, retryFails, rerr := c.monitor.GetHeartbeatsFor(ctx, missing)
+		if rerr == nil {
+			maps.Copy(hbs, retry)
+			fails = retryFails // post-retry classification uses the fresh errors
+		}
+		missing = missingWorkers(workers, hbs)
+	}
+
+	// Error-CLASS taxonomy first (spec §6): a connectivity or
+	// degrading-JetStream failure is broad by nature, regardless of how
+	// many workers it hit — in a 1-worker fleet a count-based rule alone
+	// would misclassify it as an isolated unknown and eventually
+	// empty-assign the whole fleet.
+	for _, w := range missing {
+		ferr := fails[w]
+		if natsutil.IsConnectivityError(ferr) || natsutil.IsDegradingJetStreamError(ferr) {
+			return nil, nil, fmt.Errorf("%w: worker %s: %w", errLabelReadBroadFailure, w, ferr)
+		}
+	}
+
+	broadCap := max(1, len(workers)/10)
+	if len(missing) > broadCap {
+		return nil, nil, fmt.Errorf("%w: %d of %d workers unreadable", errLabelReadBroadFailure, len(missing), len(workers))
+	}
+
+	labels := make(map[string][]string, len(hbs))
+	for w, hb := range hbs {
+		labels[w] = hb.Labels
+	}
+	unknown := make(map[string]bool, len(missing))
+	for _, w := range missing {
+		unknown[w] = true
+	}
+
+	return labels, unknown, nil
+}
+
+// missingWorkers returns workers absent from the heartbeat map, sorted.
+func missingWorkers(workers []string, hbs map[string]types.Heartbeat) []string {
+	var out []string
+	for _, w := range workers {
+		if _, ok := hbs[w]; !ok {
+			out = append(out, w)
+		}
+	}
+	slices.Sort(out)
+
+	return out
+}
+
+// partitionsContentEqual reports label-aware content equality of two
+// partition slices: pairwise-equal Keys, Weight, AND Label, in order. The
+// replay proof must compare content directly because
+// PartitionSetDigest/BatchDigest are deliberately label-blind — a label-only
+// edit slips through them. Order-sensitive by design: a source that reorders
+// its listing without changing content merely degrades replay to the benign
+// defer, the conservative outcome.
+func partitionsContentEqual(a, b []types.Partition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Weight != b[i].Weight || a[i].Label != b[i].Label || !slices.Equal(a[i].Keys, b[i].Keys) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// cachedObservationReplayable reports whether the last published commit
+// already covers the current (cached) observation exactly, so the rebalance
+// can skip the publish. Replay is provable iff:
+//
+//	(i)  the cached worker set equals the last commit's payload worker set, AND
+//	(ii) the source snapshot is unchanged since that publish — via the cheap
+//	     revision fast-path when BOTH revisions are known, else via label-aware
+//	     content equality against the snapshot retained at publish time (the
+//	     path that makes revision-blind sources provable).
+//
+// A bootstrapped commit (inherited from a previous leader, no local publish)
+// has no retained snapshot: only the revision fast-path can prove it; content
+// equality conservatively fails and the caller defers.
+func (c *Calculator) cachedObservationReplayable(workers []string, partitions []types.Partition, srcRev uint64, srcKnown bool) bool {
+	commit := c.publisher.LastCommit()
+	if commit == nil {
+		return false
+	}
+
+	// (i) worker-set equality against the commit's payload keys.
+	if len(commit.Payloads) != len(workers) {
+		return false
+	}
+	for _, w := range workers {
+		if _, ok := commit.Payloads[w]; !ok {
+			return false
+		}
+	}
+
+	// (ii) source unchanged: revision fast-path, then content equality.
+	if srcKnown && commit.SourceRevisionKnown && srcRev == commit.SourceRevision {
+		return true
+	}
+	c.mu.RLock()
+	last := c.lastPublishedPartitions
+	c.mu.RUnlock()
+
+	return last != nil && partitionsContentEqual(partitions, last)
+}
+
+// rebalanceOnCachedObservation handles a rebalance whose worker observation
+// degraded to the cached list (connectivity error or suspicious shrink)
+// WITHOUT emergency confirmation. The adjudicated contract: a non-fresh
+// observation may REPLAY the previously committed shape but must never
+// compute new label routing or mint new label provenance.
+//
+//   - Replay provable (cachedObservationReplayable): skip the publish
+//     entirely — the previous commit already covers this exact state.
+//     Success (nil).
+//   - Otherwise: benign defer (errLabelObservationDeferred; converted to a
+//     no-op by handleRebalance / triggerPartitionRebalance). Nothing is
+//     published; a pending source change is not lost — any later rebalance
+//     re-snapshots the source.
+//
+// Both exits request a label re-check (belt-and-braces; Task 9 gives the
+// stub teeth) so the system converges to a fresh label-aware rebalance once
+// conditions heal, even if no external event arrives. Neither exit advances
+// labelState: grace/confirmation clocks only move on trusted observations.
+func (c *Calculator) rebalanceOnCachedObservation( //nolint:revive // argument-limit: the rebalance-context bundle for the replay decision
+	lifecycle string, workers []string, partitions []types.Partition, srcRev uint64, srcKnown bool, start time.Time,
+) error {
+	replayable := c.cachedObservationReplayable(workers, partitions, srcRev, srcKnown)
+	c.requestLabelRecheck(reasonNonFreshObservation)
+	c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
+	c.Metrics.RecordRebalanceAttempt(lifecycle, true)
+
+	if replayable {
+		c.Logger.Info("rebalance skipped: cached worker observation already covered by the last published commit",
+			"lifecycle", lifecycle, "workers", len(workers), "partitions", len(partitions))
+		return nil
+	}
+
+	c.Logger.Info("rebalance deferred: cached worker observation not provably covered by the last published commit",
+		"lifecycle", lifecycle, "workers", len(workers), "partitions", len(partitions))
+
+	return errLabelObservationDeferred
+}
+
+// deriveRebalanceAssignments produces the assignment shape for a TRUSTED
+// worker observation by running the label pipeline (routing + parked set +
+// labels-of-record). Callers gate trust: a fresh enumeration, or the
+// emergency carve-out (emergency-confirmed deaths filtered from the cached
+// list).
+//
+// It owns the label-path side effects and their metrics: firing
+// OnLabelReadBroadFailure on a broad read failure, arming the re-check timer on
+// a deferral, and the attempt/duration metrics for the deferral and error
+// exits. A non-nil error is terminal for the rebalance — either the benign
+// errLabelObservationDeferred sentinel the caller maps to a no-op, or a wrapped
+// hard failure — and its metrics are already recorded here.
+//
+// The result is only meaningful on a nil error. Its topo/actions fields let
+// the caller's recordLabelMetrics pass report the label observability
+// metrics (spec §13) from the exact decision that will be published, without
+// recomputing (and re-mutating labelState's grace clocks) a second time.
+func (c *Calculator) deriveRebalanceAssignments(
+	ctx context.Context, lifecycle string, workers []string, partitions []types.Partition, start time.Time,
+) (labelPipelineResult, error) {
+	res, deferred, err := c.labelRoutedAssignments(ctx, workers, partitions)
+	if err != nil {
+		// Broad label-read failures (connectivity/degrading-JetStream class,
+		// or above the isolated-failure cap) route to the manager's KV-error/
+		// degraded machinery via the OnLabelReadBroadFailure seam (mirrors the
+		// OnEnumerationError precedent). Nil-safe: unit-test default leaves it
+		// unwired. Any label error aborts: a broad failure must never be
+		// converted into a label decision that empty-assigns the fleet.
+		//
+		// Suppressed while stopping: Stop's stop-channel close cancels the
+		// rebalance context, which makes the heartbeat reads abort "broadly"
+		// — that is shutdown, not a KV failure, and must not pollute the
+		// manager's degraded window. It also re-enters the manager through a
+		// lock-taking callback (recordLabelReadFailure → recordKVError →
+		// m.mu) exactly while Manager.Stop is tearing the calculator down —
+		// the Task 15 shutdown-deadlock ingredient this guard removes
+		// (defense-in-depth alongside stopCalculator's lock restructure,
+		// which is the load-bearing fix: a GENUINE broad failure can still
+		// race Stop and must not deadlock either).
+		if errors.Is(err, errLabelReadBroadFailure) && c.OnLabelReadBroadFailure != nil && !c.isStopping() {
+			c.OnLabelReadBroadFailure(err)
+		}
+		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
+
+		return labelPipelineResult{}, c.wrapStopErr(err)
+	}
+	if deferred {
+		// First observation of a disruptive label condition: confirm before
+		// acting. The label re-check timer (Task 9) re-fires the rebalance.
+		c.requestLabelRecheck("observation_deferred")
+		c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
+		c.Metrics.RecordRebalanceAttempt(lifecycle, true)
+
+		return labelPipelineResult{}, errLabelObservationDeferred
+	}
+
+	return res, nil
+}
+
+// labelPipelineResult bundles the outputs of one label-pipeline run
+// (labelRoutedAssignments) for a trusted worker observation: everything the
+// rebalance needs to publish (assignments, parked set, labels-of-record) plus
+// the topology/actions the decision was made from, which the post-publish
+// LabelMetrics pass (recordLabelMetrics) reports without recomputing.
+type labelPipelineResult struct {
+	assignments map[string][]types.Partition // worker → merged partitions
+	parked      []types.Partition            // partitions parked awaiting an eligible worker
+	labels      map[string][]string          // workerID → labels-of-record for payload stamping
+	topo        labelTopology                // the topology the assignments were computed from
+	actions     map[string]emptyPoolAction   // empty-pool decisions applied (park/spill per label)
+}
+
+// labelRoutedAssignments runs the label pipeline (spec §7) for a TRUSTED
+// worker observation: reads labels-of-record, builds the pool topology,
+// advances the grace/confirmation state, and computes per-pool assignments
+// plus the parked set.
+//
+// deferred=true means a first disruptive label observation (an unreadable
+// worker or a newly-empty pool) needs confirmation before acting; the caller
+// aborts the rebalance with errLabelObservationDeferred and arms the re-check
+// timer. A broad label-read failure returns an error wrapping
+// errLabelReadBroadFailure; a strategy failure returns an error wrapped as
+// "assignment calculation failed". On success it returns the pipeline's
+// bundled outputs: the merged assignments, the parked set, the
+// labels-of-record for payload stamping, and the topology/actions the
+// decision was made from — the caller's LabelMetrics pass
+// (recordLabelMetrics) reads these AFTER a successful publish rather than
+// recomputing them, so it reports exactly what was applied.
+func (c *Calculator) labelRoutedAssignments(ctx context.Context, workers []string, partitions []types.Partition) (labelPipelineResult, bool, error) {
+	labels, unknown, err := c.readWorkerLabels(ctx, workers)
+	if err != nil {
+		return labelPipelineResult{}, false, err
+	}
+
+	unknownList := slices.Sorted(maps.Keys(unknown))
+	unknownDeferred := c.labelState.observeUnknownWorkers(unknownList)
+
+	topo := buildLabelTopology(topologyInput{
+		Workers:    workers,
+		Labels:     labels,
+		Unknown:    unknown,
+		Partitions: partitions,
+		Policy:     c.UnlabeledPartitionPolicy,
+	})
+
+	nonEmpty := make([]string, 0, len(topo.SortedLabels))
+	for _, l := range topo.SortedLabels {
+		if len(topo.Pools[l]) > 0 {
+			nonEmpty = append(nonEmpty, l)
+		}
+	}
+	c.labelState.observeNonEmpty(nonEmpty)
+	actions, emptyDeferred := c.labelState.observeEmptyPools(topo.EmptyLabels)
+
+	currentLabels := make(map[string]bool, len(topo.SortedLabels))
+	for _, l := range topo.SortedLabels {
+		currentLabels[l] = true
+	}
+	c.labelState.prune(currentLabels)
+
+	if unknownDeferred || emptyDeferred {
+		return labelPipelineResult{}, true, nil
+	}
+
+	assignments, parked, err := computeLabelAssignments(c.Strategy, topo, actions)
+	if err != nil {
+		return labelPipelineResult{}, false, fmt.Errorf("assignment calculation failed: %w", err)
+	}
+
+	return labelPipelineResult{
+		assignments: assignments,
+		parked:      parked,
+		labels:      labels,
+		topo:        topo,
+		actions:     actions,
+	}, false, nil
+}
+
+// recordLabelMetrics emits the label-observability metrics (spec §13) for a
+// rebalance that just published successfully. Per-label gauges are
+// recomputed from the topology/parked snapshot the publish used; a label
+// that left the snapshot since the last recorded pass is explicitly zeroed
+// in this SAME pass rather than left at its last non-zero reading. The
+// spill/fallback counters are derived from the same topo/actions — never
+// recomputed — so they report exactly what was applied, and both count
+// PARTITIONS (matching their interface Godoc), not rebalances:
+//
+//   - IncrementLabelSpill fires once per partition of every label whose
+//     empty-pool decision was emptyPoolSpill in the published rebalance.
+//   - IncrementUnlabeledFallback fires once per partition of the unlabeled
+//     group when its general/fallback pool was empty and the group itself
+//     was non-empty, forcing computeLabelAssignments' ladder down to
+//     topo.AllWorkers.
+//
+// No-ops entirely when the configured collector doesn't implement
+// types.LabelMetrics. Callers must only invoke this after a successful
+// publish: the cached-observation replay/defer paths and the broad-failure/
+// error aborts earlier in rebalance never reach here, so a rebalance that
+// didn't publish records nothing.
+func (c *Calculator) recordLabelMetrics(res labelPipelineResult) {
+	lm, ok := c.Metrics.(types.LabelMetrics)
+	if !ok {
+		return
+	}
+
+	topo := res.topo
+	parkedCountByLabel := make(map[string]int, len(topo.SortedLabels))
+	for _, p := range res.parked {
+		parkedCountByLabel[p.Label]++
+	}
+
+	current := make(map[string]bool, len(topo.SortedLabels))
+	for _, l := range topo.SortedLabels {
+		current[l] = true
+		lm.RecordLabelPoolSize(l, len(topo.Pools[l]))
+		lm.RecordParkedPartitions(l, parkedCountByLabel[l])
+		if res.actions[l] == emptyPoolSpill {
+			for range topo.Groups[l] {
+				lm.IncrementLabelSpill(l)
+			}
+		}
+	}
+	// Zero gauges for labels that left the snapshot since the last recorded
+	// pass — a drained label pool must not leave a stale non-zero reading.
+	for l := range c.prevMetricLabels {
+		if !current[l] {
+			lm.RecordLabelPoolSize(l, 0)
+			lm.RecordParkedPartitions(l, 0)
+		}
+	}
+	c.prevMetricLabels = current
+
+	if len(topo.GeneralPool) == 0 {
+		for range topo.Groups[""] {
+			lm.IncrementUnlabeledFallback()
+		}
+	}
+}
+
+// zeroLabelGaugesOnStop closes out the leader-scoped gauge lifecycle (spec
+// §13): a deposed/stopping leader zeroes every per-label gauge it last
+// recorded so its own metrics export doesn't freeze at stale non-zero
+// readings — the next leader's collector, not this one, owns the live
+// values from here on. Called from Stop after all rebalance-driving
+// goroutines have joined; rebalanceMu preserves prevMetricLabels' documented
+// single-lock discipline against any straggling external TriggerRebalance.
+func (c *Calculator) zeroLabelGaugesOnStop() {
+	c.rebalanceMu.Lock()
+	defer c.rebalanceMu.Unlock()
+
+	lm, ok := c.Metrics.(types.LabelMetrics)
+	if !ok {
+		c.prevMetricLabels = nil
+
+		return
+	}
+	for l := range c.prevMetricLabels {
+		lm.RecordLabelPoolSize(l, 0)
+		lm.RecordParkedPartitions(l, 0)
+	}
+	c.prevMetricLabels = nil
+}
+
 // cacheFallbackOrDegraded is the shared exit for getActiveWorkers' two degraded
 // fallbacks (a connectivity enumeration error and a suspicious worker-shrink). On
 // a cache hit it returns the last cached worker list as a NON-fresh observation
@@ -1522,6 +2154,11 @@ func (c *Calculator) handleRebalance(ctx context.Context, reason string) error {
 		if errors.Is(err, errSuspiciousWorkerObservation) {
 			return nil
 		}
+		// A deferred label observation is an explicit "confirm before
+		// acting" decision; the label re-check timer re-fires it. Benign.
+		if errors.Is(err, errLabelObservationDeferred) {
+			return nil
+		}
 
 		return fmt.Errorf("rebalance failed for %s: %w", reason, err)
 	}
@@ -1549,13 +2186,16 @@ func (c *Calculator) handleRebalance(ctx context.Context, reason string) error {
 // subsequent disappearance starts a fresh grace period.
 //
 // Returns the worker set, plus a "deaths confirmed" flag for the F10-A
-// rebalance-side floor. The flag is true iff EmergencyDetector has
-// captured at least one death — either consumed locally on the
-// emergency lifecycle, or still resident in c.disappearedWorkers on
-// the non-emergency lifecycle. The floor's check must see the
-// pre-clear state so an emergency rebalance is never wrongly
-// suppressed by its own consumption.
-func (c *Calculator) collectRebalanceWorkers(ctx context.Context, lifecycle string) ([]string, bool, error) {
+// rebalance-side floor and a "fresh" flag. The deaths-confirmed flag is
+// true iff EmergencyDetector has captured at least one death — either
+// consumed locally on the emergency lifecycle, or still resident in
+// c.disappearedWorkers on the non-emergency lifecycle. The floor's check
+// must see the pre-clear state so an emergency rebalance is never wrongly
+// suppressed by its own consumption. The fresh flag is false when the
+// observation was degraded to the cached worker list (connectivity error
+// or suspicious shrink); the label pipeline gates on it because a cached
+// set may contain departed workers whose heartbeats no longer decode.
+func (c *Calculator) collectRebalanceWorkers(ctx context.Context, lifecycle string) ([]string, bool, bool, error) { //nolint:revive // function-result-limit: four coordinated rebalance-input signals
 	var (
 		disappearedWorkers []string
 		deathsConfirmed    bool
@@ -1574,14 +2214,14 @@ func (c *Calculator) collectRebalanceWorkers(ctx context.Context, lifecycle stri
 
 	workers, fresh, err := c.getActiveWorkersFiltered(ctx, disappearedWorkers)
 	if err != nil {
-		return nil, false, c.wrapStopErr(fmt.Errorf("failed to get active workers: %w", err))
+		return nil, false, false, c.wrapStopErr(fmt.Errorf("failed to get active workers: %w", err))
 	}
 
 	if fresh {
 		c.emergencyDetector.ObserveAlive(workers)
 	}
 
-	return workers, deathsConfirmed, nil
+	return workers, deathsConfirmed, fresh, nil
 }
 
 // snapshotSource picks the best partition snapshot path for the source. If
@@ -1624,7 +2264,7 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 
 	start := time.Now()
 
-	workers, deathsConfirmed, err := c.collectRebalanceWorkers(ctx, lifecycle)
+	workers, deathsConfirmed, workersFresh, err := c.collectRebalanceWorkers(ctx, lifecycle)
 	if err != nil {
 		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
 		return err
@@ -1703,23 +2343,43 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 	}
 	c.lastKnownPartitionCount = len(partitions)
 
-	// Calculate new assignments using strategy
-	assignments, err := c.Strategy.Assign(workers, partitions)
-	if err != nil {
-		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
-		return c.wrapStopErr(fmt.Errorf("assignment calculation failed: %w", err))
+	// Trusted-observation gate. The label pipeline computes NEW routing only
+	// from a trustworthy worker set: a fresh enumeration, or the emergency
+	// carve-out — emergency-CONFIRMED deaths filtered out of the cached list
+	// make the survivor set trusted (EmergencyDetector independently verified
+	// the removals; the per-worker label reads below are fresh reads, so
+	// nothing is fabricated, and a broad read failure still aborts — never
+	// launder). Anything else (connectivity fallback, suspicious-shrink
+	// degrade) must not mint new routing or provenance: replay the previous
+	// commit if provable, else defer benignly.
+	trusted := workersFresh || (lifecycle == "emergency" && deathsConfirmed)
+	if !trusted {
+		return c.rebalanceOnCachedObservation(lifecycle, workers, partitions, srcRev, srcKnown, start)
 	}
+
+	// Assignment shape for this rebalance: routing, the parked set, and the
+	// labels-of-record for payload stamping, from the label pipeline. A
+	// non-nil error is terminal (a benign deferral sentinel or a wrapped
+	// hard failure) and its metrics are already recorded.
+	pipeline, derr := c.deriveRebalanceAssignments(ctx, lifecycle, workers, partitions, start)
+	if derr != nil {
+		return derr
+	}
+	assignments, parked, labels := pipeline.assignments, pipeline.parked, pipeline.labels
 
 	// Coverage is enforced strictly inside the publisher via set-equality of
 	// partition CanonicalIDs (§3.8 of the assignment robustness plan). We
 	// keep the orphaned-partition gauge for ops visibility but rely on the
 	// publisher to abort the batch on mismatch with ErrCoverageMismatch.
+	// Parked partitions are deliberately unassigned, so the orphan gauge
+	// compares assigned against the ELIGIBLE count (source minus parked).
 	assignedCount := 0
 	for _, parts := range assignments {
 		assignedCount += len(parts)
 	}
-	if assignedCount != len(partitions) {
-		c.Metrics.RecordOrphanedPartitions(len(partitions) - assignedCount)
+	eligible := len(partitions) - len(parked)
+	if assignedCount != eligible {
+		c.Metrics.RecordOrphanedPartitions(eligible - assignedCount)
 	} else {
 		c.Metrics.RecordOrphanedPartitions(0)
 	}
@@ -1785,6 +2445,8 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 		LeaderRevision:      leaderRevision,
 		Lifecycle:           lifecycle,
 		WorkersToRemove:     workersToRemove,
+		ParkedPartitions:    parked,
+		WorkerLabels:        labels,
 	}); err != nil {
 		c.Metrics.RecordRebalanceAttempt(lifecycle, false)
 		return c.wrapPublishErr(err)
@@ -1794,13 +2456,25 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 	c.Metrics.RecordRebalanceDuration(time.Since(start).Seconds(), lifecycle)
 	c.Metrics.RecordRebalanceAttempt(lifecycle, true)
 
-	// Update tracking state
+	// Label observability (spec §13). Placed strictly after the publish
+	// succeeded above: the cached-observation replay/defer paths and the
+	// broad-failure/error aborts earlier in this function return before
+	// reaching here, so a rebalance that didn't publish records nothing.
+	c.recordLabelMetrics(pipeline)
+
+	// Arm/disarm the label re-check timer for any parked grace (Task 9
+	// provides the body; the stub is a no-op).
+	c.armLabelRecheckAfterRebalance(len(parked))
+
+	// Update tracking state. lastPublishedPartitions backs the
+	// cached-observation replay proof (see the field Godoc).
 	c.mu.Lock()
 	clear(c.currentWorkers)
 	for _, w := range workers {
 		c.currentWorkers[w] = true
 	}
 	c.currentAssignments = assignments
+	c.lastPublishedPartitions = partitions
 	c.mu.Unlock()
 
 	c.Logger.Info("rebalance complete",

--- a/internal/assignment/calculator_label_metrics_test.go
+++ b/internal/assignment/calculator_label_metrics_test.go
@@ -1,0 +1,327 @@
+package assignment
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// labelMetricEvent captures a single LabelMetrics call. label is "" for
+// events that don't carry one (IncrementUnlabeledFallback).
+type labelMetricEvent struct {
+	method string // "pool_size" | "parked" | "spill" | "unlabeled_fallback"
+	label  string
+	value  int // workers/count for gauge events; unused for counter events
+}
+
+// fakeLabelMetrics records every LabelMetrics call in order so a test can
+// assert both the values recorded and the exact sequence (e.g. proving a
+// zeroing pass happened exactly once and nothing "leaked" afterward). Embeds
+// NopMetrics so the full CalculatorAndAssignmentMetrics surface is satisfied
+// without listing every method, mirroring auditRecordingMetrics.
+type fakeLabelMetrics struct {
+	*metrics.NopMetrics
+
+	mu     sync.Mutex
+	events []labelMetricEvent
+}
+
+func newFakeLabelMetrics() *fakeLabelMetrics {
+	return &fakeLabelMetrics{NopMetrics: metrics.NewNop()}
+}
+
+func (m *fakeLabelMetrics) RecordLabelPoolSize(label string, workers int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, labelMetricEvent{method: "pool_size", label: label, value: workers})
+}
+
+func (m *fakeLabelMetrics) RecordParkedPartitions(label string, count int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, labelMetricEvent{method: "parked", label: label, value: count})
+}
+
+func (m *fakeLabelMetrics) IncrementLabelSpill(label string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, labelMetricEvent{method: "spill", label: label})
+}
+
+func (m *fakeLabelMetrics) IncrementUnlabeledFallback() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, labelMetricEvent{method: "unlabeled_fallback"})
+}
+
+func (m *fakeLabelMetrics) snapshot() []labelMetricEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]labelMetricEvent, len(m.events))
+	copy(out, m.events)
+
+	return out
+}
+
+// vipEvents filters recorded events down to the "vip" label (the label every
+// sequence-asserting test in this file keys on), preserving order.
+func vipEvents(events []labelMetricEvent) []labelMetricEvent {
+	var out []labelMetricEvent
+	for _, e := range events {
+		if e.label == "vip" {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+// countEvents counts recorded events matching method+label — for asserting
+// EXACT counter cardinality (the counters are per-PARTITION, not
+// per-rebalance).
+func countEvents(events []labelMetricEvent, method, label string) int {
+	n := 0
+	for _, e := range events {
+		if e.method == method && e.label == label {
+			n++
+		}
+	}
+
+	return n
+}
+
+// newLabelCalcWithMetrics builds a Calculator wired to the given KVs/source,
+// mirroring newLabelCalc, but with a caller-supplied metrics collector —
+// newLabelCalc always defaults to a no-op collector, so tests asserting on
+// LabelMetrics calls need this variant instead of widening the shared
+// labelCalcConfig used by every other label test in the package.
+func newLabelCalcWithMetrics(t *testing.T, cfg labelCalcConfig, m CalculatorAndAssignmentMetrics) *Calculator {
+	t.Helper()
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:             cfg.assignmentKV,
+		HeartbeatKV:              cfg.heartbeatKV,
+		AssignmentPrefix:         "assignment",
+		Source:                   cfg.source,
+		Strategy:                 &mockStrategy{},
+		HeartbeatPrefix:          "worker-hb",
+		HeartbeatTTL:             30 * time.Second,
+		EmergencyGracePeriod:     1 * time.Second,
+		ColdStartWindow:          10 * time.Millisecond,
+		PlannedScaleWindow:       10 * time.Millisecond,
+		Cooldown:                 0,
+		LabelSpillGrace:          cfg.grace,
+		UnlabeledPartitionPolicy: cfg.policy,
+		OnLabelReadBroadFailure:  cfg.onBroadFailure,
+		Logger:                   cfg.logger,
+		Metrics:                  m,
+	})
+	require.NoError(t, err)
+
+	return calc
+}
+
+// TestCalculator_LabelMetrics_GaugeLifecycle pins the §13 gauge lifecycle
+// contract end to end: per-label gauges are recomputed on every completed
+// (published) rebalance, and a label that leaves the snapshot is explicitly
+// zeroed in the SAME pass rather than left at its last non-zero reading.
+//
+// Pass 1: source has a vip partition + a vip-labeled worker → pool_size=1,
+// parked=0 for "vip".
+// Pass 2: source rewritten WITHOUT any vip partition (the vip worker's
+// heartbeat is untouched) → the vip label leaves topo.SortedLabels entirely,
+// so the zeroing branch (not the normal per-label branch) must emit
+// pool_size=0 and parked=0 for "vip", and nothing else references "vip"
+// afterward.
+// Pass 3: vip still absent → NO further vip records at all — the zeroing
+// happens exactly once (on departure), not once per subsequent rebalance.
+func TestCalculator_LabelMetrics_GaugeLifecycle(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-metrics-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-metrics-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+	putLabeledHeartbeat(t, ctx, hbKV, "w1", nil)
+
+	vipPart := types.Partition{Keys: []string{"v"}, Label: "vip"}
+	plainPart := types.Partition{Keys: []string{"p"}}
+	src := &mutableSource{partitions: []types.Partition{vipPart, plainPart}}
+
+	fm := newFakeLabelMetrics()
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:         asgnKV,
+		HeartbeatKV:          hbKV,
+		AssignmentPrefix:     "assignment",
+		Source:               src,
+		Strategy:             &mockStrategy{},
+		HeartbeatPrefix:      "worker-hb",
+		HeartbeatTTL:         30 * time.Second,
+		EmergencyGracePeriod: 1 * time.Second,
+		ColdStartWindow:      10 * time.Millisecond,
+		PlannedScaleWindow:   10 * time.Millisecond,
+		Cooldown:             0,
+		Metrics:              fm,
+	})
+	require.NoError(t, err)
+
+	// Pass 1: vip present.
+	require.NoError(t, calc.rebalance(ctx, "test"))
+	require.NotNil(t, readCalcCommit(t, ctx, asgnKV))
+
+	vipAfterPass1 := vipEvents(fm.snapshot())
+	require.Equal(t, []labelMetricEvent{
+		{method: "pool_size", label: "vip", value: 1},
+		{method: "parked", label: "vip", value: 0},
+	}, vipAfterPass1, "pass 1 must record the vip pool size and zero parked count")
+
+	// Pass 2: source rewritten WITHOUT any vip partition.
+	src.set([]types.Partition{plainPart})
+	require.NoError(t, calc.rebalance(ctx, "test"))
+	require.NotNil(t, readCalcCommit(t, ctx, asgnKV))
+
+	vipAfterPass2 := vipEvents(fm.snapshot())
+	require.Equal(t, []labelMetricEvent{
+		{method: "pool_size", label: "vip", value: 1},
+		{method: "parked", label: "vip", value: 0},
+		{method: "pool_size", label: "vip", value: 0},
+		{method: "parked", label: "vip", value: 0},
+	}, vipAfterPass2, "pass 2 must zero the vip gauges exactly once, in the same pass, and record nothing further for vip")
+
+	// Pass 3: vip still absent. The zeroing must NOT repeat — a departed
+	// label records nothing on subsequent rebalances.
+	require.NoError(t, calc.rebalance(ctx, "test"))
+	vipAfterPass3 := vipEvents(fm.snapshot())
+	require.Equal(t, vipAfterPass2, vipAfterPass3,
+		"pass 3 must record NO further vip events: a departed label is zeroed once, then silent")
+}
+
+// TestCalculator_LabelMetrics_SpillIncrementsOnAppliedSpill pins that
+// IncrementLabelSpill fires ONCE PER PARTITION of a label whose empty-pool
+// decision was emptyPoolSpill in the PUBLISHED rebalance — derived from the
+// same actions the publish applied, not recomputed. Two ghost partitions
+// spill together, so the counter must read exactly 2, not 1-per-rebalance.
+func TestCalculator_LabelMetrics_SpillIncrementsOnAppliedSpill(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-spill-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-spill-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil) // unlabeled worker only
+
+	ghostA := types.Partition{Keys: []string{"g1"}, Label: "ghost"}
+	ghostB := types.Partition{Keys: []string{"g2"}, Label: "ghost"}
+	src := &mutableSource{partitions: []types.Partition{ghostA, ghostB}}
+
+	fm := newFakeLabelMetrics()
+	// Zero grace: the second confirmed-empty observation spills immediately
+	// rather than parking.
+	calc := newLabelCalcWithMetrics(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV}, fm)
+
+	// Attempt 1: first empty observation defers; nothing published, nothing
+	// recorded.
+	require.NoError(t, calc.handleRebalance(ctx, "test"))
+	require.Nil(t, readCalcCommit(t, ctx, asgnKV))
+	require.Empty(t, fm.snapshot(), "a deferred (unpublished) rebalance must record nothing")
+
+	// Attempt 2: confirmed empty within a zero grace window → spill BOTH.
+	require.NoError(t, calc.handleRebalance(ctx, "test"))
+	commit := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, commit)
+	require.Equal(t, 0, commit.ParkedCount, "the ghost partitions spill onto the fallback worker, not parked")
+
+	events := fm.snapshot()
+	require.Equal(t, 2, countEvents(events, "spill", "ghost"),
+		"IncrementLabelSpill is per-PARTITION: 2 spilled ghost partitions = exactly 2 increments")
+	require.NotContains(t, events, labelMetricEvent{method: "parked", label: "ghost", value: 2},
+		"a spilled label must not also read back as parked")
+}
+
+// TestCalculator_LabelMetrics_UnlabeledFallbackIncrements pins that
+// IncrementUnlabeledFallback fires ONCE PER PARTITION of the unlabeled group
+// when its general/fallback pool is empty (every active worker is labeled)
+// and the group is non-empty, forcing the ladder down to AllWorkers. Two
+// unlabeled partitions fall back together, so the counter must read exactly
+// 2, not 1-per-rebalance.
+func TestCalculator_LabelMetrics_UnlabeledFallbackIncrements(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-fallback-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-fallback-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"}) // the ONLY worker, and it's labeled
+
+	vipPart := types.Partition{Keys: []string{"v"}, Label: "vip"}
+	plainA := types.Partition{Keys: []string{"p1"}} // unlabeled group has TWO partitions
+	plainB := types.Partition{Keys: []string{"p2"}}
+	src := &mutableSource{partitions: []types.Partition{vipPart, plainA, plainB}}
+
+	fm := newFakeLabelMetrics()
+	calc := newLabelCalcWithMetrics(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV}, fm)
+
+	require.NoError(t, calc.rebalance(ctx, "test"))
+	require.NotNil(t, readCalcCommit(t, ctx, asgnKV))
+
+	events := fm.snapshot()
+	require.Equal(t, 2, countEvents(events, "unlabeled_fallback", ""),
+		"IncrementUnlabeledFallback is per-PARTITION: 2 fallback-routed unlabeled partitions = exactly 2 increments")
+}
+
+// TestCalculator_LabelMetrics_StopZeroesGauges pins the leader-scoped gauge
+// lifecycle across leader terms: the per-label gauges live only while THIS
+// worker is the calculating leader, so the calculator's stop path must zero
+// every label it last recorded (and clear its tracking state). Without this,
+// a deposed leader's metrics export freezes at the last recorded values and
+// a label that departs while another leader calculates is never zeroed here.
+//
+// Start-driven (not direct-rebalance-driven) so Stop exercises the real
+// lifecycle: Start → initial rebalance records vip gauges → Stop zeroes them.
+func TestCalculator_LabelMetrics_StopZeroesGauges(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-stopzero-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-stopzero-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"v"}, Label: "vip"}}}
+	fm := newFakeLabelMetrics()
+	calc := newLabelCalcWithMetrics(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV}, fm)
+
+	require.NoError(t, calc.Start(ctx))
+	stopped := false
+	defer func() {
+		if !stopped {
+			_ = calc.Stop(ctx)
+		}
+	}()
+
+	// Wait for the initial rebalance to record the vip gauges.
+	require.Eventually(t, func() bool {
+		return countEvents(fm.snapshot(), "pool_size", "vip") > 0
+	}, 5*time.Second, 25*time.Millisecond, "the initial rebalance must record the vip pool gauge")
+
+	require.NoError(t, calc.Stop(ctx))
+	stopped = true
+
+	events := vipEvents(fm.snapshot())
+	require.GreaterOrEqual(t, len(events), 4, "expected at least one recording pass plus the stop-zeroing pass")
+	require.Equal(t, []labelMetricEvent{
+		{method: "pool_size", label: "vip", value: 0},
+		{method: "parked", label: "vip", value: 0},
+	}, events[len(events)-2:], "Stop must zero both vip gauges as its final records")
+	require.Contains(t, events[:len(events)-2], labelMetricEvent{method: "pool_size", label: "vip", value: 1},
+		"a non-zero pool gauge must have been recorded before Stop zeroed it")
+}

--- a/internal/assignment/calculator_labels_startup_test.go
+++ b/internal/assignment/calculator_labels_startup_test.go
@@ -1,0 +1,135 @@
+package assignment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the fix for the takeover/startup deferred-label defect found
+// by the Task 14 pool-outage integration test
+// (test/integration/assignment/label_orphan_stale_test.go,
+// TestLabelPoolOutage_ParkSpillRehome): the synchronous immediate-assignment
+// path in Calculator.Start treated the BENIGN errLabelObservationDeferred
+// sentinel as fatal. On leadership takeover that failed startCalculator, which
+// released leadership; the next leader built a fresh per-term labelState
+// (spec §8.4), deferred again, and released — an infinite leadership flap in
+// which the defer-once streak never reached 2 and parked partitions were never
+// committed (spec I2 violation). Deferral is benign EVERYWHERE (spec §8.5):
+// the previous commit stays valid, and the re-check armed inside the rebalance
+// drives the confirming second observation.
+
+// TestStart_TakeoverImmediate_DeferredLabelObservation_Benign: a new leader
+// takes over (prior commit exists) exactly when a labeled pool is empty. The
+// takeover_immediate rebalance defers (first adverse observation of a fresh
+// labelState) — Start must SUCCEED without publishing, and the armed re-check
+// must drive the confirming second observation that publishes the parked
+// commit.
+func TestStart_TakeoverImmediate_DeferredLabelObservation_Benign(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-takeover-defer-asgn")
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-takeover-defer-hb")
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+
+	plain := types.Partition{Keys: []string{"p"}}
+	ghost := types.Partition{Keys: []string{"g"}, Label: "ghost"}
+	src := &mutableSource{partitions: []types.Partition{plain}}
+
+	// Previous leader publishes a commit, then dies (never Started, so its
+	// assignment keys survive for the takeover's version discovery).
+	prev := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+	require.NoError(t, prev.rebalance(ctx, "seed"))
+	seed := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, seed)
+
+	// The ghost pool drains coincident with the takeover: the new leader's
+	// FRESH labelState sees the empty pool for the first time.
+	src.set([]types.Partition{plain, ghost})
+
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+	require.NoError(t, calc.Start(ctx),
+		"a deferred label observation during takeover_immediate is benign and must not fail Start "+
+			"(failing releases leadership and livelocks the fleet: every new leader defers its first observation)")
+	defer func() { _ = calc.Stop(ctx) }()
+
+	// The confirming SECOND observation (label re-check / stabilization
+	// rebalance) publishes the parked commit; inside grace ⇒ park.
+	require.Eventually(t, func() bool {
+		c := readCalcCommit(t, ctx, asgnKV)
+		return c != nil && c.Version > seed.Version && c.ParkedCount == 1
+	}, 5*time.Second, 20*time.Millisecond,
+		"the armed re-check must confirm the empty pool and publish the parked commit")
+}
+
+// TestStart_ColdStartImmediate_DeferredLabelObservation_Benign: same defect
+// class on the cold-start path — no prior commit, a ghost-labeled partition is
+// present at T=0. The cold_start_immediate rebalance defers; Manager.Start
+// must not fail, and the confirming observation publishes the parked commit.
+func TestStart_ColdStartImmediate_DeferredLabelObservation_Benign(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-coldstart-defer-asgn")
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-coldstart-defer-hb")
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+
+	src := &mutableSource{partitions: []types.Partition{
+		{Keys: []string{"p"}},
+		{Keys: []string{"g"}, Label: "ghost"},
+	}}
+
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+	require.NoError(t, calc.Start(ctx),
+		"a deferred label observation during cold_start_immediate is benign and must not fail Start")
+	defer func() { _ = calc.Stop(ctx) }()
+
+	require.Eventually(t, func() bool {
+		c := readCalcCommit(t, ctx, asgnKV)
+		return c != nil && c.ParkedCount == 1
+	}, 5*time.Second, 20*time.Millisecond,
+		"the confirming observation must publish the first commit with the ghost partition parked")
+}
+
+// TestTriggerRebalance_DeferredLabelObservation_Benign: the manual-refresh
+// path (Manager.TriggerRebalance → Calculator.TriggerRebalance) is the same
+// sentinel-consumer class. A deferral there is success-without-publish, not an
+// error surfaced to the API caller.
+func TestTriggerRebalance_DeferredLabelObservation_Benign(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-trigger-defer-asgn")
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-trigger-defer-hb")
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+
+	plain := types.Partition{Keys: []string{"p"}}
+	src := &mutableSource{partitions: []types.Partition{plain}}
+
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+	require.NoError(t, calc.Start(ctx), "healthy cold start must succeed")
+	defer func() { _ = calc.Stop(ctx) }()
+
+	// Wait for the startup flow (immediate + stabilization rebalance) to
+	// settle so the manual trigger below is deterministically the FIRST
+	// observation of the ghost pool.
+	require.Eventually(t, func() bool {
+		return readCalcCommit(t, ctx, asgnKV) != nil
+	}, 5*time.Second, 20*time.Millisecond, "startup must publish the healthy commit")
+
+	src.set([]types.Partition{plain, {Keys: []string{"g"}, Label: "ghost"}})
+
+	require.NoError(t, calc.TriggerRebalance(ctx),
+		"a deferred label observation on manual refresh is benign: success-without-publish, "+
+			"the armed re-check owns the confirming retry")
+}

--- a/internal/assignment/calculator_labels_test.go
+++ b/internal/assignment/calculator_labels_test.go
@@ -1,0 +1,705 @@
+package assignment
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// getFailKV wraps a real KeyValue but forces every Get to fail with a fixed
+// error, while Keys/Put/etc. delegate to the embedded bucket. Used to stage a
+// connectivity-classed heartbeat-read failure without tearing down the cluster.
+type getFailKV struct {
+	jetstream.KeyValue
+	getErr error
+}
+
+func (k *getFailKV) Get(_ context.Context, _ string) (jetstream.KeyValueEntry, error) {
+	return nil, k.getErr
+}
+
+// putLabeledHeartbeat writes a v1 JSON heartbeat carrying the given labels
+// under the "worker-hb" prefix newLabelCalc configures.
+func putLabeledHeartbeat(t *testing.T, ctx context.Context, kv jetstream.KeyValue, workerID string, labels []string) {
+	t.Helper()
+	hb := types.Heartbeat{
+		WorkerID:      workerID,
+		SchemaVersion: 1,
+		Capabilities:  types.CapAckV1,
+		Labels:        labels,
+		Timestamp:     time.Now().UTC(),
+	}
+	data, err := json.Marshal(hb)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "worker-hb."+workerID, data)
+	require.NoError(t, err)
+}
+
+// keysFailKV wraps a real KeyValue but fails every Keys scan with a fixed
+// error while the toggle is on. Used to stage a connectivity-degraded worker
+// enumeration (cache fallback) without tearing down the cluster.
+type keysFailKV struct {
+	jetstream.KeyValue
+	fail   atomic.Bool
+	keyErr error
+}
+
+func (k *keysFailKV) Keys(ctx context.Context, opts ...jetstream.WatchOpt) ([]string, error) {
+	if k.fail.Load() {
+		return nil, k.keyErr
+	}
+
+	return k.KeyValue.Keys(ctx, opts...)
+}
+
+// debugCapturingLogger records Debug-level entries (message + key/values) so a
+// test can assert the requestLabelRecheck stub fired with a specific reason.
+// Other levels are no-ops. Safe for concurrent use.
+type debugCapturingLogger struct {
+	mu      sync.Mutex
+	entries []capturedDebugLog
+}
+
+type capturedDebugLog struct {
+	msg string
+	kv  []any
+}
+
+func (l *debugCapturingLogger) Debug(msg string, kv ...any) {
+	l.mu.Lock()
+	l.entries = append(l.entries, capturedDebugLog{msg: msg, kv: kv})
+	l.mu.Unlock()
+}
+func (l *debugCapturingLogger) Info(string, ...any)  {}
+func (l *debugCapturingLogger) Warn(string, ...any)  {}
+func (l *debugCapturingLogger) Error(string, ...any) {}
+func (l *debugCapturingLogger) Fatal(string, ...any) {}
+
+// recheckRequested reports whether requestLabelRecheck fired with the given
+// reason (the Task 8 stub logs "label recheck requested" at Debug).
+func (l *debugCapturingLogger) recheckRequested(reason string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.entries {
+		if e.msg != "label recheck requested" {
+			continue
+		}
+		for i := 0; i+1 < len(e.kv); i += 2 {
+			if e.kv[i] == "reason" && e.kv[i+1] == reason {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+type labelCalcConfig struct {
+	source         types.PartitionSource
+	heartbeatKV    jetstream.KeyValue
+	assignmentKV   jetstream.KeyValue
+	grace          time.Duration
+	policy         string
+	onBroadFailure func(err error)
+	logger         types.Logger
+}
+
+// newLabelCalc builds a Calculator wired to the given KVs and source, NOT
+// Start()ed — the label tests drive rebalance directly, mirroring the F10-A /
+// F6-B fixtures, so no monitor goroutine races the explicit calls.
+func newLabelCalc(t *testing.T, cfg labelCalcConfig) *Calculator {
+	t.Helper()
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:             cfg.assignmentKV,
+		HeartbeatKV:              cfg.heartbeatKV,
+		AssignmentPrefix:         "assignment",
+		Source:                   cfg.source,
+		Strategy:                 &mockStrategy{},
+		HeartbeatPrefix:          "worker-hb",
+		HeartbeatTTL:             30 * time.Second,
+		EmergencyGracePeriod:     1 * time.Second,
+		ColdStartWindow:          10 * time.Millisecond,
+		PlannedScaleWindow:       10 * time.Millisecond,
+		Cooldown:                 0,
+		LabelSpillGrace:          cfg.grace,
+		UnlabeledPartitionPolicy: cfg.policy,
+		OnLabelReadBroadFailure:  cfg.onBroadFailure,
+		Logger:                   cfg.logger,
+	})
+	require.NoError(t, err)
+
+	return calc
+}
+
+// readCalcCommit fetches and decodes the assignment._commit key from a
+// calculator-owned assignment bucket. Returns nil when absent.
+func readCalcCommit(t *testing.T, ctx context.Context, kv jetstream.KeyValue) *types.AssignmentCommit {
+	t.Helper()
+	entry, err := kv.Get(ctx, "assignment._commit")
+	if err != nil {
+		require.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+		return nil
+	}
+	var c types.AssignmentCommit
+	require.NoError(t, json.Unmarshal(entry.Value(), &c))
+
+	return &c
+}
+
+// readCalcPayload fetches, decompresses, and decodes a payload by its key.
+func readCalcPayload(t *testing.T, ctx context.Context, kv jetstream.KeyValue, key string) types.AssignmentPayload {
+	t.Helper()
+	entry, err := kv.Get(ctx, key)
+	require.NoError(t, err)
+	plain, err := gzipDecompress(entry.Value())
+	require.NoError(t, err)
+	var p types.AssignmentPayload
+	require.NoError(t, json.Unmarshal(plain, &p))
+
+	return p
+}
+
+// TestRebalance_LabelRouting_EndToEnd: 2 workers (w0 labels=[vip], w1
+// unlabeled) with live heartbeats, source = 1 vip + 1 plain partition. After a
+// rebalance the vip partition lands on w0 (with WorkerLabels=[vip], Known=true)
+// and the plain partition on w1; nothing is parked.
+func TestRebalance_LabelRouting_EndToEnd(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-route-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-route-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+	putLabeledHeartbeat(t, ctx, hbKV, "w1", nil)
+
+	vipPart := types.Partition{Keys: []string{"v"}, Label: "vip"}
+	plainPart := types.Partition{Keys: []string{"p"}}
+	src := &mutableSource{partitions: []types.Partition{vipPart, plainPart}}
+
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+	require.NoError(t, calc.rebalance(ctx, "test"))
+
+	commit := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, commit)
+	require.Equal(t, 0, commit.ParkedCount, "nothing parked when every label pool is populated")
+
+	p0 := readCalcPayload(t, ctx, asgnKV, commit.Payloads["w0"].Key)
+	require.Len(t, p0.Partitions, 1)
+	require.Equal(t, "vip", p0.Partitions[0].Label, "w0 gets exactly the vip partition")
+	require.Equal(t, []string{"vip"}, p0.WorkerLabels)
+	require.True(t, p0.WorkerLabelsKnown)
+
+	p1 := readCalcPayload(t, ctx, asgnKV, commit.Payloads["w1"].Key)
+	require.Len(t, p1.Partitions, 1)
+	require.Equal(t, "", p1.Partitions[0].Label, "w1 gets exactly the plain partition")
+	require.Nil(t, p1.WorkerLabels, "unlabeled worker gets nil labels-of-record")
+	require.True(t, p1.WorkerLabelsKnown)
+}
+
+// TestRebalance_EmptyPool_DeferThenPark: a "ghost"-labeled partition with no
+// matching worker. Via handleRebalance the first attempt is a benign no-op (no
+// commit, deferred pending confirmation); the second parks the ghost partition.
+func TestRebalance_EmptyPool_DeferThenPark(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-park-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-park-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil) // unlabeled worker only
+
+	ghost := types.Partition{Keys: []string{"g"}, Label: "ghost"}
+	src := &mutableSource{partitions: []types.Partition{ghost}}
+
+	// Large grace so the confirmed-empty pool PARKS (not spills) on attempt 2.
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+
+	// Attempt 1: first empty observation → defer. handleRebalance maps the
+	// benign sentinel to nil, and nothing is published.
+	require.NoError(t, calc.handleRebalance(ctx, "test"))
+	require.Nil(t, readCalcCommit(t, ctx, asgnKV), "first (deferred) attempt must not publish")
+
+	// Attempt 2: confirmed empty within grace → park the ghost partition.
+	require.NoError(t, calc.handleRebalance(ctx, "test"))
+	commit := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, commit)
+	require.Equal(t, 1, commit.ParkedCount, "the ghost partition is parked")
+
+	p0 := readCalcPayload(t, ctx, asgnKV, commit.Payloads["w0"].Key)
+	require.Empty(t, p0.Partitions, "the parked ghost partition appears in no worker payload")
+}
+
+// TestRebalance_EmptyPool_DeferReturnsSentinel pins that the first empty-pool
+// observation surfaces errLabelObservationDeferred from rebalance itself.
+func TestRebalance_EmptyPool_DeferReturnsSentinel(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-sentinel-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-sentinel-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+
+	ghost := types.Partition{Keys: []string{"g"}, Label: "ghost"}
+	src := &mutableSource{partitions: []types.Partition{ghost}}
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+
+	require.ErrorIs(t, calc.rebalance(ctx, "test"), errLabelObservationDeferred)
+}
+
+// TestReadWorkerLabels_SmallFleetTaxonomy pins the §14 small-fleet
+// classification: isolated per-worker misses stay unknown; broad failures
+// (over the max(1,10%) cap, or ANY connectivity/degrading-class error) abort.
+func TestReadWorkerLabels_SmallFleetTaxonomy(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	t.Run("1-of-3 isolated unknown", func(t *testing.T) {
+		t.Parallel()
+		asgnKV := partitest.CreateJetStreamKV(t, nc, "tax-a-asgn")
+		hbKV := partitest.CreateJetStreamKV(t, nc, "tax-a-hb")
+		putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+		putLabeledHeartbeat(t, ctx, hbKV, "w1", nil)
+		calc := newLabelCalc(t, labelCalcConfig{source: &mutableSource{}, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+		labels, unknown, err := calc.readWorkerLabels(ctx, []string{"w0", "w1", "w2"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"vip"}, labels["w0"])
+		require.Contains(t, labels, "w1")
+		require.Equal(t, map[string]bool{"w2": true}, unknown)
+	})
+
+	t.Run("1-of-2 isolated unknown (cap=max(1,10%)=1)", func(t *testing.T) {
+		t.Parallel()
+		asgnKV := partitest.CreateJetStreamKV(t, nc, "tax-b-asgn")
+		hbKV := partitest.CreateJetStreamKV(t, nc, "tax-b-hb")
+		putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+		calc := newLabelCalc(t, labelCalcConfig{source: &mutableSource{}, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+		_, unknown, err := calc.readWorkerLabels(ctx, []string{"w0", "w1"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]bool{"w1": true}, unknown)
+	})
+
+	t.Run("2-of-3 broad (over the count cap)", func(t *testing.T) {
+		t.Parallel()
+		asgnKV := partitest.CreateJetStreamKV(t, nc, "tax-c-asgn")
+		hbKV := partitest.CreateJetStreamKV(t, nc, "tax-c-hb")
+		putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+		calc := newLabelCalc(t, labelCalcConfig{source: &mutableSource{}, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+		_, _, err := calc.readWorkerLabels(ctx, []string{"w0", "w1", "w2"})
+		require.ErrorIs(t, err, errLabelReadBroadFailure)
+	})
+
+	t.Run("1-worker connectivity error (class beats count)", func(t *testing.T) {
+		t.Parallel()
+		asgnKV := partitest.CreateJetStreamKV(t, nc, "tax-d-asgn")
+		hbKV := partitest.CreateJetStreamKV(t, nc, "tax-d-hb")
+		failKV := &getFailKV{KeyValue: hbKV, getErr: nats.ErrTimeout}
+		calc := newLabelCalc(t, labelCalcConfig{source: &mutableSource{}, heartbeatKV: failKV, assignmentKV: asgnKV})
+
+		_, _, err := calc.readWorkerLabels(ctx, []string{"w0"})
+		require.ErrorIs(t, err, errLabelReadBroadFailure,
+			"a connectivity-classed error on the only worker must NOT be treated as an isolated unknown")
+	})
+
+	t.Run("1-of-3 malformed-present is unknown, not unlabeled", func(t *testing.T) {
+		t.Parallel()
+		asgnKV := partitest.CreateJetStreamKV(t, nc, "tax-e-asgn")
+		hbKV := partitest.CreateJetStreamKV(t, nc, "tax-e-hb")
+		putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+		putLabeledHeartbeat(t, ctx, hbKV, "w1", nil)
+		// w2's heartbeat KEY exists but the payload is unparseable: neither
+		// JSON nor a legacy timestamp. Spec §6: unreadable labels are
+		// unknown, never guessed — "unlabeled" would hand general work to
+		// what may be a dedicated worker under the dedicated policy.
+		_, err := hbKV.Put(ctx, "worker-hb.w2", []byte("not-a-heartbeat"))
+		require.NoError(t, err)
+		calc := newLabelCalc(t, labelCalcConfig{source: &mutableSource{}, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+		labels, unknown, err := calc.readWorkerLabels(ctx, []string{"w0", "w1", "w2"})
+		require.NoError(t, err, "one malformed worker of three is an isolated unknown, not broad")
+		require.Equal(t, map[string]bool{"w2": true}, unknown,
+			"a present-but-undecodeable heartbeat is UNKNOWN")
+		require.NotContains(t, labels, "w2",
+			"an unknown worker must not appear in the labels map as unlabeled")
+	})
+
+	t.Run("malformed plus missing crossing the cap is broad", func(t *testing.T) {
+		t.Parallel()
+		asgnKV := partitest.CreateJetStreamKV(t, nc, "tax-f-asgn")
+		hbKV := partitest.CreateJetStreamKV(t, nc, "tax-f-hb")
+		putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+		// w1 present-but-malformed, w2 absent: together 2 of 3 unreadable,
+		// over the max(1, 3/10)=1 cap — malformed payloads count toward the
+		// broad-failure cap exactly like missing keys.
+		_, err := hbKV.Put(ctx, "worker-hb.w1", []byte("not-a-heartbeat"))
+		require.NoError(t, err)
+		calc := newLabelCalc(t, labelCalcConfig{source: &mutableSource{}, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+		_, _, err = calc.readWorkerLabels(ctx, []string{"w0", "w1", "w2"})
+		require.ErrorIs(t, err, errLabelReadBroadFailure,
+			"malformed-present and absent workers must both count toward the broad cap")
+	})
+}
+
+// TestRebalance_BroadLabelReadFailure_AbortsBeforeDecision: a broad heartbeat
+// label-read failure aborts the rebalance before any label decision — no
+// commit, labelState streaks untouched, and OnLabelReadBroadFailure fires once.
+func TestRebalance_BroadLabelReadFailure_AbortsBeforeDecision(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-broad-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-broad-hb-"+t.Name())
+
+	// A real key so the Keys()-based active-worker scan returns w0, but a Get
+	// that always fails with a connectivity-classed error.
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+	failKV := &getFailKV{KeyValue: hbKV, getErr: nats.ErrTimeout}
+
+	var broadFires atomic.Int64
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"v"}, Label: "vip"}}}
+	calc := newLabelCalc(t, labelCalcConfig{
+		source:         src,
+		heartbeatKV:    failKV,
+		assignmentKV:   asgnKV,
+		onBroadFailure: func(error) { broadFires.Add(1) },
+	})
+
+	err := calc.rebalance(ctx, "test")
+	require.ErrorIs(t, err, errLabelReadBroadFailure)
+	require.Nil(t, readCalcCommit(t, ctx, asgnKV), "broad failure must abort before publishing")
+	require.Equal(t, int64(1), broadFires.Load(), "OnLabelReadBroadFailure fires exactly once")
+	require.Empty(t, calc.labelState.emptyStreak, "empty-pool streak must not advance on a broad-failure abort")
+	require.Empty(t, calc.labelState.unknownStreak, "unknown-worker streak must not advance on a broad-failure abort")
+}
+
+// seedReplayFixture builds a 4-worker calculator (decodable heartbeats), runs
+// one fresh seed rebalance so a commit + retained snapshot exist, then deletes
+// 3 of the 4 heartbeat keys so the next enumeration is a suspicious shrink
+// (1*100 < 4*50, counter 1 < ConfirmCount default 2) that degrades to the
+// CACHED 4-worker list with fresh=false — the replay-or-defer path.
+func seedReplayFixture(t *testing.T, ctx context.Context, src *mutableSource, logger types.Logger) (*Calculator, jetstream.KeyValue) {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-replay-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-replay-hb-"+t.Name())
+
+	for _, w := range []string{"w0", "w1", "w2", "w3"} {
+		putLabeledHeartbeat(t, ctx, hbKV, w, nil)
+	}
+
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, logger: logger})
+	require.NoError(t, calc.rebalance(ctx, "seed"))
+	require.NotNil(t, readCalcCommit(t, ctx, asgnKV), "seed rebalance must publish")
+
+	for _, w := range []string{"w1", "w2", "w3"} {
+		require.NoError(t, hbKV.Delete(ctx, "worker-hb."+w))
+	}
+
+	return calc, asgnKV
+}
+
+// TestRebalance_CachedObservation_ReplaySkipsPublish: cached observation +
+// prior commit + content-unchanged source ⇒ replay is provable and the publish
+// is skipped entirely — NoError, no new commit bytes, labelState untouched,
+// and the label re-check was requested (belt-and-braces convergence).
+func TestRebalance_CachedObservation_ReplaySkipsPublish(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	logger := &debugCapturingLogger{}
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"a"}}, {Keys: []string{"b"}}}}
+	calc, asgnKV := seedReplayFixture(t, ctx, src, logger)
+
+	before := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, before)
+
+	require.NoError(t, calc.rebalance(ctx, "test"),
+		"a replay-provable cached observation is a successful no-op")
+
+	after := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, after)
+	require.Equal(t, before.Version, after.Version, "replay must not publish a new commit")
+	require.Equal(t, before.Payloads, after.Payloads, "replay must not write new payload bytes")
+	require.Empty(t, calc.labelState.emptyStreak, "replay must not advance empty-pool streaks")
+	require.Empty(t, calc.labelState.unknownStreak, "replay must not advance unknown-worker streaks")
+	require.True(t, logger.recheckRequested("non_fresh_observation"),
+		"every replay-skip must arm the label re-check so the system converges once conditions heal")
+}
+
+// TestRebalance_CachedObservation_SourceContentChanged_Defers: cached
+// observation + a LABEL-ONLY source change since the last publish ⇒ replay is
+// not provable (content equality is label-aware; the digests are deliberately
+// label-blind and would miss this) ⇒ benign defer: no publish,
+// requestLabelRecheck fired, and handleRebalance treats it as a no-op.
+func TestRebalance_CachedObservation_SourceContentChanged_Defers(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	logger := &debugCapturingLogger{}
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"a"}}, {Keys: []string{"b"}}}}
+	calc, asgnKV := seedReplayFixture(t, ctx, src, logger)
+
+	// Label-only edit: same count (partition guard silent), same label-blind
+	// digest — only label-aware content equality can catch it.
+	src.set([]types.Partition{{Keys: []string{"a"}}, {Keys: []string{"b"}, Label: "vip"}})
+
+	before := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, before)
+
+	require.ErrorIs(t, calc.rebalance(ctx, "test"), errLabelObservationDeferred,
+		"a cached observation with changed source content must defer, not compute new routing")
+	require.NoError(t, calc.handleRebalance(ctx, "test"),
+		"handleRebalance must treat the deferred outcome as benign")
+
+	after := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, after)
+	require.Equal(t, before.Version, after.Version, "a deferred cached observation must not publish")
+	require.True(t, logger.recheckRequested("non_fresh_observation"),
+		"the defer must arm the label re-check")
+}
+
+// TestRebalance_CachedObservation_NoPriorCommit_Defers: a connectivity-degraded
+// (cached) observation with NO prior commit has nothing to replay ⇒ benign
+// defer, nothing published.
+func TestRebalance_CachedObservation_NoPriorCommit_Defers(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-nocommit-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-nocommit-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+	putLabeledHeartbeat(t, ctx, hbKV, "w1", nil)
+	failKV := &keysFailKV{KeyValue: hbKV, keyErr: nats.ErrTimeout}
+
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"a"}}}}
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: failKV, assignmentKV: asgnKV})
+
+	// Populate the worker cache with a healthy enumeration, then degrade the
+	// scan so the rebalance observes the cached list with fresh=false.
+	workers, fresh, err := calc.getActiveWorkers(ctx)
+	require.NoError(t, err)
+	require.True(t, fresh)
+	require.Len(t, workers, 2)
+	failKV.fail.Store(true)
+
+	require.ErrorIs(t, calc.rebalance(ctx, "test"), errLabelObservationDeferred,
+		"no prior commit means nothing to replay: the cached observation must defer")
+	require.Nil(t, readCalcCommit(t, ctx, asgnKV), "the deferred rebalance must not publish")
+}
+
+// TestRebalance_EmergencyCarveOut_LabeledSurvivor pins the emergency carve-out
+// at the label level: an emergency rebalance whose enumeration degraded to the
+// cached list but whose removals are emergency-CONFIRMED runs the FULL label
+// pipeline on the survivor set — the committed payload carries the survivor's
+// real labels-of-record, proving the pipeline (not a fabricated stamp) ran.
+func TestRebalance_EmergencyCarveOut_LabeledSurvivor(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-emerg-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-emerg-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+	for _, w := range []string{"w1", "w2", "w3"} {
+		putLabeledHeartbeat(t, ctx, hbKV, w, nil)
+	}
+
+	vipPart := types.Partition{Keys: []string{"v"}, Label: "vip"}
+	plainPart := types.Partition{Keys: []string{"p"}}
+	src := &mutableSource{partitions: []types.Partition{vipPart, plainPart}}
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+	require.NoError(t, calc.rebalance(ctx, "seed"))
+	seedCommit := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, seedCommit)
+
+	// w1..w3 die; EmergencyDetector confirms (simulated by populating the
+	// buffer, mirroring the F10-A floor-release fixture). The next enumeration
+	// is a suspicious 4→1 shrink that degrades to the cached 4-worker list;
+	// the emergency filter strips the confirmed-dead → survivor set [w0],
+	// fresh=false, deathsConfirmed=true.
+	for _, w := range []string{"w1", "w2", "w3"} {
+		require.NoError(t, hbKV.Delete(ctx, "worker-hb."+w))
+	}
+	calc.mu.Lock()
+	calc.disappearedWorkers = []string{"w1", "w2", "w3"}
+	calc.mu.Unlock()
+
+	require.NoError(t, calc.rebalance(ctx, "emergency"),
+		"emergency-confirmed deaths make the survivor set trusted: the rebalance must proceed and commit")
+
+	commit := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, commit)
+	require.Greater(t, commit.Version, seedCommit.Version, "the emergency rebalance must publish a NEW commit")
+	require.Contains(t, commit.Payloads, "w0")
+	require.Len(t, commit.Payloads, 1, "only the survivor gets a payload")
+
+	p0 := readCalcPayload(t, ctx, asgnKV, commit.Payloads["w0"].Key)
+	require.Equal(t, []string{"vip"}, p0.WorkerLabels,
+		"the carve-out must run the real label pipeline: labels-of-record come from a fresh heartbeat read, not a fabricated stamp")
+	require.True(t, p0.WorkerLabelsKnown)
+	require.Len(t, p0.Partitions, 2, "the survivor absorbs both partitions (vip pool + all-workers fallback)")
+}
+
+// vipInWorkerPayload reports whether the given worker's committed payload
+// carries a vip-labeled partition.
+func vipInWorkerPayload(t *testing.T, ctx context.Context, kv jetstream.KeyValue, commit *types.AssignmentCommit, workerID string) bool {
+	t.Helper()
+	ref, ok := commit.Payloads[workerID]
+	if !ok {
+		return false
+	}
+	p := readCalcPayload(t, ctx, kv, ref.Key)
+	for _, part := range p.Partitions {
+		if part.Label == "vip" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestCalculator_TightTakeover_LabelChangeTriggersRebalance proves the
+// label-change trigger drives a rebalance through requestLabelRecheck end to
+// end. worker-0 heartbeats with ["vip"] and holds the one vip partition. A
+// tight takeover keeps the SAME heartbeat key alive but swaps its payload to
+// labels [] (a different process incarnation; the key never lapses, so the
+// worker SET never changes).
+//
+// Two independent signals confirm the wiring:
+//
+//  1. requestLabelRecheck fires with reason "label_change" — the load-bearing,
+//     wiring-specific proof. Only SetOnLabelChange → requestLabelRecheck
+//     ("label_change") produces this reason; the generic recheck reasons
+//     (observation_deferred / grace_expiry) do not. Without the calculator
+//     wiring this reason never appears, so this assertion is what fails RED.
+//  2. A NEW commit reassigns the vip partition off w0 (parked). A long
+//     LabelSpillGrace keeps the park stable within the window (no spill-back
+//     to the now-unlabeled w0), so the end-to-end outcome is deterministic.
+func TestCalculator_TightTakeover_LabelChangeTriggersRebalance(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-takeover-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-takeover-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+
+	src := &mockWatchableSource{partitions: []types.Partition{{Keys: []string{"v"}, Label: "vip"}}}
+	lg := &debugCapturingLogger{}
+
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:                asgnKV,
+		HeartbeatKV:                 hbKV,
+		AssignmentPrefix:            "assignment",
+		HeartbeatPrefix:             "worker-hb",
+		HeartbeatTTL:                30 * time.Second,
+		Source:                      src,
+		Strategy:                    &mockStrategy{},
+		EmergencyGracePeriod:        5 * time.Second,
+		Cooldown:                    0,
+		ColdStartWindow:             10 * time.Millisecond,
+		PlannedScaleWindow:          10 * time.Millisecond,
+		LabelSpillGrace:             30 * time.Second, // long: the park stays put for the window
+		RebalanceGraceDrainInterval: 75 * time.Millisecond,
+		Logger:                      lg,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, calc.Start(ctx))
+	defer func() { _ = calc.Stop(ctx) }()
+
+	// Initial rebalance: the vip partition lands on w0. Waiting for this commit
+	// also guarantees the monitor's watcher has replayed w0's ["vip"] heartbeat
+	// and seeded its label fingerprint before the takeover flips the labels.
+	var initialVersion int64
+	require.Eventually(t, func() bool {
+		commit := readCalcCommit(t, ctx, asgnKV)
+		if commit == nil || !vipInWorkerPayload(t, ctx, asgnKV, commit, "w0") {
+			return false
+		}
+		initialVersion = commit.Version
+
+		return true
+	}, 3*time.Second, 25*time.Millisecond, "the vip partition must initially land on w0")
+
+	// Tight takeover: the SAME heartbeat key stays alive but its labels flip to
+	// [] — the worker SET never changes.
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+
+	// The label change must (1) route through requestLabelRecheck("label_change")
+	// and (2) drive a NEW commit that removes the vip partition from w0.
+	require.Eventually(t, func() bool {
+		if !lg.recheckRequested("label_change") {
+			return false
+		}
+		commit := readCalcCommit(t, ctx, asgnKV)
+
+		return commit != nil && commit.Version > initialVersion &&
+			!vipInWorkerPayload(t, ctx, asgnKV, commit, "w0")
+	}, 5*time.Second, 25*time.Millisecond,
+		"the label change must fire requestLabelRecheck(\"label_change\") and reassign the vip partition off w0")
+}
+
+// TestBroadLabelReadFailure_SuppressedDuringShutdown: a broad label-read
+// failure induced by shutdown (stop channel closed, so the stop-aware
+// rebalance context aborts the heartbeat reads) is NOT a KV failure and must
+// not fire OnLabelReadBroadFailure — the manager routes that callback into
+// the degraded circuit under m.mu, and Stop-time noise there both pollutes
+// the degraded window and (before the stopCalculator lock restructure)
+// closed a lock cycle that deadlocked Manager.Stop. The rebalance still
+// aborts; only the callback is suppressed.
+func TestBroadLabelReadFailure_SuppressedDuringShutdown(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-stop-suppress-asgn")
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-stop-suppress-hb")
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", nil)
+	failKV := &getFailKV{KeyValue: hbKV, getErr: nats.ErrTimeout}
+
+	var fires atomic.Int64
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"p"}}}}
+	calc := newLabelCalc(t, labelCalcConfig{
+		source:         src,
+		heartbeatKV:    failKV,
+		assignmentKV:   asgnKV,
+		onBroadFailure: func(error) { fires.Add(1) },
+	})
+
+	// Simulate Stop having signalled: the stop channel is closed while a
+	// rebalance is still deriving assignments.
+	close(calc.stopCh)
+
+	_, err := calc.deriveRebalanceAssignments(ctx, "test", []string{"w0"}, src.partitions, time.Now())
+	require.Error(t, err, "the broad failure still aborts the rebalance")
+	require.Zero(t, fires.Load(),
+		"a shutdown-induced broad label-read failure must not enter the manager's degraded circuit")
+}

--- a/internal/assignment/calculator_state_test.go
+++ b/internal/assignment/calculator_state_test.go
@@ -602,10 +602,15 @@ func newV9Calculator(t *testing.T, bucketSuffix string) (*Calculator, *time.Time
 	return calc, &now
 }
 
-// putHeartbeat publishes a heartbeat for a worker so monitor.GetActiveWorkers sees it.
+// putHeartbeat publishes a heartbeat for a worker so monitor.GetActiveWorkers
+// sees it. The payload is a legacy timestamp (not an opaque marker): the
+// label-aware rebalance decodes heartbeats to read labels-of-record, and a
+// legacy timestamp decodes as a well-formed pre-label worker (nil labels),
+// whereas an undecodeable marker would be an UNKNOWN worker and defer or
+// broad-fail the rebalance.
 func putHeartbeat(t *testing.T, calc *Calculator, ctx context.Context, workerID string) {
 	t.Helper()
-	_, err := calc.HeartbeatKV.Put(ctx, "v9-hb."+workerID, []byte("alive"))
+	_, err := calc.HeartbeatKV.Put(ctx, "v9-hb."+workerID, []byte(time.Now().Format(time.RFC3339Nano)))
 	require.NoError(t, err)
 }
 

--- a/internal/assignment/calculator_test.go
+++ b/internal/assignment/calculator_test.go
@@ -483,9 +483,13 @@ func TestCalculator_Stop_PreserveAssignments(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Publish heartbeats for 3 workers
+	// Publish heartbeats for 3 workers. Legacy timestamp payloads (not an
+	// opaque marker): the label-aware rebalance decodes heartbeats to read
+	// labels-of-record, and a legacy timestamp decodes as a well-formed
+	// pre-label worker (nil labels), whereas an undecodeable marker would be
+	// an UNKNOWN worker and trip the broad-failure abort.
 	for _, workerID := range []string{"w1", "w2", "w3"} {
-		_, err := heartbeatKV.Put(ctx, fmt.Sprintf("worker.%s", workerID), []byte("heartbeat"))
+		_, err := heartbeatKV.Put(ctx, fmt.Sprintf("worker.%s", workerID), []byte(time.Now().Format(time.RFC3339Nano)))
 		require.NoError(t, err)
 	}
 
@@ -844,10 +848,12 @@ func TestCalculator_CacheFallback_ConnectivityError(t *testing.T) {
 	heartbeatKV := partitest.CreateJetStreamKV(t, ncConn, "test-cache-fallback-heartbeat")
 	assignmentKV := partitest.CreateJetStreamKV(t, ncConn, "test-cache-fallback-assignment")
 
-	// Create initial worker heartbeats
+	// Create initial worker heartbeats. Legacy timestamp payloads so the
+	// label-aware initial rebalance decodes them as pre-label workers (nil
+	// labels) instead of tripping the unreadable-labels broad-failure abort.
 	initialWorkers := []string{"worker-1", "worker-2", "worker-3"}
 	for _, workerID := range initialWorkers {
-		_, err := heartbeatKV.Put(ctx, "worker-hb."+workerID, []byte("active"))
+		_, err := heartbeatKV.Put(ctx, "worker-hb."+workerID, []byte(time.Now().Format(time.RFC3339Nano)))
 		require.NoError(t, err)
 	}
 
@@ -964,10 +970,11 @@ func TestCalculator_CacheUpdate_OnSuccess(t *testing.T) {
 	heartbeatKV := partitest.CreateJetStreamKV(t, ncConn, "test-cache-update-heartbeat")
 	assignmentKV := partitest.CreateJetStreamKV(t, ncConn, "test-cache-update-assignment")
 
-	// Create initial worker heartbeats
+	// Create initial worker heartbeats (legacy timestamp payloads — decodable
+	// by the label-aware rebalance path, consistent with the other fixtures).
 	initialWorkers := []string{"worker-1", "worker-2"}
 	for _, workerID := range initialWorkers {
-		_, err := heartbeatKV.Put(ctx, "worker-hb."+workerID, []byte("active"))
+		_, err := heartbeatKV.Put(ctx, "worker-hb."+workerID, []byte(time.Now().Format(time.RFC3339Nano)))
 		require.NoError(t, err)
 	}
 
@@ -1002,7 +1009,7 @@ func TestCalculator_CacheUpdate_OnSuccess(t *testing.T) {
 	require.Less(t, age1, 1*time.Second)
 
 	// Add a new worker
-	_, err = heartbeatKV.Put(ctx, "worker-hb.worker-3", []byte("active"))
+	_, err = heartbeatKV.Put(ctx, "worker-hb.worker-3", []byte(time.Now().Format(time.RFC3339Nano)))
 	require.NoError(t, err)
 
 	// Fetch workers again - should update cache

--- a/internal/assignment/config.go
+++ b/internal/assignment/config.go
@@ -173,6 +173,23 @@ type Config struct {
 	// applied to any value < 1, so a zero/negative config cannot fire on the
 	// first failure). Set explicitly to 1 to fire on the first failure.
 	EnumerationFailureThreshold int
+
+	// UnlabeledPartitionPolicy: "dedicated" (default when empty) routes
+	// unlabeled partitions to unlabeled workers only (falling back to all
+	// workers when none are live); "shared" routes them to all workers.
+	UnlabeledPartitionPolicy string
+
+	// LabelSpillGrace is how long a label pool must be continuously empty
+	// before its partitions spill. 0 = immediate spill.
+	LabelSpillGrace time.Duration
+
+	// OnLabelReadBroadFailure, if set, is invoked when a rebalance aborts
+	// because worker label reads failed broadly (connectivity/degrading-
+	// JetStream class, or above the isolated-failure cap). The manager
+	// wires this to its KV-error recorder so sustained heartbeat-read
+	// trouble trips the degraded circuit (spec §6). Mirrors the
+	// OnEnumerationError seam. Must be safe for concurrent use.
+	OnLabelReadBroadFailure func(err error)
 }
 
 // Validate checks configuration validity.
@@ -256,5 +273,8 @@ func (c *Config) SetDefaults() {
 	}
 	if c.EnumerationFailureThreshold < 1 {
 		c.EnumerationFailureThreshold = 3
+	}
+	if c.UnlabeledPartitionPolicy == "" {
+		c.UnlabeledPartitionPolicy = "dedicated"
 	}
 }

--- a/internal/assignment/labels.go
+++ b/internal/assignment/labels.go
@@ -1,0 +1,187 @@
+package assignment
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// topologyInput is the input to buildLabelTopology: the active worker set,
+// their label reads, the partition snapshot, and the unlabeled-partition
+// policy.
+type topologyInput struct {
+	Workers    []string            // active set, post-filter
+	Labels     map[string][]string // workerID → sorted label set (successful reads)
+	Unknown    map[string]bool     // workerID → labels unreadable (§6); disjoint from Labels
+	Partitions []types.Partition   // source snapshot
+	Policy     string              // "dedicated" | "shared" ("" = dedicated)
+}
+
+// labelTopology is the output of buildLabelTopology: workers partitioned
+// into label pools, partitions partitioned into label groups, plus the
+// derived pools computeLabelAssignments needs to run the strategy per
+// group and merge.
+type labelTopology struct {
+	Pools        map[string][]string          // label → matching workers (sorted)
+	Groups       map[string][]types.Partition // label → partitions; "" key = unlabeled group
+	SortedLabels []string                     // sorted keys of Groups, excluding ""
+	EmptyLabels  []string                     // labels whose pool is empty (sorted)
+	GeneralPool  []string                     // per policy; empty ⇒ caller uses AllWorkers
+	FallbackPool []string                     // unlabeled workers; empty ⇒ caller uses AllWorkers
+	AllWorkers   []string                     // Workers minus Unknown (sorted)
+	UnknownSet   map[string]bool              // pass-through of in.Unknown
+}
+
+// emptyPoolAction is the caller-supplied decision for a labeled group whose
+// pool is empty: park the group's partitions (leave them unassigned) or
+// spill them onto the fallback/general pool.
+type emptyPoolAction int
+
+const (
+	emptyPoolPark emptyPoolAction = iota
+	emptyPoolSpill
+)
+
+// buildLabelTopology partitions workers and partitions into label pools
+// and groups (spec §7). Pure and deterministic: all slices sorted.
+func buildLabelTopology(in topologyInput) labelTopology {
+	topo := labelTopology{
+		Pools:      map[string][]string{},
+		Groups:     map[string][]types.Partition{},
+		UnknownSet: in.Unknown,
+	}
+
+	// Active workers minus unknown-label workers, sorted.
+	for _, w := range in.Workers {
+		if in.Unknown[w] {
+			continue
+		}
+		topo.AllWorkers = append(topo.AllWorkers, w)
+		labels := in.Labels[w]
+		if len(labels) == 0 {
+			topo.FallbackPool = append(topo.FallbackPool, w)
+		}
+		for _, l := range labels {
+			topo.Pools[l] = append(topo.Pools[l], w)
+		}
+	}
+	slices.Sort(topo.AllWorkers)
+	slices.Sort(topo.FallbackPool)
+	for l := range topo.Pools {
+		slices.Sort(topo.Pools[l])
+	}
+
+	if in.Policy == "shared" {
+		topo.GeneralPool = topo.AllWorkers
+	} else { // "dedicated" and "" default
+		topo.GeneralPool = topo.FallbackPool
+	}
+
+	for _, p := range in.Partitions {
+		topo.Groups[p.Label] = append(topo.Groups[p.Label], p)
+	}
+	for l := range topo.Groups {
+		if l == "" {
+			continue
+		}
+		topo.SortedLabels = append(topo.SortedLabels, l)
+		if len(topo.Pools[l]) == 0 {
+			topo.EmptyLabels = append(topo.EmptyLabels, l)
+		}
+	}
+	slices.Sort(topo.SortedLabels)
+	slices.Sort(topo.EmptyLabels)
+
+	return topo
+}
+
+// computeLabelAssignments runs the configured strategy once per pool and
+// merges (spec §7). actions supplies the park/spill decision for each
+// empty-pool label (Task 8 computes them from grace state); a missing
+// entry defaults to park — the conservative choice, and unreachable in
+// production because the calculator always populates every EmptyLabels
+// entry.
+func computeLabelAssignments(
+	strategy types.AssignmentStrategy,
+	topo labelTopology,
+	actions map[string]emptyPoolAction,
+) (map[string][]types.Partition, []types.Partition, error) {
+	merged := make(map[string][]types.Partition, len(topo.AllWorkers)+len(topo.UnknownSet))
+	var parked []types.Partition
+
+	assignGroup := func(pool []string, group []types.Partition, what string) error {
+		if len(group) == 0 {
+			return nil
+		}
+		if len(pool) == 0 {
+			pool = topo.AllWorkers // guarded final rung; callers pre-check
+		}
+		if len(pool) == 0 {
+			return fmt.Errorf("label pipeline: no workers available for %s", what)
+		}
+		out, err := strategy.Assign(pool, group)
+		if err != nil {
+			return fmt.Errorf("label pipeline: %s: %w", what, err)
+		}
+		for w, ps := range out {
+			// First write stores the strategy's slice untouched — the I1
+			// golden contract is nil-vs-empty sensitive, and appending zero
+			// elements to a nil slice would turn a strategy's non-nil empty
+			// slice into nil. Storing the slice is safe: each Assign call
+			// returns a freshly allocated map owned solely by this function.
+			if cur, ok := merged[w]; ok {
+				merged[w] = append(cur, ps...)
+			} else {
+				merged[w] = ps
+			}
+		}
+
+		return nil
+	}
+
+	// Unlabeled group → general pool (ladder: general → all).
+	if err := assignGroup(topo.GeneralPool, topo.Groups[""], "unlabeled group"); err != nil {
+		return nil, nil, err
+	}
+
+	// Labeled groups in sorted order.
+	for _, l := range topo.SortedLabels {
+		pool := topo.Pools[l]
+		if len(pool) > 0 {
+			if err := assignGroup(pool, topo.Groups[l], "label "+l); err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+		//nolint:exhaustive // default arm handles emptyPoolPark AND any out-of-range value: park is the safety net that keeps I9 (no partition vanishes) on enum drift.
+		switch actions[l] {
+		case emptyPoolSpill:
+			// Ladder: unlabeled workers first (never another label's
+			// dedicated pool), then all workers.
+			if err := assignGroup(topo.FallbackPool, topo.Groups[l], "spilled label "+l); err != nil {
+				return nil, nil, err
+			}
+		default:
+			// Park — covers emptyPoolPark, missing actions[l] entries (the
+			// zero value is emptyPoolPark, the conservative default), and
+			// any future/invalid enum value. Missing entries are unreachable
+			// in production: the calculator populates every EmptyLabels
+			// entry.
+			parked = append(parked, topo.Groups[l]...)
+		}
+	}
+
+	// I8: every active worker appears exactly once — explicit empty
+	// entries for workers in no pool and for unknown-label workers.
+	for _, w := range topo.AllWorkers {
+		if _, ok := merged[w]; !ok {
+			merged[w] = []types.Partition{}
+		}
+	}
+	for w := range topo.UnknownSet {
+		merged[w] = []types.Partition{}
+	}
+
+	return merged, parked, nil
+}

--- a/internal/assignment/labels_recheck_test.go
+++ b/internal/assignment/labels_recheck_test.go
@@ -1,0 +1,327 @@
+package assignment
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// buildLabelRecheckCalc constructs a Started-ready Calculator wired to a
+// watchable source and a short RebalanceGraceDrainInterval so the label
+// re-check monitor drives progression without external events. The heartbeat
+// KV can be wrapped (wrapHB) to stage a connectivity-degraded enumeration for
+// the spin-hazard test; sp (optional, nil-safe) wires a StateProvider for the
+// recovery-grace tests. One unlabeled worker w0 is seeded — enough for the
+// ghost partition to spill onto once grace expires.
+func buildLabelRecheckCalc( //nolint:revive // argument-limit: test fixture bundles the scenario's coordinated knobs
+	t *testing.T,
+	name string,
+	src *mockWatchableSource,
+	grace, drain time.Duration,
+	wrapHB func(kv jetstream.KeyValue) jetstream.KeyValue,
+	sp types.StateProvider,
+) (*Calculator, jetstream.KeyValue) {
+	t.Helper()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, name+"-asgn")
+	realHB := partitest.CreateJetStreamKV(t, nc, name+"-hb")
+
+	putLabeledHeartbeat(t, ctx, realHB, "w0", nil)
+
+	hbKV := realHB
+	if wrapHB != nil {
+		hbKV = wrapHB(realHB)
+	}
+
+	calc, err := NewCalculator(&Config{
+		AssignmentKV:                asgnKV,
+		HeartbeatKV:                 hbKV,
+		AssignmentPrefix:            "assignment",
+		HeartbeatPrefix:             "worker-hb",
+		HeartbeatTTL:                30 * time.Second,
+		Source:                      src,
+		Strategy:                    &mockStrategy{},
+		EmergencyGracePeriod:        5 * time.Second,
+		Cooldown:                    0,
+		ColdStartWindow:             10 * time.Millisecond,
+		PlannedScaleWindow:          10 * time.Millisecond,
+		LabelSpillGrace:             grace,
+		RebalanceGraceDrainInterval: drain,
+		StateProvider:               sp,
+	})
+	require.NoError(t, err)
+
+	return calc, asgnKV
+}
+
+// waitCalcIdle blocks until the calculator has published its initial commit and
+// returned to Idle.
+func waitCalcIdle(t *testing.T, calc *Calculator) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return calc.CurrentVersion() >= 1 && calc.GetState() == types.CalcStateIdle
+	}, 3*time.Second, 10*time.Millisecond, "calc should reach Idle after the initial rebalance")
+}
+
+// TestLabelRecheck_GhostLabelProgressesWithoutExternalEvents is the spec §14
+// no-external-event progression pin. A "ghost"-labeled partition that no worker
+// ever carries must progress defer → confirm → park → (grace) → spill driven
+// ONLY by the internal re-check timer, with a single external event (the label
+// edit) at the start.
+func TestLabelRecheck_GhostLabelProgressesWithoutExternalEvents(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const grace = 600 * time.Millisecond
+	const drain = 150 * time.Millisecond
+
+	// Start with a single plain partition so the cold-start rebalance succeeds
+	// (no empty label pool yet).
+	src := &mockWatchableSource{partitions: []types.Partition{{Keys: []string{"p"}}}}
+	calc, asgnKV := buildLabelRecheckCalc(t, "lbl-recheck-ghost", src, grace, drain, nil, nil)
+
+	require.NoError(t, calc.Start(ctx))
+	defer func() { _ = calc.Stop(ctx) }()
+	waitCalcIdle(t, calc)
+
+	// ONE external event: the label edit that introduces the ghost partition.
+	src.Update([]types.Partition{{Keys: []string{"p"}}, {Keys: []string{"g"}, Label: "ghost"}})
+
+	// Phase 1 — with no further external events, the re-check timer must drive
+	// defer → confirm → park within grace.
+	require.Eventually(t, func() bool {
+		commit := readCalcCommit(t, ctx, asgnKV)
+		return commit != nil && commit.ParkedCount == 1
+	}, 2*time.Second, 10*time.Millisecond, "the ghost pool must park after the deferred observation is confirmed")
+
+	// Phase 2 — after grace expiry the grace-expiry timer must re-fire on its
+	// own and the ghost must spill (ParkedCount back to 0, ghost present in some
+	// worker's payload).
+	require.Eventually(t, func() bool {
+		commit := readCalcCommit(t, ctx, asgnKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+
+		return ghostPresentInAnyPayload(t, ctx, asgnKV, commit)
+	}, 3*time.Second, 20*time.Millisecond, "after grace the ghost partition must spill into a worker payload")
+}
+
+// ghostPresentInAnyPayload reports whether any committed payload carries a
+// partition labeled "ghost".
+func ghostPresentInAnyPayload(t *testing.T, ctx context.Context, kv jetstream.KeyValue, commit *types.AssignmentCommit) bool {
+	t.Helper()
+	for _, ref := range commit.Payloads {
+		p := readCalcPayload(t, ctx, kv, ref.Key)
+		for _, part := range p.Partitions {
+			if part.Label == "ghost" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// TestLabelRecheck_StickyUnderBusyStateMachine pins that a re-check request
+// raised while the state machine is busy (claim held) is not lost: the sticky
+// pendingLabelRecheck flag survives, no rebalance runs while busy, and the
+// drain tick picks it up once the claim releases.
+func TestLabelRecheck_StickyUnderBusyStateMachine(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const drain = 100 * time.Millisecond
+
+	src := &mockWatchableSource{partitions: []types.Partition{{Keys: []string{"p"}}}}
+	calc, _ := buildLabelRecheckCalc(t, "lbl-recheck-busy", src, time.Hour, drain, nil, nil)
+
+	require.NoError(t, calc.Start(ctx))
+	defer func() { _ = calc.Stop(ctx) }()
+	waitCalcIdle(t, calc)
+
+	// Hold the rebalancing claim so the monitor cannot claim.
+	require.True(t, calc.stateMach.TryClaimRebalancing(context.Background(), "test-hold"),
+		"test must be able to claim the idle state machine")
+
+	base := PartitionRebalanceEntries(calc)
+	calc.requestLabelRecheck("grace_expiry")
+
+	// While the claim is held: the sticky flag survives and no label-recheck
+	// rebalance runs (the counter does not advance) across several drain ticks.
+	require.Eventually(t, func() bool { return calc.pendingLabelRecheck.Load() }, 2*drain, drain/4,
+		"pendingLabelRecheck must stay set while the state machine is busy")
+	time.Sleep(3 * drain)
+	require.Equal(t, base, PartitionRebalanceEntries(calc),
+		"no label-recheck rebalance may run while the claim is held")
+	require.True(t, calc.pendingLabelRecheck.Load(), "the flag must still be pending after the busy window")
+
+	// Release the claim WITHOUT running a rebalance; the drain tick must now
+	// pick up the pending re-check.
+	calc.stateMach.ReturnToIdle()
+	require.Eventually(t, func() bool {
+		return PartitionRebalanceEntries(calc) > base
+	}, 2*time.Second, drain/2, "the drain tick must service the pending re-check once the claim releases")
+}
+
+// TestLabelRecheck_NonFreshDoesNotSpin is the adjudicated liveness pin: a
+// calculator pinned in a persistently non-fresh (connectivity-degraded)
+// observation must NOT spin — the "non_fresh_observation" re-check fired from
+// inside the rebalance sets the sticky flag but does not wake the monitor
+// synchronously, so re-attempts happen on the drain cadence, not at full speed.
+func TestLabelRecheck_NonFreshDoesNotSpin(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const drain = 100 * time.Millisecond
+
+	failKV := &keysFailKV{keyErr: nats.ErrTimeout}
+	src := &mockWatchableSource{partitions: []types.Partition{{Keys: []string{"a"}}}}
+	calc, _ := buildLabelRecheckCalc(t, "lbl-recheck-spin", src, time.Hour, drain,
+		func(kv jetstream.KeyValue) jetstream.KeyValue {
+			failKV.KeyValue = kv
+			return failKV
+		}, nil)
+
+	require.NoError(t, calc.Start(ctx))
+	defer func() { _ = calc.Stop(ctx) }()
+	waitCalcIdle(t, calc)
+
+	// Degrade every enumeration: getActiveWorkers now falls back to the cached
+	// worker list with fresh=false, so each rebalance takes the non-fresh path
+	// and re-fires requestLabelRecheck("non_fresh_observation").
+	failKV.fail.Store(true)
+
+	// Prime the monitor once (grace_expiry does the immediate send).
+	base := PartitionRebalanceEntries(calc)
+	calc.requestLabelRecheck("grace_expiry")
+
+	// No starvation: the pending re-check must be serviced repeatedly on the
+	// drain cadence.
+	require.Eventually(t, func() bool {
+		return PartitionRebalanceEntries(calc)-base >= 2
+	}, 8*drain, drain/2, "non-fresh re-checks must still re-attempt on the drain cadence (no starvation)")
+
+	// No spin: over a fixed 3-drain window the re-attempts stay bounded to
+	// roughly one per drain tick, not a runaway full-speed loop.
+	mid := PartitionRebalanceEntries(calc)
+	time.Sleep(3 * drain)
+	delta := PartitionRebalanceEntries(calc) - mid
+	require.LessOrEqual(t, delta, int64(8),
+		"non-fresh re-checks must not spin: at most ~1 rebalance per drain tick (got %d over 3 drain intervals)", delta)
+}
+
+// TestLabelRecheck_DisarmedOnStop pins that the re-check monitor joins cleanly
+// on Stop (no goroutine leak — Stop's wg.Wait would hang otherwise) and that no
+// rebalance fires after Stop, even with a re-check requested.
+func TestLabelRecheck_DisarmedOnStop(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const drain = 100 * time.Millisecond
+
+	src := &mockWatchableSource{partitions: []types.Partition{{Keys: []string{"p"}}}}
+	calc, _ := buildLabelRecheckCalc(t, "lbl-recheck-stop", src, time.Hour, drain, nil, nil)
+
+	require.NoError(t, calc.Start(ctx))
+	waitCalcIdle(t, calc)
+
+	// A re-check pending at Stop time must not leak the monitor goroutine.
+	calc.requestLabelRecheck("grace_expiry")
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, calc.Stop(stopCtx), "Stop must return cleanly (monitor goroutine joins)")
+
+	// After Stop, another re-check request must drive no rebalance.
+	postStopVersion := calc.CurrentVersion()
+	base := PartitionRebalanceEntries(calc)
+	calc.requestLabelRecheck("grace_expiry")
+	time.Sleep(3 * drain)
+
+	require.False(t, calc.IsStarted(), "calc must be stopped")
+	require.Equal(t, base, PartitionRebalanceEntries(calc), "no rebalance may run after Stop")
+	require.Equal(t, postStopVersion, calc.CurrentVersion(), "assignment version must not advance after Stop")
+}
+
+// TestLabelRecheck_GraceFlipRestoresPendingAndDefersPublish mirrors
+// TestPartitionLifecycle_GraceFlipPropagatesErrShuttingDown for the
+// label_recheck lifecycle: when recovery grace flips between the monitor's
+// pre-claim inRecoveryGrace check (grace=false) and rebalanceMu acquisition
+// (grace=true), the in-rebalance shouldDeferForRecoveryGrace re-check must
+// bail with errShuttingDown, restorePendingLabelOnGraceBail must restore
+// pendingLabelRecheck, no publish may land, and the drain tick must complete
+// the re-check once grace lifts.
+//
+// The flip is sequenced deterministically via the partitionRebalanceBlocker
+// seam: handlePartitionRebalance (the shared claim-path callback) parks on the
+// blocker AFTER the monitor's pre-claim check accepted the re-check at
+// grace=false, but BEFORE c.rebalance acquires rebalanceMu.
+func TestLabelRecheck_GraceFlipRestoresPendingAndDefersPublish(t *testing.T) {
+	// No t.Parallel(): uses the shared partitionRebalanceBlocker test seam.
+	ctx := t.Context()
+
+	const drain = 25 * time.Millisecond
+
+	sp := &mockStateProvider{}
+	src := &mockWatchableSource{partitions: []types.Partition{{Keys: []string{"p"}}}}
+	calc, _ := buildLabelRecheckCalc(t, "lbl-recheck-graceflip", src, time.Hour, drain, nil, sp)
+
+	blocker := make(chan struct{})
+	SetPartitionRebalanceBlocker(blocker)
+	defer SetPartitionRebalanceBlocker(nil)
+
+	require.NoError(t, calc.Start(ctx))
+	defer func() { _ = calc.Stop(ctx) }()
+	waitCalcIdle(t, calc)
+
+	startEntries := PartitionRebalanceEntries(calc)
+	v0 := calc.CurrentVersion()
+
+	// Grace is FALSE so the monitor's pre-claim check passes and the claimed
+	// rebalance enters handlePartitionRebalance, parking on the blocker.
+	require.False(t, sp.IsInRecoveryGrace(),
+		"grace must be false so the monitor's pre-claim check passes")
+	calc.requestLabelRecheck("grace_expiry")
+
+	require.Eventually(t, func() bool {
+		return PartitionRebalanceEntries(calc) == startEntries+1
+	}, 2*time.Second, 5*time.Millisecond,
+		"the label-recheck rebalance must enter the callback and park on the blocker")
+
+	// Flip grace while the callback is parked; releasing the blocker drives
+	// c.rebalance into shouldDeferForRecoveryGrace, which must bail. The
+	// closed channel also lets the retry-after-grace-lifts callback through
+	// immediately (do not mutate the blocker again — that races under -race).
+	sp.SetGrace(true)
+	close(blocker)
+
+	// No publish may land after the bail.
+	require.Never(t, func() bool {
+		return calc.CurrentVersion() > v0
+	}, 250*time.Millisecond, 25*time.Millisecond,
+		"rebalance must not publish after the grace-flip errShuttingDown bail")
+
+	// restorePendingLabelOnGraceBail must restore the sticky flag so the drain
+	// tick has work once grace lifts. (While grace holds, each tick re-stores
+	// it via the monitor's inRecoveryGrace branch.)
+	require.Eventually(t, func() bool {
+		return calc.pendingLabelRecheck.Load()
+	}, time.Second, 10*time.Millisecond,
+		"pendingLabelRecheck must be restored after the grace-flip bail")
+
+	// Lift grace: the drain tick must service the restored re-check.
+	sp.SetGrace(false)
+	require.Eventually(t, func() bool {
+		return calc.CurrentVersion() > v0
+	}, 2*time.Second, 10*time.Millisecond,
+		"the restored label re-check must drain and publish after grace lifts")
+}

--- a/internal/assignment/labels_state.go
+++ b/internal/assignment/labels_state.go
@@ -1,0 +1,222 @@
+package assignment
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// errLabelObservationDeferred is the benign-abort sentinel for the first
+// observation of a disruptive label condition (previously non-empty pool
+// reads empty; worker labels unreadable). Deliberately distinct from the
+// suspicious-observation sentinels: those are swallowed without
+// label-aware re-arm; this one arms the label re-check timer.
+var errLabelObservationDeferred = errors.New("label observation deferred pending confirmation")
+
+// errLabelReadBroadFailure aborts a rebalance whose heartbeat label reads
+// failed broadly (bucket/connectivity-class trouble or more than
+// max(1, 10%) of workers unreadable). Never converted into label
+// decisions: a broad failure must not empty-assign the fleet.
+var errLabelReadBroadFailure = errors.New("worker label read failed broadly")
+
+// labelState tracks per-label grace clocks and defer-once confirmation
+// streaks (spec §8.5). All methods are called from the rebalance path
+// (serialized by rebalanceMu) but the mutex keeps the timer path (Task 9)
+// safe when it inspects remaining grace.
+type labelState struct {
+	mu    sync.Mutex
+	grace time.Duration
+	now   func() time.Time
+
+	emptySince    map[string]time.Time // label → first empty observation
+	emptyStreak   map[string]int       // label → consecutive empty observations
+	unknownStreak map[string]int       // workerID → consecutive unreadable-label observations
+}
+
+func newLabelState(grace time.Duration, now func() time.Time) *labelState {
+	if now == nil {
+		now = time.Now
+	}
+	return &labelState{
+		grace:         grace,
+		now:           now,
+		emptySince:    map[string]time.Time{},
+		emptyStreak:   map[string]int{},
+		unknownStreak: map[string]int{},
+	}
+}
+
+// observeEmptyPools records this rebalance's empty-pool set and returns
+// the action per confirmed-empty label. deferred=true means at least one
+// label is on its FIRST empty observation — the caller aborts the
+// rebalance with errLabelObservationDeferred and arms the re-check timer.
+// emptySince always starts at the first observation so the deferral does
+// not extend the effective grace window.
+func (s *labelState) observeEmptyPools(empty []string) (map[string]emptyPoolAction, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	deferred := false
+	actions := make(map[string]emptyPoolAction, len(empty))
+	for _, l := range empty {
+		if _, ok := s.emptySince[l]; !ok {
+			s.emptySince[l] = now
+		}
+		s.emptyStreak[l]++
+		if s.emptyStreak[l] < 2 {
+			deferred = true
+			continue
+		}
+		if now.Sub(s.emptySince[l]) < s.grace {
+			actions[l] = emptyPoolPark
+		} else {
+			actions[l] = emptyPoolSpill
+		}
+	}
+
+	return actions, deferred
+}
+
+// observeNonEmpty resets streak and grace clock for recovered pools.
+func (s *labelState) observeNonEmpty(labels []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, l := range labels {
+		delete(s.emptySince, l)
+		delete(s.emptyStreak, l)
+	}
+}
+
+// observeUnknownWorkers implements defer-once for unreadable labels.
+// Returns true when at least one worker is on its first unreadable
+// observation (caller defers). Passing the empty set resets everything
+// (a fully successful read).
+func (s *labelState) observeUnknownWorkers(unknown []string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(unknown) == 0 {
+		clear(s.unknownStreak)
+		return false
+	}
+	current := make(map[string]bool, len(unknown))
+	deferred := false
+	for _, w := range unknown {
+		current[w] = true
+		s.unknownStreak[w]++
+		if s.unknownStreak[w] < 2 {
+			deferred = true
+		}
+	}
+	// Workers that recovered reset their streak.
+	for w := range s.unknownStreak {
+		if !current[w] {
+			delete(s.unknownStreak, w)
+		}
+	}
+
+	return deferred
+}
+
+// prune drops state for labels absent from the current snapshot.
+func (s *labelState) prune(currentLabels map[string]bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for l := range s.emptySince {
+		if !currentLabels[l] {
+			delete(s.emptySince, l)
+			delete(s.emptyStreak, l)
+		}
+	}
+}
+
+// minRemainingGrace returns the shortest time until an emptySince clock
+// crosses grace, and whether any clock is running. The re-check timer
+// (armLabelRecheckAfterRebalance) arms with this value after a rebalance that
+// parked anything.
+func (s *labelState) minRemainingGrace() (time.Duration, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	found := false
+	var minLeft time.Duration
+	now := s.now()
+	for _, since := range s.emptySince {
+		left := s.grace - now.Sub(since)
+		if left < 0 {
+			left = 0
+		}
+		if !found || left < minLeft {
+			minLeft, found = left, true
+		}
+	}
+
+	return minLeft, found
+}
+
+// requestLabelRecheck records that a label re-check is owed and, for the
+// fast-confirmation reasons, wakes monitorLabelRecheck immediately. The sticky
+// pendingLabelRecheck flag guarantees the re-check survives a busy state
+// machine; the capacity-1 channel coalesces concurrent requests into one wake.
+//
+// Per-reason send behavior (liveness): reasonNonFreshObservation is fired from
+// INSIDE a rebalance whose worker observation degraded to the cached list. If
+// the observation is a persistent connectivity outage, waking the monitor
+// synchronously would re-run the rebalance, re-observe non-fresh, re-fire, and
+// spin at full speed for the outage's duration. For that reason we set the
+// sticky flag only and let the drain tick (or any other wake) service it. Every
+// other reason — deferral confirmation and grace expiry — keeps the immediate
+// send so it re-fires well under the drain cadence (spec §16 item 7).
+func (c *Calculator) requestLabelRecheck(reason string) {
+	c.pendingLabelRecheck.Store(true)
+	c.Logger.Debug("label recheck requested", "reason", reason)
+
+	if reason == reasonNonFreshObservation {
+		return
+	}
+
+	select {
+	case c.labelRecheckCh <- struct{}{}:
+	default:
+	}
+}
+
+// armLabelRecheckAfterRebalance arms (or cancels) the grace-expiry re-check
+// timer after a rebalance. When something was parked, it schedules a re-check
+// just past the shortest remaining grace window so the parked pool spills
+// without any external event; a fresh rebalance supersedes any previously-armed
+// timer. When nothing is parked and no re-check is already pending, it cancels
+// a stale timer. Guarded by labelRecheckTimerMu so Stop and re-arm race safely.
+func (c *Calculator) armLabelRecheckAfterRebalance(parkedCount int) {
+	c.labelRecheckTimerMu.Lock()
+	defer c.labelRecheckTimerMu.Unlock()
+
+	if parkedCount <= 0 {
+		// Nothing parked: no grace clock to wait on. Cancel a stale timer
+		// unless a re-check is already pending — the monitor's drain tick will
+		// service that one.
+		if c.labelRecheckTimer != nil && !c.pendingLabelRecheck.Load() {
+			c.labelRecheckTimer.Stop()
+			c.labelRecheckTimer = nil
+		}
+
+		return
+	}
+
+	// Something parked: (re)arm from the shortest remaining grace window. A
+	// fresh rebalance supersedes any previously-armed timer.
+	if c.labelRecheckTimer != nil {
+		c.labelRecheckTimer.Stop()
+		c.labelRecheckTimer = nil
+	}
+
+	left, running := c.labelState.minRemainingGrace()
+	if !running {
+		return
+	}
+
+	c.labelRecheckTimer = time.AfterFunc(left+50*time.Millisecond, func() {
+		c.requestLabelRecheck("grace_expiry")
+	})
+}

--- a/internal/assignment/labels_state_test.go
+++ b/internal/assignment/labels_state_test.go
@@ -1,0 +1,81 @@
+package assignment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newLabelStateForTest(now func() time.Time, grace time.Duration) *labelState {
+	return newLabelState(grace, now)
+}
+
+func TestLabelState_DeferOnceThenPark(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	st := newLabelStateForTest(clock, time.Minute)
+
+	// First observation of an empty pool for "vip": defer (spec §8.5).
+	act, deferred := st.observeEmptyPools([]string{"vip"})
+	require.True(t, deferred)
+	require.Empty(t, act)
+
+	// Second consecutive observation: act — inside grace ⇒ park.
+	act, deferred = st.observeEmptyPools([]string{"vip"})
+	require.False(t, deferred)
+	require.Equal(t, emptyPoolPark, act["vip"])
+
+	// emptySince started at the FIRST observation: advancing the clock
+	// past grace-from-first flips to spill (confirmation does not extend
+	// the grace window).
+	now = now.Add(61 * time.Second)
+	act, deferred = st.observeEmptyPools([]string{"vip"})
+	require.False(t, deferred)
+	require.Equal(t, emptyPoolSpill, act["vip"])
+}
+
+func TestLabelState_NonEmptyResets(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	st := newLabelStateForTest(func() time.Time { return now }, time.Minute)
+
+	_, _ = st.observeEmptyPools([]string{"vip"})
+	st.observeNonEmpty([]string{"vip"}) // pool recovered
+	_, deferred := st.observeEmptyPools([]string{"vip"})
+	require.True(t, deferred, "recovery resets the confirmation streak AND emptySince")
+}
+
+func TestLabelState_PruneRemovedLabels(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	st := newLabelStateForTest(func() time.Time { return now }, time.Minute)
+	_, _ = st.observeEmptyPools([]string{"vip"})
+	st.prune(map[string]bool{}) // "vip" no longer in the snapshot
+	require.Empty(t, st.emptySince, "stale grace clocks must not leak")
+}
+
+func TestLabelState_ZeroGraceSpillsImmediatelyAfterConfirmation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	st := newLabelStateForTest(func() time.Time { return now }, 0)
+	_, deferred := st.observeEmptyPools([]string{"vip"})
+	require.True(t, deferred, "confirmation still applies at grace=0")
+	act, _ := st.observeEmptyPools([]string{"vip"})
+	require.Equal(t, emptyPoolSpill, act["vip"], "grace 0 = spill as soon as confirmed")
+}
+
+func TestLabelState_UnknownWorkerDeferThenAct(t *testing.T) {
+	t.Parallel()
+
+	st := newLabelStateForTest(time.Now, time.Minute)
+	require.True(t, st.observeUnknownWorkers([]string{"w2"}), "first: defer")
+	require.False(t, st.observeUnknownWorkers([]string{"w2"}), "second consecutive: act")
+	st.observeUnknownWorkers(nil) // successful read resets
+	require.True(t, st.observeUnknownWorkers([]string{"w2"}), "reset after recovery")
+}

--- a/internal/assignment/labels_test.go
+++ b/internal/assignment/labels_test.go
@@ -1,0 +1,202 @@
+package assignment
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func parts(labels ...string) []types.Partition {
+	out := make([]types.Partition, len(labels))
+	for i, l := range labels {
+		out[i] = types.Partition{Keys: []string{string(rune('a' + i))}, Label: l}
+	}
+	return out
+}
+
+func topo(workers []string, labels map[string][]string, partitions []types.Partition, policy string) labelTopology {
+	return buildLabelTopology(topologyInput{
+		Workers: workers, Labels: labels, Partitions: partitions, Policy: policy,
+	})
+}
+
+func TestBuildLabelTopology_PoolsAndGroups(t *testing.T) {
+	t.Parallel()
+
+	tp := topo(
+		[]string{"w0", "w1", "w2"},
+		map[string][]string{"w0": {"vip"}, "w1": {"batch", "vip"}, "w2": nil},
+		parts("vip", "", "batch", "ghost"),
+		"dedicated",
+	)
+
+	require.Equal(t, []string{"w0", "w1"}, tp.Pools["vip"])
+	require.Equal(t, []string{"w1"}, tp.Pools["batch"])
+	require.Equal(t, []string{"w2"}, tp.GeneralPool, "dedicated: unlabeled workers only")
+	require.Equal(t, []string{"w2"}, tp.FallbackPool)
+	require.Equal(t, []string{"ghost"}, tp.EmptyLabels, "label with no matching worker")
+	require.Len(t, tp.Groups[""], 1)
+	require.Len(t, tp.Groups["vip"], 1)
+}
+
+func TestBuildLabelTopology_SharedPolicy(t *testing.T) {
+	t.Parallel()
+
+	tp := topo(
+		[]string{"w0", "w1"},
+		map[string][]string{"w0": {"vip"}, "w1": nil},
+		parts(""),
+		"shared",
+	)
+	require.Equal(t, []string{"w0", "w1"}, tp.GeneralPool, "shared: all workers")
+}
+
+func TestComputeLabelAssignments_MergeContract(t *testing.T) {
+	t.Parallel()
+
+	// w0 vip-only; w1 unlabeled; w2 unknown labels; one vip partition,
+	// one unlabeled partition. Expect: w0 gets vip, w1 gets unlabeled,
+	// w2 present with EMPTY slice (I8 — no stale-assignment leak).
+	in := topologyInput{
+		Workers:    []string{"w0", "w1", "w2"},
+		Labels:     map[string][]string{"w0": {"vip"}, "w1": nil},
+		Unknown:    map[string]bool{"w2": true},
+		Partitions: parts("vip", ""),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	merged, parked, err := computeLabelAssignments(strategy.NewRoundRobin(), tp, nil)
+	require.NoError(t, err)
+	require.Empty(t, parked)
+
+	require.Len(t, merged, 3, "every active worker gets an entry")
+	require.NotNil(t, merged["w2"])
+	require.Empty(t, merged["w2"], "unknown-label worker: explicit empty entry")
+	require.Len(t, merged["w0"], 1)
+	require.Equal(t, "vip", merged["w0"][0].Label)
+	require.Len(t, merged["w1"], 1)
+
+	total := 0
+	for _, ps := range merged {
+		total += len(ps)
+	}
+	require.Equal(t, 2, total, "each partition exactly once (I9)")
+}
+
+func TestComputeLabelAssignments_ParkAndSpill(t *testing.T) {
+	t.Parallel()
+
+	in := topologyInput{
+		Workers:    []string{"w0"},
+		Labels:     map[string][]string{"w0": nil},
+		Partitions: parts("vip", ""),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	require.Equal(t, []string{"vip"}, tp.EmptyLabels)
+
+	// Park:
+	merged, parked, err := computeLabelAssignments(strategy.NewRoundRobin(), tp,
+		map[string]emptyPoolAction{"vip": emptyPoolPark})
+	require.NoError(t, err)
+	require.Len(t, parked, 1)
+	require.Equal(t, "vip", parked[0].Label)
+	require.Len(t, merged["w0"], 1, "unlabeled partition still assigned")
+
+	// Spill:
+	merged, parked, err = computeLabelAssignments(strategy.NewRoundRobin(), tp,
+		map[string]emptyPoolAction{"vip": emptyPoolSpill})
+	require.NoError(t, err)
+	require.Empty(t, parked)
+	require.Len(t, merged["w0"], 2, "spilled onto the fallback pool")
+}
+
+func TestComputeLabelAssignments_SpillPrefersUnlabeledWorkers(t *testing.T) {
+	t.Parallel()
+
+	// vip pool empty; batch pool exists; one unlabeled worker. Spilled
+	// vip partitions must land on the unlabeled worker, never invade the
+	// batch pool (spec I5).
+	in := topologyInput{
+		Workers:    []string{"batchw", "plainw"},
+		Labels:     map[string][]string{"batchw": {"batch"}, "plainw": nil},
+		Partitions: parts("vip"),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	merged, _, err := computeLabelAssignments(strategy.NewRoundRobin(), tp,
+		map[string]emptyPoolAction{"vip": emptyPoolSpill})
+	require.NoError(t, err)
+	require.Empty(t, merged["batchw"], "spill must not invade another label's pool")
+	require.Len(t, merged["plainw"], 1)
+}
+
+// TestComputeLabelAssignments_I1Golden: with zero labels anywhere the
+// pipeline output must be identical to a direct Strategy.Assign call.
+// Two geometries: more partitions than workers (every worker gets some),
+// and more workers than partitions (some workers get zero — pins that the
+// merge preserves the strategy's non-nil empty slices untouched).
+func TestComputeLabelAssignments_I1Golden(t *testing.T) {
+	t.Parallel()
+
+	geometries := []struct {
+		name       string
+		workers    []string
+		partitions int
+	}{
+		{"more partitions than workers", []string{"w0", "w1", "w2"}, 10},
+		{"more workers than partitions", []string{"w0", "w1", "w2", "w3", "w4"}, 3},
+	}
+
+	for _, g := range geometries {
+		partitions := make([]types.Partition, g.partitions)
+		for i := range partitions {
+			partitions[i] = types.Partition{Keys: []string{"p", string(rune('0' + i))}, Weight: int64(i%3 + 1)}
+		}
+		labels := make(map[string][]string, len(g.workers))
+		for _, w := range g.workers {
+			labels[w] = nil
+		}
+
+		for _, st := range []types.AssignmentStrategy{
+			strategy.NewRoundRobin(),
+			strategy.NewConsistentHash(),
+		} {
+			direct, err := st.Assign(g.workers, partitions)
+			require.NoError(t, err)
+
+			tp := buildLabelTopology(topologyInput{
+				Workers:    g.workers,
+				Labels:     labels,
+				Partitions: partitions,
+				Policy:     "dedicated",
+			})
+			merged, parked, err := computeLabelAssignments(st, tp, nil)
+			require.NoError(t, err)
+			require.Empty(t, parked)
+			require.Equal(t, direct, merged, "label-free pipeline must equal direct Assign (%s)", g.name)
+		}
+	}
+}
+
+func TestComputeLabelAssignments_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	in := topologyInput{
+		Workers:    []string{"w2", "w0", "w1"},
+		Labels:     map[string][]string{"w0": {"vip"}, "w1": {"batch"}, "w2": nil},
+		Partitions: parts("vip", "batch", "", "vip"),
+		Policy:     "dedicated",
+	}
+	tp := buildLabelTopology(in)
+	first, _, err := computeLabelAssignments(strategy.NewConsistentHash(), tp, nil)
+	require.NoError(t, err)
+	for range 20 {
+		tp2 := buildLabelTopology(in)
+		again, _, err := computeLabelAssignments(strategy.NewConsistentHash(), tp2, nil)
+		require.NoError(t, err)
+		require.Equal(t, first, again)
+	}
+}

--- a/internal/assignment/state_machine.go
+++ b/internal/assignment/state_machine.go
@@ -376,7 +376,16 @@ func (sm *StateMachine) RunClaimedRebalanceErr(ctx context.Context, reason strin
 		// Logging it as a "failed" Error would surface false failures to
 		// operators tailing worker logs; the suppression is already
 		// recorded at Warn level by partitionInputCredibilityGuard.
-		if cbErr != nil && !errors.Is(cbErr, errSuspiciousPartitionObservation) {
+		//
+		// errLabelObservationDeferred is likewise benign: a "confirm before
+		// acting" decision whose retry the label re-check monitor owns (the
+		// deferral re-arms the sticky flag inside the rebalance). During a
+		// persistent non-fresh outage it recurs every drain tick, so an
+		// Error here would stream false failures for healthy degraded
+		// behavior.
+		if cbErr != nil &&
+			!errors.Is(cbErr, errSuspiciousPartitionObservation) &&
+			!errors.Is(cbErr, errLabelObservationDeferred) {
 			sm.logger.Error("partition rebalance failed", "reason", reason, "error", cbErr)
 		}
 	}

--- a/internal/assignment/worker_monitor.go
+++ b/internal/assignment/worker_monitor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
+	"github.com/zeebo/xxh3"
 )
 
 // Package-private backoff constants for the heartbeat watcher retry loop.
@@ -68,6 +69,22 @@ type WorkerMonitor struct {
 	// Callback invoked when changes are detected (from polling or watcher)
 	onChangeCb func(ctx context.Context) error
 
+	// onLabelChangeCb is invoked (coalesced by the caller) whenever a heartbeat
+	// PUT's labels differ from the retained fingerprint for that key — a label
+	// change behind a live worker ID that the worker-change path cannot see.
+	// Set once via SetOnLabelChange before Start, like onChangeCb; read only by
+	// the watcher goroutine thereafter.
+	onLabelChangeCb func()
+
+	// labelFP maps a heartbeat key to the fingerprint of its last well-formed
+	// label set. It is MONITOR-lifetime (survives watcher-session restarts) so a
+	// takeover PUT that lands while the watch is down is caught when the next
+	// session's initial replay delivers the key's current value and it differs
+	// from the retained fingerprint. Guarded by labelFPMu — the watcher
+	// goroutine mutates it and (in principle) concurrent readers are excluded.
+	labelFPMu sync.Mutex
+	labelFP   map[string]uint64
+
 	logger types.Logger
 
 	// watchBaseBackoff is the initial backoff for the watcher retry loop.
@@ -111,12 +128,112 @@ func NewWorkerMonitor(
 		hbTTL:            hbTTL,
 		hbWatchPattern:   fmt.Sprintf("%s.*", hbPrefix),
 		onChangeCb:       onChange,
+		labelFP:          make(map[string]uint64),
 		logger:           logger,
 		watchBaseBackoff: workerWatcherBaseBackoff,
 		now:              time.Now,
 		stopCh:           make(chan struct{}),
 		doneCh:           make(chan struct{}),
 	}
+}
+
+// SetOnLabelChange registers a callback invoked when a heartbeat PUT's labels
+// differ from the retained fingerprint for that key — a worker-label change
+// behind a live worker ID (e.g. a stale-ID takeover) that the worker-set change
+// path cannot detect. The callback is coalesced by the caller (the calculator
+// routes it through requestLabelRecheck). It must be called before Start, like
+// the constructor's onChange callback; the field is read only by the watcher
+// goroutine afterward.
+func (m *WorkerMonitor) SetOnLabelChange(fn func()) {
+	m.onLabelChangeCb = fn
+}
+
+// classifyPutSuppressed records a PUT's receive time in lastSeen and reports
+// whether it is a suppressible refresh — a key last seen < hbTTL ago while
+// outside a suppression holiday means the worker was continuously alive, so
+// topology cannot have changed and the expensive Keys()-scan check is skipped.
+// It bumps suppressedCount on suppression. hbTTL==0: now.Sub(prev) is never
+// negative under a forward clock, so this never suppresses — mirrors the
+// explicit guard in sweepExpired.
+func (m *WorkerMonitor) classifyPutSuppressed(key string, lastSeen map[string]time.Time, now, unsuppressedUntil time.Time, suppressedCount *uint64) bool {
+	prev, known := lastSeen[key]
+	lastSeen[key] = now
+	if known && now.Sub(prev) < m.hbTTL && now.After(unsuppressedUntil) {
+		*suppressedCount++
+		return true
+	}
+
+	return false
+}
+
+// checkLabelChange updates the retained fingerprint for a heartbeat key from
+// the PUT payload and reports whether the labels differ from a previously-seen
+// value (level-triggered across watcher sessions — labelFP is monitor-lifetime).
+// It is called on the watcher hot path once per PUT.
+//
+// Behavior:
+//   - Malformed payload: no-op — neither reports a change nor erases the
+//     retained fingerprint (a distinct decode failure must not churn state).
+//   - First-seen key: seeds the fingerprint silently and reports no change
+//     (joins are the worker-change path's job).
+//   - Fingerprint mismatch: retains the new fingerprint, logs, invokes the
+//     onLabelChange callback (outside labelFPMu), and reports a change.
+func (m *WorkerMonitor) checkLabelChange(key string, value []byte) bool {
+	hb, derr := types.DecodeHeartbeat(value)
+	if derr != nil {
+		return false
+	}
+	fp := labelFingerprint(hb.Labels)
+
+	m.labelFPMu.Lock()
+	prevFP, seen := m.labelFP[key]
+	m.labelFP[key] = fp
+	m.labelFPMu.Unlock()
+
+	if !seen || prevFP == fp {
+		return false
+	}
+
+	m.logger.Info("worker label change detected", "key", key)
+	if m.onLabelChangeCb != nil {
+		m.onLabelChangeCb()
+	}
+
+	return true
+}
+
+// dropLabelFingerprint forgets a heartbeat key's retained fingerprint on a
+// DELETE/PURGE (a leave), so a later rejoin with new labels seeds silently as a
+// first-seen join rather than firing a spurious label change.
+func (m *WorkerMonitor) dropLabelFingerprint(key string) {
+	m.labelFPMu.Lock()
+	delete(m.labelFP, key)
+	m.labelFPMu.Unlock()
+}
+
+// labelFingerprint hashes a label set into a 64-bit fingerprint used to detect
+// label changes across heartbeat PUTs. 0 is reserved for "no labels" so an
+// unlabeled worker fingerprints stably; a genuine hash that collides with 0 is
+// remapped to 1. The input is assumed pre-sorted and deduplicated (heartbeat
+// publishers sort labels at publish time), so the fingerprint is order-stable
+// for a given label set without re-sorting on the watcher hot path.
+func labelFingerprint(labels []string) uint64 {
+	if len(labels) == 0 {
+		return 0
+	}
+	var h xxh3.Hasher
+	for i, l := range labels {
+		if i > 0 {
+			_, _ = h.WriteString("\n")
+		}
+		_, _ = h.WriteString(l)
+	}
+	fp := h.Sum64()
+	if fp == 0 {
+		fp = 1
+	}
+
+	return fp
 }
 
 // Start begins monitoring workers in a background goroutine.
@@ -272,6 +389,46 @@ func (m *WorkerMonitor) GetHeartbeats(ctx context.Context) (map[string]types.Hea
 	}
 
 	return out, nil
+}
+
+// GetHeartbeatsFor returns decoded heartbeats for exactly the given
+// worker IDs, keyed by worker ID. Unlike GetHeartbeats it does NOT run a
+// Keys() scan — callers that already hold the active worker list (the
+// rebalance path) use this to avoid a second stream-wide enumeration.
+//
+// Per-worker Get or decode failures omit that worker from the heartbeat
+// map (logged at debug) but populate the error map under that worker ID
+// with the original error, so the caller can classify the failure
+// (connectivity/degrading-JetStream vs not) rather than have it
+// masquerade as a bare "unknown labels" omission. The only non-nil
+// returned error is context cancellation/deadline.
+func (m *WorkerMonitor) GetHeartbeatsFor(ctx context.Context, workerIDs []string) (map[string]types.Heartbeat, map[string]error, error) {
+	opCtx, cancel := m.boundedOpCtx(ctx)
+	defer cancel()
+
+	out := make(map[string]types.Heartbeat, len(workerIDs))
+	fails := make(map[string]error)
+	for _, workerID := range workerIDs {
+		if err := opCtx.Err(); err != nil {
+			return out, fails, fmt.Errorf("heartbeat fetch aborted: %w", err)
+		}
+		key := m.hbPrefix + "." + workerID
+		entry, gerr := m.heartbeatKV.Get(opCtx, key)
+		if gerr != nil {
+			m.logger.Debug("heartbeat get failed during targeted fetch", "key", key, "error", gerr)
+			fails[workerID] = gerr
+			continue
+		}
+		hb, derr := types.DecodeHeartbeat(entry.Value())
+		if derr != nil {
+			m.logger.Debug("heartbeat decode failed during targeted fetch", "key", key, "error", derr)
+			fails[workerID] = derr
+			continue
+		}
+		out[workerID] = hb
+	}
+
+	return out, fails, nil
 }
 
 // boundedOpCtx returns a child context with a deadline bounded to hbTTL/2.
@@ -433,19 +590,23 @@ func (m *WorkerMonitor) processWatcherEvents(ctx context.Context) error {
 			switch entry.Operation() {
 			case jetstream.KeyValuePut:
 				key := entry.Key()
-				prev, known := lastSeen[key]
-				lastSeen[key] = now
-				// hbTTL==0: now.Sub(prev) is never negative under a forward
-				// clock, so this never suppresses — mirrors the explicit
-				// guard in sweepExpired.
-				if known && now.Sub(prev) < m.hbTTL && now.After(unsuppressedUntil) {
+				if m.classifyPutSuppressed(key, lastSeen, now, unsuppressedUntil, &suppressedCount) {
 					// Refresh under active suppression: worker was
 					// continuously alive; skip the check.
 					trigger = false
-					suppressedCount++
+				}
+
+				// Label fingerprint: level-triggered across watcher sessions.
+				// A label change is never a suppressible refresh.
+				if m.checkLabelChange(key, entry.Value()) {
+					trigger = true
 				}
 			case jetstream.KeyValueDelete, jetstream.KeyValuePurge:
 				delete(lastSeen, entry.Key())
+				// Drop the retained fingerprint: a leave. A rejoin with new
+				// labels is a first-seen join covered by the worker-change path,
+				// so it must seed silently rather than fire a spurious change.
+				m.dropLabelFingerprint(entry.Key())
 			}
 
 			if m.sweepExpired(lastSeen, now, &unsuppressedUntil) {

--- a/internal/assignment/worker_monitor_label_test.go
+++ b/internal/assignment/worker_monitor_label_test.go
@@ -1,0 +1,231 @@
+package assignment
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// hbValue marshals a v1 JSON heartbeat carrying the given labels so the fakeKV
+// watcher harness delivers real, decodeable payloads (fakeKVEntry.Value()). The
+// heartbeat's WorkerID is irrelevant to the label fingerprint (only Labels are
+// hashed), so it is fixed.
+func hbValue(t *testing.T, labels []string) []byte {
+	t.Helper()
+	data, err := json.Marshal(types.Heartbeat{
+		WorkerID:      "w0",
+		SchemaVersion: 1,
+		Capabilities:  types.CapAckV1,
+		Labels:        labels,
+		Timestamp:     time.Unix(1000, 0).UTC(),
+	})
+	require.NoError(t, err)
+
+	return data
+}
+
+// labelChangeCounters bundles the two callback counters a label-change monitor
+// test observes (keeps newLabelChangeMonitor within the result-count limit).
+type labelChangeCounters struct {
+	onChange atomic.Int32 // worker-change (onChange) callback invocations
+	onLabel  atomic.Int32 // onLabelChange callback invocations
+}
+
+// newLabelChangeMonitor builds a monitor wired to a fake clock, an onChange
+// (worker-change) counter, and an onLabelChange counter, suitable for driving
+// processWatcherEvents directly through the fakeKV harness. hbTTL is fixed at
+// 10s — long enough that every same-clock refresh in these tests classifies as
+// suppressible, so the label-change escape is what any trigger proves.
+func newLabelChangeMonitor(clock *fakeClock) (*WorkerMonitor, *fakeKV, *labelChangeCounters) {
+	kv := &fakeKV{}
+	c := &labelChangeCounters{}
+	m := NewWorkerMonitor(kv, "worker", 10*time.Second,
+		func(ctx context.Context) error { c.onChange.Add(1); return nil },
+		logging.NewNop(),
+	)
+	m.now = clock.Now
+	m.SetOnLabelChange(func() { c.onLabel.Add(1) })
+
+	return m, kv, c
+}
+
+// pushToCurrentWatcher delivers an entry to the fakeKV's active watcher session
+// (used across watcher-restart boundaries where the session handle rotates).
+func pushToCurrentWatcher(t *testing.T, kv *fakeKV, e jetstream.KeyValueEntry) {
+	t.Helper()
+	kv.mu.Lock()
+	w := kv.currentWatcher
+	kv.mu.Unlock()
+	require.NotNil(t, w)
+	select {
+	case w.updates <- e:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher loop did not consume entry")
+	}
+}
+
+// TestWorkerMonitor_LabelChangeEscapesSuppression: a label change on a live,
+// continuously-refreshing key is never a suppressible refresh — it fires
+// onLabelChange AND forces a worker-change check even though the same key's
+// same-label refreshes are suppressed.
+func TestWorkerMonitor_LabelChangeEscapesSuppression(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, c := newLabelChangeMonitor(clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// Join with ["vip"] — first-seen seeds the fingerprint silently.
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 1, c.onChange.Load(), "join must trigger one worker-change check")
+	require.EqualValues(t, 0, c.onLabel.Load(), "first-seen key must seed the fingerprint silently")
+
+	// A same-label refresh within hbTTL is suppressed and does not re-fire.
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 1, c.onChange.Load(), "same-label refresh must stay suppressed (no worker-change check)")
+	require.EqualValues(t, 0, c.onLabel.Load(), "unchanged labels must not fire onLabelChange")
+
+	// Flip labels on the SAME live key: the change escapes suppression.
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"batch"})})
+	waitDebounce()
+	require.EqualValues(t, 1, c.onLabel.Load(), "a label change must fire onLabelChange exactly once")
+	require.EqualValues(t, 2, c.onChange.Load(), "a label change must escape suppression and force a worker-change check")
+
+	// A subsequent identical-labels beat does NOT re-fire (fingerprint updated).
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"batch"})})
+	waitDebounce()
+	require.EqualValues(t, 1, c.onLabel.Load(), "identical labels after a change must not re-fire onLabelChange")
+	require.EqualValues(t, 2, c.onChange.Load(), "identical-labels refresh must be suppressed again")
+}
+
+// TestWorkerMonitor_LabelChangeAcrossWatcherRestart pins the monitor-lifetime
+// fingerprint map: a takeover PUT that lands while the watch is down is caught
+// when the next session's initial replay delivers the key's current value and
+// it differs from the retained fingerprint (spec §9 watcher-restart edge).
+func TestWorkerMonitor_LabelChangeAcrossWatcherRestart(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+
+	kv := &fakeKV{}
+	var onChange, onLabel atomic.Int32
+	m := NewWorkerMonitor(kv, "worker", 10*time.Second,
+		func(ctx context.Context) error { onChange.Add(1); return nil },
+		logging.NewNop(),
+	)
+	m.now = clock.Now
+	m.watchBaseBackoff = 10 * time.Millisecond // fast retry, matches sibling restart tests
+	m.SetOnLabelChange(func() { onLabel.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.monitorWatcherWithRetry(ctx)
+	require.Eventually(t, func() bool { return kv.WatchCallCount() >= 1 }, time.Second, time.Millisecond)
+
+	// Session 1: worker-0 with ["vip"] seeds the fingerprint silently.
+	pushToCurrentWatcher(t, kv, &fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 0, onLabel.Load(), "first-seen must seed the fingerprint silently")
+
+	// Kill the session; the retry loop starts a fresh one. While the watch is
+	// down a takeover swaps the labels behind the same live worker ID.
+	kv.CloseUpdates()
+	require.Eventually(t, func() bool { return kv.WatchCallCount() >= 2 }, 2*time.Second, 10*time.Millisecond)
+
+	// Session 2's initial replay delivers the current value ["batch"]; the
+	// MONITOR-lifetime fingerprint (retained from session 1) differs → fires once.
+	pushToCurrentWatcher(t, kv, &fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"batch"})})
+	waitDebounce()
+	require.EqualValues(t, 1, onLabel.Load(), "a label change across a watcher restart must fire exactly once")
+}
+
+// TestWorkerMonitor_MalformedPayloadNoFingerprintChurn: a malformed heartbeat
+// PUT neither fires onLabelChange nor erases the retained fingerprint (the next
+// well-formed identical-labels beat stays quiet, and a genuinely different beat
+// still fires against the surviving fingerprint).
+func TestWorkerMonitor_MalformedPayloadNoFingerprintChurn(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, c := newLabelChangeMonitor(clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// Seed ["vip"].
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 0, c.onLabel.Load())
+
+	// A malformed payload must not fire onLabelChange.
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: []byte("not-a-heartbeat")})
+	waitDebounce()
+	require.EqualValues(t, 0, c.onLabel.Load(), "malformed payload must not fire onLabelChange")
+
+	// The retained fingerprint survived: an identical well-formed beat stays quiet.
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 0, c.onLabel.Load(), "identical labels after a malformed beat must stay quiet")
+
+	// ...and a genuinely different beat still fires — proving the malformed beat
+	// did not erase the retained ["vip"] fingerprint.
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"batch"})})
+	waitDebounce()
+	require.EqualValues(t, 1, c.onLabel.Load(), "a real label change after a malformed beat must still fire")
+}
+
+// TestWorkerMonitor_FirstSeenSeedsSilently: a brand-new worker key with labels
+// never fires onLabelChange — joins are the worker-change path's job.
+func TestWorkerMonitor_FirstSeenSeedsSilently(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, c := newLabelChangeMonitor(clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 1, c.onChange.Load(), "a new worker key must trigger the worker-change (join) path")
+	require.EqualValues(t, 0, c.onLabel.Load(), "first-seen key must never fire onLabelChange")
+}
+
+// TestWorkerMonitor_DeleteDropsFingerprint: a DELETE drops the key's retained
+// fingerprint, so a rejoin with different labels is a first-seen join (silent),
+// not a spurious label change — the join/leave key-set delta drives the
+// worker-change rebalance instead.
+func TestWorkerMonitor_DeleteDropsFingerprint(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClockAt(time.Unix(1000, 0))
+	m, kv, c := newLabelChangeMonitor(clock)
+	s := startWatcherSession(t, m, kv)
+	defer s.stop()
+
+	// Seed ["vip"].
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"vip"})})
+	waitDebounce()
+	require.EqualValues(t, 0, c.onLabel.Load())
+
+	// Graceful leave drops the fingerprint.
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValueDelete})
+	waitDebounce()
+
+	// Rejoin with DIFFERENT labels: first-seen again → seeds silently, does not
+	// fire onLabelChange (would fire if the DELETE had left the stale fingerprint).
+	clock.Advance(200 * time.Millisecond)
+	s.push(&fakeKVEntry{key: "worker.w0", op: jetstream.KeyValuePut, value: hbValue(t, []string{"batch"})})
+	waitDebounce()
+	require.EqualValues(t, 0, c.onLabel.Load(), "rejoin after DELETE must seed silently, not fire onLabelChange")
+}

--- a/internal/assignment/worker_monitor_test.go
+++ b/internal/assignment/worker_monitor_test.go
@@ -236,6 +236,58 @@ func jsonMarshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
+// putHeartbeatJSON marshals hb to v1 JSON and Puts it under key. Named
+// distinctly from the package's existing putHeartbeat helper (in
+// calculator_state_test.go, which Puts a bare "alive" string keyed by
+// worker ID) to avoid a redeclaration in this package.
+func putHeartbeatJSON(t *testing.T, kv jetstream.KeyValue, key string, hb types.Heartbeat) {
+	t.Helper()
+	b, err := jsonMarshal(hb)
+	require.NoError(t, err)
+	_, err = kv.Put(context.Background(), key, b)
+	require.NoError(t, err)
+}
+
+// TestWorkerMonitor_GetHeartbeatsFor verifies the targeted per-worker fetch
+// used by the rebalance path: exactly one bounded Get per listed worker ID,
+// no Keys() scan. Per-worker Get/decode failures must be absent from the
+// heartbeat map but present in the error map with the original error, so
+// the caller can classify the failure (connectivity vs not) rather than
+// having it masquerade as a bare "unknown labels" omission.
+func TestWorkerMonitor_GetHeartbeatsFor(t *testing.T) {
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	hbKV := partitest.CreateJetStreamKV(t, nc, "test-monitor-hbfor")
+
+	ctx := context.Background()
+
+	// Seed: worker-0 v1 JSON with labels, worker-1 v1 JSON without,
+	// worker-2 malformed payload. worker-9 is never written (missing key).
+	putHeartbeatJSON(t, hbKV, "heartbeat.worker-0", types.Heartbeat{
+		WorkerID: "worker-0", SchemaVersion: 1, Labels: []string{"vip"},
+		Timestamp: time.Now(),
+	})
+	putHeartbeatJSON(t, hbKV, "heartbeat.worker-1", types.Heartbeat{
+		WorkerID: "worker-1", SchemaVersion: 1, Timestamp: time.Now(),
+	})
+	_, err := hbKV.Put(ctx, "heartbeat.worker-2", []byte("not-json-not-time"))
+	require.NoError(t, err)
+
+	m := NewWorkerMonitor(hbKV, "heartbeat", 5*time.Second, nil, logging.NewNop())
+
+	got, errs, err := m.GetHeartbeatsFor(ctx, []string{"worker-0", "worker-1", "worker-2", "worker-9"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"vip"}, got["worker-0"].Labels)
+	require.Empty(t, got["worker-1"].Labels)
+	_, ok := got["worker-2"]
+	require.False(t, ok, "malformed payload omitted from heartbeats")
+	require.Error(t, errs["worker-2"], "…but its decode error is preserved for classification")
+	_, ok = got["worker-9"]
+	require.False(t, ok, "missing key omitted from heartbeats")
+	require.Error(t, errs["worker-9"], "…and its Get error is preserved (jetstream.ErrKeyNotFound)")
+	require.Len(t, errs, 2)
+}
+
 func TestWorkerMonitor_GetActiveWorkers_EmptyPrefix(t *testing.T) {
 	t.Parallel()
 	_, nc := partitest.StartEmbeddedNATS(t)
@@ -627,15 +679,19 @@ func TestWorkerMonitor_GetActiveWorkers_BoundedTimeout(t *testing.T) {
 }
 
 // fakeKVEntry is a minimal jetstream.KeyValueEntry double for driving
-// processWatcherEvents directly.
+// processWatcherEvents directly. value is nil unless the test carries a
+// heartbeat payload (label-fingerprint tests); nil reproduces the pre-existing
+// behavior of every classification test — Value() returns nil and the label
+// decode is skipped.
 type fakeKVEntry struct {
-	key string
-	op  jetstream.KeyValueOp
+	key   string
+	op    jetstream.KeyValueOp
+	value []byte
 }
 
 func (e *fakeKVEntry) Bucket() string                  { return "fake" }
 func (e *fakeKVEntry) Key() string                     { return e.key }
-func (e *fakeKVEntry) Value() []byte                   { return nil }
+func (e *fakeKVEntry) Value() []byte                   { return e.value }
 func (e *fakeKVEntry) Revision() uint64                { return 0 }
 func (e *fakeKVEntry) Created() time.Time              { return time.Time{} }
 func (e *fakeKVEntry) Delta() uint64                   { return 0 }

--- a/internal/heartbeat/publisher.go
+++ b/internal/heartbeat/publisher.go
@@ -68,6 +68,11 @@ type Publisher struct {
 	// via SetCapabilitiesFn before Start is called.
 	capsFn func() uint32
 
+	// labels is the worker's label set, included in every heartbeat. Set once
+	// via SetLabels before Start (same set-once-before-Start discipline as
+	// capsFn), so build reads it without additional synchronization.
+	labels []string
+
 	// mu guards lifecycle fields: started, ticker, metrics, workerID.
 	mu        sync.Mutex
 	started   bool
@@ -155,6 +160,19 @@ func (p *Publisher) SetCapabilitiesFn(fn func() uint32) {
 	defer p.mu.Unlock()
 
 	p.capsFn = fn
+}
+
+// SetLabels registers the worker's label set to include in every
+// heartbeat. Call before Start. The slice is stored as-is (the manager
+// passes an already-normalized copy) and must not be mutated afterwards.
+//
+// Parameters:
+//   - labels: Worker label set (already normalized by the caller)
+func (p *Publisher) SetLabels(labels []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.labels = labels
 }
 
 // SetOnError registers a callback invoked on each heartbeat publish failure.
@@ -391,6 +409,7 @@ func (p *Publisher) build() types.Heartbeat {
 		WorkerID:              p.workerID,
 		SchemaVersion:         1, // v1 JSON writers always emit SchemaVersion=1; 0 is only for decoded legacy payloads
 		Capabilities:          caps,
+		Labels:                p.labels,
 		LeaderRevision:        snap.LeaderRevision,
 		AppliedVersion:        snap.AppliedVersion,
 		AppliedDigest:         snap.AppliedDigest,

--- a/internal/heartbeat/publisher_test.go
+++ b/internal/heartbeat/publisher_test.go
@@ -537,6 +537,47 @@ func TestPublisher_JSONOutputRoundTrip(t *testing.T) {
 	require.False(t, hb.Timestamp.IsZero())
 }
 
+// TestPublisher_EmitsLabels verifies SetLabels is reflected in every published
+// heartbeat, and that an unlabeled publisher emits payload bytes with no "labels"
+// field (byte-compat for unlabeled fleets and pre-label readers).
+func TestPublisher_EmitsLabels(t *testing.T) {
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	t.Run("labels present after SetLabels", func(t *testing.T) {
+		kv := partitest.CreateJetStreamKV(t, nc, "test-hb-labels-present")
+		p := New(kv, "worker-hb", "worker-1", 10*time.Second, nil, nil)
+		p.SetLabels([]string{"vip"})
+		require.NoError(t, p.Start(ctx))
+		t.Cleanup(func() { _ = p.Stop() })
+
+		entry, err := kv.Get(ctx, "worker-hb.worker-1")
+		require.NoError(t, err)
+		require.Contains(t, string(entry.Value()), `"labels":["vip"]`)
+
+		hb, err := types.DecodeHeartbeat(entry.Value())
+		require.NoError(t, err)
+		require.Equal(t, []string{"vip"}, hb.Labels)
+	})
+
+	t.Run("labels field absent without SetLabels", func(t *testing.T) {
+		kv := partitest.CreateJetStreamKV(t, nc, "test-hb-labels-absent")
+		p := New(kv, "worker-hb", "worker-2", 10*time.Second, nil, nil)
+		require.NoError(t, p.Start(ctx))
+		t.Cleanup(func() { _ = p.Stop() })
+
+		entry, err := kv.Get(ctx, "worker-hb.worker-2")
+		require.NoError(t, err)
+		require.NotContains(t, string(entry.Value()), "labels",
+			"unlabeled fleets must keep byte-compatible payloads (omitempty)")
+
+		hb, err := types.DecodeHeartbeat(entry.Value())
+		require.NoError(t, err)
+		require.Nil(t, hb.Labels)
+	})
+}
+
 // capturingLogger captures Warn messages for test assertions.
 type capturingLogger struct {
 	mu    sync.Mutex

--- a/internal/metrics/nop.go
+++ b/internal/metrics/nop.go
@@ -11,6 +11,10 @@ type NopMetrics struct{}
 // Compile-time assertion that NopMetrics implements MetricsCollector.
 var _ types.MetricsCollector = (*NopMetrics)(nil)
 
+// Compile-time assertion that NopMetrics implements the optional LabelMetrics
+// extension interface (spec §13).
+var _ types.LabelMetrics = (*NopMetrics)(nil)
+
 // NewNop creates a new no-op metrics collector.
 //
 // Returns:
@@ -329,6 +333,38 @@ func (n *NopMetrics) ObserveWorkerConsumerRecreationDuration(_ /* seconds */ flo
 
 // IncrementWorkerConsumerPullSuppressed discards pull suppression increments.
 func (n *NopMetrics) IncrementWorkerConsumerPullSuppressed(_ /* reason */ string) {
+	// No-op
+}
+
+// LabelMetrics implementation (optional extension interface, spec §13)
+
+// RecordLabelPoolSize discards the per-label worker pool size gauge.
+func (n *NopMetrics) RecordLabelPoolSize(_ /* label */ string, _ /* workers */ int) {
+	// No-op
+}
+
+// RecordParkedPartitions discards the per-label parked-partition count gauge.
+func (n *NopMetrics) RecordParkedPartitions(_ /* label */ string, _ /* count */ int) {
+	// No-op
+}
+
+// IncrementLabelSpill discards the label-spill counter.
+func (n *NopMetrics) IncrementLabelSpill(_ /* label */ string) {
+	// No-op
+}
+
+// IncrementLabelChangeTrigger discards the label-change-triggered-rebalance counter.
+func (n *NopMetrics) IncrementLabelChangeTrigger() {
+	// No-op
+}
+
+// IncrementLabelIncarnationReject discards the stale-incarnation label rejection counter.
+func (n *NopMetrics) IncrementLabelIncarnationReject() {
+	// No-op
+}
+
+// IncrementUnlabeledFallback discards the unlabeled-fallback counter.
+func (n *NopMetrics) IncrementUnlabeledFallback() {
 	// No-op
 }
 

--- a/internal/metrics/nop_test.go
+++ b/internal/metrics/nop_test.go
@@ -103,6 +103,23 @@ func TestNopMetrics_InterfaceImplementation(t *testing.T) {
 	require.Implements(t, (*types.WorkerMetrics)(nil), metrics)
 	require.Implements(t, (*types.AssignmentMetrics)(nil), metrics)
 	require.Implements(t, (*types.MetricsCollector)(nil), metrics)
+	require.Implements(t, (*types.LabelMetrics)(nil), metrics)
+}
+
+func TestNopMetrics_LabelMetrics(t *testing.T) {
+	metrics := NewNop()
+
+	// Should not panic with label-metrics inputs
+	require.NotPanics(t, func() {
+		metrics.RecordLabelPoolSize("vip", 3)
+		metrics.RecordLabelPoolSize("", 0)
+		metrics.RecordParkedPartitions("vip", 2)
+		metrics.RecordParkedPartitions("", 0)
+		metrics.IncrementLabelSpill("vip")
+		metrics.IncrementLabelChangeTrigger()
+		metrics.IncrementLabelIncarnationReject()
+		metrics.IncrementUnlabeledFallback()
+	})
 }
 
 func BenchmarkNopMetrics_RecordStateTransition(b *testing.B) {

--- a/kv_error_classify_test.go
+++ b/kv_error_classify_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/internal/metrics"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -40,4 +43,89 @@ func TestClassifyKVError(t *testing.T) {
 			require.Equal(t, tc.transient, got.transient, "transient for %v", tc.err)
 		})
 	}
+}
+
+// TestRecordLabelReadFailure_Routing pins the manager-side adapter that routes a
+// broad label-read failure from the calculator into the degraded circuit. A
+// classed cause (connectivity / degrading JetStream) passes through as a
+// non-transient whole-bucket-loss window entry; a bare count-based error is
+// wrapped ErrKVUnavailable so it enters as the transient (F-D1) class and, when
+// sustained, degrades with DegradeReasonKVUnavailable; nil is a no-op.
+func TestRecordLabelReadFailure_Routing(t *testing.T) {
+	logger := logging.NewNop()
+	nopMetrics := metrics.NewNop()
+	cfg := Config{
+		DegradedBehavior: DegradedBehaviorConfig{
+			KVErrorThreshold: 3,
+			KVErrorWindow:    10 * time.Second,
+		},
+		DegradedAlert: DegradedAlertConfig{
+			AlertInterval: 1 * time.Minute,
+		},
+	}
+
+	t.Run("connectivity-classed cause passes through non-transient", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+
+		m.recordLabelReadFailure(nats.ErrTimeout)
+
+		require.Equal(t, int32(1), m.kvErrorCount.Load())
+		require.Len(t, m.kvErrorWindow, 1)
+		require.False(t, m.kvErrorWindow[0].transient,
+			"connectivity cause must be admitted as a whole-bucket-loss (non-transient) entry")
+	})
+
+	t.Run("bare count-based error is wrapped transient", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+
+		m.recordLabelReadFailure(errors.New("2 of 3 worker label reads failed"))
+
+		require.Equal(t, int32(1), m.kvErrorCount.Load())
+		require.Len(t, m.kvErrorWindow, 1)
+		require.True(t, m.kvErrorWindow[0].transient,
+			"a bare count-based failure must be wrapped ErrKVUnavailable and enter as the transient class")
+	})
+
+	t.Run("wrapped shape classifies as transient window entry", func(t *testing.T) {
+		// Lock the exact wrapping shape the adapter uses so classifyKVError keeps
+		// routing it to the transient (F-D1) window class.
+		wrapped := fmt.Errorf("%w: broad worker label read failure: %w", ErrKVUnavailable, errors.New("boom"))
+		got := classifyKVError(wrapped)
+		require.Equal(t, kvRouteWindow, got.route)
+		require.True(t, got.transient)
+	})
+
+	t.Run("sustained bare failures trip degraded with kv-unavailable reason", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+		m.state.Store(int32(StateStable)) // must be a state that allows Degraded entry
+
+		for range 3 {
+			m.recordLabelReadFailure(errors.New("broad worker label read failure"))
+		}
+		// Stop the monitorDegradedAlerts goroutine started by enterDegraded.
+		cancel()
+		m.wg.Wait()
+
+		require.Equal(t, StateDegraded, m.State())
+		rec := m.degraded.Load()
+		require.NotNil(t, rec)
+		require.Equal(t, DegradeReasonKVUnavailable, rec.reason)
+	})
+
+	t.Run("nil is a no-op", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := &Manager{logger: logger, cfg: cfg, hooks: &Hooks{}, metrics: nopMetrics, ctx: ctx, cancel: cancel}
+
+		m.recordLabelReadFailure(nil)
+
+		require.Equal(t, int32(0), m.kvErrorCount.Load())
+		require.Empty(t, m.kvErrorWindow)
+	})
 }

--- a/manager.go
+++ b/manager.go
@@ -61,6 +61,12 @@ type Manager struct {
 	hooks         *Hooks
 	metrics       MetricsCollector
 	logger        Logger
+
+	// workerLabels is this worker's resolved label set (WithWorkerLabels
+	// overrides Config.WorkerLabels). Normalized once in NewManager and
+	// immutable for the manager's lifetime; published in every heartbeat and
+	// consumed by label-based assignment. nil/empty = unlabeled worker.
+	workerLabels []string
 	// Optional worker consumer updater
 	consumerUpdater WorkerConsumerUpdater
 	// Cached CapabilityReporter view of consumerUpdater. Set once at
@@ -444,6 +450,22 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 		hooksInstance = &nopHooks
 	}
 
+	// Resolve the worker label set once, immutable for the manager's lifetime.
+	// WithWorkerLabels wins over Config.WorkerLabels; the config path is already
+	// normalized by cfg.Validate above, so only the option path needs normalizing
+	// here (Option cannot return an error, so validation is deferred to here).
+	workerLabels := cfg.WorkerLabels
+	if options.workerLabelsSet {
+		normalized, err := normalizeWorkerLabels(options.workerLabels)
+		if err != nil {
+			return nil, fmt.Errorf("WithWorkerLabels: %w", err)
+		}
+		workerLabels = normalized
+	}
+	if len(workerLabels) > 0 {
+		logger.Info("resolved worker labels", "labels", workerLabels)
+	}
+
 	// Initialize internal components with Nop implementations
 	// This ensures that these fields are never nil, simplifying lifecycle management
 	// and avoiding nil pointer checks in operational methods.
@@ -456,6 +478,7 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 		hooks:             hooksInstance,
 		metrics:           metricsCollector,
 		logger:            logger,
+		workerLabels:      workerLabels,
 		consumerUpdater:   options.consumerUpdater,
 		capReporter:       asCapabilityReporter(options.consumerUpdater),
 		fleetSizeObserver: asFleetSizeObserver(options.consumerUpdater),
@@ -714,6 +737,25 @@ func (m *Manager) applyInitialAssignment(ctx context.Context, assignmentKV jetst
 			// of truth — see applyAssignment Godoc). The watcher will
 			// redeliver on the next tick if Apply failed.
 			if err := m.applyAssignmentWithPrev(Assignment{}, newAsg); err != nil {
+				if errors.Is(err, errLabelIncarnationRejected) {
+					// The current commit was computed for a different
+					// incarnation of this worker ID (labels-of-record mismatch).
+					// Do NOT surface it as authoritative or apply it; the
+					// leader's label-change trigger republishes a label-correct
+					// commit, which the commit watcher applies normally.
+					//
+					// Clear the raw store from waitForAssignment: unlike an
+					// ordinary apply failure (which retries the SAME assignment
+					// until it lands), a rejected assignment is never applied
+					// by this incarnation, so leaving it stored would expose
+					// partitions this worker is NOT consuming through the
+					// public CurrentAssignment() until the label-correct
+					// commit arrives.
+					m.assignment.Store(Assignment{})
+					m.logger.Warn("startup: current commit is for a different incarnation; waiting for a label-correct commit")
+					return nil
+				}
+
 				return err
 			}
 			commitCopy := *commit
@@ -778,6 +820,17 @@ func (m *Manager) applyInitialAssignment(ctx context.Context, assignmentKV jetst
 		m.observeFleetSizeN(initial.Version, initial.LeaderRevision, initial.TotalWorkers)
 	}
 	if err := m.applyAssignmentWithPrev(Assignment{}, initial); err != nil {
+		if errors.Is(err, errLabelIncarnationRejected) {
+			// The legacy-alias-derived assignment carries labels-of-record for
+			// a different incarnation of this worker ID. Same disposition as the
+			// commit path: wait for a label-correct assignment via the watcher,
+			// and clear the raw store so the rejected assignment does not leak
+			// through CurrentAssignment() meanwhile.
+			m.assignment.Store(Assignment{})
+			m.logger.Warn("startup: current alias assignment is for a different incarnation; waiting for a label-correct assignment")
+			return nil
+		}
+
 		return err
 	}
 	m.runInitialHandoffResumeIfPending()

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -122,25 +122,28 @@ func (m *Manager) startCalculator(assignmentKV, heartbeatKV jetstream.KeyValue) 
 	}
 
 	calc, err := assignment.NewCalculator(&assignment.Config{
-		AssignmentKV:          assignmentKV,
-		HeartbeatKV:           heartbeatKV,
-		Source:                m.source,
-		Strategy:              m.strategy,
-		AssignmentPrefix:      "assignment",
-		HeartbeatPrefix:       "heartbeat",
-		HeartbeatTTL:          m.cfg.HeartbeatTTL,
-		EmergencyGracePeriod:  m.cfg.EmergencyGracePeriod,
-		Cooldown:              m.cfg.RebalanceCooldown,
-		ColdStartWindow:       m.cfg.ColdStartWindow,
-		PlannedScaleWindow:    m.cfg.PlannedScaleWindow,
-		EnableTwoPhaseHandoff: m.cfg.EnableTwoPhaseHandoff,
-		Metrics:               m.metrics,
-		Logger:                m.logger,
-		StateProvider:         m, // Pass manager as state provider for degraded mode checks
-		LeaderRevision:        m.electionRevision,
-		LeaderCheck:           m.checkElectionLeadership,
-		OnEnumerationError:    m.onEnumerationStall,
-		OnEnumerationSuccess:  m.recordEnumerationSuccess,
+		AssignmentKV:             assignmentKV,
+		HeartbeatKV:              heartbeatKV,
+		Source:                   m.source,
+		Strategy:                 m.strategy,
+		AssignmentPrefix:         "assignment",
+		HeartbeatPrefix:          "heartbeat",
+		HeartbeatTTL:             m.cfg.HeartbeatTTL,
+		EmergencyGracePeriod:     m.cfg.EmergencyGracePeriod,
+		Cooldown:                 m.cfg.RebalanceCooldown,
+		ColdStartWindow:          m.cfg.ColdStartWindow,
+		PlannedScaleWindow:       m.cfg.PlannedScaleWindow,
+		EnableTwoPhaseHandoff:    m.cfg.EnableTwoPhaseHandoff,
+		Metrics:                  m.metrics,
+		Logger:                   m.logger,
+		StateProvider:            m, // Pass manager as state provider for degraded mode checks
+		LeaderRevision:           m.electionRevision,
+		LeaderCheck:              m.checkElectionLeadership,
+		OnEnumerationError:       m.onEnumerationStall,
+		OnEnumerationSuccess:     m.recordEnumerationSuccess,
+		UnlabeledPartitionPolicy: m.cfg.UnlabeledPartitionPolicy,
+		LabelSpillGrace:          m.cfg.LabelSpillGrace,
+		OnLabelReadBroadFailure:  m.recordLabelReadFailure,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create calculator: %w", err)
@@ -248,12 +251,33 @@ func (m *Manager) monitorCalculatorState(calc assignmentCalculator, readyCh chan
 }
 
 // stopCalculator stops the assignment calculator, returning true if it was running.
+//
+// LOCK ORDER (deadlock-critical): m.mu must NOT be held across calc.Stop().
+// calc.Stop joins the calculator's goroutines (worker monitor, state machine,
+// partition/label monitors), and an in-flight rebalance on those goroutines
+// re-enters the manager through lock-taking callbacks —
+// OnLabelReadBroadFailure → recordLabelReadFailure → recordKVError →
+// m.mu.Lock() — so holding m.mu here closed a circular wait that hung
+// Manager.Stop forever (the Task 15 pool-outage shutdown deadlock; the
+// pre-existing OnEnumerationError sibling deliberately avoids m.mu via
+// atomic CAS, which is why the cycle only appeared with the label seam).
+//
+// The calculator-field swap to the Nop default stays INSIDE the lock, which
+// is what keeps the unlock safe against interleavings: a concurrent
+// stopCalculator sees the Nop and returns false (exactly one caller reaches
+// calc.Stop — belt-and-braces on top of calc.Stop's own started-CAS
+// idempotence), and a concurrent startCalculator builds a fresh calculator
+// while the old instance drains outside the lock. In practice stop/start are
+// already serialized: the election monitor invokes both from one goroutine
+// (program order, and this function returns only after calc.Stop completes),
+// and Manager.Stop cancels m.ctx before calling here, so the election loop
+// is exiting.
 func (m *Manager) stopCalculator() bool {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	calc, ok := m.calculator.(*assignment.Calculator)
 	if !ok {
+		m.mu.Unlock()
 		return false
 	}
 
@@ -284,7 +308,14 @@ func (m *Manager) stopCalculator() bool {
 		// No state transition needed for non-leader states
 	}
 
-	// Stop calculator with fresh context for cleanup
+	// Swap in the Nop default while still holding the lock so every other
+	// m.calculator reader immediately sees a non-nil calculator that is not
+	// the draining instance.
+	m.calculator = assignment.NewNopCalculator()
+	m.mu.Unlock()
+
+	// Stop calculator OUTSIDE m.mu (see the lock-order note above) with a
+	// fresh context for cleanup.
 	// IMPORTANT: Cannot use m.ctx here because it's already cancelled during Stop()
 	// Creating a timeout from cancelled context would result in immediate cancellation
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), m.cfg.OperationTimeout)
@@ -293,8 +324,6 @@ func (m *Manager) stopCalculator() bool {
 	if err := calc.Stop(stopCtx); err != nil {
 		m.logError("failed to stop calculator", "error", err)
 	}
-
-	m.calculator = assignment.NewNopCalculator()
 
 	return true
 }
@@ -1217,6 +1246,8 @@ func (m *Manager) buildAssignmentFromCommit(commit *types.AssignmentCommit, work
 		SourceRevision:      commit.SourceRevision,
 		SourceRevisionKnown: commit.SourceRevisionKnown,
 		TotalWorkers:        len(commit.Workers),
+		WorkerLabels:        payload.WorkerLabels,
+		WorkerLabelsKnown:   payload.WorkerLabelsKnown,
 	}, true
 }
 
@@ -1422,6 +1453,56 @@ func (m *Manager) currentAssignmentApplied(cur Assignment) bool {
 		types.PartitionSetDigest(c.Partitions) == types.PartitionSetDigest(cur.Partitions)
 }
 
+// errLabelIncarnationRejected marks an assignment payload computed for a
+// different process incarnation behind this worker's stable ID (the
+// labels-of-record mismatch this worker's configured labels). Rejection
+// is terminal for that payload: no alias fallback, no apply retry, no
+// ack — convergence arrives as the next label-correct commit via the
+// leader's label-change trigger.
+var errLabelIncarnationRejected = errors.New("assignment labels-of-record mismatch worker labels; payload from a different incarnation")
+
+// labelIncarnationMismatch implements the spec §9 guard matrix. Both
+// sides are sorted+deduplicated (normalizeWorkerLabels for the worker,
+// publisher-normalized labels-of-record for the payload), so slice
+// equality is set equality.
+//
+//	WorkerLabelsKnown=false        → apply (pre-label leader; compat)
+//	Known + equal label sets       → apply
+//	Known + differing label sets   → reject
+//	Known + empty vs labeled worker→ reject
+//	Known + empty vs unlabeled     → apply (both empty)
+func (m *Manager) labelIncarnationMismatch(a Assignment) bool {
+	if !a.WorkerLabelsKnown {
+		return false // pre-label payload: compat apply
+	}
+
+	return !slices.Equal(a.WorkerLabels, m.workerLabels)
+}
+
+// rejectIfStaleIncarnation is the shared stale-incarnation guard invoked at
+// the head of BOTH applyAssignmentWithPrev and applyAssignmentWithPrevSkipJitter,
+// before jitter, before applyAssignmentWithPrevCore, and before any side
+// effect (no coordinator Apply, no LSR/snapshot advance, no ack, no retry
+// stash). On mismatch it returns errLabelIncarnationRejected so the payload is
+// dropped terminally rather than routed through scheduleApplyRetry (retrying a
+// payload that can never become applicable is the futile loop §9 forbids).
+func (m *Manager) rejectIfStaleIncarnation(newAssignment Assignment) error {
+	if m.labelIncarnationMismatch(newAssignment) {
+		m.logger.Warn("rejecting assignment computed for a different incarnation of this worker ID",
+			"worker_id", m.WorkerID(),
+			"payload_labels", newAssignment.WorkerLabels,
+			"worker_labels", m.workerLabels,
+			"version", newAssignment.Version)
+		if lm, ok := m.metrics.(types.LabelMetrics); ok {
+			lm.IncrementLabelIncarnationReject()
+		}
+
+		return errLabelIncarnationRejected
+	}
+
+	return nil
+}
+
 // applyAssignmentWithPrev is the fresh-version apply entry (watcher,
 // commit, alias, initial-bootstrap). It jitters once before calling core,
 // so a fleet of workers observing the same fresh version spreads its
@@ -1432,6 +1513,9 @@ func (m *Manager) currentAssignmentApplied(cur Assignment) bool {
 // exponential backoff; adding jitter on top compounds latency for no
 // fleet-spread benefit (the retry is one worker, not a fleet).
 func (m *Manager) applyAssignmentWithPrev(oldAssignment, newAssignment Assignment) error {
+	if err := m.rejectIfStaleIncarnation(newAssignment); err != nil {
+		return err
+	}
 	if jitter := m.cfg.ApplyStartJitter; jitter > 0 {
 		if hook := m.testHookApplyJittered; hook != nil {
 			hook()
@@ -1452,6 +1536,10 @@ func (m *Manager) applyAssignmentWithPrev(oldAssignment, newAssignment Assignmen
 // scheduleApplyRetry so a retry's compound delay is bounded by the
 // retry-backoff envelope alone.
 func (m *Manager) applyAssignmentWithPrevSkipJitter(oldAssignment, newAssignment Assignment) error {
+	if err := m.rejectIfStaleIncarnation(newAssignment); err != nil {
+		return err
+	}
+
 	return m.applyAssignmentWithPrevCore(oldAssignment, newAssignment)
 }
 

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -3,6 +3,7 @@ package parti
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"time"
 
@@ -210,6 +211,25 @@ func (m *Manager) recordKVError(err error) {
 // does NOT route through here, keeping its claim-lost shutdown semantics.
 func (m *Manager) recordKVOpError(err error) {
 	m.recordKVError(markKVUnavailable(err))
+}
+
+// recordLabelReadFailure routes a broad label-read failure from the
+// calculator into the degraded circuit. Classed causes (connectivity /
+// degrading JetStream) pass through and are admitted as whole-bucket
+// loss. Count-based broad failures (many unclassified per-worker Get
+// failures — a connected-but-KV-misbehaving shape) carry no admissible
+// class of their own, so wrap ErrKVUnavailable: they enter the window as
+// the F-D1 transient class (DegradeReasonKVUnavailable), which healthy
+// ops clear — sustained trouble degrades, a transient blip does not.
+func (m *Manager) recordLabelReadFailure(err error) {
+	if err == nil {
+		return // classifyKVError(nil) is also kvRouteDrop — without this
+		//        guard a nil input would be wrapped into a live window entry
+	}
+	if classifyKVError(err).route == kvRouteDrop {
+		err = fmt.Errorf("%w: broad worker label read failure: %w", ErrKVUnavailable, err)
+	}
+	m.recordKVError(err)
 }
 
 // recordKVSuccess clears the ENTIRE degraded-circuit error window (both

--- a/manager_election.go
+++ b/manager_election.go
@@ -430,6 +430,10 @@ func (m *Manager) startHeartbeat(kv jetstream.KeyValue) error {
 	// Wire the capability function so the publisher reads the live bitmask on
 	// every heartbeat composition, reflecting runtime wire-up state.
 	publisher.SetCapabilitiesFn(m.Capabilities)
+	// Publish this worker's resolved label set in every heartbeat so the leader
+	// can drive label-based partition assignment. Set before Start (set-once
+	// discipline). nil/empty for unlabeled workers (field is omitempty).
+	publisher.SetLabels(m.workerLabels)
 	m.heartbeat = publisher
 
 	// Start heartbeat in background

--- a/manager_label_guard_test.go
+++ b/manager_label_guard_test.go
@@ -1,0 +1,229 @@
+package parti
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLabelGuard_Matrix exercises the spec §9 guard matrix directly against
+// labelIncarnationMismatch. Both the worker's labels and the payload's
+// labels-of-record are normalized (sorted+deduped) upstream, so slice
+// equality is set equality.
+func TestLabelGuard_Matrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		workerLabels []string
+		asg          Assignment
+		rejected     bool
+	}{
+		{"known+equal applies", []string{"vip"},
+			Assignment{WorkerLabels: []string{"vip"}, WorkerLabelsKnown: true}, false},
+		{"known+mismatch rejects", nil,
+			Assignment{WorkerLabels: []string{"vip"}, WorkerLabelsKnown: true}, true},
+		{"known+empty vs labeled worker rejects", []string{"vip"},
+			Assignment{WorkerLabelsKnown: true}, true},
+		{"unknown (pre-label payload) applies", []string{"vip"},
+			Assignment{}, false},
+		{"known+empty vs unlabeled worker applies", nil,
+			Assignment{WorkerLabelsKnown: true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := &Manager{workerLabels: tc.workerLabels}
+			require.Equal(t, tc.rejected, m.labelIncarnationMismatch(tc.asg))
+		})
+	}
+}
+
+// TestLabelGuard_RejectIsTerminalNoRetryNoAck feeds a mismatched assignment
+// through applyAssignmentWithPrev (the fresh-version entrypoint) and asserts
+// the reject is terminal: the sentinel surfaces, the handoff coordinator's
+// Apply never runs, the applied-snapshot ack does not advance, and no
+// apply-retry is stashed.
+func TestLabelGuard_RejectIsTerminalNoRetryNoAck(t *testing.T) {
+	t.Parallel()
+	m, rh, hb, _ := newTestManager(t)
+	m.workerLabels = []string{"batch"} // this worker's configured labels
+
+	err := m.applyAssignmentWithPrev(Assignment{}, Assignment{
+		Version:           7,
+		WorkerLabels:      []string{"vip"}, // computed for a different incarnation
+		WorkerLabelsKnown: true,
+	})
+
+	require.ErrorIs(t, err, errLabelIncarnationRejected)
+	require.Zero(t, rh.applyCount.Load(), "handoff Apply must not run on a stale-incarnation reject")
+	_, ok := hb.latestSnap()
+	require.False(t, ok, "applied ack must not advance on reject")
+	require.Nil(t, m.stashedApplyRetry.Load(), "no apply retry may be stashed on reject")
+}
+
+// TestLabelGuard_RetryEntrypointAlsoGuarded feeds a mismatched assignment
+// through applyAssignmentWithPrevSkipJitter (the scheduleApplyRetry
+// entrypoint) and asserts the same terminal reject. Defense in depth: labels
+// are immutable per process, so a stashed retry that matched at stash time
+// still matches — but the guard here makes the coverage claim true by
+// construction.
+func TestLabelGuard_RetryEntrypointAlsoGuarded(t *testing.T) {
+	t.Parallel()
+	m, rh, hb, _ := newTestManager(t)
+	m.workerLabels = []string{"batch"}
+
+	err := m.applyAssignmentWithPrevSkipJitter(Assignment{}, Assignment{
+		Version:           7,
+		WorkerLabels:      []string{"vip"},
+		WorkerLabelsKnown: true,
+	})
+
+	require.ErrorIs(t, err, errLabelIncarnationRejected)
+	require.Zero(t, rh.applyCount.Load(), "handoff Apply must not run on the retry entrypoint reject")
+	_, ok := hb.latestSnap()
+	require.False(t, ok, "applied ack must not advance on the retry entrypoint reject")
+	require.Nil(t, m.stashedApplyRetry.Load(), "no apply retry may be re-stashed on reject")
+}
+
+// TestLabelGuard_BuildAssignmentCopiesLabels proves buildAssignmentFromCommit
+// round-trips the payload's labels-of-record onto the returned Assignment so
+// the guard can compare them.
+func TestLabelGuard_BuildAssignmentCopiesLabels(t *testing.T) {
+	t.Parallel()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	akv := partitest.CreateJetStreamKV(t, nc, "label-guard-build-asgn")
+
+	m, _, _, _ := newTestManager(t)
+	m.assignmentKV = akv
+	wid := m.WorkerID()
+
+	parts := []types.Partition{{Keys: []string{"p1"}}}
+	ref := publishLabeledCommitPayload(t, akv, parts, []string{"vip"}, true)
+
+	commit := &types.AssignmentCommit{
+		Version:        9,
+		LeaderRevision: 3,
+		Workers:        []string{wid},
+		Payloads:       map[string]types.AssignmentPayloadRef{wid: ref},
+	}
+
+	asg, ok := m.buildAssignmentFromCommit(commit, wid)
+	require.True(t, ok)
+	require.Equal(t, []string{"vip"}, asg.WorkerLabels)
+	require.True(t, asg.WorkerLabelsKnown)
+}
+
+// publishLabeledCommitPayload mirrors publishCommitPayload but stamps the
+// labels-of-record so buildAssignmentFromCommit's copy can be asserted.
+func publishLabeledCommitPayload(t *testing.T, kv jetstream.KeyValue, parts []types.Partition, labels []string, known bool) types.AssignmentPayloadRef {
+	t.Helper()
+	payload := types.AssignmentPayload{
+		SchemaVersion:     types.AssignmentSchemaVersion,
+		Partitions:        parts,
+		WorkerLabels:      labels,
+		WorkerLabelsKnown: known,
+	}
+	canonical, err := json.Marshal(payload)
+	require.NoError(t, err)
+	hash := sha256.Sum256(canonical)
+	hashHex := hex.EncodeToString(hash[:])
+	key := "assignment._payload." + hashHex
+
+	var gzBuf bytes.Buffer
+	gzw, _ := gzip.NewWriterLevel(&gzBuf, gzip.BestCompression)
+	_, err = gzw.Write(canonical)
+	require.NoError(t, err)
+	require.NoError(t, gzw.Close())
+	_, err = kv.Create(t.Context(), key, gzBuf.Bytes())
+	require.NoError(t, err)
+
+	return types.AssignmentPayloadRef{
+		Key:         key,
+		PayloadHash: hashHex,
+		SetDigest:   types.PartitionSetDigest(parts),
+	}
+}
+
+// TestLabelGuard_StartupReject_ClearsExposedAssignment pins the CurrentAssignment
+// exposure fix: waitForAssignment raw-stores the fetched assignment BEFORE the
+// startup apply runs the stale-incarnation guard, so a guard reject used to
+// leave the fetched-but-never-applied assignment visible through the public
+// CurrentAssignment() until the leader republished a label-correct commit.
+// After a startup reject the store must be empty. The reject itself stays
+// benign (returns nil; the Stable transition stands as adjudicated) — only the
+// exposure changes. Covers both applyInitialAssignment branches.
+func TestLabelGuard_StartupReject_ClearsExposedAssignment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("commit branch", func(t *testing.T) {
+		t.Parallel()
+		_, nc := partitest.StartEmbeddedNATS(t)
+		akv := partitest.CreateJetStreamKV(t, nc, "label-guard-startup-commit")
+
+		m, rh, _, _ := newTestManager(t)
+		m.assignmentKV = akv
+		m.workerLabels = []string{"batch"} // this incarnation's labels
+		wid := m.WorkerID()
+
+		parts := []types.Partition{{Keys: []string{"p1"}}}
+		ref := publishLabeledCommitPayload(t, akv, parts, []string{"vip"}, true)
+		commit := types.AssignmentCommit{
+			Version:        3,
+			LeaderRevision: 2,
+			Workers:        []string{wid},
+			Payloads:       map[string]types.AssignmentPayloadRef{wid: ref},
+		}
+		commitBytes, err := json.Marshal(commit)
+		require.NoError(t, err)
+		_, err = akv.Put(t.Context(), "assignment._commit", commitBytes)
+		require.NoError(t, err)
+
+		// Mirror waitForAssignment's raw store of the fetched assignment.
+		m.assignment.Store(Assignment{
+			Version:           3,
+			Partitions:        parts,
+			WorkerLabels:      []string{"vip"},
+			WorkerLabelsKnown: true,
+		})
+
+		require.NoError(t, m.applyInitialAssignment(t.Context(), akv),
+			"startup reject is benign (adjudicated): startup proceeds")
+		require.Zero(t, rh.applyCount.Load(), "reject must not run Apply")
+		require.Equal(t, Assignment{}, m.CurrentAssignment(),
+			"the fetched-but-rejected assignment must not leak through CurrentAssignment")
+	})
+
+	t.Run("alias branch", func(t *testing.T) {
+		t.Parallel()
+		_, nc := partitest.StartEmbeddedNATS(t)
+		akv := partitest.CreateJetStreamKV(t, nc, "label-guard-startup-alias")
+
+		m, rh, _, _ := newTestManager(t)
+		m.assignmentKV = akv
+		m.workerLabels = []string{"batch"}
+
+		// No _commit key exists: applyInitialAssignment falls through to the
+		// legacy-alias branch, applying what waitForAssignment surfaced.
+		m.assignment.Store(Assignment{
+			Version:           2,
+			Partitions:        []types.Partition{{Keys: []string{"p1"}}},
+			WorkerLabels:      []string{"vip"},
+			WorkerLabelsKnown: true,
+		})
+
+		require.NoError(t, m.applyInitialAssignment(t.Context(), akv),
+			"startup reject is benign (adjudicated): startup proceeds")
+		require.Zero(t, rh.applyCount.Load(), "reject must not run Apply")
+		require.Equal(t, Assignment{}, m.CurrentAssignment(),
+			"the alias-branch reject must clear the raw store too")
+	})
+}

--- a/manager_label_stop_test.go
+++ b/manager_label_stop_test.go
@@ -1,0 +1,128 @@
+package parti_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// rebalanceGateLogger implements parti.Logger and, once armed, blocks the
+// FIRST calculator "partitions retrieved" Debug line (emitted mid-rebalance,
+// after the fresh worker enumeration and before the label-read phase) until
+// released. It lets the test park a real partition-lifecycle rebalance — on
+// the calculator-owned monitorPartitions goroutine that calc.Stop joins —
+// at exactly the point where a concurrent Manager.Stop closes the
+// calculator's stop channel, so the resumed label reads abort broadly.
+type rebalanceGateLogger struct {
+	armed   atomic.Bool
+	once    sync.Once
+	entered chan struct{} // closed when the gated rebalance reaches the gate
+	release chan struct{} // test closes to resume the rebalance
+}
+
+func newRebalanceGateLogger() *rebalanceGateLogger {
+	return &rebalanceGateLogger{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (l *rebalanceGateLogger) Debug(msg string, _ ...any) {
+	if msg == "partitions retrieved" && l.armed.Load() {
+		l.once.Do(func() { close(l.entered) })
+		<-l.release
+	}
+}
+func (l *rebalanceGateLogger) Info(string, ...any)  {}
+func (l *rebalanceGateLogger) Warn(string, ...any)  {}
+func (l *rebalanceGateLogger) Error(string, ...any) {}
+func (l *rebalanceGateLogger) Fatal(string, ...any) {}
+
+// TestManagerStop_NoDeadlock_LabelReadFailureDuringStop reproduces the Task 15
+// shutdown deadlock: stopCalculator held m.mu across calc.Stop(), whose joins
+// wait for the in-flight rebalance; Stop's stop-channel close makes that
+// rebalance's label reads abort broadly, so it re-enters the manager via
+// OnLabelReadBroadFailure → recordLabelReadFailure → recordKVError →
+// m.mu.Lock() — a circular wait that hung Manager.Stop forever.
+//
+// Staging (near-deterministic): a gate logger parks a partition-lifecycle
+// rebalance right after the fresh worker enumeration; Manager.Stop is then
+// started and given time to reach calc.Stop (closing the calculator's stopCh)
+// while blocked joining the parked goroutine; the gate is released and the
+// resumed label reads abort into the callback. On the unfixed code Stop never
+// returns (bounded wait fails the test); fixed, it completes promptly.
+//
+// Deliberately NO t.Cleanup(mgr.Stop): on the unfixed code a second Stop would
+// deadlock the cleanup phase too and convert the failure into a package
+// timeout. The single in-test Stop is the assertion.
+func TestManagerStop_NoDeadlock_LabelReadFailureDuringStop(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	srcKV := partitest.CreateJetStreamKV(t, nc, "lbl-stop-deadlock-partitions")
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, []types.Partition{
+		{Keys: []string{"p0"}},
+		{Keys: []string{"p1"}},
+	}))
+
+	gate := newRebalanceGateLogger()
+	cfg := testutil.IntegrationTestConfig()
+
+	mgr, err := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(), parti.WithLogger(gate))
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Start(ctx))
+	require.NoError(t, <-mgr.WaitState(types.StateStable, 20*time.Second))
+
+	// Arm the gate, then trigger a partition-lifecycle rebalance via a real
+	// source change; the watcher drives it on the calculator's
+	// monitorPartitions goroutine, which calc.Stop joins.
+	gate.armed.Store(true)
+	require.NoError(t, src.Update(ctx, []types.Partition{
+		{Keys: []string{"p0"}},
+		{Keys: []string{"p1"}},
+		{Keys: []string{"p2"}},
+	}))
+
+	select {
+	case <-gate.entered:
+	case <-time.After(20 * time.Second):
+		t.Fatal("the source-change rebalance never reached the gate")
+	}
+
+	// Stop while the rebalance is parked mid-flight.
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- mgr.Stop(context.Background()) }()
+
+	// Wait for Stop to be underway (it transitions to Shutdown synchronously
+	// at entry), then give it ample time to reach calc.Stop and close the
+	// calculator's stop channel while it blocks joining the parked goroutine.
+	require.Eventually(t, func() bool { return mgr.State() == types.StateShutdown },
+		10*time.Second, 10*time.Millisecond, "Stop must transition to Shutdown")
+	time.Sleep(1 * time.Second)
+
+	// Resume the rebalance: its label reads now abort broadly (stop-cancelled
+	// context) and fire the manager's broad-failure callback.
+	close(gate.release)
+
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err, "Manager.Stop must complete cleanly")
+	case <-time.After(20 * time.Second):
+		t.Fatal("Manager.Stop deadlocked: stopCalculator held m.mu across calc.Stop while the " +
+			"in-flight rebalance's broad label-read failure re-entered recordKVError → m.mu.Lock")
+	}
+}

--- a/options.go
+++ b/options.go
@@ -13,6 +13,13 @@ type managerOptions struct {
 	logger          Logger
 	consumerUpdater WorkerConsumerUpdater
 	handoffMetrics  HandoffMetricsRecorder
+
+	// workerLabels carries the raw label set supplied via WithWorkerLabels;
+	// workerLabelsSet distinguishes "option provided" from "unset" so the
+	// option can override Config.WorkerLabels. Normalized (and validated) in
+	// NewManager, because Option cannot return an error.
+	workerLabels    []string
+	workerLabelsSet bool
 }
 
 // WithElectionAgent sets a custom election agent.
@@ -97,6 +104,26 @@ func WithMetrics(metrics MetricsCollector) Option {
 func WithLogger(logger Logger) Option {
 	return func(o *managerOptions) {
 		o.logger = logger
+	}
+}
+
+// WithWorkerLabels sets this worker's label set, overriding
+// Config.WorkerLabels. Labels are fixed for the manager's lifetime,
+// published in every heartbeat, and drive label-based partition
+// assignment. Invalid labels cause NewManager to return an error.
+//
+// Use this instead of Config.WorkerLabels when several workers share one
+// Config value (e.g. test clusters) but need distinct labels.
+//
+// Parameters:
+//   - labels: Worker label set (validated, sorted, and deduplicated by NewManager)
+//
+// Returns:
+//   - Option: Functional option for NewManager
+func WithWorkerLabels(labels ...string) Option {
+	return func(o *managerOptions) {
+		o.workerLabels = labels
+		o.workerLabelsSet = true
 	}
 }
 

--- a/provision/apply_partitions.go
+++ b/provision/apply_partitions.go
@@ -315,22 +315,26 @@ func skippedWritePartitions(res *WritePartitionsResource) SkippedAction {
 }
 
 // partitionTablesEqual reports whether a and b describe the same partition
-// table: the same set of CanonicalIDs with the same per-record Weight, order
-// independent. Both inputs are duplicate-free (partcodec.Decode and
-// ValidatePartitionSet reject duplicate CanonicalIDs), so an equal length plus
-// a matching lookup is a bijection.
+// table: the same set of CanonicalIDs with the same per-record Weight and
+// Label, order independent. Both inputs are duplicate-free (partcodec.Decode
+// and ValidatePartitionSet reject duplicate CanonicalIDs), so an equal
+// length plus a matching lookup is a bijection.
 func partitionTablesEqual(a, b []types.Partition) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	weightByID := make(map[string]int64, len(a))
+	type wl struct {
+		w int64
+		l string
+	}
+	byID := make(map[string]wl, len(a))
 	for _, p := range a {
-		weightByID[p.CanonicalID()] = p.Weight
+		byID[p.CanonicalID()] = wl{w: p.Weight, l: p.Label}
 	}
 	for _, p := range b {
-		w, ok := weightByID[p.CanonicalID()]
-		if !ok || w != p.Weight {
+		v, ok := byID[p.CanonicalID()]
+		if !ok || v.w != p.Weight || v.l != p.Label {
 			return false
 		}
 	}

--- a/provision/partition_label_test.go
+++ b/provision/partition_label_test.go
@@ -1,0 +1,43 @@
+package provision
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClonePartition_PreservesLabel(t *testing.T) {
+	t.Parallel()
+
+	p := types.Partition{Keys: []string{"a"}, Weight: 2, Label: "vip"}
+	got := clonePartition(p)
+	require.Equal(t, p, got)
+}
+
+func TestDiffPartitions_LabelOnlyChangeIsVisible(t *testing.T) {
+	t.Parallel()
+
+	live := []types.Partition{{Keys: []string{"a"}, Weight: 1}}
+	desired := []types.Partition{{Keys: []string{"a"}, Weight: 1, Label: "vip"}}
+
+	added, removed, changed := diffPartitions(live, desired)
+	require.Empty(t, added)
+	require.Empty(t, removed)
+	require.Len(t, changed, 1, "label-only edit must surface as a change in plan output")
+	require.Equal(t, "", changed[0].OldLabel)
+	require.Equal(t, "vip", changed[0].NewLabel)
+	require.Equal(t, int64(1), changed[0].OldWeight)
+	require.Equal(t, int64(1), changed[0].NewWeight)
+}
+
+func TestPartitionTablesEqual_LabelAware(t *testing.T) {
+	t.Parallel()
+
+	a := []types.Partition{{Keys: []string{"a"}, Weight: 1}}
+	b := []types.Partition{{Keys: []string{"a"}, Weight: 1, Label: "vip"}}
+
+	require.True(t, partitionTablesEqual(a, a))
+	require.False(t, partitionTablesEqual(a, b),
+		"label-only apply must not be skipped as a no-op")
+}

--- a/provision/partition_records.go
+++ b/provision/partition_records.go
@@ -159,7 +159,7 @@ func readPartitionKey(ctx context.Context, js jetstream.JetStream, bucket, key s
 //
 //   - added   — declared records absent from live.
 //   - removed — live records absent from the declared set.
-//   - changed — records present in both whose Weight differs.
+//   - changed — records present in both whose Weight or Label differs.
 //
 // A record whose key set differs is a distinct partition: it appears as one
 // add and one remove, never a change. Every returned slice is non-nil and
@@ -185,11 +185,13 @@ func diffPartitions(live, desired []types.Partition) (added, removed []types.Par
 			added = append(added, clonePartition(d))
 			continue
 		}
-		if live.Weight != d.Weight {
+		if live.Weight != d.Weight || live.Label != d.Label {
 			changed = append(changed, PartitionWeightChange{
 				Keys:      slices.Clone(d.Keys),
 				OldWeight: live.Weight,
 				NewWeight: d.Weight,
+				OldLabel:  live.Label,
+				NewLabel:  d.Label,
 			})
 		}
 	}
@@ -220,7 +222,10 @@ func canonicalIDOfKeys(keys []string) string {
 
 // clonePartition deep-copies a partition, reallocating its Keys slice.
 func clonePartition(p types.Partition) types.Partition {
-	return types.Partition{Keys: slices.Clone(p.Keys), Weight: p.Weight}
+	cp := p // struct-value copy: Weight, Label, and future fields
+	cp.Keys = slices.Clone(p.Keys)
+
+	return cp
 }
 
 // clonePartitions deep-copies a partition slice. The result is always non-nil

--- a/provision/types.go
+++ b/provision/types.go
@@ -341,13 +341,16 @@ type StreamStampMarkerResource struct {
 }
 
 // PartitionWeightChange records a partition present in both the live and
-// declared tables whose Weight differs. Keys identifies the partition (it is
-// unchanged — a different key set is a different partition, i.e. an add plus
-// a remove, not a change).
+// declared tables whose Weight or Label differs. Keys identifies the
+// partition (it is unchanged — a different key set is a different
+// partition, i.e. an add plus a remove, not a change). The name predates
+// label support and is kept for API compatibility.
 type PartitionWeightChange struct {
 	Keys      []string `json:"keys"`
 	OldWeight int64    `json:"oldWeight"`
 	NewWeight int64    `json:"newWeight"`
+	OldLabel  string   `json:"oldLabel,omitempty"`
+	NewLabel  string   `json:"newLabel,omitempty"`
 }
 
 // DriftFinding describes how a live resource differs from the desired state,

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -1271,7 +1271,7 @@ func (s *NatsKV) fetchFromKV(ctx context.Context) ([]types.Partition, uint64, er
 func deepCopyPartitions(partitions []types.Partition) []types.Partition {
 	result := make([]types.Partition, len(partitions))
 	for i, p := range partitions {
-		cp := types.Partition{Weight: p.Weight}
+		cp := p // struct-value copy: all scalar fields (Weight, Label, future additions)
 		cp.Keys = make([]string, len(p.Keys))
 		copy(cp.Keys, p.Keys)
 		result[i] = cp
@@ -1290,13 +1290,11 @@ func partitionsEqual(a, b []types.Partition) bool {
 		if a[i].Weight != b[i].Weight {
 			return false
 		}
-		if len(a[i].Keys) != len(b[i].Keys) {
+		if a[i].Label != b[i].Label {
 			return false
 		}
-		for j := range a[i].Keys {
-			if a[i].Keys[j] != b[i].Keys[j] {
-				return false
-			}
+		if !slices.Equal(a[i].Keys, b[i].Keys) {
+			return false
 		}
 	}
 
@@ -1324,7 +1322,7 @@ func validateAndDedupe(partitions []types.Partition) ([]types.Partition, error) 
 		}
 		seen[cid] = struct{}{}
 		// Deep-copy Keys to protect the encode→write window against caller mutation.
-		cp := types.Partition{Weight: p.Weight}
+		cp := p // struct-value copy preserves Weight, Label, and future fields
 		cp.Keys = make([]string, len(p.Keys))
 		copy(cp.Keys, p.Keys)
 		result = append(result, cp)

--- a/source/nats_kv_label_test.go
+++ b/source/nats_kv_label_test.go
@@ -1,0 +1,184 @@
+package source
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepCopyPartitions_PreservesLabel(t *testing.T) {
+	t.Parallel()
+
+	in := []types.Partition{{Keys: []string{"a"}, Weight: 2, Label: "vip"}}
+	out := deepCopyPartitions(in)
+
+	require.Equal(t, in, out)
+	// Still a deep copy: mutating the copy's Keys must not alias the input.
+	out[0].Keys[0] = "mutated"
+	require.Equal(t, "a", in[0].Keys[0])
+}
+
+func TestValidateAndDedupe_PreservesLabel(t *testing.T) {
+	t.Parallel()
+
+	in := []types.Partition{{Keys: []string{"a"}, Weight: 2, Label: "vip"}}
+	out, err := validateAndDedupe(in)
+	require.NoError(t, err)
+	require.Equal(t, "vip", out[0].Label)
+
+	// Same keys + different labels = duplicate identity → error (spec §4.1).
+	_, err = validateAndDedupe([]types.Partition{
+		{Keys: []string{"a"}, Label: "vip"},
+		{Keys: []string{"a"}, Label: "batch"},
+	})
+	require.Error(t, err)
+}
+
+func TestPartitionsEqual_LabelAware(t *testing.T) {
+	t.Parallel()
+
+	a := []types.Partition{{Keys: []string{"a"}, Weight: 1}}
+	b := []types.Partition{{Keys: []string{"a"}, Weight: 1, Label: "vip"}}
+
+	require.True(t, partitionsEqual(a, a))
+	require.False(t, partitionsEqual(a, b), "label-only difference must be a change")
+}
+
+// newLabelTestSource creates a real KV bucket, seeds it with `initial`,
+// and returns a started NatsKV plus the raw KV handle for out-of-band
+// writes (simulating an external operator/writer process).
+func newLabelTestSource(t *testing.T, initial []types.Partition) (*NatsKV, jetstream.KeyValue, context.Context) {
+	t.Helper()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-src-test"})
+	require.NoError(t, err)
+
+	seed, err := partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", seed)
+	require.NoError(t, err)
+
+	src := NewNatsKV(kv, "partitions", nil) // nil logger is the package's test convention
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	return src, kv, ctx
+}
+
+// TestNatsKV_LabelOnlyEdit_WatchPathPropagates is the spec §10 regression:
+// a rewrite that changes ONLY a label (same keys, same weights) must fire
+// the Watch signal and the next Snapshot must carry the label.
+func TestNatsKV_LabelOnlyEdit_WatchPathPropagates(t *testing.T) {
+	t.Parallel()
+
+	initial := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1},
+		{Keys: []string{"p1"}, Weight: 1},
+	}
+	src, kv, ctx := newLabelTestSource(t, initial)
+
+	watchCh := src.Watch(ctx)
+
+	// Label-only rewrite via an out-of-band KV write (external writer).
+	promoted := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1, Label: "vip"}, // <- only delta
+		{Keys: []string{"p1"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	select {
+	case <-watchCh:
+		// change notification observed
+	case <-time.After(10 * time.Second):
+		t.Fatal("label-only edit did not fire the source Watch signal")
+	}
+
+	parts, _, _, err := src.Snapshot(ctx)
+	require.NoError(t, err)
+	byID := map[string]string{}
+	for _, p := range parts {
+		byID[p.CanonicalID()] = p.Label
+	}
+	require.Equal(t, "vip", byID[types.Partition{Keys: []string{"p0"}}.CanonicalID()],
+		"snapshot must carry the label through decode → deep-copy → store")
+}
+
+// TestNatsKV_LabelOnlyEdit_ReconcilePathPropagates drives the same edit
+// through the reconcile path: the watcher is starved by writing while the
+// source's watch is torn down, then the periodic reconcile must pick up
+// the label-only change and notify.
+func TestNatsKV_LabelOnlyEdit_ReconcilePathPropagates(t *testing.T) {
+	t.Parallel()
+
+	initial := []types.Partition{{Keys: []string{"p0"}, Weight: 1}}
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-src-reconcile"})
+	require.NoError(t, err)
+	seed, err := partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", seed)
+	require.NoError(t, err)
+
+	// Aggressive fixed-cadence reconcile. NOTE: WithLeadershipProbe is
+	// deliberately NOT used here — when a leadership probe is wired,
+	// nextReconcileInterval ignores WithReconcileInterval entirely (ties
+	// the cadence to leaderReconcileInterval=30s / followerReconcileInterval=5min
+	// instead, see nats_kv.go:reconcileLoop), which would make this test's
+	// 10s timeout unreachable. The watcher is FROZEN (a never-delivering
+	// injected watchFn, the same harness shape existing reconcile tests
+	// use — see source/nats_kv_test.go:437
+	// TestNatsKV_Reconcile_RecoversFromMissedWatcherEvent) so ONLY the
+	// reconcile loop can observe the direct KV write. Without freezing,
+	// the watch path could deliver first and this test would prove
+	// nothing about reconcile.
+	src := NewNatsKV(kv, "partitions", nil, WithReconcileInterval(200*time.Millisecond))
+	frozenUpdates := make(chan jetstream.KeyValueEntry) // never written
+	src.watchFn = func(_ context.Context) (jetstream.KeyWatcher, error) {
+		return &fakeKeyWatcher{updates: frozenUpdates}, nil
+	}
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	watchCh := src.Watch(ctx)
+
+	promoted := []types.Partition{{Keys: []string{"p0"}, Weight: 1, Label: "vip"}}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = kv.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	// With the watcher frozen, this notification can ONLY come from the
+	// reconcile loop — pinning that reconcile's skip-guard does not skip
+	// a label-only change (its identity check is revision-based and every
+	// KV Put advances the revision).
+	select {
+	case <-watchCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("label-only edit did not propagate via the reconcile path")
+	}
+
+	parts, _, _, err := src.Snapshot(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "vip", parts[0].Label)
+}

--- a/test/integration/assignment/label_incarnation_test.go
+++ b/test/integration/assignment/label_incarnation_test.go
@@ -1,0 +1,408 @@
+package assignment_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/assignment"
+	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/kvutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Hand-written commit/payload helpers (spec §3.5 wire format)
+//
+// These reproduce the publisher's content-addressed layout from OUTSIDE the
+// leader so a test can stage a commit that a real library version would never
+// emit (a pre-label payload with worker_labels_known absent) or that a stale
+// incarnation left behind. The payload is JSON-marshalled in canonical form,
+// gzip-compressed, and Created at "assignment._payload.<hex(sha256)>"; the
+// commit references it by hash + set-digest exactly as
+// assignment.FetchAndVerifyCommitPayload verifies on the read side.
+// ---------------------------------------------------------------------------
+
+// writeCommitPayload stages one content-addressed AssignmentPayload and returns
+// the ref a commit embeds. known=false + labels=nil reproduces a pre-label
+// leader's payload (worker_labels_known omitted by omitempty); known=true +
+// labels reproduces a label-aware leader's labels-of-record.
+func writeCommitPayload(t *testing.T, ctx context.Context, kv jetstream.KeyValue, parts []types.Partition, labels []string, known bool) types.AssignmentPayloadRef {
+	t.Helper()
+
+	// Canonicalize partitions by CanonicalID, mirroring the publisher, so the
+	// hashed bytes match what a real leader would have produced for this set.
+	canonical := slices.Clone(parts)
+	slices.SortFunc(canonical, func(a, b types.Partition) int {
+		return strings.Compare(a.CanonicalID(), b.CanonicalID())
+	})
+
+	payload := types.AssignmentPayload{
+		SchemaVersion:     types.AssignmentSchemaVersion,
+		Partitions:        canonical,
+		WorkerLabels:      labels,
+		WorkerLabelsKnown: known,
+	}
+	canonicalBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	hash := sha256.Sum256(canonicalBytes)
+	hashHex := hex.EncodeToString(hash[:])
+	key := "assignment._payload." + hashHex
+
+	var gzBuf bytes.Buffer
+	gzw, err := gzip.NewWriterLevel(&gzBuf, gzip.BestCompression)
+	require.NoError(t, err)
+	_, err = gzw.Write(canonicalBytes)
+	require.NoError(t, err)
+	require.NoError(t, gzw.Close())
+
+	// Create is idempotent by content address: an identical payload staged by a
+	// prior write (or the real leader) is a benign ErrKeyExists.
+	_, err = kv.Create(ctx, key, gzBuf.Bytes())
+	if err != nil && !errors.Is(err, jetstream.ErrKeyExists) {
+		require.NoError(t, err)
+	}
+
+	return types.AssignmentPayloadRef{
+		Key:         key,
+		PayloadHash: hashHex,
+		SetDigest:   types.PartitionSetDigest(canonical),
+	}
+}
+
+// putCommit writes a single-worker AssignmentCommit to the singleton commit key
+// in canonical JSON, exactly as the publisher's CAS write would land it, so a
+// running worker's commit watcher observes and applies it.
+func putCommit(t *testing.T, ctx context.Context, kv jetstream.KeyValue, version int64, leaderRev uint64, workerID string, ref types.AssignmentPayloadRef, parts []types.Partition) {
+	t.Helper()
+	commit := types.AssignmentCommit{
+		Version:        version,
+		LeaderRevision: leaderRev,
+		PublishedAt:    time.Now(),
+		Workers:        []string{workerID},
+		Payloads:       map[string]types.AssignmentPayloadRef{workerID: ref},
+		BatchDigest:    types.PartitionSetDigest(parts),
+	}
+	_, err := kvutil.PutJSON(ctx, kv, assignmentCommitKey, commit)
+	require.NoError(t, err)
+}
+
+// waitCommitVersionStable blocks until the commit version stops advancing for a
+// quiet window, returning the settled commit. Used before staging a hand-written
+// commit so a still-churning cold-start publisher cannot immediately supersede
+// the staged version.
+func waitCommitVersionStable(t *testing.T, ctx context.Context, kv jetstream.KeyValue, quiet time.Duration) *types.AssignmentCommit {
+	t.Helper()
+	var last int64 = -1
+	stableSince := time.Now()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		commit := readLatestCommit(ctx, kv)
+		if commit == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if commit.Version != last {
+			last = commit.Version
+			stableSince = time.Now()
+		} else if time.Since(stableSince) >= quiet {
+			return commit
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.FailNow(t, "commit version never stabilized")
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: stable-ID reuse across label classes — guard + convergence
+// ---------------------------------------------------------------------------
+
+// TestStableIDReuse_DifferentLabels_NoStaleExposureAndConverge proves the incarnation
+// half of spec §9 end to end with full managers: when a stable worker ID is
+// reused by a NEW process whose labels differ from the labels-of-record stamped
+// into the previous incarnation's still-live commit, the new worker never
+// adopts the stale assignment and converges to a fresh, label-correct one.
+//
+// A (labels=[vip]) claims worker-0, becomes leader, and — after a vip partition
+// is promoted in — publishes commit V1 whose worker-0 payload records
+// labels-of-record ["vip"]. A stops gracefully (releasing the stable ID), and
+// B (UNLABELED) starts and reclaims worker-0 (the lowest free ID). B's own
+// leader term republishes a label-correct commit (worker-0 labels-of-record
+// []), so B never applies the stale V1 (its assignment version jumps from 0
+// straight past V1) and B's heartbeat never acks V1. Convergence lands the vip
+// partition — which has no eligible worker under B's unlabeled fleet — parked
+// then spilled onto B after the grace window.
+//
+// The stale-incarnation REJECT path itself (guard fires, terminal drop) is not
+// observable through this single-worker full-manager flow, because a lone
+// worker wins leadership synchronously during Start and republishes a
+// label-correct commit before it ever reads the stale one. That reject is
+// pinned at the component level (TestLabelGuard_Matrix,
+// TestLabelGuard_RejectIsTerminalNoRetryNoAck); this test pins the reuse +
+// convergence half the component tests cannot exercise.
+func TestStableIDReuse_DifferentLabels_NoStaleExposureAndConverge(t *testing.T) { //nolint:cyclop // linear reuse→converge scenario kept in one function
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-incarn-partitions"})
+	require.NoError(t, err)
+	// Seed all-plain; the vip label is promoted out-of-band after A is stable
+	// (the proven pattern — a labeled partition seeded at T=0 races the vip
+	// worker's first heartbeat through the cold-start assignment).
+	plain := []types.Partition{
+		{Keys: []string{"ir-v"}, Weight: 1},
+		{Keys: []string{"ir-p"}, Weight: 1},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, plain))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig() // dedicated policy (default)
+	cfg.LabelSpillGrace = 5 * time.Second
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	t.Cleanup(cluster.StopWorkers)
+
+	// --- Incarnation A: labeled "vip", claims worker-0, publishes V1. ---
+	a := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	require.NoError(t, a.Start(ctx))
+	require.NoError(t, <-a.WaitState(parti.StateStable, 15*time.Second))
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+	hbKV := openHeartbeatKV(t, ctx, js, cfg)
+	worker0 := a.WorkerID()
+
+	vID := types.Partition{Keys: []string{"ir-v"}}.CanonicalID()
+	pID := types.Partition{Keys: []string{"ir-p"}}.CanonicalID()
+
+	// Promote ir-v to "vip" out-of-band so A (the vip worker) homes it — this
+	// makes V1's worker-0 payload labels-of-record concretely ["vip"].
+	promoted := []types.Partition{
+		{Keys: []string{"ir-v"}, Weight: 1, Label: "vip"},
+		{Keys: []string{"ir-p"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return partitionsOf(a)[vID]
+	}, 30*time.Second, 200*time.Millisecond, "A (vip) must home the promoted vip partition")
+
+	// Capture the stale commit V1: worker-0's labels-of-record are ["vip"].
+	v1Commit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, v1Commit)
+	v1Ref, ok := v1Commit.Payloads[worker0]
+	require.True(t, ok, "V1 must carry a payload for worker-0")
+	v1Payload, err := assignment.FetchAndVerifyCommitPayload(ctx, assignKV, v1Ref)
+	require.NoError(t, err)
+	require.Equal(t, []string{"vip"}, v1Payload.WorkerLabels, "V1 stamps worker-0 labels-of-record ['vip']")
+	require.True(t, v1Payload.WorkerLabelsKnown)
+	v1 := v1Commit.Version
+	require.Positive(t, v1)
+
+	// --- Stop A (graceful: releases the stable ID; the commit V1 persists). ---
+	stopWorker(t, a)
+
+	// --- Incarnation B: UNLABELED, reclaims worker-0 (lowest free ID). ---
+	b := cluster.AddWorkerWithOptions(ctx) // no labels
+	require.NoError(t, b.Start(ctx))
+	require.NoError(t, <-b.WaitState(parti.StateStable, 15*time.Second),
+		"B must reach StateStable (startup converts the stale-incarnation reject to success-without-apply and CASes to Stable)")
+	require.Equal(t, worker0, b.WorkerID(), "B must reuse A's stable ID worker-0")
+
+	// Strong post-reject exposure contract: the startup runner clears the raw
+	// waitForAssignment store when the guard rejects the stale commit, BEFORE it
+	// CASes to Stable. So from the instant B is Stable, CurrentAssignment() is
+	// either still empty (version 0, no partitions) or already B's own
+	// label-correct commit (version > V1) — it must NEVER surface the rejected
+	// stale-incarnation V1 through the public API.
+	curAtStable := b.CurrentAssignment()
+	require.NotEqual(t, v1, curAtStable.Version,
+		"CurrentAssignment must never expose the rejected stale-incarnation V1")
+	if curAtStable.Version == 0 {
+		require.Empty(t, curAtStable.Partitions,
+			"pre-convergence CurrentAssignment must be empty, not the stale payload")
+	} else {
+		require.Greater(t, curAtStable.Version, v1,
+			"a non-empty CurrentAssignment at Stable must already be B's own label-correct commit")
+	}
+
+	// Convergence: B publishes a NEW commit (version > V1) whose worker-0
+	// labels-of-record are [] (unlabeled), and owns both partitions once the vip
+	// partition — with no eligible vip worker — spills after grace.
+	//
+	// Throughout the wait, B must never expose V1 via CurrentAssignment (the
+	// exposure contract above, held continuously) and must never ACK V1 via its
+	// heartbeat (the guard contract: a rejected payload is never applied, so no
+	// receipt for it ever reaches the leader).
+	ackedV1 := false
+	exposedV1 := false
+	require.Eventually(t, func() bool {
+		if hb, ok := readWorkerHeartbeat(ctx, hbKV, worker0); ok && hb.AppliedVersion == v1 {
+			ackedV1 = true
+		}
+		if b.CurrentAssignment().Version == v1 {
+			exposedV1 = true
+		}
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.Version <= v1 {
+			return false
+		}
+		ref, ok := commit.Payloads[worker0]
+		if !ok {
+			return false
+		}
+		pl, err := assignment.FetchAndVerifyCommitPayload(ctx, assignKV, ref)
+		if err != nil {
+			return false
+		}
+		if !pl.WorkerLabelsKnown || len(pl.WorkerLabels) != 0 {
+			return false // worker-0's labels-of-record must be the unlabeled [] of incarnation B
+		}
+		owned := partitionsOf(b)
+
+		return b.CurrentAssignment().Version > v1 && owned[vID] && owned[pID]
+	}, 60*time.Second, 200*time.Millisecond,
+		"B must converge to a label-correct commit (> V1, labels-of-record []) and own both partitions after the vip spill")
+
+	require.False(t, ackedV1, "B never acks the stale V1")
+	require.False(t, exposedV1, "the stale V1 was never exposed through CurrentAssignment")
+
+	// B's heartbeat advanced straight past V1 to its own label-correct commit.
+	hb, ok := readWorkerHeartbeat(ctx, hbKV, worker0)
+	require.True(t, ok)
+	require.NotEqual(t, v1, hb.AppliedVersion, "B's heartbeat must never ack the stale V1")
+	require.Greater(t, hb.AppliedVersion, v1, "B's applied version advanced past V1")
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: pre-label commit compat (mixed-version — worker-side half)
+// ---------------------------------------------------------------------------
+
+// TestPreLabelCommit_CompatApplies proves the spec §9 compat branch end to end:
+// a LABELED worker APPLIES a commit whose payload has NO presence bit
+// (worker_labels_known=false — exactly what a pre-label leader publishes),
+// rather than rejecting it. Under the guard matrix, a labels-KNOWN payload with
+// empty labels-of-record would be REJECTED for a labeled worker (empty !=
+// ["vip"]); the pre-label payload (labels-UNKNOWN) must instead apply, so a new
+// worker can honor commits from an old leader mid rollout.
+//
+// Two library versions cannot run in one Go test binary, so rather than run an
+// old leader we hand-write the pre-label commit directly into the assignment
+// bucket in front of a running worker. The worker is stabilized first (a lone
+// worker owns everything via the fallback ladder under the dedicated policy),
+// its calculator quiesced, then a pre-label commit that assigns it a SUBSET is
+// staged; its commit watcher observes and applies it via the compat branch.
+func TestPreLabelCommit_CompatApplies(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 180*time.Second)
+	defer cancel()
+
+	// All-plain source so the labeled worker's calculator quiesces after cold
+	// start (no label pools to re-check), leaving the staged pre-label commit
+	// unchallenged by a republish.
+	plain := []types.Partition{
+		{Keys: []string{"cp-0"}, Weight: 1},
+		{Keys: []string{"cp-1"}, Weight: 1},
+		{Keys: []string{"cp-2"}, Weight: 1},
+	}
+	src := newKVSource(t, ctx, js, "label-compat-partitions", plain)
+
+	cfg := testutil.IntegrationTestConfig() // dedicated
+
+	rec := newRecordingLabelMetrics()
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	worker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"), parti.WithMetrics(rec))
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+	hbKV := openHeartbeatKV(t, ctx, js, cfg)
+	workerID := worker.WorkerID()
+
+	// The lone labeled worker owns all three partitions via the fallback ladder
+	// (empty general pool under dedicated). Wait for that, then let the
+	// calculator quiesce so its version stops advancing.
+	require.Eventually(t, func() bool {
+		return len(partitionsOf(worker)) == len(plain)
+	}, 30*time.Second, 200*time.Millisecond, "labeled worker must own every partition via fallback before staging")
+
+	settled := waitCommitVersionStable(t, ctx, assignKV, 2*time.Second)
+	baseVersion := settled.Version
+
+	// Stage a PRE-LABEL commit (worker_labels_known=false) that assigns the
+	// worker a strict SUBSET, at the next version, reusing the settled leader
+	// revision so the worker-side stale-leader fence accepts it.
+	subset := []types.Partition{
+		{Keys: []string{"cp-0"}, Weight: 1},
+		{Keys: []string{"cp-1"}, Weight: 1},
+	}
+	preRef := writeCommitPayload(t, ctx, assignKV, subset, nil, false)
+	putCommit(t, ctx, assignKV, baseVersion+1, settled.LeaderRevision, workerID, preRef, subset)
+
+	cp0 := types.Partition{Keys: []string{"cp-0"}}.CanonicalID()
+	cp1 := types.Partition{Keys: []string{"cp-1"}}.CanonicalID()
+	cp2 := types.Partition{Keys: []string{"cp-2"}}.CanonicalID()
+
+	// The worker must APPLY the pre-label commit via the compat branch: its
+	// assignment advances to the staged version and its ownership becomes the
+	// pre-label subset (cp-0, cp-1 — not cp-2).
+	require.Eventually(t, func() bool {
+		cur := worker.CurrentAssignment()
+		owned := partitionsOf(worker)
+
+		return cur.Version == baseVersion+1 && len(owned) == 2 && owned[cp0] && owned[cp1] && !owned[cp2]
+	}, 30*time.Second, 200*time.Millisecond,
+		"labeled worker must APPLY the pre-label (labels-unknown) commit, adopting the staged subset")
+
+	// It applied — it did NOT route through the incarnation-reject guard.
+	require.Zero(t, rec.rejects(),
+		"a pre-label (labels-unknown) commit must apply via the compat branch, not the incarnation-reject guard")
+
+	// The heartbeat acks the staged version, proving the apply committed a
+	// receipt (not a silent drop).
+	require.Eventually(t, func() bool {
+		hb, ok := readWorkerHeartbeat(ctx, hbKV, workerID)
+
+		return ok && hb.AppliedVersion == baseVersion+1
+	}, 15*time.Second, 100*time.Millisecond, "worker must ack the applied pre-label commit version")
+}

--- a/test/integration/assignment/label_orphan_stale_test.go
+++ b/test/integration/assignment/label_orphan_stale_test.go
@@ -1,0 +1,820 @@
+package assignment_test
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/assignment"
+	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/kvutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Orphan / stale-assignment helpers (spec I2/I8)
+//
+// These tests read the ASSIGNMENT KV bucket directly, not just the in-memory
+// CurrentAssignment(), so they can prove the coverage contract at the wire
+// level: assigned ∪ parked == source, with no source partition silently
+// dropped and no stale worker payload left dangling.
+// ---------------------------------------------------------------------------
+
+// assignmentCommitKey is the singleton commit key the publisher CAS-writes:
+// "<prefix>._commit" with the fixed leader-side prefix "assignment"
+// (manager_assignment.go: AssignmentPrefix). The commit maps each worker to a
+// content-addressable payload ref and carries the parked-set metadata.
+const assignmentCommitKey = "assignment._commit"
+
+// openAssignmentKV opens the leader-written assignment bucket. Only valid after
+// StartWorkers — the manager creates the bucket on Start.
+func openAssignmentKV(t *testing.T, ctx context.Context, js jetstream.JetStream, cfg parti.Config) jetstream.KeyValue {
+	t.Helper()
+	kv, err := js.KeyValue(ctx, cfg.KVBuckets.AssignmentBucket)
+	require.NoError(t, err, "open assignment bucket %q", cfg.KVBuckets.AssignmentBucket)
+
+	return kv
+}
+
+// openHeartbeatKV opens the heartbeat bucket. Only valid after StartWorkers.
+func openHeartbeatKV(t *testing.T, ctx context.Context, js jetstream.JetStream, cfg parti.Config) jetstream.KeyValue {
+	t.Helper()
+	kv, err := js.KeyValue(ctx, cfg.KVBuckets.HeartbeatBucket)
+	require.NoError(t, err, "open heartbeat bucket %q", cfg.KVBuckets.HeartbeatBucket)
+
+	return kv
+}
+
+// readLatestCommit fetches the current AssignmentCommit, returning nil when the
+// commit has not been written yet (cold start) or on any transient read error.
+// Callers treat nil as "not converged" inside require.Eventually predicates.
+func readLatestCommit(ctx context.Context, kv jetstream.KeyValue) *types.AssignmentCommit {
+	commit, _, err := kvutil.GetJSON[types.AssignmentCommit](ctx, kv, assignmentCommitKey)
+	if err != nil {
+		return nil
+	}
+
+	return commit
+}
+
+// fetchAssignedIDs returns the union of every worker payload's partition
+// CanonicalID set referenced by commit. ok=false signals a transient fetch
+// failure (payload not yet visible); callers treat that as "not converged".
+func fetchAssignedIDs(ctx context.Context, kv jetstream.KeyValue, commit *types.AssignmentCommit) (map[string]bool, bool) {
+	out := make(map[string]bool)
+	for _, wid := range commit.Workers {
+		ref, ok := commit.Payloads[wid]
+		if !ok {
+			return nil, false
+		}
+		payload, err := assignment.FetchAndVerifyCommitPayload(ctx, kv, ref)
+		if err != nil {
+			return nil, false
+		}
+		for _, p := range payload.Partitions {
+			out[p.CanonicalID()] = true
+		}
+	}
+
+	return out, true
+}
+
+// canonicalIDSet returns the CanonicalID set of a partition slice.
+func canonicalIDSet(parts []types.Partition) map[string]bool {
+	out := make(map[string]bool, len(parts))
+	for _, p := range parts {
+		out[p.CanonicalID()] = true
+	}
+
+	return out
+}
+
+// coverageResult carries the outcome of a coverage check plus the assigned set
+// so callers can make finer per-phase assertions.
+type coverageResult struct {
+	ok       bool // assigned ∪ parked == source AND parked metadata matches source\assigned
+	assigned map[string]bool
+	reason   string
+}
+
+// checkCoverage validates the spec I2/I8 coverage contract against a live
+// commit for a KNOWN-CONSTANT source set: every source partition is either
+// assigned (present in some payload) or parked, with the commit's
+// ParkedCount / ParkedDigest exactly describing the source∖assigned remainder.
+//
+// This catches a silently-orphaned partition: if a source partition is neither
+// assigned nor recorded as parked, the source∖assigned remainder grows past
+// ParkedCount / ParkedDigest and the check fails loudly.
+func checkCoverage(ctx context.Context, kv jetstream.KeyValue, commit *types.AssignmentCommit, source []types.Partition) coverageResult {
+	if commit == nil {
+		return coverageResult{reason: "no commit yet"}
+	}
+	assigned, ok := fetchAssignedIDs(ctx, kv, commit)
+	if !ok {
+		return coverageResult{reason: "payload fetch pending"}
+	}
+
+	srcIDs := canonicalIDSet(source)
+	// Every assigned partition must belong to the source set.
+	for id := range assigned {
+		if !srcIDs[id] {
+			return coverageResult{assigned: assigned, reason: "assigned partition not in source: " + id}
+		}
+	}
+
+	// parked = source ∖ assigned (by construction disjoint from assigned).
+	var parkedParts []types.Partition
+	for _, p := range source {
+		if !assigned[p.CanonicalID()] {
+			parkedParts = append(parkedParts, p)
+		}
+	}
+
+	if commit.ParkedCount != len(parkedParts) {
+		return coverageResult{assigned: assigned, reason: "ParkedCount mismatch vs source∖assigned"}
+	}
+	if commit.ParkedDigest != types.PartitionSetDigest(parkedParts) {
+		return coverageResult{assigned: assigned, reason: "ParkedDigest mismatch vs source∖assigned"}
+	}
+
+	return coverageResult{ok: true, assigned: assigned}
+}
+
+// readWorkerHeartbeat decodes a worker's current heartbeat. ok=false when the
+// key is absent or unparseable (treated as "not yet published").
+func readWorkerHeartbeat(ctx context.Context, hbKV jetstream.KeyValue, workerID string) (types.Heartbeat, bool) {
+	entry, err := hbKV.Get(ctx, "heartbeat."+workerID)
+	if err != nil {
+		return types.Heartbeat{}, false
+	}
+	hb, err := types.DecodeHeartbeat(entry.Value())
+	if err != nil {
+		return types.Heartbeat{}, false
+	}
+
+	return hb, true
+}
+
+// recordingUpdater is a parti.WorkerConsumerUpdater that records the
+// CanonicalID set applied on every UpdateWorkerConsumer call. It performs no
+// real JetStream work — the tests only care about which partition sets the
+// manager pushes through the ownership (consumer) layer, to prove a label-only
+// edit that does not move ownership triggers no detach/attach churn.
+type recordingUpdater struct {
+	mu    sync.Mutex
+	calls [][]string // each entry: sorted CanonicalID set for one UpdateWorkerConsumer call
+}
+
+// UpdateWorkerConsumer implements parti.WorkerConsumerUpdater.
+func (r *recordingUpdater) UpdateWorkerConsumer(_ context.Context, _ string, partitions []types.Partition) error {
+	ids := make([]string, 0, len(partitions))
+	for _, p := range partitions {
+		ids = append(ids, p.CanonicalID())
+	}
+	slices.Sort(ids)
+
+	r.mu.Lock()
+	r.calls = append(r.calls, ids)
+	r.mu.Unlock()
+
+	return nil
+}
+
+// snapshot returns a copy of all recorded calls.
+func (r *recordingUpdater) snapshot() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([][]string, len(r.calls))
+	for i, c := range r.calls {
+		out[i] = slices.Clone(c)
+	}
+
+	return out
+}
+
+// setsEqual reports whether two sorted CanonicalID slices describe the same set.
+func setsEqual(a, b []string) bool {
+	return slices.Equal(a, b)
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: stale-assignment (I8) regression
+// ---------------------------------------------------------------------------
+
+// TestLabelDemotion_NoStaleAssignmentInKV proves spec I8: when a labeled
+// worker's last labeled partition is demoted away, the assignment KV does NOT
+// keep a stale non-empty payload for it. The merge contract publishes an
+// explicit EMPTY payload (WorkerLabelsKnown=true, zero partitions) rather than
+// leaving the old vip payload dangling, and the worker ACKS that empty version
+// (AppliedVersion advances) — proving the empty assignment was APPLIED, not
+// ignored.
+//
+// Same 2-worker dedicated setup as Task 13 (vip + plain). The rewrites go
+// through a raw out-of-band kv.Put so the leader can only learn via the source
+// watcher, exactly as an external writer would drive it.
+func TestLabelDemotion_NoStaleAssignmentInKV(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-i8-partitions"})
+	require.NoError(t, err)
+	initial := []types.Partition{
+		{Keys: []string{"d-p0"}, Weight: 1},
+		{Keys: []string{"d-p1"}, Weight: 1},
+		{Keys: []string{"d-p2"}, Weight: 1},
+		{Keys: []string{"d-p3"}, Weight: 1},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, initial))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.LabelSpillGrace = 5 * time.Second
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	vipWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	plainWorker := cluster.AddWorkerWithOptions(ctx)
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+	hbKV := openHeartbeatKV(t, ctx, js, cfg)
+	vipID := vipWorker.WorkerID()
+
+	p0 := types.Partition{Keys: []string{"d-p0"}}.CanonicalID()
+
+	// PROMOTE d-p0 to vip out-of-band, then wait until the vip worker owns it.
+	promoted := []types.Partition{
+		{Keys: []string{"d-p0"}, Weight: 1, Label: "vip"},
+		{Keys: []string{"d-p1"}, Weight: 1},
+		{Keys: []string{"d-p2"}, Weight: 1},
+		{Keys: []string{"d-p3"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return partitionsOf(vipWorker)[p0] && !partitionsOf(plainWorker)[p0]
+	}, 30*time.Second, 200*time.Millisecond, "promotion must move d-p0 to the vip worker")
+
+	// DEMOTE d-p0 back out-of-band. Under dedicated policy the vip worker must
+	// drain to empty.
+	encoded, err = partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	// Assert against the KV bucket directly: the commit still lists the vip
+	// worker, its payload exists and is EXPLICITLY empty (labels known), and the
+	// worker's heartbeat has acked that commit's version — the empty assignment
+	// was applied, not ignored. A stale non-empty vip payload would fail here.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil {
+			return false
+		}
+		ref, ok := commit.Payloads[vipID]
+		if !ok {
+			return false // vip worker must remain in the commit with a payload
+		}
+		payload, err := assignment.FetchAndVerifyCommitPayload(ctx, assignKV, ref)
+		if err != nil {
+			return false
+		}
+		if len(payload.Partitions) != 0 || !payload.WorkerLabelsKnown {
+			return false
+		}
+		// The plain worker must now own d-p0 again (no orphan).
+		if !partitionsOf(plainWorker)[p0] {
+			return false
+		}
+		hb, ok := readWorkerHeartbeat(ctx, hbKV, vipID)
+
+		return ok && hb.AppliedVersion == commit.Version
+	}, 30*time.Second, 200*time.Millisecond,
+		"demotion must publish an explicit empty vip payload that the worker acks (no stale KV assignment)")
+
+	// Hard final assertions for a precise failure message.
+	commit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, commit, "commit must exist after demotion")
+	require.Contains(t, commit.Workers, vipID, "vip worker must stay in the commit")
+	ref := commit.Payloads[vipID]
+	payload, err := assignment.FetchAndVerifyCommitPayload(ctx, assignKV, ref)
+	require.NoError(t, err)
+	require.Empty(t, payload.Partitions, "vip worker payload must be explicitly empty, not stale")
+	require.True(t, payload.WorkerLabelsKnown, "empty payload must be labels-of-record, not a pre-label default")
+	require.Zero(t, commit.ParkedCount, "demotion to a live pool parks nothing")
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: parked-coverage (ghost label) — park → spill → re-home
+// ---------------------------------------------------------------------------
+
+// TestGhostLabel_ParksThenSpills_NeverOrphans proves the full parked-coverage
+// lifecycle for a label no live worker can ever carry: the partition is PARKED
+// (not silently dropped, not prematurely spilled) during grace, SPILLS to the
+// fallback ladder after grace with NO external event (the label re-check timer
+// drives it end to end), and RE-HOMES when a matching worker finally joins.
+//
+// The coverage invariant assigned ∪ parked == source holds at every converged
+// observation because the source set is constant throughout.
+func TestGhostLabel_ParksThenSpills_NeverOrphans(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-ghost-partitions"})
+	require.NoError(t, err)
+	// Cold start with 3 plain partitions only. The "ghost" label is introduced
+	// out-of-band AFTER the cluster is stable (Task 13's proven pattern): the
+	// leader's synchronous cold-start assignment does not tolerate a first-
+	// observation label deferral, so a label with an empty pool is always driven
+	// in through the steady-state source-watch → rebalance path.
+	plain := []types.Partition{
+		{Keys: []string{"g-p0"}, Weight: 1},
+		{Keys: []string{"g-p1"}, Weight: 1},
+		{Keys: []string{"g-p2"}, Weight: 1},
+	}
+	// Full source once the ghost partition is added: 3 plain + 1 ghost. This is
+	// the constant source set for the coverage invariant across every phase.
+	withGhost := []types.Partition{
+		{Keys: []string{"g-p0"}, Weight: 1},
+		{Keys: []string{"g-p1"}, Weight: 1},
+		{Keys: []string{"g-p2"}, Weight: 1},
+		{Keys: []string{"g-ghost"}, Weight: 1, Label: "ghost"},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, plain))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.LabelSpillGrace = 6 * time.Second
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	plainWorker := cluster.AddWorkerWithOptions(ctx) // single unlabeled worker
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+
+	ghostID := types.Partition{Keys: []string{"g-ghost"}}.CanonicalID()
+	plainIDs := canonicalIDSet(plain)
+
+	// Steady state: the single unlabeled worker owns all 3 plain partitions.
+	require.Eventually(t, func() bool {
+		return len(partitionsOf(plainWorker)) == 3
+	}, 20*time.Second, 200*time.Millisecond, "unlabeled worker must own the 3 plain partitions")
+
+	// Introduce the ghost-labeled partition out-of-band (raw kv.Put): the leader
+	// learns via its source watcher exactly as an external writer would drive it.
+	encoded, err := partcodec.Encode(withGhost)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	// PHASE PARK: within detection + defer-once confirmation the leader parks
+	// the ghost partition. ParkedCount==1, ParkedDigest == digest({ghost}), the
+	// 3 plain partitions are assigned, and the ghost is in NO payload.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 1 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, withGhost)
+		if !cov.ok {
+			return false
+		}
+		// assigned must be exactly the 3 plain partitions (ghost parked).
+		if len(cov.assigned) != len(plainIDs) {
+			return false
+		}
+		for id := range plainIDs {
+			if !cov.assigned[id] {
+				return false
+			}
+		}
+
+		return !cov.assigned[ghostID]
+	}, 30*time.Second, 100*time.Millisecond, "ghost label must be parked during grace, plain partitions assigned")
+
+	parkCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, parkCommit)
+	require.Equal(t, 1, parkCommit.ParkedCount, "exactly one partition parked")
+	require.Equal(t,
+		types.PartitionSetDigest([]types.Partition{{Keys: []string{"g-ghost"}, Label: "ghost"}}),
+		parkCommit.ParkedDigest, "parked digest must be the ghost partition")
+	require.True(t, checkCoverage(ctx, assignKV, parkCommit, withGhost).ok, "coverage during park")
+
+	// PHASE SPILL: after grace, with NO source/worker event, the re-check timer
+	// spills the ghost onto the fallback ladder (the unlabeled worker).
+	// ParkedCount==0 and the ghost is now in a payload.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, withGhost)
+
+		return cov.ok && cov.assigned[ghostID]
+	}, 30*time.Second, 200*time.Millisecond, "ghost must spill after grace via the label re-check timer (no external event)")
+
+	spillCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, spillCommit)
+	require.Zero(t, spillCommit.ParkedCount, "nothing parked after spill")
+	require.True(t, checkCoverage(ctx, assignKV, spillCommit, withGhost).ok, "coverage after spill")
+	require.True(t, partitionsOf(plainWorker)[ghostID], "spilled ghost lands on the unlabeled fallback worker")
+
+	// PHASE RECOVER: add a ghost-labeled worker. The ghost partition re-homes to
+	// it and the coverage invariant still holds across both workers.
+	ghostWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("ghost"))
+	require.NoError(t, ghostWorker.Start(ctx))
+	require.NoError(t, <-ghostWorker.WaitState(parti.StateStable, 15*time.Second))
+
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, withGhost)
+
+		return cov.ok && partitionsOf(ghostWorker)[ghostID] && !partitionsOf(plainWorker)[ghostID]
+	}, 30*time.Second, 200*time.Millisecond, "ghost partition must re-home to the newly-joined ghost worker")
+
+	// Full coverage set assertion after recovery: assigned across both workers ==
+	// all four source partitions, nothing parked.
+	recoverCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, recoverCommit)
+	assigned, ok := fetchAssignedIDs(ctx, assignKV, recoverCommit)
+	require.True(t, ok)
+	require.Equal(t, canonicalIDSet(withGhost), assigned, "every source partition assigned exactly once after recovery")
+	require.Zero(t, recoverCommit.ParkedCount)
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: pool-outage lifecycle — park → spill → re-home under worker loss
+// ---------------------------------------------------------------------------
+
+// TestLabelPoolOutage_ParkSpillRehome drives the labeled-pool outage lifecycle
+// with real worker loss: partitions concentrate while the pool is non-empty
+// (no parking), park when the pool empties, spill after grace, and re-home when
+// a labeled worker returns. The coverage invariant assigned ∪ parked == source
+// (source constant) is asserted at every converged phase so any orphan window
+// fails loudly.
+//
+// Phase 3 doubles as the regression pin for the takeover-deferral fix: when
+// the LAST labeled worker stopped is also the current leader, draining its
+// pool forces a leadership takeover, and the new leader's synchronous
+// "takeover_immediate" assignment observes the empty pool FIRST — a benign
+// errLabelObservationDeferred. Before the fix, that sentinel escaped
+// startCalculator as fatal, releasing leadership and livelocking the fleet in
+// a takeover flap: each takeover rebuilt labelState, so the defer-once streak
+// never confirmed the empty pool and the park never committed (spec I2
+// violation — the vip partitions stayed stuck on the dead worker). The fix
+// treats the deferral as success-without-publish, so the new leader keeps
+// leadership and the label re-check timer drives the park to commit.
+func TestLabelPoolOutage_ParkSpillRehome(t *testing.T) { //nolint:cyclop // five-phase pool-outage lifecycle kept as one function for readability
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-outage-partitions"})
+	require.NoError(t, err)
+	// Seed all-plain; the vip labels are promoted out-of-band after the cluster
+	// is stable (same rationale as the ghost test — the cold-start assignment
+	// does not tolerate a first-observation label deferral, and seeding labels
+	// at T=0 races the vip workers' first heartbeat).
+	plain := []types.Partition{
+		{Keys: []string{"o-v0"}, Weight: 1},
+		{Keys: []string{"o-v1"}, Weight: 1},
+		{Keys: []string{"o-p0"}, Weight: 1},
+		{Keys: []string{"o-p1"}, Weight: 1},
+	}
+	// Constant source set for the coverage invariant once the vip labels exist.
+	partitions := []types.Partition{
+		{Keys: []string{"o-v0"}, Weight: 1, Label: "vip"},
+		{Keys: []string{"o-v1"}, Weight: 1, Label: "vip"},
+		{Keys: []string{"o-p0"}, Weight: 1},
+		{Keys: []string{"o-p1"}, Weight: 1},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, plain))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.LabelSpillGrace = 8 * time.Second
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	vip1 := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	vip2 := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	// TWO plain workers so the fleet never shrinks to a single total worker when
+	// both vip workers are stopped: a lone worker under the aggressive
+	// integration TTLs oscillates leadership and cannot run its calculator to
+	// completion (an election-layer artifact, orthogonal to the parking
+	// machinery under test). Two plain workers keep a stable multi-worker fleet
+	// with an empty vip pool, which is exactly what phase 3 needs.
+	plain1 := cluster.AddWorkerWithOptions(ctx)
+	plain2 := cluster.AddWorkerWithOptions(ctx)
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+
+	v0 := types.Partition{Keys: []string{"o-v0"}}.CanonicalID()
+	v1 := types.Partition{Keys: []string{"o-v1"}}.CanonicalID()
+
+	// plainHasVip reports whether either plain worker owns a vip partition.
+	plainHasVip := func() bool {
+		for _, w := range []*parti.Manager{plain1, plain2} {
+			p := partitionsOf(w)
+			if p[v0] || p[v1] {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// Promote o-v0/o-v1 to "vip" out-of-band so the vip pool (both vip workers,
+	// now stable and heartbeating their labels) is non-empty when the labels
+	// first appear — no cold-start deferral.
+	encoded, err := partcodec.Encode(partitions)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	// PHASE 1 — stable: vip partitions live only on the vip workers, never the
+	// plain worker, and nothing is parked.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, partitions)
+		vipOnVipPool := (partitionsOf(vip1)[v0] || partitionsOf(vip2)[v0]) &&
+			(partitionsOf(vip1)[v1] || partitionsOf(vip2)[v1])
+
+		return cov.ok && vipOnVipPool && !plainHasVip()
+	}, 30*time.Second, 200*time.Millisecond, "stable: vip partitions on vip workers, none parked")
+
+	// PHASE 2 — stop ONE vip worker: its partitions concentrate onto the
+	// surviving vip worker. The pool is still non-empty, so NOTHING parks.
+	stopWorker(t, vip2)
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, partitions)
+
+		return cov.ok && partitionsOf(vip1)[v0] && partitionsOf(vip1)[v1] && !plainHasVip()
+	}, 30*time.Second, 200*time.Millisecond,
+		"one vip down: partitions concentrate on the survivor, no parking")
+
+	// PHASE 3 — stop the SECOND vip worker: pool now empty. Within detection +
+	// defer-once confirmation, BOTH vip partitions park (ParkedCount==2) and the
+	// plain workers do NOT receive them during grace.
+	stopWorker(t, vip1)
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 2 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, partitions)
+
+		return cov.ok && !plainHasVip()
+	}, 30*time.Second, 100*time.Millisecond,
+		"empty vip pool must park both vip partitions during grace; plain workers get none")
+
+	parkCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, parkCommit)
+	require.Equal(t, 2, parkCommit.ParkedCount, "both vip partitions parked")
+	require.Equal(t,
+		types.PartitionSetDigest([]types.Partition{
+			{Keys: []string{"o-v0"}, Label: "vip"}, {Keys: []string{"o-v1"}, Label: "vip"},
+		}),
+		parkCommit.ParkedDigest, "parked digest must be the two vip partitions")
+
+	// PHASE 4 — after grace: spill. The vip partitions appear in the plain
+	// pool's payloads (assigned to some plain worker) and ParkedCount returns
+	// to 0.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, partitions)
+
+		return cov.ok && cov.assigned[v0] && cov.assigned[v1] && plainHasVip()
+	}, 30*time.Second, 200*time.Millisecond, "after grace the vip partitions spill to the plain pool")
+
+	spillCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, spillCommit)
+	assignedSpill, ok := fetchAssignedIDs(ctx, assignKV, spillCommit)
+	require.True(t, ok)
+	require.Equal(t, canonicalIDSet(partitions), assignedSpill, "full coverage after spill: all four partitions assigned")
+
+	// PHASE 5 — restart a vip worker: the vip partitions re-home to it and the
+	// plain worker sheds them; nothing parks.
+	vip3 := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	require.NoError(t, vip3.Start(ctx))
+	require.NoError(t, <-vip3.WaitState(parti.StateStable, 15*time.Second))
+
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		cov := checkCoverage(ctx, assignKV, commit, partitions)
+
+		return cov.ok && partitionsOf(vip3)[v0] && partitionsOf(vip3)[v1] && !plainHasVip()
+	}, 30*time.Second, 200*time.Millisecond, "vip partitions re-home to the restarted vip worker; plain worker sheds them")
+
+	// Full coverage set assertion after re-home.
+	rehomeCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, rehomeCommit)
+	assignedRehome, ok := fetchAssignedIDs(ctx, assignKV, rehomeCommit)
+	require.True(t, ok)
+	require.Equal(t, canonicalIDSet(partitions), assignedRehome, "full coverage after re-home")
+}
+
+// stopWorker stops a single manager with a bounded timeout. The cluster's
+// StopWorkers cleanup skips already-shutdown workers, so stopping here is safe.
+func stopWorker(t *testing.T, mgr *parti.Manager) {
+	t.Helper()
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, mgr.Stop(stopCtx), "stop worker %s", mgr.WorkerID())
+}
+
+// ---------------------------------------------------------------------------
+// Step 3b: no ownership movement on a label-only edit (spec §4.1 pin)
+// ---------------------------------------------------------------------------
+
+// TestLabelOnlyEdit_NoConsumerChurnWhenPlacementUnchanged proves that a
+// label-only source edit that CANNOT change placement (the only vip-capable
+// worker already owns the partition) still advances the assignment version
+// (the payload hash changes because labels-of-record are part of it) but
+// triggers NO detach/attach at the ownership layer — every UpdateWorkerConsumer
+// call carries the same partition CanonicalID set.
+//
+// Single worker labeled "vip" under the SHARED policy, so it also serves
+// unlabeled work and therefore owns every partition regardless of labels.
+func TestLabelOnlyEdit_NoConsumerChurnWhenPlacementUnchanged(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-nochurn-partitions"})
+	require.NoError(t, err)
+	initial := []types.Partition{
+		{Keys: []string{"c-p0"}, Weight: 1},
+		{Keys: []string{"c-p1"}, Weight: 1},
+		{Keys: []string{"c-p2"}, Weight: 1},
+		{Keys: []string{"c-p3"}, Weight: 1},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, initial))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.UnlabeledPartitionPolicy = "shared"
+	cfg.LabelSpillGrace = 5 * time.Second
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	rec := &recordingUpdater{}
+	vipWorker := cluster.AddWorkerWithOptions(ctx,
+		parti.WithWorkerLabels("vip"), parti.WithWorkerConsumerUpdater(rec))
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	fullSet := canonicalIDSet(initial)
+	p0 := types.Partition{Keys: []string{"c-p0"}}.CanonicalID()
+
+	// Steady state: the single shared worker owns ALL partitions, including the
+	// (unlabeled) c-p0.
+	require.Eventually(t, func() bool {
+		owned := partitionsOf(vipWorker)
+		if len(owned) != len(fullSet) {
+			return false
+		}
+		for id := range fullSet {
+			if !owned[id] {
+				return false
+			}
+		}
+
+		return owned[p0]
+	}, 30*time.Second, 200*time.Millisecond, "shared single worker must own every partition")
+
+	// Baseline: the ownership set the consumer layer has settled on, and the
+	// current applied version. Wait for at least one settled consumer update
+	// carrying the full set so the baseline is meaningful.
+	sortedFull := make([]string, 0, len(fullSet))
+	for id := range fullSet {
+		sortedFull = append(sortedFull, id)
+	}
+	slices.Sort(sortedFull)
+
+	require.Eventually(t, func() bool {
+		calls := rec.snapshot()
+		if len(calls) == 0 {
+			return false
+		}
+
+		return setsEqual(calls[len(calls)-1], sortedFull)
+	}, 30*time.Second, 200*time.Millisecond, "consumer layer must settle on the full ownership set")
+
+	baselineCalls := len(rec.snapshot())
+	v0 := vipWorker.CurrentAssignment().Version
+	require.Positive(t, v0, "worker must have a committed version at steady state")
+
+	// PROMOTE c-p0 to vip out-of-band (label-only edit). Placement cannot change:
+	// the sole vip-capable worker already owns it.
+	promoted := []types.Partition{
+		{Keys: []string{"c-p0"}, Weight: 1, Label: "vip"},
+		{Keys: []string{"c-p1"}, Weight: 1},
+		{Keys: []string{"c-p2"}, Weight: 1},
+		{Keys: []string{"c-p3"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	// A NEW assignment version must be applied (payload hash changed because
+	// labels-of-record are part of the payload), AND a new consumer update must
+	// fire (the apply path runs UpdateWorkerConsumer on every version).
+	require.Eventually(t, func() bool {
+		return vipWorker.CurrentAssignment().Version > v0 && len(rec.snapshot()) > baselineCalls
+	}, 30*time.Second, 200*time.Millisecond,
+		"label-only promotion must advance the version and re-run the consumer update")
+
+	// NO CHURN: every consumer update from the settled baseline onward — across
+	// the promotion — carries the SAME CanonicalID set. No partition was
+	// detached or attached at the ownership layer.
+	calls := rec.snapshot()
+	require.Greater(t, len(calls), baselineCalls, "a post-promotion consumer update was recorded")
+	for i := baselineCalls - 1; i < len(calls); i++ {
+		require.Truef(t, setsEqual(calls[i], sortedFull),
+			"consumer update #%d changed the ownership set: got %v, want %v", i, calls[i], sortedFull)
+	}
+
+	// The partition is now vip-labeled in the payload but still owned by the same
+	// worker — confirm placement is genuinely unchanged.
+	require.True(t, partitionsOf(vipWorker)[p0], "c-p0 stays on the same worker after promotion")
+}

--- a/test/integration/assignment/label_policy_test.go
+++ b/test/integration/assignment/label_policy_test.go
@@ -1,0 +1,272 @@
+package assignment_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Shared label-metrics recorder (spec §13)
+//
+// recordingLabelMetrics is a real MetricsCollector (via the embedded
+// internal/metrics.NopMetrics) that ALSO satisfies the optional
+// types.LabelMetrics extension, so it can be installed on a live Manager with
+// parti.WithMetrics and observe the label counters the manager/calculator emit.
+// Only the two counters these tests key on are overridden; every other
+// MetricsCollector + LabelMetrics method is inherited (no-op) from NopMetrics.
+// ---------------------------------------------------------------------------
+
+type recordingLabelMetrics struct {
+	*metrics.NopMetrics
+
+	mu                sync.Mutex
+	incarnationReject int
+	unlabeledFallback int
+}
+
+// Compile-time proof the recorder satisfies BOTH surfaces WithMetrics needs:
+// the full MetricsCollector (so parti.WithMetrics accepts it) and the optional
+// LabelMetrics extension (so the manager's type-assertion succeeds and the
+// label counters actually reach it).
+var (
+	_ types.MetricsCollector = (*recordingLabelMetrics)(nil)
+	_ types.LabelMetrics     = (*recordingLabelMetrics)(nil)
+)
+
+func newRecordingLabelMetrics() *recordingLabelMetrics {
+	return &recordingLabelMetrics{NopMetrics: metrics.NewNop()}
+}
+
+func (m *recordingLabelMetrics) IncrementLabelIncarnationReject() {
+	m.mu.Lock()
+	m.incarnationReject++
+	m.mu.Unlock()
+}
+
+func (m *recordingLabelMetrics) IncrementUnlabeledFallback() {
+	m.mu.Lock()
+	m.unlabeledFallback++
+	m.mu.Unlock()
+}
+
+func (m *recordingLabelMetrics) rejects() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.incarnationReject
+}
+
+func (m *recordingLabelMetrics) fallbacks() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.unlabeledFallback
+}
+
+// newKVSource seeds a NatsKV partition source in its own bucket and starts its
+// watch/reconcile loops. Mirrors the setup every other label integration test
+// uses so these policy tests learn partitions through the production watcher
+// path, not an in-process shortcut.
+func newKVSource(t *testing.T, ctx context.Context, js jetstream.JetStream, bucket string, parts []types.Partition) *source.NatsKV {
+	t.Helper()
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, parts))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	return src
+}
+
+// ---------------------------------------------------------------------------
+// Policy matrix: dedicated (reserve labeled workers) vs shared (route to all)
+// ---------------------------------------------------------------------------
+
+// TestUnlabeledPartitionPolicy_SharedVsDedicated pins spec §7's two unlabeled
+// routing policies against a live fleet of one labeled + one plain worker with
+// an ALL-UNLABELED source:
+//
+//   - dedicated (default): the labeled worker is RESERVED for labeled work, so
+//     it owns nothing; every unlabeled partition lands on the plain worker.
+//   - shared: unlabeled partitions route to ALL workers, so both the labeled
+//     and the plain worker carry a share.
+//
+// The two sub-scenarios run on independent embedded NATS servers so their
+// coordination buckets (which share default names) never collide.
+func TestUnlabeledPartitionPolicy_SharedVsDedicated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	unlabeled := []types.Partition{
+		{Keys: []string{"u-p0"}, Weight: 1},
+		{Keys: []string{"u-p1"}, Weight: 1},
+		{Keys: []string{"u-p2"}, Weight: 1},
+		{Keys: []string{"u-p3"}, Weight: 1},
+	}
+
+	t.Run("dedicated_reserves_labeled_worker", func(t *testing.T) {
+		nc, cleanup := testutil.StartEmbeddedNATS(t)
+		defer cleanup()
+		js, err := jetstream.New(nc)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+		defer cancel()
+
+		src := newKVSource(t, ctx, js, "label-policy-dedicated", unlabeled)
+
+		cfg := testutil.IntegrationTestConfig() // UnlabeledPartitionPolicy defaults to "dedicated"
+
+		cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+		vipWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+		plainWorker := cluster.AddWorkerWithOptions(ctx)
+		t.Cleanup(cluster.StopWorkers)
+		cluster.StartWorkers(ctx)
+		cluster.WaitForStableState(20 * time.Second)
+
+		// Dedicated policy reserves the labeled worker: it owns NOTHING while
+		// every unlabeled partition lands on the plain worker.
+		require.Eventually(t, func() bool {
+			return len(partitionsOf(vipWorker)) == 0 && len(partitionsOf(plainWorker)) == len(unlabeled)
+		}, 30*time.Second, 200*time.Millisecond,
+			"dedicated: labeled worker reserved (owns 0), plain worker owns every unlabeled partition")
+
+		// Hold the reservation for a settle window so a late rebalance cannot
+		// silently leak an unlabeled partition onto the reserved worker.
+		require.Never(t, func() bool {
+			return len(partitionsOf(vipWorker)) != 0
+		}, 3*time.Second, 200*time.Millisecond, "reserved worker must stay empty under dedicated policy")
+	})
+
+	t.Run("shared_routes_to_all_workers", func(t *testing.T) {
+		nc, cleanup := testutil.StartEmbeddedNATS(t)
+		defer cleanup()
+		js, err := jetstream.New(nc)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+		defer cancel()
+
+		src := newKVSource(t, ctx, js, "label-policy-shared", unlabeled)
+
+		cfg := testutil.IntegrationTestConfig()
+		cfg.UnlabeledPartitionPolicy = "shared"
+
+		cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+		vipWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+		plainWorker := cluster.AddWorkerWithOptions(ctx)
+		t.Cleanup(cluster.StopWorkers)
+		cluster.StartWorkers(ctx)
+		cluster.WaitForStableState(20 * time.Second)
+
+		// Shared policy routes unlabeled partitions to ALL workers, so both the
+		// labeled and plain worker carry a share and the split is balanced.
+		require.True(t, cluster.WaitForBalancedAssignments(len(unlabeled), 1, 30*time.Second),
+			"shared: unlabeled partitions must balance across both workers")
+		require.Eventually(t, func() bool {
+			return len(partitionsOf(vipWorker)) > 0 && len(partitionsOf(plainWorker)) > 0
+		}, 30*time.Second, 200*time.Millisecond,
+			"shared: both the labeled and plain worker must own partitions")
+
+		// Coverage: every unlabeled partition owned exactly once across the fleet.
+		vip, plain := partitionsOf(vipWorker), partitionsOf(plainWorker)
+		require.Equal(t, len(unlabeled), len(vip)+len(plain), "no duplicate or orphan under shared policy")
+		for id := range vip {
+			require.NotContains(t, plain, id, "partition %s owned by both workers", id)
+		}
+	})
+}
+
+// TestAllWorkersLabeled_UnlabeledPartitionsFallBack pins the spec §7 fallback
+// ladder: when EVERY active worker is labeled and the source is entirely
+// unlabeled under the dedicated policy, the unlabeled group's general pool is
+// empty, so the ladder falls back to AllWorkers rather than orphaning the
+// partitions. The IncrementUnlabeledFallback counter fires once PER unlabeled
+// partition of each such rebalance, so the observed count reaches at least the
+// partition count (it is monotonic and re-increments on any later rebalance —
+// hence >=, not ==).
+func TestAllWorkersLabeled_UnlabeledPartitionsFallBack(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
+	defer cancel()
+
+	unlabeled := []types.Partition{
+		{Keys: []string{"f-p0"}, Weight: 1},
+		{Keys: []string{"f-p1"}, Weight: 1},
+		{Keys: []string{"f-p2"}, Weight: 1},
+		{Keys: []string{"f-p3"}, Weight: 1},
+	}
+	src := newKVSource(t, ctx, js, "label-fallback-partitions", unlabeled)
+
+	cfg := testutil.IntegrationTestConfig() // dedicated
+
+	// One shared recorder installed on every worker: only the current leader's
+	// calculator emits the label counters, and we do not know which worker wins
+	// leadership, so a shared thread-safe recorder captures whichever does.
+	rec := newRecordingLabelMetrics()
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	// Every worker is labeled "vip" — the general (unlabeled) pool is empty.
+	w0 := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"), parti.WithMetrics(rec))
+	w1 := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"), parti.WithMetrics(rec))
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+
+	// Full coverage via the fallback ladder: every unlabeled partition is owned
+	// exactly once across the all-labeled fleet, nothing parked.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+		w0p, w1p := partitionsOf(w0), partitionsOf(w1)
+		if len(w0p)+len(w1p) != len(unlabeled) {
+			return false
+		}
+		for id := range w0p {
+			if w1p[id] {
+				return false
+			}
+		}
+
+		return true
+	}, 30*time.Second, 200*time.Millisecond,
+		"all-labeled fleet must fully cover the unlabeled source via the fallback ladder, nothing parked")
+
+	// The unlabeled-fallback counter must have fired at least once per unlabeled
+	// partition (it is per-partition, and re-increments on any later rebalance).
+	require.Eventually(t, func() bool {
+		return rec.fallbacks() >= len(unlabeled)
+	}, 15*time.Second, 100*time.Millisecond,
+		"IncrementUnlabeledFallback must fire at least once per unlabeled partition routed to the fallback ladder")
+
+	// Union coverage assertion for a precise failure message.
+	assigned, ok := fetchAssignedIDs(ctx, assignKV, readLatestCommit(ctx, assignKV))
+	require.True(t, ok)
+	require.Equal(t, canonicalIDSet(unlabeled), assigned, "every unlabeled partition assigned exactly once")
+}

--- a/test/integration/assignment/label_promotion_test.go
+++ b/test/integration/assignment/label_promotion_test.go
@@ -1,0 +1,143 @@
+package assignment_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/partcodec"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// partitionsOf returns the CanonicalID set of a manager's current assignment.
+func partitionsOf(m *parti.Manager) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range m.CurrentAssignment().Partitions {
+		out[p.CanonicalID()] = true
+	}
+
+	return out
+}
+
+// TestLabelPromotion_EndToEnd is the user-priority end-to-end proof that a
+// label-only rewrite (same keys, same weights, new label) pushed through the
+// production update path flows KV source watch → leader rebalance → new
+// assignments on live managers. Task 2 proved source-level propagation in
+// isolation; this proves the whole system converges.
+//
+// The rewrites in Phase 1/2 go through a RAW kv.Put (out-of-band), NOT
+// src.Update. NatsKV.Update refreshes its local cache and notifies its own
+// listeners directly (without the KV watcher round trip), so a same-instance
+// Update would let this test pass even with the watch path broken. A raw
+// kv.Put is exactly what an external operator/writer process does, and the
+// manager-owned source can only learn about it through its WATCHER — the
+// propagation path this test exists to pin.
+func TestLabelPromotion_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	// Generous overall budget: the phased Eventually windows below can sum to
+	// well over 100s under CI load, and every NATS KV op (Put/Update/Get) is
+	// bounded by this ctx. Kept comfortably under the 300s test -timeout.
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	// Production-shaped source: partition list in a KV bucket, learned via a
+	// live watcher + reconcile loop.
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-e2e-partitions"})
+	require.NoError(t, err)
+	initial := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1},
+		{Keys: []string{"p1"}, Weight: 1},
+		{Keys: []string{"p2"}, Weight: 1},
+		{Keys: []string{"p3"}, Weight: 1},
+	}
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, initial)) // seeds the bucket
+	require.NoError(t, src.Start(ctx))           // watch + reconcile loops
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	cfg.LabelSpillGrace = 5 * time.Second
+
+	// NewWorkerClusterWithSource wires the shared source + config and defaults
+	// the strategy to consistent-hash (same construction the manager E2E
+	// invariant test uses). Its config parameter fits our LabelSpillGrace tweak,
+	// so it is preferred over a hand-rolled WorkerCluster literal.
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	vipWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	plainWorker := cluster.AddWorkerWithOptions(ctx)
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	p0 := types.Partition{Keys: []string{"p0"}}.CanonicalID()
+
+	// Phase 0 — dedicated reservation: no labeled partitions yet, so the vip
+	// worker idles and the plain worker owns everything (spec §7 dedicated
+	// policy reserves labeled workers for labeled partitions only).
+	require.Eventually(t, func() bool {
+		return len(partitionsOf(plainWorker)) == 4 && len(partitionsOf(vipWorker)) == 0
+	}, 20*time.Second, 200*time.Millisecond,
+		"dedicated policy must reserve the labeled worker")
+
+	// Phase 1 — PROMOTION: rewrite the full list with ONLY p0's label changed
+	// (same keys, same weights), OUT-OF-BAND via a raw KV write (see the
+	// function doc for why this must not be src.Update).
+	promoted := []types.Partition{
+		{Keys: []string{"p0"}, Weight: 1, Label: "vip"}, // <- the only delta
+		{Keys: []string{"p1"}, Weight: 1},
+		{Keys: []string{"p2"}, Weight: 1},
+		{Keys: []string{"p3"}, Weight: 1},
+	}
+	encoded, err := partcodec.Encode(promoted)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return partitionsOf(vipWorker)[p0] && !partitionsOf(plainWorker)[p0]
+	}, 30*time.Second, 200*time.Millisecond,
+		"label-only promotion must move p0 to the vip worker: KV watch → rebalance → assignment")
+
+	// Coverage invariant across the move: every partition owned exactly once.
+	require.Eventually(t, func() bool {
+		vip, plain := partitionsOf(vipWorker), partitionsOf(plainWorker)
+		if len(vip)+len(plain) != 4 {
+			return false
+		}
+		for id := range vip {
+			if plain[id] {
+				return false
+			}
+		}
+
+		return true
+	}, 20*time.Second, 200*time.Millisecond, "no orphan, no duplicate during promotion")
+
+	// Phase 2 — DEMOTION: label-only rewrite back, same out-of-band path. Under
+	// dedicated policy p0 must return to the plain worker and the vip worker
+	// must drain to empty (its KV assignment updated, not stale).
+	encoded, err = partcodec.Encode(initial)
+	require.NoError(t, err)
+	_, err = srcKV.Put(ctx, "partitions", encoded)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return !partitionsOf(vipWorker)[p0] && partitionsOf(plainWorker)[p0] &&
+			len(partitionsOf(vipWorker)) == 0
+	}, 30*time.Second, 200*time.Millisecond,
+		"label-only demotion must move p0 back and drain the reserved worker")
+}

--- a/test/integration/assignment/label_stress_test.go
+++ b/test/integration/assignment/label_stress_test.go
@@ -1,0 +1,436 @@
+package assignment_test
+
+// Concurrency stress test for the label-assignment feature's two new
+// ticker/watcher paths, per the AGENTS.md "monitor goroutine on a ticker"
+// rule: aggressive cadence, concurrent production KV traffic, and the race
+// detector as the primary oracle. Patterned on
+// test/integration/manager/manager_epoch_monitor_concurrency_test.go.
+//
+// The two paths under stress:
+//
+//  1. monitorLabelRecheck (internal/assignment/calculator.go) — the leader's
+//     label re-check ticker. It owns the guaranteed second observation for
+//     deferred label decisions (park confirmation, grace expiry) and shares
+//     nats.go's cached *stream state with the assignment publisher and the
+//     source watcher on the same buckets. Armed by the batch-pool-down
+//     window g3 opens: 300ms after the pool empties, the grace timer expires
+//     and requests a "grace_expiry" recheck.
+//  2. WorkerMonitor's per-heartbeat-PUT label fingerprint decode
+//     (internal/assignment/worker_monitor.go: dropLabelFingerprint /
+//     SetOnLabelChange) — decoded via xxh3 on every heartbeat entry the
+//     leader observes, sharing the heartbeat bucket's cached *stream state
+//     with the heartbeat publisher and the election/heartbeat scan paths.
+//     The decode runs continuously (every heartbeat PUT from every worker).
+//     g3's relabeled restart (below) does not reach the SetOnLabelChange
+//     change-branch itself: the graceful stop it performs deletes the old
+//     heartbeat key first, and dropLabelFingerprint forgets the retained
+//     fingerprint on that delete, so the rejoin seeds silently as a
+//     first-seen join by design (worker_monitor.go: the comment on
+//     dropLabelFingerprint) — that branch exists for a stale-ID takeover
+//     without an intervening leave, pinned against a live NATS watcher by
+//     TestCalculator_TightTakeover_LabelChangeTriggersRebalance.
+//     What the relabeled restart does reliably exercise is a live
+//     worker-side incarnation-guard reject: the leader's in-flight
+//     assignment for the reused worker ID still carries the old ["batch"]
+//     labels-of-record, which mismatch the rejoined worker's new
+//     ["batch","vip"] configured labels, so the worker rejects it; the next
+//     ordinary rebalance then re-derives that worker's labels-of-record from
+//     its current heartbeat and converges.
+//
+// Both paths run continuously on a live 3-worker cluster with real label
+// churn, so unit tests exercising either monitor in isolation cannot
+// reproduce a race between them and the production goroutines sharing the
+// same KV handles — only a live-cluster -race run can.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// soakFailure captures the first hard failure reported by a background soak
+// goroutine so the main test goroutine can require.Empty it after the soak
+// completes. testify's require.* wraps t.FailNow, which per the testing
+// package's documented contract must only be called from the goroutine
+// running the test itself — so soak goroutines record here instead of
+// asserting directly, and the main goroutine turns the record into a real
+// (hard) test failure once every soak goroutine has returned.
+type soakFailure struct {
+	mu  sync.Mutex
+	msg string
+}
+
+// record stores msg as the failure reason if none has been recorded yet
+// (first-writer-wins — later detail from other goroutines is redundant once
+// the soak is already known to be broken).
+func (f *soakFailure) record(msg string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.msg == "" {
+		f.msg = msg
+	}
+}
+
+// get returns the recorded failure reason, or "" if none was recorded.
+func (f *soakFailure) get() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.msg
+}
+
+// versionSet is a concurrency-safe set of observed commit versions, used as
+// part of the liveness proxy (spec: "assignment version strictly increases
+// during the soak").
+type versionSet struct {
+	mu   sync.Mutex
+	seen map[int64]struct{}
+}
+
+func newVersionSet() *versionSet {
+	return &versionSet{seen: make(map[int64]struct{})}
+}
+
+func (s *versionSet) record(v int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seen[v] = struct{}{}
+}
+
+func (s *versionSet) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return len(s.seen)
+}
+
+// TestLabelMachinery_NoRaceUnderConcurrentTraffic drives a real 3-worker
+// cluster (labels [vip], [batch], []) through ~5 seconds of concurrent label
+// churn, coverage verification, and a worker bounce, all racing the leader's
+// label-recheck ticker and the worker monitor's per-heartbeat label
+// fingerprint decode against the same KV buckets those production paths use.
+//
+//   - g1 (every 150ms): rewrites the 12-partition source via src.Update,
+//     rotating each partition's Label across vip/batch/unlabeled. This is a
+//     label-only edit — Keys and Weight never change — driven through the
+//     source API directly (not an out-of-band raw KV write): this test
+//     stresses the monitor/watcher machinery under load, not the watch-path
+//     propagation itself (pinned by TestLabelPromotion_EndToEnd and
+//     friends).
+//
+//   - g2 (every 200ms): reads the latest assignment commit, then verifies the
+//     coverage invariant assigned ∪ parked == source AGAINST THAT SAME
+//     COMMIT via checkCoverage. checkCoverage's payload fetches are
+//     content-addressed off commit.Payloads, so once a specific *commit is
+//     in hand its payloads can never drift to a different commit's parked
+//     set — reading the commit first and deriving everything else from it is
+//     the fetch-consistency pattern the rest of this package's tests already
+//     rely on (see label_orphan_stale_test.go). The identity set passed to
+//     checkCoverage (basePartitions) never changes even though the live
+//     source's labels do: Label is documented as excluded from CanonicalID,
+//     HashID, and PartitionSetDigest, so a label-agnostic identity snapshot
+//     is valid at every tick regardless of which label rotation is live.
+//     A transient fetch failure (checkCoverage's cov.assigned == nil — no
+//     commit yet, or a referenced payload not yet visible) is treated as
+//     "not converged", not a violation: this is expected during the g3
+//     worker bounce, when a deliberate restart can leave a payload
+//     momentarily unwritten. Only a SUCCESSFULLY fetched commit that fails
+//     the invariant (cov.assigned != nil, cov.ok == false) is a hard
+//     failure, recorded via soakFailure.
+//
+//   - g3 (once, at +2s): stops the batch worker, waits 2s, then restarts it
+//     under the same worker ID with labels ("batch", "vip") instead of its
+//     original ("batch") — exercising pool-empty detection, defer/confirm,
+//     park, and re-home while g1's label churn is still in flight. The
+//     relabeled restart reliably produces a live worker-side
+//     incarnation-guard reject: the leader's in-flight assignment for the
+//     reused worker ID still carries the old ["batch"] labels-of-record,
+//     which mismatch the new incarnation's ["batch","vip"] configured
+//     labels, so the worker rejects the payload; the next ordinary rebalance
+//     re-derives the worker's labels-of-record from its current heartbeat
+//     and converges. (It does not additionally exercise the
+//     SetOnLabelChange change-branch — see the file header comment.) The
+//     batch pool stays populated post-restart (the worker still carries
+//     "batch"), so full coverage is still expected within the post-soak
+//     convergence window.
+//
+// Liveness proxy: the assignment version must strictly progress across the
+// soak (final commit version > the pre-soak version), and g2 must have
+// observed a handful of distinct commit versions along the way — not just
+// one at the start and one at the end. Label churn debounces internally, so
+// this is a soak-wide progress assertion, not a per-tick monotonic-growth
+// assertion.
+//
+// Pass criteria: no race-detector trigger, no coverage violation, and the
+// cluster returns to a stable full-coverage state (ParkedCount == 0,
+// assigned == source) within 20s after the churn stops.
+func TestLabelMachinery_NoRaceUnderConcurrentTraffic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	defer cleanup()
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	// Generous overall budget: g3's restart WaitState alone can take up to
+	// 15s, and the post-soak convergence Eventually can take up to 20s on
+	// top of the 5s soak, well within this ceiling even under CI load.
+	ctx, cancel := context.WithTimeout(t.Context(), 280*time.Second)
+	defer cancel()
+
+	const numPartitions = 12
+	basePartitions := make([]types.Partition, numPartitions)
+	for i := range basePartitions {
+		basePartitions[i] = types.Partition{Keys: []string{"ls-p", fmt.Sprintf("%02d", i)}, Weight: 1}
+	}
+
+	srcKV, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "label-stress-partitions"})
+	require.NoError(t, err)
+	src := source.NewNatsKV(srcKV, "partitions", nil)
+	require.NoError(t, src.Update(ctx, basePartitions))
+	require.NoError(t, src.Start(ctx))
+	t.Cleanup(func() { _ = src.Stop(context.Background()) })
+
+	cfg := testutil.IntegrationTestConfig()
+	// Aggressive: park/spill transitions churn constantly, maximising how
+	// many times the label-recheck ticker and the fingerprint decode fire
+	// per second of soak.
+	cfg.LabelSpillGrace = 300 * time.Millisecond
+
+	cluster := testutil.NewWorkerClusterWithSource(t, nc, src, cfg)
+	cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("vip"))
+	batchWorker := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("batch"))
+	cluster.AddWorkerWithOptions(ctx) // unlabeled
+	t.Cleanup(cluster.StopWorkers)
+	cluster.StartWorkers(ctx)
+	cluster.WaitForStableState(20 * time.Second)
+
+	assignKV := openAssignmentKV(t, ctx, js, cfg)
+
+	initialCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, initialCommit, "cluster must have a committed assignment before the soak begins")
+	initialVersion := initialCommit.Version
+
+	var failure soakFailure
+	observedVersions := newVersionSet()
+
+	soakCtx, soakCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer soakCancel()
+
+	var wg sync.WaitGroup
+
+	// g1: label-only source churn every 150ms, rotating each partition's
+	// Label across vip/batch/unlabeled (a rotating subset — the specific
+	// partitions in each bucket shift every tick).
+	wg.Go(func() {
+		runLabelChurn(ctx, soakCtx, src, basePartitions, &failure)
+	})
+
+	// g2: every 200ms, read the commit and verify the coverage invariant
+	// against that exact commit; track distinct versions for the liveness
+	// proxy.
+	wg.Go(func() {
+		runCoverageWatch(ctx, soakCtx, assignKV, basePartitions, observedVersions, &failure)
+	})
+
+	// g3: stop the batch worker mid-soak, then restart it under the same
+	// worker ID with an added "vip" label 2s later — exercising pool-empty
+	// detection, defer/confirm, park, re-home, and a live incarnation-guard
+	// reject while g1's churn is still in flight. Uses the outer ctx (not
+	// soakCtx) for its waits so the restart can complete even if it lands
+	// close to (or just after) the soak's 5s boundary.
+	wg.Go(func() {
+		runBatchWorkerBounce(ctx, cluster, batchWorker, &failure)
+	})
+
+	<-soakCtx.Done()
+	wg.Wait()
+
+	require.Empty(t, failure.get(), "a soak goroutine reported a hard failure")
+
+	// Pass criterion: the cluster returns to a stable full-coverage state
+	// (nothing parked, every source partition assigned exactly once) within
+	// 20s after the churn stops.
+	require.Eventually(t, func() bool {
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil || commit.ParkedCount != 0 {
+			return false
+		}
+
+		return checkCoverage(ctx, assignKV, commit, basePartitions).ok
+	}, 20*time.Second, 200*time.Millisecond,
+		"cluster must return to full coverage with nothing parked within 20s after the churn stops")
+
+	// Liveness proxy: the assignment version made real, sustained progress
+	// across the soak — not just one initial and one final bump.
+	finalCommit := readLatestCommit(ctx, assignKV)
+	require.NotNil(t, finalCommit)
+	require.Greater(t, finalCommit.Version, initialVersion,
+		"assignment version must have advanced across the soak (liveness proxy)")
+	require.GreaterOrEqual(t, observedVersions.count(), 3,
+		"expected a handful of distinct assignment versions observed during the soak, got %d", observedVersions.count())
+
+	// Confirm the test ran without the race detector failing. See the
+	// epoch-monitor template's doc comment for why t.Failed() is the most
+	// reliable in-body signal available for a race-detector trigger.
+	require.False(t, t.Failed(),
+		"race detector or a soak assertion failed during the concurrent run; "+
+			"check stderr for WARNING: DATA RACE blocks")
+}
+
+// runLabelChurn is g1: every 150ms it rewrites the source via src.Update,
+// rotating each partition's Label across vip/batch/unlabeled (a rotating
+// subset — the specific partitions in each bucket shift every tick). Keys
+// and Weight never change, so every write is a pure label-only edit driven
+// through the source API directly, not an out-of-band raw KV write: this
+// test stresses the monitor/watcher machinery under load, not the
+// watch-path propagation itself (pinned by TestLabelPromotion_EndToEnd and
+// friends). ctx bounds the KV write itself; soakCtx bounds the loop's
+// lifetime.
+func runLabelChurn(ctx, soakCtx context.Context, src *source.NatsKV, base []types.Partition, failure *soakFailure) {
+	rotatingLabels := [3]string{"vip", "batch", ""}
+	ticker := time.NewTicker(150 * time.Millisecond)
+	defer ticker.Stop()
+	tick := 0
+	for {
+		select {
+		case <-soakCtx.Done():
+			return
+		case <-ticker.C:
+		}
+		tick++
+		parts := make([]types.Partition, len(base))
+		for i, p := range base {
+			p.Label = rotatingLabels[(i+tick)%len(rotatingLabels)]
+			parts[i] = p
+		}
+		if err := src.Update(ctx, parts); err != nil && ctx.Err() == nil {
+			failure.record(fmt.Sprintf("g1: source label-only update failed: %v", err))
+
+			return
+		}
+	}
+}
+
+// runCoverageWatch is g2: every 200ms it reads the latest assignment commit,
+// then verifies the coverage invariant assigned ∪ parked == source AGAINST
+// THAT SAME COMMIT via checkCoverage. checkCoverage's payload fetches are
+// content-addressed off commit.Payloads, so once a specific *commit is in
+// hand its payloads can never drift to a different commit's parked set —
+// reading the commit first and deriving everything else from it is the
+// fetch-consistency pattern the rest of this package's tests rely on (see
+// label_orphan_stale_test.go). base never changes even though the live
+// source's labels do: Label is documented as excluded from CanonicalID,
+// HashID, and PartitionSetDigest, so this label-agnostic identity snapshot
+// is valid at every tick regardless of which label rotation is live.
+//
+// A transient fetch failure (checkCoverage's cov.assigned == nil — no
+// commit yet, or a referenced payload not yet visible) is treated as "not
+// converged", not a violation: this is expected during the g3 worker
+// bounce, when a deliberate restart can leave a payload momentarily
+// unwritten. Only a SUCCESSFULLY fetched commit that fails the invariant
+// (cov.assigned != nil, cov.ok == false) is a hard failure, recorded via
+// soakFailure. ctx bounds the KV reads; soakCtx bounds the loop's lifetime.
+func runCoverageWatch(
+	ctx, soakCtx context.Context,
+	assignKV jetstream.KeyValue,
+	base []types.Partition,
+	observed *versionSet,
+	failure *soakFailure,
+) {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-soakCtx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		commit := readLatestCommit(ctx, assignKV)
+		if commit == nil {
+			continue // cold-start / transient; not yet converged
+		}
+		observed.record(commit.Version)
+
+		cov := checkCoverage(ctx, assignKV, commit, base)
+		if cov.ok {
+			continue
+		}
+		if cov.assigned == nil {
+			// Transient: payload fetch pending (e.g. racing the g3 worker
+			// bounce). Only a SUCCESSFULLY fetched commit that fails the
+			// invariant is an orphan violation.
+			continue
+		}
+		failure.record(fmt.Sprintf("coverage violation at commit version %d: %s", commit.Version, cov.reason))
+
+		return
+	}
+}
+
+// runBatchWorkerBounce is g3: it stops the batch worker mid-soak, waits 2s,
+// then restarts it under the same worker ID with labels ("batch", "vip")
+// instead of its original ("batch") — exercising pool-empty detection,
+// defer/confirm, park, and re-home while g1's label churn is still in
+// flight. The relabeled restart reliably produces a live worker-side
+// incarnation-guard reject: the leader's in-flight assignment for the
+// reused worker ID still carries the old ["batch"] labels-of-record, which
+// mismatch the new incarnation's ["batch","vip"] configured labels, so the
+// worker rejects the payload; the next ordinary rebalance re-derives the
+// worker's labels-of-record from its current heartbeat and converges. The
+// batch pool stays populated post-restart (the worker still carries
+// "batch"). It waits on ctx (not soakCtx) so the restart can complete even
+// if it lands close to (or just after) the soak's boundary.
+//
+// The stop below is the same bounded call this package's stopWorker helper
+// makes (5s timeout), inlined so any error can be routed through soakFailure
+// instead of require.NoError — testify's require.* must only be invoked from
+// the test's own goroutine, and this runs on g3.
+func runBatchWorkerBounce(
+	ctx context.Context,
+	cluster *testutil.WorkerCluster,
+	batchWorker *parti.Manager,
+	failure *soakFailure,
+) {
+	select {
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return
+	}
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	err := batchWorker.Stop(stopCtx)
+	stopCancel()
+	if err != nil {
+		failure.record(fmt.Sprintf("g3: failed to stop batch worker %s: %v", batchWorker.WorkerID(), err))
+
+		return
+	}
+
+	select {
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return
+	}
+	newBatch := cluster.AddWorkerWithOptions(ctx, parti.WithWorkerLabels("batch", "vip"))
+	if err := newBatch.Start(ctx); err != nil {
+		failure.record(fmt.Sprintf("g3: restarted batch worker failed to start: %v", err))
+
+		return
+	}
+	if err := <-newBatch.WaitState(parti.StateStable, 15*time.Second); err != nil {
+		failure.record(fmt.Sprintf("g3: restarted batch worker did not reach StateStable: %v", err))
+	}
+}

--- a/types/assignment_commit.go
+++ b/types/assignment_commit.go
@@ -31,6 +31,17 @@ type AssignmentPayload struct {
 	// CanonicalID. Sort is the canonicalization step that lets
 	// content-addressable keys reuse across commits.
 	Partitions []Partition `json:"partitions"`
+
+	// WorkerLabels is the labels-of-record: the label set the leader read
+	// from this worker's heartbeat when computing the assignment. Part of
+	// the canonical payload bytes (and therefore PayloadHash).
+	WorkerLabels []string `json:"worker_labels,omitempty"`
+
+	// WorkerLabelsKnown distinguishes "computed for an unlabeled worker"
+	// (true + empty WorkerLabels) from "computed by a pre-label leader"
+	// (false). Label-aware leaders ALWAYS set true. Mirrors the
+	// SourceRevisionKnown presence-bit precedent.
+	WorkerLabelsKnown bool `json:"worker_labels_known,omitempty"`
 }
 
 // AssignmentPayloadRef points to a content-addressable AssignmentPayload key in
@@ -112,6 +123,15 @@ type AssignmentCommit struct {
 	// Used as a coverage-proof handle for audit; matches the source partition
 	// set's digest at publish time.
 	BatchDigest uint64 `json:"batch_digest"`
+
+	// ParkedCount is the number of partitions intentionally left
+	// unassigned in this batch (label pool empty, spill grace not yet
+	// expired). Zero when nothing is parked.
+	ParkedCount int `json:"parked_count,omitempty"`
+
+	// ParkedDigest is types.PartitionSetDigest over the parked set.
+	// Zero when nothing is parked.
+	ParkedDigest uint64 `json:"parked_digest,omitempty"`
 
 	// PrevCommitRev is the KV revision the publisher CAS-updated FROM. Zero on
 	// the first ever commit (Create instead of Update). Diagnostic only —

--- a/types/heartbeat.go
+++ b/types/heartbeat.go
@@ -20,9 +20,15 @@ import (
 // v1 publishers always emit JSON. Legacy timestamp-byte payloads are parsed
 // for backwards-compatibility with pre-v1 workers.
 type Heartbeat struct {
-	WorkerID              string    `json:"worker_id"`
-	SchemaVersion         uint8     `json:"schema_version,omitempty"`
-	Capabilities          uint32    `json:"capabilities,omitempty"`
+	WorkerID      string `json:"worker_id"`
+	SchemaVersion uint8  `json:"schema_version,omitempty"`
+	Capabilities  uint32 `json:"capabilities,omitempty"`
+
+	// Labels is the worker's label set, fixed for the process lifetime.
+	// Sorted and deduplicated at publish time. Empty for unlabeled
+	// workers and for pre-label workers (additive JSON field).
+	Labels []string `json:"labels,omitempty"`
+
 	LeaderRevision        uint64    `json:"leader_revision,omitempty"`
 	AppliedVersion        int64     `json:"applied_version,omitempty"`
 	AppliedDigest         uint64    `json:"applied_digest,omitempty"`

--- a/types/heartbeat_test.go
+++ b/types/heartbeat_test.go
@@ -83,6 +83,37 @@ func TestHeartbeat_DecodeV1JSON(t *testing.T) {
 	require.True(t, hb.Timestamp.Equal(ts))
 }
 
+// TestHeartbeat_DecodeLabels verifies the additive Labels field: a v1 payload
+// carrying "labels" decodes to the set; a legacy timestamp payload and a v1
+// payload without the field both decode to Labels=nil (distinct from error).
+func TestHeartbeat_DecodeLabels(t *testing.T) {
+	t.Run("v1 JSON with labels", func(t *testing.T) {
+		hb, err := types.DecodeHeartbeat([]byte(`{"worker_id":"w1","schema_version":1,"labels":["vip"],"applied_at":"0001-01-01T00:00:00Z","timestamp":"0001-01-01T00:00:00Z"}`))
+		require.NoError(t, err)
+		require.Equal(t, []string{"vip"}, hb.Labels)
+	})
+
+	t.Run("legacy timestamp payload has nil labels", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Nanosecond)
+		hb, err := types.DecodeHeartbeat([]byte(now.Format(time.RFC3339Nano)))
+		require.NoError(t, err)
+		require.Nil(t, hb.Labels, "pre-label workers decode with nil Labels")
+	})
+
+	t.Run("v1 JSON without labels field has nil labels", func(t *testing.T) {
+		// A pre-label v1 worker's payload omits "labels"; it must decode to nil,
+		// which is distinct from a decode error.
+		src := types.Heartbeat{WorkerID: "w2", SchemaVersion: 1}
+		payload, err := json.Marshal(src)
+		require.NoError(t, err)
+		require.NotContains(t, string(payload), "labels", "omitempty must drop the empty field")
+
+		hb, err := types.DecodeHeartbeat(payload)
+		require.NoError(t, err)
+		require.Nil(t, hb.Labels)
+	})
+}
+
 // TestHeartbeat_DecodeMalformed_ReturnsError verifies that a payload that is
 // neither valid JSON nor a parseable RFC3339 timestamp is returned as an error,
 // not silently degraded to an empty Heartbeat. Importantly, a payload that

--- a/types/metrics_collector.go
+++ b/types/metrics_collector.go
@@ -381,3 +381,55 @@ type WorkerConsumerMetrics interface {
 	// due to ownership/state gating (v2 per-subject mode). Reason examples: "not_owner", "state_blocked".
 	IncrementWorkerConsumerPullSuppressed(reason string)
 }
+
+// LabelMetrics is an optional extension interface for label-based partition
+// assignment observability. A MetricsCollector implementation MAY also satisfy
+// LabelMetrics; the manager and calculator type-assert their configured
+// collector to LabelMetrics and, when the assertion fails, silently skip these
+// recordings (label mode still functions without them).
+//
+// Semantics:
+//   - The per-label gauges (RecordLabelPoolSize, RecordParkedPartitions) are
+//     recomputed on every completed rebalance. A label absent from the current
+//     snapshot is explicitly zeroed in the same pass, so a drained label pool
+//     does not leave a stale non-zero reading.
+//   - The per-label gauges are leader-scoped and are zeroed by the departing
+//     leader when it stops calculating, so a deposed leader's export does not
+//     freeze at stale non-zero readings.
+//   - The counters (IncrementLabelSpill, IncrementLabelChangeTrigger,
+//     IncrementLabelIncarnationReject, IncrementUnlabeledFallback) are
+//     monotonic per process.
+//
+// Implementations must be non-blocking and thread-safe: methods are called
+// from internal goroutines, matching the MetricsCollector contract.
+type LabelMetrics interface {
+	// RecordLabelPoolSize records the number of workers currently eligible for
+	// the given label. Recomputed each rebalance; absent labels are zeroed.
+	RecordLabelPoolSize(label string, workers int)
+
+	// RecordParkedPartitions records the number of partitions parked (awaiting
+	// an eligible worker) for the given label. Recomputed each rebalance;
+	// absent labels are zeroed.
+	RecordParkedPartitions(label string, count int)
+
+	// IncrementLabelSpill increments the count of partitions that spilled from
+	// their labeled pool to an unlabeled fallback worker for the given label.
+	IncrementLabelSpill(label string)
+
+	// IncrementLabelChangeTrigger increments the count of rebalances triggered
+	// by a detected worker-label change.
+	IncrementLabelChangeTrigger()
+
+	// IncrementLabelIncarnationReject increments the count of assignment
+	// payloads rejected by the worker-side stale-incarnation guard because the
+	// labels-of-record did not match the worker's configured labels.
+	IncrementLabelIncarnationReject()
+
+	// IncrementUnlabeledFallback increments once per unlabeled partition
+	// assigned while no worker was eligible for the unlabeled pool: under the
+	// "dedicated" policy this means the unlabeled pool was empty and the
+	// partitions were served by labeled workers; under "shared" (where every
+	// worker is eligible for unlabeled work) it fires only in the degenerate
+	// case of no live workers at all.
+	IncrementUnlabeledFallback()
+}

--- a/types/partition.go
+++ b/types/partition.go
@@ -23,6 +23,13 @@ type Partition struct {
 	// Negative values are treated as zero (strategy default).
 	// Used by weighted assignment strategies for load balancing.
 	Weight int64 `json:"weight" yaml:"weight"`
+
+	// Label optionally pins this partition to workers that carry the same
+	// label (see Heartbeat.Labels). Empty means unlabeled: the partition
+	// is assigned according to the unlabeled-partition policy. Label is a
+	// routing hint, NOT part of partition identity: it does not
+	// participate in CanonicalID, HashID, Compare, or PartitionSetDigest.
+	Label string `json:"label,omitempty" yaml:"label,omitempty"`
 }
 
 // Validate checks if the partition configuration is valid.
@@ -45,6 +52,18 @@ func (p Partition) Validate() error {
 		}
 		if strings.ContainsAny(key, " \t\n\r") {
 			return fmt.Errorf("partition key at index %d contains whitespace: %q", i, key)
+		}
+	}
+
+	if p.Label != "" {
+		if len(p.Label) > 64 {
+			return fmt.Errorf("partition label exceeds 64 bytes: %q", p.Label)
+		}
+		if strings.Contains(p.Label, ".") {
+			return fmt.Errorf("partition label contains invalid character '.': %q", p.Label)
+		}
+		if strings.ContainsAny(p.Label, " \t\n\r") {
+			return fmt.Errorf("partition label contains whitespace: %q", p.Label)
 		}
 	}
 
@@ -252,6 +271,14 @@ type Assignment struct {
 	// This field is informational only — the manager does not enforce it internally.
 	// Zero when not set by the publisher.
 	TotalWorkers int `json:"total_workers,omitempty"`
+
+	// WorkerLabels / WorkerLabelsKnown mirror the fetched AssignmentPayload's
+	// labels-of-record so the worker-side stale-incarnation guard can compare
+	// against its own label set. A label-aware leader stamps them onto both the
+	// payload and the legacy alias envelope; a pre-label leader leaves them
+	// empty/false (WorkerLabelsKnown=false).
+	WorkerLabels      []string `json:"worker_labels,omitempty"`
+	WorkerLabelsKnown bool     `json:"worker_labels_known,omitempty"`
 }
 
 // PartitionSetDigest returns the xxh3 hash of the sorted CanonicalIDs of the

--- a/types/partition_label_test.go
+++ b/types/partition_label_test.go
@@ -1,0 +1,63 @@
+package types_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionLabel_IdentityBlind(t *testing.T) {
+	t.Parallel()
+
+	plain := types.Partition{Keys: []string{"topic", "42"}, Weight: 3}
+	vip := types.Partition{Keys: []string{"topic", "42"}, Weight: 3, Label: "vip"}
+
+	require.Equal(t, plain.CanonicalID(), vip.CanonicalID(), "CanonicalID must be label-blind")
+	require.Equal(t, plain.HashID(), vip.HashID(), "HashID must be label-blind")
+	require.Equal(t, plain.HashIDSeed(7), vip.HashIDSeed(7), "HashIDSeed must be label-blind")
+	require.Zero(t, plain.Compare(vip), "Compare must be label-blind")
+	require.Equal(t,
+		types.PartitionSetDigest([]types.Partition{plain}),
+		types.PartitionSetDigest([]types.Partition{vip}),
+		"PartitionSetDigest must be label-blind")
+}
+
+func TestPartitionLabel_Validate(t *testing.T) {
+	t.Parallel()
+
+	valid := func(label string) error {
+		return types.Partition{Keys: []string{"k"}, Label: label}.Validate()
+	}
+
+	require.NoError(t, valid(""), "empty label = unlabeled, valid")
+	require.NoError(t, valid("vip"))
+	require.NoError(t, valid("gpu-batch_2"))
+
+	require.Error(t, valid("has space"))
+	require.Error(t, valid("has\ttab"))
+	require.Error(t, valid("dotted.label"))
+	require.Error(t, valid(strings.Repeat("x", 65)), "over 64-byte cap")
+	require.NoError(t, valid(strings.Repeat("x", 64)), "exactly 64 bytes ok")
+}
+
+func TestPartitionLabel_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	p := types.Partition{Keys: []string{"a"}, Weight: 2, Label: "vip"}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"label":"vip"`)
+
+	var back types.Partition
+	require.NoError(t, json.Unmarshal(b, &back))
+	require.Equal(t, p, back)
+
+	// omitempty: unlabeled partitions marshal without the field, so the
+	// wire bytes of existing label-free lists are unchanged.
+	b2, err := json.Marshal(types.Partition{Keys: []string{"a"}})
+	require.NoError(t, err)
+	require.NotContains(t, string(b2), "label")
+}


### PR DESCRIPTION
# feat: label-based partition assignment (v2.9.0)

Adds label-based partition routing: partitions may carry one optional label; workers declare a label set at startup (heartbeats carry it); the leader routes labeled partitions to matching workers with park-then-spill semantics, a defer-once confirmation ladder, and a worker-side stale-incarnation guard. Additive-only release — a fleet with zero labels anywhere gets identical assignment decisions to today.

Spec: `docs/plans/label-assignment/00-design-spec.md` · Plan: `docs/plans/label-assignment/01-implementation-plan.md`

## Surface

- `types.Partition.Label` — routing hint, excluded from identity (CanonicalID/HashID/Compare/PartitionSetDigest), so a label-only edit moves no ownership
- `Config.WorkerLabels` / `WithWorkerLabels`, `Config.UnlabeledPartitionPolicy` (`dedicated`|`shared`), `Config.LabelSpillGrace`
- `types.Heartbeat.Labels`; payload labels-of-record + `WorkerLabelsKnown` presence bit; commit `ParkedCount`/`ParkedDigest`
- `types.LabelMetrics` optional collector extension; provision records carry labels (`OldLabel`/`NewLabel` change reporting)
- Operator guide: `docs/LABELS.md`

## Invariant → test matrix

| Invariant | Test |
|---|---|
| I1 zero-labels identical output | `TestComputeLabelAssignments_I1Golden` + full existing calculator suite green |
| I2 assigned ∪ parked == source | `TestCheckCoverage_ParkedUnionAndDisjointness`, `TestGhostLabel_ParksThenSpills_NeverOrphans`, stress g2 assertions |
| I3 label-blind identity | `TestPartitionLabel_IdentityBlind` |
| I4 label-only change notifies | `TestPartitionsEqual_LabelAware`, `TestNatsKV_LabelOnlyEdit_{Watch,Reconcile}PathPropagates`, `TestLabelPromotion_EndToEnd` |
| I5 spill never invades other pools | `TestComputeLabelAssignments_SpillPrefersUnlabeledWorkers` |
| I6 recheck fires without events | `TestLabelRecheck_GhostLabelProgressesWithoutExternalEvents`, `TestGhostLabel_ParksThenSpills_NeverOrphans` |
| I7 labels immutable per lifetime | `TestConfig_WorkerLabelsNormalization` + heartbeat emission tests |
| I8 merged keys == active set | `TestComputeLabelAssignments_MergeContract`, `TestLabelDemotion_NoStaleAssignmentInKV` |
| I9 one group per partition | `TestComputeLabelAssignments_MergeContract` (count assertion) |
| I10 label survives copy paths | source struct-copy + provision round-trip tests |
| I11 guard on both wire paths | `TestLabelGuard_Matrix`, `TestLabelGuard_RejectIsTerminalNoRetryNoAck`, `TestLabelGuard_RetryEntrypointAlsoGuarded`, `TestStableIDReuse_DifferentLabels_NoStaleExposureAndConverge` |
| §4.1 no ownership movement on label-only edit | `TestLabelOnlyEdit_NoConsumerChurnWhenPlacementUnchanged` (+ `TestPublish_PayloadCarriesLabelsOfRecord` for the hash side) |
| I12 defer-once confirmation | `TestLabelState_DeferOnceThenPark`, `TestLabelState_UnknownWorkerDeferThenAct` |
| I13 label-change trigger | `TestWorkerMonitor_LabelChangeEscapesSuppression`, `TestWorkerMonitor_LabelChangeAcrossWatcherRestart`, `TestCalculator_TightTakeover_LabelChangeTriggersRebalance` |

Concurrency stress (per AGENTS.md monitor-goroutine rule): `TestLabelMachinery_NoRaceUnderConcurrentTraffic` — 5s live-cluster soak, concurrent label churn + coverage polling + relabeled worker bounce, race detector as oracle.

## Scoping notes

1. **Mixed-version leader-bouncing dynamics have no in-tree test** — two library versions cannot coexist in one Go test binary. The compat matrix is pinned piecewise instead: a hand-written pre-label commit (`TestPreLabelCommit_CompatApplies`), legacy heartbeat decode unit tests, and the label-blind-writer rollout rule documented in `docs/LABELS.md`.
2. **The worker monitor's `SetOnLabelChange` change branch is not reachable in the live stress soak** — any clean leave+rejoin drops the retained fingerprint on the graceful heartbeat delete by design, so only an unclean same-key takeover reaches it. It is pinned against a live NATS watcher by `TestCalculator_TightTakeover_LabelChangeTriggersRebalance`. A forged-heartbeat mechanism could reach it in-soak but crosses the stress test's no-out-of-band-KV-writes design line and adds churn to a load-sensitive package for a monitor-local (not shared-stream-state) branch.

## Fixes surfaced by the integration phase

- Startup/rebalance paths treated a benign label-observation defer as fatal, releasing leadership in a loop (fixed; pinned by the takeover/orphan regression suites).
- `Manager.Stop` could deadlock when a mid-rebalance label-read failure callback re-entered the manager mutex held across calculator stop (fixed via handoff-then-stop outside the lock; deterministic reproducer included).
- A fetched-but-guard-rejected startup assignment stayed visible through `CurrentAssignment()` (fixed; both reject sites clear the store, regression test red→green).

## Validation

- `make pre-pr` green first run (lint + unit `-race` + live-NATS integration `-race`), no flake re-runs
- Cross-feature contract tests explicitly re-run green: `TestManager_LiveNATSBucketLoss*`, `TestStableID_StaleKeyTakeover_Reclaim`, `TestStart_*`
- Every commit in the series builds and vets independently (bisectable)
- External cross-model post-implementation review: merge verdict, zero P0/P1 (`tmp/label-assignment_post_implementation_review_v1.md`)
