### PR TITLE
sim: add label-assignment chaos coverage to the simulation harness

### DIFF
--- a/.github/workflows/simulation-stress.yml
+++ b/.github/workflows/simulation-stress.yml
@@ -450,3 +450,57 @@ jobs:
             tmp/storage_*.log
             tmp/burst_*.log
             tmp/heartbeat_scan_flatness.log
+
+  # ---------------------------------------------------------------------------
+  # Label-assignment coverage (added 2026-07-09).
+  #
+  # Exercises the label-based (VIP) partition assignment feature under
+  # concurrent chaos: pool-outage spill, live heartbeat relabeling that
+  # races an in-flight rebalance/election, a multi-worker emergency
+  # carveout, and a relabel storm. Unlike its sibling per-pillar jobs
+  # above, this job builds the simulation binary with -race: developing
+  # this coverage found and fixed about half a dozen real, pre-existing
+  # concurrency bugs in the simulation harness itself, all invisible
+  # without the race detector, so the coverage is only meaningful with it
+  # on. Two of the four scenarios also drive random background chaos
+  # (leader failures / disconnects) alongside their fixed schedule, so
+  # some non-determinism is possible; per the policy above, raise the
+  # timeout or add retries only if a specific scenario demonstrates
+  # flakiness in CI.
+  # ---------------------------------------------------------------------------
+
+  sim-label-assignment:
+    runs-on: ubuntu-latest
+    # 4 scenarios: 90s + 3m + 2m30s + 90s = 8.5m raw scenario time. The
+    # -race build is slower to compile and its higher CPU/memory pressure
+    # can also slow scenario settle windows, so this pads further than
+    # sibling jobs' ~1.7x ratio.
+    timeout-minutes: 24
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build Simulation
+        run: go build -race -o tmp/simulation ./test/simulation/cmd/simulation
+      - name: Run Label Assignment Scenarios
+        run: |
+          set -eo pipefail
+          for scn in label_pool_outage_spill label_tight_takeover_churn label_emergency_carveout label_relabel_storm; do
+            echo "::group::${scn}"
+            ./tmp/simulation \
+              --config "test/simulation/configs/${scn}.yaml" \
+              --stop-on-failure=false \
+              2>&1 | tee "tmp/${scn}.log"
+            echo "::endgroup::"
+          done
+      - name: Upload Failure Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-label-assignment-failure
+          path: |
+            failure_report.json
+            tmp/label_*.log

--- a/manager.go
+++ b/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -967,6 +968,18 @@ func (m *Manager) WorkerID() string {
 //   - bool: true if this manager is the leader, false otherwise.
 func (m *Manager) IsLeader() bool {
 	return m.isLeader.Load()
+}
+
+// WorkerLabels returns this worker's resolved label set (sorted,
+// deduplicated, normalized at construction — see NewManager and
+// normalizeWorkerLabels). Each call returns a fresh clone of the manager's
+// internal label slice, so the caller owns the result and may freely mutate
+// it without affecting the manager's internal state.
+//
+// Returns:
+//   - []string: A fresh copy of this worker's label set, or nil if unlabeled.
+func (m *Manager) WorkerLabels() []string {
+	return slices.Clone(m.workerLabels)
 }
 
 // CurrentAssignment returns the current partition assignment for this worker.

--- a/manager_test.go
+++ b/manager_test.go
@@ -121,6 +121,55 @@ func TestNewManager_RequiredParameters(t *testing.T) {
 	})
 }
 
+// TestManager_WorkerLabels verifies that WorkerLabels returns the label set
+// resolved at construction, normalized (sorted, deduplicated) by
+// cfg.Validate via normalizeWorkerLabels. No live NATS connection is needed
+// for this construction path — mirrors TestNewManager_NilSafety's helper
+// pattern (mock source/strategy + an unconnected jetstream.JetStream).
+func TestManager_WorkerLabels(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.WorkerLabels = []string{"vip-b", "vip-a"} // deliberately unsorted input
+
+	conn := &nats.Conn{}
+	js, _ := jetstream.New(conn)
+	src := &mockSource{}
+	assignStrat := &mockStrategy{}
+
+	mgr, err := NewManager(&cfg, js, src, assignStrat)
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+
+	got := mgr.WorkerLabels()
+	want := []string{"vip-a", "vip-b"} // normalizeWorkerLabels sorts
+	require.Equal(t, want, got)
+}
+
+// TestManager_WorkerLabels_WithOptionOverride verifies that WithWorkerLabels
+// takes priority over Config.WorkerLabels when both are set, and that the
+// option's labels are independently normalized (sorted, deduplicated) before
+// being exposed through WorkerLabels.
+func TestManager_WorkerLabels_WithOptionOverride(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.WorkerLabels = []string{"other"} // must be overridden by the option
+
+	conn := &nats.Conn{}
+	js, _ := jetstream.New(conn)
+	src := &mockSource{}
+	assignStrat := &mockStrategy{}
+
+	mgr, err := NewManager(&cfg, js, src, assignStrat, WithWorkerLabels("vip-b", "vip-a"))
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+
+	got := mgr.WorkerLabels()
+	want := []string{"vip-a", "vip-b"} // normalizeWorkerLabels sorts the option's labels
+	require.Equal(t, want, got)
+}
+
 // TestManager_SetCapability_AtomicBitmask verifies that SetCapability correctly
 // sets and clears individual bits in the capability bitmask, and that Capabilities
 // reflects the live value after each mutation.

--- a/test/simulation/cmd/simulation/label_chaos.go
+++ b/test/simulation/cmd/simulation/label_chaos.go
@@ -1,0 +1,153 @@
+// label_chaos.go implements the label_heartbeat_takeover chaos primitive:
+// see coordinator.LabelHeartbeatTakeoverEvent's doc comment for the full
+// rationale (why this replaces a kill+respawn approach).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/test/simulation/internal/coordinator"
+	"github.com/arloliu/parti/v2/test/simulation/internal/worker"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+)
+
+// stringSliceFromParam coerces a chaos param value into []string. YAML
+// nested lists inside a Params map[string]any decode to []any (each
+// element itself an any wrapping a string), not []string directly — this
+// mirrors the durationFromParams coercion-helper pattern used elsewhere in
+// this package for the same params-map YAML-decoding quirk.
+func stringSliceFromParam(v any) []string {
+	switch vv := v.(type) {
+	case []string:
+		return vv
+	case []any:
+		out := make([]string, 0, len(vv))
+		for _, e := range vv {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+
+		return out
+	default:
+		return nil
+	}
+}
+
+// handleLabelHeartbeatTakeover resolves targetWorker (sim ID, e.g.
+// "worker-2"; "" or "random" picks the first live labeled worker) to its
+// current heartbeat KV entry, decodes it, replaces Labels with newLabels,
+// refreshes Timestamp to now, and Puts it back onto the SAME key
+// (heartbeat prefix is hardcoded "heartbeat" — see manager_assignment.go's
+// HeartbeatPrefix: "heartbeat" — bucket is
+// parti.DefaultConfig().KVBuckets.HeartbeatBucket, default
+// "parti-heartbeat"). The target worker process is never touched — it
+// keeps running and remains unaware its own heartbeat key was rewritten.
+func handleLabelHeartbeatTakeover(ctx context.Context, registry *coordinator.GoroutineRegistry, targetWorker string, newLabels []string) {
+	js, err := freshJS()
+	if err != nil {
+		log.Printf("[Chaos] label_heartbeat_takeover: failed to open probe JS: %v", err)
+		return
+	}
+
+	pc := parti.DefaultConfig()
+	bucket := pc.KVBuckets.HeartbeatBucket
+	const heartbeatPrefix = "heartbeat" // matches manager_assignment.go's hardcoded HeartbeatPrefix
+
+	workers := registry.GetByType(coordinator.WorkerGoroutine)
+	if len(workers) == 0 {
+		log.Println("[Chaos] label_heartbeat_takeover: no live workers")
+		return
+	}
+	var simID, stableID string
+	if targetWorker == "" || targetWorker == "random" {
+		for _, info := range workers {
+			if wobj, ok := info.Obj.(*worker.Worker); ok {
+				if id := wobj.StableWorkerID(); id != "" {
+					simID, stableID = info.ID, id
+					break
+				}
+			}
+		}
+	} else {
+		for _, info := range workers {
+			if info.ID != targetWorker {
+				continue
+			}
+			if wobj, ok := info.Obj.(*worker.Worker); ok {
+				stableID = wobj.StableWorkerID()
+			}
+			simID = info.ID
+
+			break
+		}
+	}
+	if stableID == "" {
+		log.Printf("[Chaos] label_heartbeat_takeover: could not resolve stable worker ID (targetWorker=%q)", targetWorker)
+		return
+	}
+
+	kv, kerr := js.KeyValue(ctx, bucket)
+	if kerr != nil {
+		log.Printf("[Chaos] label_heartbeat_takeover: UNEXPECTED KeyValue error: %v", kerr)
+		return
+	}
+
+	key := heartbeatPrefix + "." + stableID
+	getCtx, getCancel := context.WithTimeout(ctx, 5*time.Second)
+	entry, gerr := kv.Get(getCtx, key)
+	getCancel()
+	if gerr != nil {
+		log.Printf("[Chaos] label_heartbeat_takeover: heartbeat key %q not found (worker not yet published?): %v", key, gerr)
+		return
+	}
+
+	hb, derr := types.DecodeHeartbeat(entry.Value())
+	if derr != nil {
+		log.Printf("[Chaos] label_heartbeat_takeover: failed to decode existing heartbeat at %q: %v", key, derr)
+		return
+	}
+	hb.Labels = newLabels
+	hb.Timestamp = time.Now()
+
+	newValue, merr := json.Marshal(hb)
+	if merr != nil {
+		log.Printf("[Chaos] label_heartbeat_takeover: failed to encode new heartbeat: %v", merr)
+		return
+	}
+
+	putCtx, putCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer putCancel()
+	// Plain Put (not Update-with-revision): this must look exactly like a
+	// normal live heartbeat refresh to the watcher, which is the point —
+	// checkLabelChange doesn't care how the PUT arrived, only that the
+	// decoded Labels differ from its retained fingerprint for this key.
+	if _, perr := kv.Put(putCtx, key, newValue); perr != nil {
+		if errors.Is(perr, nats.ErrNoResponders) {
+			log.Printf("[Chaos] label_heartbeat_takeover: ErrNoResponders (tolerated): %v", perr)
+			return
+		}
+		log.Printf("[Chaos] label_heartbeat_takeover: UNEXPECTED Put error: %v", perr)
+		return
+	}
+	log.Printf("[Chaos] label_heartbeat_takeover: rewrote heartbeat key %q (sim_id=%s stable_id=%s) with labels=%v",
+		key, simID, stableID, newLabels)
+
+	// Tell the LabelAffinityOracle about the tamper: it reads labels via
+	// WorkerObserver.WorkerLabels() (the worker's own Manager/Config), which
+	// this out-of-band KV rewrite never touches, so without this the oracle
+	// would judge affinity by a label set that's now stale relative to what
+	// production actually reads from KV. See SetLiveLabelOverride's doc
+	// comment for the full rationale.
+	if aioCoord != nil {
+		if o := aioCoord.LabelAffinityOracle(); o != nil {
+			o.SetLiveLabelOverride(simID, newLabels)
+		}
+	}
+}

--- a/test/simulation/cmd/simulation/label_chaos_test.go
+++ b/test/simulation/cmd/simulation/label_chaos_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/test/simulation/internal/coordinator"
+	"github.com/arloliu/parti/v2/test/simulation/internal/natsutil"
+	"github.com/arloliu/parti/v2/test/simulation/internal/worker"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleLabelHeartbeatTakeover_FiresTightTakeoverBranch proves the new
+// chaos primitive lands on a still-live heartbeat key and triggers the
+// worker-monitor's tight-takeover fingerprint-mismatch callback — the
+// specific branch no other test in this repo reaches (see
+// test/integration/assignment/label_stress_test.go's own doc comment,
+// which documents its g3 goroutine does NOT reach this branch because a
+// graceful stop deletes the key first).
+//
+// This test spins up ONE real worker directly against embedded NATS
+// (bypassing the full sim orchestrator) so it's fast and focused — the
+// full scenario-level proof lives in label_tight_takeover_churn.yaml
+// (Task 10), which exercises this primitive under concurrent chaos.
+//
+// NOTE: this test does NOT call t.Parallel(). handleLabelHeartbeatTakeover
+// resolves its probe JetStream via freshJS() → the package-global aioNS,
+// which this test must set. Mutating a package global under t.Parallel()
+// would be a data race under -race against any future parallel test in this
+// package that also touches aioNS, so the test runs serially and resets the
+// global on cleanup.
+func TestHandleLabelHeartbeatTakeover_FiresTightTakeoverBranch(t *testing.T) {
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	// freshJS() (used by the handler under test) opens its probe JetStream
+	// against aioNS. In the real all-in-one run this is the shared
+	// connection every worker goroutine uses; here we point it at the same
+	// embedded-NATS conn the worker below uses so the handler reads and
+	// rewrites the very heartbeat key the worker publishes.
+	aioNS = nc
+	t.Cleanup(func() { aioNS = nil })
+
+	// The worker's manager reaches StateStable only after it applies its
+	// assignment, which creates JetStream consumers on the "SIMULATION"
+	// work stream. In the full sim, main.go creates this stream before any
+	// worker starts (natsutil.CreateStream at main.go:338); this isolated
+	// test must do the same or the worker never leaves WaitingAssignment.
+	require.NoError(t, natsutil.CreateStream(nc, 4))
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	coordCh := make(chan coordinator.AssignmentReport, 8)
+	w, err := worker.NewWorker(worker.Config{
+		ID:                 "worker-0",
+		NC:                 nc,
+		JS:                 js,
+		PartitionCount:     4,
+		AssignmentStrategy: "ConsistentHash",
+		AckWait:            2 * time.Second,
+		AssignmentReportCh: coordCh,
+		WorkerLabels:       []string{"vip-a"},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, w.Start(ctx))
+	defer w.Stop()
+
+	// Wait for the worker to reach Stable so its heartbeat key exists and
+	// is being actively watched by its own calculator (single-worker
+	// cluster: it's its own leader, so its own monitor observes its own
+	// PUT).
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if parti.State(w.WorkerStateInt()) == parti.StateStable {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if parti.State(w.WorkerStateInt()) != parti.StateStable {
+		t.Fatalf("worker did not reach Stable in time (state=%d)", w.WorkerStateInt())
+	}
+
+	registry := coordinator.NewGoroutineRegistry()
+	registry.Register("worker-0", coordinator.WorkerGoroutine, cancel, nil, w)
+
+	before := w.ChaosProof().LabelChangeTriggers()
+	handleLabelHeartbeatTakeover(ctx, registry, "worker-0", []string{"vip-b"})
+
+	deadline = time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if w.ChaosProof().LabelChangeTriggers() > before {
+			return // success: the tight-takeover branch fired
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("expected LabelChangeTriggers to increase after handleLabelHeartbeatTakeover; still %d", w.ChaosProof().LabelChangeTriggers())
+}

--- a/test/simulation/cmd/simulation/main.go
+++ b/test/simulation/cmd/simulation/main.go
@@ -31,19 +31,20 @@ import (
 
 // Globals for all-in-one dynamic scale control (minimize invasive changes).
 var (
-	aioNS             *nats.Conn
-	aioJS             jetstream.JetStream
-	aioEmbeddedServer *server.Server
-	aioCfg            *config.Config
-	aioCoord          *coordinator.Coordinator
-	aioMetrics        *metrics.Collector
-	aioCheckpoint     *coordinator.CheckpointManager
-	aioRegistry       *coordinator.GoroutineRegistry
-	aioWeights        []int64
-	aioScaleUpOnce    int
-	aioMinWorkers     int
-	aioMaxWorkers     int
-	aioKVFaults       *simKVFaultController
+	aioNS              *nats.Conn
+	aioJS              jetstream.JetStream
+	aioEmbeddedServer  *server.Server
+	aioCfg             *config.Config
+	aioCoord           *coordinator.Coordinator
+	aioMetrics         *metrics.Collector
+	aioCheckpoint      *coordinator.CheckpointManager
+	aioRegistry        *coordinator.GoroutineRegistry
+	aioWeights         []int64
+	aioPartitionLabels []string
+	aioScaleUpOnce     int
+	aioMinWorkers      int
+	aioMaxWorkers      int
+	aioKVFaults        *simKVFaultController
 
 	// procCfg holds the active config in process-orchestrator mode so chaos
 	// handlers can resolve per-worker StableID overrides without threading
@@ -533,11 +534,40 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 		cfg.Coordinator.SLO.CatchUpPercent,
 		cfg.Coordinator.SLO.AbsenceThreshold,
 	)
+	// Expand labeled_subsets into a flat per-partition label array. Computed
+	// here — earlier than the weights flattening below it mirrors — because
+	// EnableShutdownOracles (immediately below) needs it to construct the
+	// label-affinity oracle before coord.Start(). Saved for dynamic spawns too.
+	partitionLabels := cfg.Partitions.ExpandLabels()
+	aioPartitionLabels = partitionLabels
+
 	// Create goroutine registry for all-in-one mode chaos.
 	// Must be created BEFORE coord.Start so EnableShutdownOracles can attach
 	// the registry to the oracle watchers before the coordinator's goroutines start.
 	goroutineRegistry := coordinator.NewGoroutineRegistry()
-	coord.EnableShutdownOracles(goroutineRegistry)
+	labelAffinityPartitions := make(map[int]string, len(partitionLabels))
+	for i, label := range partitionLabels {
+		if label != "" {
+			labelAffinityPartitions[i] = label
+		}
+	}
+	// Resolve the same "0 means defer to parti's own default" semantic that
+	// worker.go's override-if-set wiring already applies to every worker's
+	// real partiCfg.LabelSpillGrace (Task 2) — cfg.Workers.LabelSpillGrace==0
+	// means "scenario didn't set it," NOT "zero tolerance" (that's a
+	// different, sim-config-level zero than parti.Config.LabelSpillGrace's
+	// own "0 spills immediately" semantic — see Task 6 review notes). If the
+	// oracle used the raw scenario-config zero directly, it would fire on
+	// any transient mismatch while the real managers underneath are actually
+	// running at parti's 60s default, a false-positive trap for any future
+	// scenario that leaves label_spill_grace unset. Every scenario THIS plan
+	// ships (Tasks 9-12) sets an explicit non-zero value, so this resolution
+	// is defense-in-depth, not something exercised by this plan's own tests.
+	effectiveLabelSpillGrace := cfg.Workers.LabelSpillGrace
+	if effectiveLabelSpillGrace == 0 {
+		effectiveLabelSpillGrace = parti.DefaultConfig().LabelSpillGrace
+	}
+	coord.EnableShutdownOracles(goroutineRegistry, labelAffinityPartitions, effectiveLabelSpillGrace)
 
 	go coord.Start(ctx)
 
@@ -692,6 +722,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			},
 			PartitionCount:      cfg.Partitions.Count,
 			PartitionWeights:    weights,
+			PartitionLabels:     partitionLabels,
 			AssignmentStrategy:  cfg.Workers.AssignmentStrategy,
 			ProcessingDelayMin:  cfg.Workers.ProcessingDelay.Min,
 			ProcessingDelayMax:  cfg.Workers.ProcessingDelay.Max,
@@ -716,6 +747,8 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			PartitionSource:             cfg.Workers.PartitionSource,
 			SourceBucket:                cfg.Workers.SourceBucket,
 			SourceReconcileInterval:     cfg.Workers.SourceReconcileInterval,
+			UnlabeledPartitionPolicy:    cfg.Workers.UnlabeledPartitionPolicy,
+			LabelSpillGrace:             cfg.Workers.LabelSpillGrace,
 			RevocationReportCh:          coord.GetRevocationReportsChannel(),
 			RevocationReportDropFn:      coord.IncRevocationReportDropped,
 		}
@@ -726,6 +759,11 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			return fmt.Errorf("failed to create worker %d: %w", i, err)
 		}
 		w.SetNetworkControl(netCtrl)
+		// Pin the positive-proof collector so every crash+respawn of this sim
+		// worker ID reuses it (workerStart copies workerCfg): label-chaos
+		// counters that increment on whichever incarnation was leader at
+		// detection time then survive a subsequent respawn of that worker.
+		workerCfg.ChaosProof = w.ChaosProof()
 
 		// Create cancelable context for this worker
 		workerCtx, workerCancel := context.WithCancel(ctx)
@@ -759,13 +797,13 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			go func(worker *worker.Worker, id string, wctx context.Context) {
 				if err := worker.Start(wctx); err != nil {
 					log.Printf("Failed to start worker %s: %v", id, err)
-					goroutineRegistry.MarkInactive(id)
+					goroutineRegistry.MarkInactiveObj(id, worker)
 					wcancel()
 					return
 				}
 				<-wctx.Done()
 				worker.Stop()
-				goroutineRegistry.MarkInactive(id)
+				goroutineRegistry.MarkInactiveObj(id, worker)
 			}(nw, workerID, wc)
 		}
 		goroutineRegistry.Register(workerID, coordinator.WorkerGoroutine, workerCancel, workerStart, w)
@@ -774,7 +812,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 		go func(worker *worker.Worker, id string, workerCtx context.Context) {
 			if err := worker.Start(workerCtx); err != nil {
 				log.Printf("Failed to start worker %s: %v", id, err)
-				goroutineRegistry.MarkInactive(id)
+				goroutineRegistry.MarkInactiveObj(id, worker)
 				return
 			}
 
@@ -784,8 +822,9 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 			// Give worker time to cleanup
 			worker.Stop()
 
-			// Worker stopped, mark as inactive
-			goroutineRegistry.MarkInactive(id)
+			// Worker stopped, mark as inactive (incarnation-guarded so a
+			// restart that already re-registered a successor is not clobbered)
+			goroutineRegistry.MarkInactiveObj(id, worker)
 		}(w, workerID, workerCtx)
 
 		// Small pacing delay between starting workers
@@ -1041,6 +1080,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 				inconclusive := tr.GetOwnershipInconclusiveCount()
 				_, unobservedPost := tr.GetOwnershipUnobservedCounts()
 				snapshotOverlaps := coord.GetSnapshotOverlapCount()
+				labelAffinityViol := coord.GetLabelAffinityViolations()
 				doubleLeaders := coord.GetDoubleLeaderObservations()
 				stateReconcileViol := coord.GetStateReconcileViolations()
 				expDegMissing := coord.GetExpectedDegradedMissing()
@@ -1098,18 +1138,69 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 						ldStrictViol++
 					}
 				}
+				// Label positive-proof strict gates (Gap 2+): scenario tasks
+				// fold their own ExpectLabel* checks into this shared counter
+				// rather than each declaring their own OR-condition clause.
+				var labelTakeoverStrictViol int
+				if scenarioHasLabelPoolSpill(cfg) {
+					labelSpills := sumWorkerLabelSpills(goroutineRegistry)
+					if labelSpills == 0 {
+						log.Print("[LabelSpill] STRICT GATE FAIL: label_spills=0 — scenario expects a label pool outage to spill but IncrementLabelSpill never fired")
+						labelTakeoverStrictViol++
+					}
+				}
+				// Label tight-takeover strict gate: only enforced when the
+				// scenario actually schedules label_heartbeat_takeover.
+				// Otherwise labelChangeTriggers==0 is normal and must not
+				// fail unrelated scenarios. labelTakeoverStrictViol is the
+				// shared counter declared above for the spill gate.
+				if scenarioHasLabelHeartbeatTakeover(cfg) {
+					labelChangeTriggers := sumWorkerLabelChangeTriggers(goroutineRegistry)
+					if labelChangeTriggers == 0 {
+						log.Print("[LabelTakeover] STRICT GATE FAIL: label_change_triggers=0 — scenario schedules label_heartbeat_takeover but the tight-takeover fingerprint-change branch never fired")
+						labelTakeoverStrictViol++
+					}
+				}
+				// Label emergency-carve-out strict gate: only enforced when
+				// the scenario opts in via chaos.expect_label_emergency_carveout
+				// (there is no dedicated chaos event to key off of — see
+				// scenarioHasLabelEmergencyCarveout). labelTakeoverStrictViol
+				// is the shared counter declared above for the spill/takeover
+				// gates.
+				if scenarioHasLabelEmergencyCarveout(cfg) {
+					emergencyClaims := sumWorkerEmergencyClaims(goroutineRegistry)
+					if emergencyClaims == 0 {
+						log.Print("[LabelEmergency] STRICT GATE FAIL: emergency_claims=0 — scenario expects an emergency carve-out but StateEmergency was never claimed")
+						labelTakeoverStrictViol++
+					}
+				}
+				// Label relabel-storm coalescing-bound strict gate: only
+				// enforced when the scenario opts in via
+				// chaos.relabel_storm_event_count (see
+				// scenarioHasLabelRelabelStorm). Unlike the spill/takeover
+				// gates above, this is not just "did it fire" but "did it
+				// stay bounded" — a decoalesced storm would make
+				// LabelRechecksRun scale linearly with event count instead
+				// of staying flat, a silent regression rather than a
+				// crash. labelTakeoverStrictViol is the shared counter
+				// declared above for the spill/takeover/emergency gates.
+				// Evaluated via a helper function (unlike its sibling
+				// gates) because its two-branch check pushed this call
+				// site's already-deep control nesting past revive's
+				// max-control-nesting threshold.
+				labelTakeoverStrictViol += checkLabelRelabelStormGate(cfg, goroutineRegistry)
 				claimLossGate := scenarioHasClaimLossChaos(cfg)
-				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 || inconclusive > 0 || unobservedPost > 0 || snapshotOverlaps > 0 || doubleLeaders > 0 || stateReconcileViol > 0 || expDegMissing > 0 || (claimLossGate && unexpClaimLost > 0) || srcConvMissing > 0 || spuriousUnavail > 0 || ldReassignMissing > 0 || (claimLossGate && claimLossOrderViol > 0) || producerResumeMissing > 0 || casStormPanics > 0 || handoffMaxAgeViol > 0 || orphanClaimDrift > 0 || storageTypeViol > 0 || electionReplicasViol > 0 || kvOpRateCeilingViol > 0 || revocationDropped > 0 || ldStrictViol > 0 {
+				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 || inconclusive > 0 || unobservedPost > 0 || snapshotOverlaps > 0 || labelAffinityViol > 0 || doubleLeaders > 0 || stateReconcileViol > 0 || expDegMissing > 0 || (claimLossGate && unexpClaimLost > 0) || srcConvMissing > 0 || spuriousUnavail > 0 || ldReassignMissing > 0 || (claimLossGate && claimLossOrderViol > 0) || producerResumeMissing > 0 || casStormPanics > 0 || handoffMaxAgeViol > 0 || orphanClaimDrift > 0 || storageTypeViol > 0 || electionReplicasViol > 0 || kvOpRateCeilingViol > 0 || revocationDropped > 0 || ldStrictViol > 0 || labelTakeoverStrictViol > 0 {
 					// Record error but proceed to ordered shutdown
-					invariantsErr = fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
-						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
+					invariantsErr = fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d label_affinity_violations=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
+						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, labelAffinityViol, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
 				}
 				if invariantsErr == nil && scenarioHasHandoffClaimWriteFault(cfg) && handoffClaimWriteFaultInjected() == 0 {
 					invariantsErr = errors.New("handoff_claim_write_fault_injected=0: scenario expected at least one claim write to fault")
 				}
 				if invariantsErr == nil {
-					log.Printf("Stability invariants passed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
-						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
+					log.Printf("Stability invariants passed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d label_affinity_violations=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
+						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, labelAffinityViol, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
 				} else {
 					log.Printf("Stability invariants failed: %v", invariantsErr)
 				}
@@ -1156,6 +1247,7 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 				inconclusive := tr.GetOwnershipInconclusiveCount()
 				_, unobservedPost := tr.GetOwnershipUnobservedCounts()
 				snapshotOverlaps := coord.GetSnapshotOverlapCount()
+				labelAffinityViol := coord.GetLabelAffinityViolations()
 				doubleLeaders := coord.GetDoubleLeaderObservations()
 				stateReconcileViol := coord.GetStateReconcileViolations()
 				expDegMissing := coord.GetExpectedDegradedMissing()
@@ -1213,10 +1305,61 @@ func runAllInOne(ctx context.Context, cfg *config.Config, cfgPath string, cooldo
 						ldStrictViol++
 					}
 				}
+				// Label positive-proof strict gates (Gap 2+): scenario tasks
+				// fold their own ExpectLabel* checks into this shared counter
+				// rather than each declaring their own OR-condition clause.
+				var labelTakeoverStrictViol int
+				if scenarioHasLabelPoolSpill(cfg) {
+					labelSpills := sumWorkerLabelSpills(goroutineRegistry)
+					if labelSpills == 0 {
+						log.Print("[LabelSpill] STRICT GATE FAIL: label_spills=0 — scenario expects a label pool outage to spill but IncrementLabelSpill never fired")
+						labelTakeoverStrictViol++
+					}
+				}
+				// Label tight-takeover strict gate: only enforced when the
+				// scenario actually schedules label_heartbeat_takeover.
+				// Otherwise labelChangeTriggers==0 is normal and must not
+				// fail unrelated scenarios. labelTakeoverStrictViol is the
+				// shared counter declared above for the spill gate.
+				if scenarioHasLabelHeartbeatTakeover(cfg) {
+					labelChangeTriggers := sumWorkerLabelChangeTriggers(goroutineRegistry)
+					if labelChangeTriggers == 0 {
+						log.Print("[LabelTakeover] STRICT GATE FAIL: label_change_triggers=0 — scenario schedules label_heartbeat_takeover but the tight-takeover fingerprint-change branch never fired")
+						labelTakeoverStrictViol++
+					}
+				}
+				// Label emergency-carve-out strict gate: only enforced when
+				// the scenario opts in via chaos.expect_label_emergency_carveout
+				// (there is no dedicated chaos event to key off of — see
+				// scenarioHasLabelEmergencyCarveout). labelTakeoverStrictViol
+				// is the shared counter declared above for the spill/takeover
+				// gates.
+				if scenarioHasLabelEmergencyCarveout(cfg) {
+					emergencyClaims := sumWorkerEmergencyClaims(goroutineRegistry)
+					if emergencyClaims == 0 {
+						log.Print("[LabelEmergency] STRICT GATE FAIL: emergency_claims=0 — scenario expects an emergency carve-out but StateEmergency was never claimed")
+						labelTakeoverStrictViol++
+					}
+				}
+				// Label relabel-storm coalescing-bound strict gate: only
+				// enforced when the scenario opts in via
+				// chaos.relabel_storm_event_count (see
+				// scenarioHasLabelRelabelStorm). Unlike the spill/takeover
+				// gates above, this is not just "did it fire" but "did it
+				// stay bounded" — a decoalesced storm would make
+				// LabelRechecksRun scale linearly with event count instead
+				// of staying flat, a silent regression rather than a
+				// crash. labelTakeoverStrictViol is the shared counter
+				// declared above for the spill/takeover/emergency gates.
+				// Evaluated via a helper function (unlike its sibling
+				// gates) because its two-branch check pushed this call
+				// site's already-deep control nesting past revive's
+				// max-control-nesting threshold.
+				labelTakeoverStrictViol += checkLabelRelabelStormGate(cfg, goroutineRegistry)
 				claimLossGate := scenarioHasClaimLossChaos(cfg)
-				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 || inconclusive > 0 || unobservedPost > 0 || snapshotOverlaps > 0 || doubleLeaders > 0 || stateReconcileViol > 0 || expDegMissing > 0 || (claimLossGate && unexpClaimLost > 0) || srcConvMissing > 0 || spuriousUnavail > 0 || ldReassignMissing > 0 || (claimLossGate && claimLossOrderViol > 0) || producerResumeMissing > 0 || casStormPanics > 0 || handoffMaxAgeViol > 0 || orphanClaimDrift > 0 || storageTypeViol > 0 || electionReplicasViol > 0 || kvOpRateCeilingViol > 0 || revocationDropped > 0 || ldStrictViol > 0 {
-					invariantsErr := fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
-						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
+				if failures > 0 || late > 0 || lost > 0 || initialExc > 0 || takeoverExc > 0 || violations > 0 || inconclusive > 0 || unobservedPost > 0 || snapshotOverlaps > 0 || labelAffinityViol > 0 || doubleLeaders > 0 || stateReconcileViol > 0 || expDegMissing > 0 || (claimLossGate && unexpClaimLost > 0) || srcConvMissing > 0 || spuriousUnavail > 0 || ldReassignMissing > 0 || (claimLossGate && claimLossOrderViol > 0) || producerResumeMissing > 0 || casStormPanics > 0 || handoffMaxAgeViol > 0 || orphanClaimDrift > 0 || storageTypeViol > 0 || electionReplicasViol > 0 || kvOpRateCeilingViol > 0 || revocationDropped > 0 || ldStrictViol > 0 || labelTakeoverStrictViol > 0 {
+					invariantsErr := fmt.Errorf("stability invariants failed: audit_failures=%d late=%d lost=%d slow_start_initial=%d slow_start_takeover=%d ownership_violations=%d concurrent_owners=%d inconclusive=%d unobserved_post_chaos=%d snapshot_overlaps=%d label_affinity_violations=%d double_leaders=%d state_reconcile_violations=%d expected_degraded_observed=%d expected_degraded_missing=%d unexpected_claim_lost_shutdown=%d source_convergence_observed=%d source_convergence_missing=%d spurious_source_unavailable=%d long_disconnect_reassignment_observed=%d long_disconnect_reassignment_missing=%d long_disconnect_reassignment_inconclusive=%d long_disconnect_skipped=%d claim_loss_stop_ordering_violations=%d producer_resume_missing=%d assignment_cas_storm_unexpected_panic=%d handoff_bucket_maxage_violation=%d orphan_stable_claim_drift=%d storage_type_violation=%d election_replicas_violation=%d kv_op_rate_ceiling_violation=%d revocation_report_dropped=%d",
+						failures, late, lost, initialExc, takeoverExc, violations, concurrent, inconclusive, unobservedPost, snapshotOverlaps, labelAffinityViol, doubleLeaders, stateReconcileViol, expDegObserved, expDegMissing, unexpClaimLost, srcConvObserved, srcConvMissing, spuriousUnavail, ldReassignObserved, ldReassignMissing, ldReassignInconclusive, ldSkipped, claimLossOrderViol, producerResumeMissing, casStormPanics, handoffMaxAgeViol, orphanClaimDrift, storageTypeViol, electionReplicasViol, kvOpRateCeilingViol, revocationDropped)
 					// Emit the structured failure_report.json so CI artifacts
 					// include InconclusiveOwnerEvents / unobserved counters /
 					// FirstChaosEventAt — auditability that the new
@@ -1701,7 +1844,7 @@ func runProcessOrchestrator(ctx context.Context, cfg *config.Config, cfgPath str
 		coord.SetExpectedWorkers(cfg.Workers.Count)
 	}
 	registry := coordinator.NewGoroutineRegistry()
-	coord.EnableShutdownOracles(registry)
+	coord.EnableShutdownOracles(registry, nil, 0) // label affinity is all-in-one-only; process mode passes nil/0
 	go coord.Start(ctx)
 
 	// IPC smoke oracle (Phase 7a gating; Phase 7b reads its counter).
@@ -2045,7 +2188,8 @@ func handleChaosEvent(
 	case coordinator.BucketDeleteEvent, coordinator.BucketRecreateEvent, coordinator.BucketPeerTakeoverEvent,
 		coordinator.WatcherStallEvent, coordinator.StableIDClaimStealEvent,
 		coordinator.ProducerDisconnectEvent, coordinator.AssignmentCASStormEvent, coordinator.AssignmentBucketDeleteEvent,
-		coordinator.HandoffOrphanClaimWriteEvent, coordinator.KVUnavailableEvent, coordinator.HandoffClaimWriteFaultEvent:
+		coordinator.HandoffOrphanClaimWriteEvent, coordinator.KVUnavailableEvent, coordinator.HandoffClaimWriteFaultEvent,
+		coordinator.LabelHeartbeatTakeoverEvent:
 		// Process-mode dispatch is intentionally a log-and-skip per the
 		// plan's risk note (lines 386-388). Whole-bucket actions in
 		// process mode would need cross-process visibility into the
@@ -2073,7 +2217,7 @@ func handleGoroutineChaos( //nolint:cyclop,gocyclo,funlen,revive // dispatch gro
 	// Guard: skip worker-related events when no active workers
 	activeWorkers := registry.GetActiveCount(coordinator.WorkerGoroutine)
 	switch event {
-	case coordinator.WorkerCrashEvent, coordinator.WorkerRestartEvent, coordinator.LeaderFailureEvent, coordinator.ScaleDownEvent, coordinator.NetworkDisconnectEvent, coordinator.NetworkDisconnectLeaderEvent, coordinator.NetworkDisconnectLongEvent, coordinator.WorkerPauseEvent, coordinator.SlowConsumerEvent, coordinator.BucketPeerTakeoverEvent, coordinator.StableIDClaimStealEvent:
+	case coordinator.WorkerCrashEvent, coordinator.WorkerRestartEvent, coordinator.LeaderFailureEvent, coordinator.ScaleDownEvent, coordinator.NetworkDisconnectEvent, coordinator.NetworkDisconnectLeaderEvent, coordinator.NetworkDisconnectLongEvent, coordinator.WorkerPauseEvent, coordinator.SlowConsumerEvent, coordinator.BucketPeerTakeoverEvent, coordinator.StableIDClaimStealEvent, coordinator.LabelHeartbeatTakeoverEvent:
 		if activeWorkers == 0 {
 			log.Printf("[Chaos] Skipping %s: no active workers", event)
 			return
@@ -2265,6 +2409,11 @@ func handleGoroutineChaos( //nolint:cyclop,gocyclo,funlen,revive // dispatch gro
 		// kv.Put against the victim's stable-ID claim key.
 		target, _ := params["target_worker"].(string)
 		handleBucketPeerTakeover(ctx, registry, target)
+
+	case coordinator.LabelHeartbeatTakeoverEvent:
+		targetWorker, _ := params["target_worker"].(string)
+		newLabels := stringSliceFromParam(params["new_labels"])
+		handleLabelHeartbeatTakeover(ctx, registry, targetWorker, newLabels)
 
 	case coordinator.StableIDTinyPoolRespawnEvent:
 		// Phase 4: spawn a fresh all-in-one worker into the dead worker's
@@ -2475,6 +2624,22 @@ func applyWorkerOverrides(wcfg *worker.Config, scfg *config.Config, workerID str
 			}
 		}
 	}
+	// Per-worker label set, keyed identically to PerWorker.
+	//
+	// This function is also called from runWorker (process-orchestrator
+	// mode, main.go's process-mode worker construction), which does NOT
+	// wire PartitionLabels/UnlabeledPartitionPolicy/LabelSpillGrace into
+	// its worker.Config literal (label plumbing is all-in-one-mode only —
+	// see the sim label design). A scenario that sets workers.labels and
+	// runs in process mode would get WorkerLabels stamped here while every
+	// partition stays unlabeled and the policy/grace fields stay zero-value
+	// — a half-wired, inconsistent state. No current scenario does this
+	// (workers.labels is unused outside all-in-one-mode scenarios), so
+	// this is a latent risk, not an active bug: flag it before extending
+	// label support to process mode.
+	if labels, ok := scfg.Workers.Labels[workerID]; ok {
+		wcfg.WorkerLabels = labels
+	}
 }
 
 // spawnAllInOneWorker creates, registers, and starts a new worker goroutine with the given ID.
@@ -2516,6 +2681,7 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 		},
 		PartitionCount:              aioCfg.Partitions.Count,
 		PartitionWeights:            aioWeights,
+		PartitionLabels:             aioPartitionLabels,
 		AssignmentStrategy:          aioCfg.Workers.AssignmentStrategy,
 		ProcessingDelayMin:          aioCfg.Workers.ProcessingDelay.Min,
 		ProcessingDelayMax:          aioCfg.Workers.ProcessingDelay.Max,
@@ -2539,6 +2705,8 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 		PartitionSource:             aioCfg.Workers.PartitionSource,
 		SourceBucket:                aioCfg.Workers.SourceBucket,
 		SourceReconcileInterval:     aioCfg.Workers.SourceReconcileInterval,
+		UnlabeledPartitionPolicy:    aioCfg.Workers.UnlabeledPartitionPolicy,
+		LabelSpillGrace:             aioCfg.Workers.LabelSpillGrace,
 		RevocationReportCh:          aioCoord.GetRevocationReportsChannel(),
 		RevocationReportDropFn:      aioCoord.IncRevocationReportDropped,
 	}
@@ -2549,6 +2717,8 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 		return false
 	}
 	w.SetNetworkControl(netCtrl)
+	// Pin the positive-proof collector across respawns (startFn copies wcfg).
+	wcfg.ChaosProof = w.ChaosProof()
 
 	wctx, wcancel := context.WithCancel(parent)
 	var startFn func(context.Context)
@@ -2578,25 +2748,25 @@ func spawnAllInOneWorker(parent context.Context, workerID string) bool {
 		go func(ww *worker.Worker, id string, c context.Context) {
 			if err := ww.Start(c); err != nil {
 				log.Printf("[ScaleUp] start error for %s: %v", id, err)
-				aioRegistry.MarkInactive(id)
+				aioRegistry.MarkInactiveObj(id, ww)
 				pcancel()
 				return
 			}
 			<-c.Done()
 			ww.Stop()
-			aioRegistry.MarkInactive(id)
+			aioRegistry.MarkInactiveObj(id, ww)
 		}(nw, workerID, pc)
 	}
 	aioRegistry.Register(workerID, coordinator.WorkerGoroutine, wcancel, startFn, w)
 	go func(ww *worker.Worker, id string, c context.Context) {
 		if err := ww.Start(c); err != nil {
 			log.Printf("[ScaleUp] start error for %s: %v", id, err)
-			aioRegistry.MarkInactive(id)
+			aioRegistry.MarkInactiveObj(id, ww)
 			return
 		}
 		<-c.Done()
 		ww.Stop()
-		aioRegistry.MarkInactive(id)
+		aioRegistry.MarkInactiveObj(id, ww)
 	}(w, workerID, wctx)
 
 	return true
@@ -3085,6 +3255,213 @@ func scenarioHasHandoffClaimWriteFault(cfg *config.Config) bool {
 	}
 
 	return scenarioHasChaosEvent(cfg, coordinator.HandoffClaimWriteFaultEvent)
+}
+
+// scenarioHasLabelPoolSpill reports whether the configured scenario expects
+// a labeled pool to fully empty and spill its partitions to the unlabeled
+// fallback (types.LabelMetrics.IncrementLabelSpill). Opt-in via
+// chaos.expect_label_spill so ordinary scenarios with labeled partitions
+// that never fully lose a pool aren't held to this stricter gate.
+func scenarioHasLabelPoolSpill(cfg *config.Config) bool {
+	return cfg.Chaos.ExpectLabelSpill
+}
+
+// scenarioHasLabelHeartbeatTakeover reports whether the scenario config
+// schedules at least one label_heartbeat_takeover event (random pool or
+// scheduled_events), gating the strict positive-proof assertion so
+// unrelated scenarios aren't affected.
+func scenarioHasLabelHeartbeatTakeover(cfg *config.Config) bool {
+	return scenarioHasChaosEvent(cfg, coordinator.LabelHeartbeatTakeoverEvent)
+}
+
+// scenarioHasLabelEmergencyCarveout reports whether the scenario config
+// opts into the strict emergency-carve-out positive-proof gate. Unlike
+// scenarioHasLabelHeartbeatTakeover, this is NOT inferred from a chaos
+// event name: there is no dedicated "emergency" event, since emergency is
+// a calculator-side reaction to enough simultaneous worker deaths rather
+// than a chaos primitive in its own right. Keyed off an explicit opt-in
+// config marker instead, so ordinary burst-kill scenarios that don't
+// intend to prove the emergency path aren't held to this stricter gate.
+func scenarioHasLabelEmergencyCarveout(cfg *config.Config) bool {
+	return cfg.Chaos.ExpectLabelEmergencyCarveout
+}
+
+// scenarioHasLabelRelabelStorm reports whether the scenario config opts
+// into the strict recheck-coalescing positive-proof gate. Like
+// scenarioHasLabelEmergencyCarveout, this is keyed off an explicit opt-in
+// counter (chaos.relabel_storm_event_count) rather than a chaos-event name
+// lookup, since the gate needs the scenario's own event count to compute
+// its coalescing ceiling, not just a yes/no signal.
+func scenarioHasLabelRelabelStorm(cfg *config.Config) bool {
+	return cfg.Chaos.RelabelStormEventCount > 0
+}
+
+// checkLabelRelabelStormGate evaluates the relabel-storm scenario's
+// coalescing-bound positive-proof gate: unlike the spill/takeover/
+// emergency gates ("did it fire at all"), this asserts the recheck count
+// stayed BOUNDED under a storm of triggers rather than growing without
+// limit (a stuck pendingLabelRecheck flag or a drain tick that keeps
+// re-firing after it should have cleared would be a silent regression,
+// not a crash). Returns 1 if the gate fails, 0 otherwise, for the caller
+// to accumulate into the shared labelTakeoverStrictViol counter. A no-op
+// (returns 0) unless the scenario opts in via
+// chaos.relabel_storm_event_count.
+//
+// Ceiling rationale (see the YAML comment for the full empirical trace):
+// an earlier draft of this gate assumed heavy coalescing would compress
+// the storm's 20 triggering events into a handful of actual reruns
+// (event_count/2 = 10 ceiling). Empirically that assumption was wrong FOR
+// THIS SCENARIO'S CADENCE: at 2s between events, each relabel's rebalance
+// completes well before the next one arrives, so there is rarely a
+// still-in-flight run for a new signal to coalesce against — the healthy,
+// stable baseline (5/5 local runs, label_spill topology fixed to avoid
+// the fleet-wide-empty-pool path) is 19 of 20 events producing their own
+// successful "label_recheck" rebalance. The gate's real value here is
+// proving the count does NOT keep growing during the ~40s of quiet after
+// the storm ends (it doesn't, across all empirical runs) and does not
+// multiply per-partition or per-tick. event_count*3/2 gives ~58%
+// headroom over the observed 19 while still catching a regression that
+// pushes back toward "more than one successful rerun per triggering
+// event" (observed at ~1.4x under the pre-fix topology that emptied the
+// vip-a pool on every flap — see the YAML comment).
+func checkLabelRelabelStormGate(cfg *config.Config, registry *coordinator.GoroutineRegistry) int {
+	if !scenarioHasLabelRelabelStorm(cfg) {
+		return 0
+	}
+	labelRechecksRun := sumWorkerLabelRechecksRun(registry)
+	ceiling := cfg.Chaos.RelabelStormEventCount * 3 / 2
+	switch {
+	case labelRechecksRun == 0:
+		log.Print("[LabelStorm] STRICT GATE FAIL: label_rechecks_run=0 — scenario storms label_heartbeat_takeover but no recheck ever actually ran")
+		return 1
+	case int(labelRechecksRun) > ceiling:
+		log.Printf("[LabelStorm] STRICT GATE FAIL: label_rechecks_run=%d exceeds coalescing ceiling=%d (event_count=%d) — pendingLabelRecheck coalescing appears to have decoalesced under storm load",
+			labelRechecksRun, ceiling, cfg.Chaos.RelabelStormEventCount)
+		return 1
+	}
+
+	return 0
+}
+
+// sumWorkerLabelSpills totals ChaosProofMetrics.LabelSpills() across every
+// worker goroutine ever registered, active or not.
+//
+// Deliberately GetAll() + manual type filter rather than
+// GetByType(WorkerGoroutine): GetByType only returns Active==true entries,
+// and the final-gate block that calls this runs AFTER the ordered-shutdown
+// wait loop has already driven every worker's Active flag to false —
+// GetByType would always observe zero workers there and silently zero out
+// the result regardless of what actually happened. GetAll() is immune to
+// that ordering and also picks up spills recorded by a worker that was
+// later crashed by this very scenario (e.g. the vip-a leader itself,
+// before a peer took over).
+func sumWorkerLabelSpills(registry *coordinator.GoroutineRegistry) int64 {
+	if registry == nil {
+		return 0
+	}
+	var total int64
+	for _, info := range registry.GetAll() {
+		if info.Type != coordinator.WorkerGoroutine {
+			continue
+		}
+		if w, ok := info.Obj.(*worker.Worker); ok {
+			total += w.ChaosProof().LabelSpills()
+		}
+	}
+
+	return total
+}
+
+// sumWorkerLabelChangeTriggers totals ChaosProofMetrics.LabelChangeTriggers()
+// across every worker goroutine ever registered, active or not. Mirrors
+// sumWorkerLabelSpills's GetAll()-over-GetByType(Active-only) choice for the
+// same two reasons: the final-gate block that calls this runs AFTER the
+// ordered-shutdown wait loop has already driven every worker's Active flag
+// to false (GetByType would always observe zero workers), and
+// LabelChangeTriggers increments on whichever worker's Calculator was the
+// CURRENT LEADER at the moment its WorkerMonitor observed the fingerprint
+// mismatch (calculator.go's SetOnLabelChange wiring) — not necessarily the
+// takeover target.
+//
+// GetAll() alone is NOT sufficient when concurrent leader-flap chaos
+// (leader_failure) crashes and respawns the very leader that detected a
+// change: Register replaces that id's entry with a fresh *worker.Worker, so
+// GetAll() would return a successor whose freshly-allocated collector reads 0
+// and the earlier count would be lost. The all-in-one construction pins the
+// collector across respawns (worker.Config.ChaosProof, set from the first
+// incarnation's ChaosProof()), so the successor keeps accumulating into the
+// same instance and GetAll() reads the preserved total.
+func sumWorkerLabelChangeTriggers(registry *coordinator.GoroutineRegistry) int64 {
+	if registry == nil {
+		return 0
+	}
+	var total int64
+	for _, info := range registry.GetAll() {
+		if info.Type != coordinator.WorkerGoroutine {
+			continue
+		}
+		if w, ok := info.Obj.(*worker.Worker); ok {
+			total += w.ChaosProof().LabelChangeTriggers()
+		}
+	}
+
+	return total
+}
+
+// sumWorkerEmergencyClaims totals ChaosProofMetrics.EmergencyClaims() across
+// every worker goroutine ever registered, active or not. Mirrors
+// sumWorkerLabelChangeTriggers's GetAll()-over-GetByType(Active-only) choice
+// for the same reasons: the gate blocks that call this run at (or after) the
+// ordered-shutdown wait loop where GetByType would observe zero active
+// workers, and RecordEmergencyRebalance increments on whichever worker's
+// Calculator was the CURRENT LEADER at the moment its EmergencyDetector
+// confirmed the disappeared workers — not necessarily one of the crashed
+// workers themselves. The same collector-pinning-across-respawns mechanism
+// (worker.Config.ChaosProof) keeps the count intact if the leader itself
+// later restarts.
+func sumWorkerEmergencyClaims(registry *coordinator.GoroutineRegistry) int64 {
+	if registry == nil {
+		return 0
+	}
+	var total int64
+	for _, info := range registry.GetAll() {
+		if info.Type != coordinator.WorkerGoroutine {
+			continue
+		}
+		if w, ok := info.Obj.(*worker.Worker); ok {
+			total += w.ChaosProof().EmergencyClaims()
+		}
+	}
+
+	return total
+}
+
+// sumWorkerLabelRechecksRun totals ChaosProofMetrics.LabelRechecksRun()
+// across every worker goroutine ever registered, active or not. Mirrors
+// sumWorkerEmergencyClaims's GetAll()-over-GetByType(Active-only) choice
+// for the same reason: the gate blocks that call this run at (or after)
+// the ordered-shutdown wait loop where GetByType would observe zero
+// active workers and silently zero out the result — the storm scenario's
+// coalescing-bound check would then spuriously read
+// labelRechecksRun==0 and trip the "no recheck ever ran" branch instead
+// of the intended "decoalesced" branch, on every run. Uses the same
+// collector-pinning-across-respawns mechanism (worker.Config.ChaosProof)
+// as its siblings if a worker restarts mid-run.
+func sumWorkerLabelRechecksRun(registry *coordinator.GoroutineRegistry) int64 {
+	if registry == nil {
+		return 0
+	}
+	var total int64
+	for _, info := range registry.GetAll() {
+		if info.Type != coordinator.WorkerGoroutine {
+			continue
+		}
+		if w, ok := info.Obj.(*worker.Worker); ok {
+			total += w.ChaosProof().LabelRechecksRun()
+		}
+	}
+
+	return total
 }
 
 // workerStateShutdownInt mirrors coordinator.workerStateShutdown (the int

--- a/test/simulation/configs/label_emergency_carveout.yaml
+++ b/test/simulation/configs/label_emergency_carveout.yaml
@@ -1,0 +1,221 @@
+# Gap 4 — emergency carve-out under concurrent instability.
+#
+# A burst-kill that empties the vip-a pool (worker-0/1/2, all no_restart)
+# runs concurrently with a label_heartbeat_takeover on a SEPARATE,
+# surviving, initially-unlabeled worker (worker-4) — so trust gating (the
+# calculator's emergency carve-out) and label state genuinely race, rather
+# than being tested as isolated straight-line calls (the only existing
+# coverage, TestRebalance_EmergencyCarveOut_LabeledSurvivor in
+# internal/assignment/calculator_labels_test.go, manually pokes
+# calc.disappearedWorkers and calls calc.rebalance directly — no real
+# timing, no concurrent label churn).
+#
+# Positive-proof gate (chaos.expect_label_emergency_carveout, wired in
+# main.go): the run fails if EmergencyClaims() (RecordEmergencyRebalance)
+# is 0 across the fleet, even with zero oracle violations — a burst-kill
+# that never actually reaches the emergency lifecycle would otherwise pass
+# vacuously.
+#
+# KILL STAGGERING — READ BEFORE "fixing" this back to 3 simultaneous kills:
+#
+# The 3 vip-a workers die one at a time, 20s apart (t=20s/40s/60s), not in
+# a tight simultaneous window. This is deliberate, evidence-based scenario
+# design forced by two rounds of empirical failure — see task-11-report.md
+# for the full investigation trace. Summary:
+#
+#   Round 1 (3 simultaneous kills): leader election in this harness is a
+#   first-come KV-Create race with no affinity to registry ID, so the
+#   pre-crash LEADER is, in effect, a random draw among all workers. If the
+#   leader happens to be one of the 3 killed, the surviving fleet elects a
+#   brand-new leader whose Calculator starts with an EMPTY EmergencyDetector
+#   and an empty lastWorkers baseline — its first action is the
+#   "takeover_immediate" lifecycle (calculator.go), an immediate rebalance
+#   covering whatever it currently observes (the 3 survivors) as its OWN
+#   baseline. That new leader has no memory that 6 workers ever existed, so
+#   it never sees a worker-count DROP relative to a prior observation, and
+#   EmergencyDetector.CheckEmergency never gets a "prev has it, curr
+#   doesn't" transition to track — RecordEmergencyRebalance requires
+#   exactly that transition, so it's never called. This is correct,
+#   intentional production behavior (a new leader legitimately can't know
+#   what it never observed), NOT a bug. Roughly half of simultaneous-kill
+#   trial runs hit this.
+#
+#   Round 2 (1-then-2 staggered kill, ~18s apart): cuts the failure
+#   probability substantially but does not eliminate it — if the SAME
+#   leader-lands-on-a-kill-target coincidence recurs for the second wave
+#   (now a 2-of-5 draw instead of 3-of-6), EmergencyClaims() can still land
+#   at 0 for the whole run. Reproduced empirically (task-11-report.md run
+#   15).
+#
+#   Fully sequential staggering (this file, 20s apart) reduces the residual
+#   to a compound coincidence: EVERY one of the 3 kills would have to ALSO
+#   be the then-current leader, IN SEQUENCE (leader lands on worker-0, its
+#   successor lands on worker-1, THAT successor lands on worker-2) — each
+#   successor is drawn from a shrinking pool of survivors with no bias
+#   toward the next scheduled victim, so the compound probability is on the
+#   order of 1% rather than the ~15-50% of the tighter variants. 20s
+#   between kills is chosen because it comfortably exceeds the calculator's
+#   10s post-takeover stabilization window (entering/exiting the "Scaling"
+#   state after a takeover_immediate rebalance) plus election overhead, so
+#   whichever worker is leader by the time of the NEXT kill has had time to
+#   reach a stable, accurate view — the "fresh leader with no memory" case
+#   can only recur if the new leader ALSO happens to be the next scheduled
+#   victim, not merely "some leader change happened recently."
+#
+#   This does trade away the "near-simultaneous 3-of-3" framing for "3
+#   sequential deaths, each independently exercising the SAME emergency
+#   confirmation mechanism" — mechanically equivalent proof of the
+#   RecordEmergencyRebalance path (the calculator does not distinguish a
+#   batch confirmation from a sequence of solo ones; EmergencyClaims()
+#   counts CALLS, not magnitude), just without the "3 workers vanish in the
+#   same 400ms" narrative. Given the reliability cost of preserving that
+#   narrative (empirically ~15-50% failure across two prior designs), this
+#   is the right trade.
+#
+# Timing model (6 workers; no heartbeat/emergency overrides — this
+# scenario deliberately runs on parti's DEFAULT HeartbeatInterval=5s /
+# HeartbeatTTL=15s / EmergencyGracePeriod=7.5s, i.e. production values, not
+# scenario-shortened ones):
+#   - a crashed worker's heartbeat key is explicitly deleted as part of its
+#     shutdown cleanup (confirmed via KeyValueDeleteOp in the heartbeat
+#     watcher log), so detection is watcher-fast (<1s), NOT gated by the
+#     15s HeartbeatTTL. Confirmation is dominated by EmergencyGracePeriod
+#     (7.5s) plus scheduling overhead, so EmergencyClaims()>0 typically
+#     lands within ~10s of a tracked disappearance on a stable (non-failed-
+#     over) leader.
+#   - killing 3 of 6 (50% survive) sits exactly at the calculator's 50%
+#     "sharply shrunk" floor (WorkerShrinkConfirmationThresholdPct) boundary
+#     (observed*100 < lastKnown*50 is false at exactly 50%), so the shrink
+#     is never flagged suspicious independent of emergency confirmation —
+#     this is not a floor-triggering scenario.
+#   - the min_workers guard does NOT gate this scenario's kills: an explicit
+#     target_worker + no_restart:true routes to handleTargetedWorkerCrash
+#     (stableid_chaos.go), which has no min_workers check at all (unlike
+#     the random handleWorkerGoroutineCrash / scale_down paths). min_workers
+#     is set anyway for documentation parity with the other label scenarios
+#     and in case a future edit adds random chaos.events here.
+#   - NOT evidence of a code defect (dry-run finding): a 7-worker variant
+#     of this scenario intermittently tripped slow_start_initial because
+#     one worker's cold-start convergence occasionally exceeded the 25s
+#     budget under a labeled, all-in-one, -race build with 7 concurrent
+#     managers. 6 workers converges in ~10s flat across every trial;
+#     widen the worker count only with fresh empirical verification.
+#
+# The concurrent worker-4 takeover (unlabeled -> vip-a at t=60s, back to
+# unlabeled at t=100s) exercises the SAME tight-takeover fast path Task
+# 10's flagship scenario proved (SetOnLabelChange -> requestLabelRecheck).
+# It is timed to land on the THIRD kill (t=60s) — the moment the vip-a pool
+# actually empties — so the label-recheck rebalance genuinely races the
+# emergency-confirmation path for the same event, not an earlier, still-
+# partially-covered moment.
+#
+# IMPORTANT — worker-4 can NEVER durably become a vip-a partition's owner
+# via this primitive, and that is not a bug either. Discovered during this
+# task's investigation: label_heartbeat_takeover rewrites ONLY the KV
+# heartbeat entry, never the target's own Manager/Config. When the
+# calculator computes an assignment for worker-4 using the tampered
+# (vip-a) label, worker-4's OWN manager compares the payload's WorkerLabels
+# against its own config-time belief ([]), finds a mismatch, and logs
+# "rejecting assignment computed for a different incarnation of this
+# worker ID" — a deliberate safety check against processing an assignment
+# meant for a different incarnation of the same worker ID, and correct
+# here too: worker-4 has no way to distinguish "my heartbeat was
+# legitimately relabeled" from "this assignment is stale, computed before
+# a restart changed my labels." The vip-a partitions therefore always
+# settle on an ALREADY label-consistent unlabeled survivor (worker-3 or
+# worker-5) via the normal park-then-spill path, not on worker-4 — the
+# same outcome label_pool_outage_spill.yaml already proves, here happening
+# concurrently with the emergency path and the takeover's OWN
+# LabelChangeTriggers()-proving fingerprint-mismatch detection (both still
+# fire independently of where the partitions end up).
+#
+# label_spill_grace=15s. LabelAffinityOracle's threshold is
+# spillGrace+labelAffinitySettleAllowance; the latter was widened from 2s
+# to 20s during this task's investigation specifically to absorb a leader
+# failover's ~10s stabilization window plus election overhead landing
+# in front of the label pipeline's first chance to observe the empty pool
+# (see oracles.go's doc comment on labelAffinitySettleAllowance for the
+# full trace) — re-verified harmless for label_pool_outage_spill.yaml and
+# label_tight_takeover_churn.yaml (task-11-report.md).
+
+simulation:
+  duration: 2m30s
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 20
+  message_rate_per_partition: 2
+  distribution: uniform
+  labeled_subsets:
+    - label: vip-a
+      start: 0
+      end: 6
+
+producers:
+  count: 2
+
+workers:
+  count: 6
+  assignment_strategy: WeightedConsistentHash
+  processing_delay:
+    min: 1ms
+    max: 5ms
+  ack_wait: 20s
+  unlabeled_partition_policy: shared
+  label_spill_grace: 15s
+  labels:
+    worker-0: [vip-a]
+    worker-1: [vip-a]
+    worker-2: [vip-a]
+
+chaos:
+  enabled: true
+  interval: "3600s-3601s" # no random chaos; deterministic scheduled events only
+  events: []
+  min_workers: 3
+  expect_label_emergency_carveout: true
+  scheduled_events:
+    # Sequential vip-a pool teardown, 20s apart — see KILL STAGGERING above
+    # for why this isn't a tight simultaneous burst.
+    - at: 20s
+      event: worker_crash
+      params:
+        target_worker: worker-0
+        no_restart: true
+    - at: 40s
+      event: worker_crash
+      params:
+        target_worker: worker-1
+        no_restart: true
+    - at: 60s
+      event: worker_crash
+      params:
+        target_worker: worker-2
+        no_restart: true
+    # Concurrent, independent label churn on a surviving unlabeled worker,
+    # timed to the moment the vip-a pool actually empties (the third kill).
+    - at: 60s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-4
+        new_labels: [vip-a]
+    - at: 100s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-4
+        new_labels: []
+
+coordinator:
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 45s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/label_pool_outage_spill.yaml
+++ b/test/simulation/configs/label_pool_outage_spill.yaml
@@ -1,0 +1,101 @@
+# Gap 2 — label pool-outage park-then-spill under real chaos timing.
+#
+# 2 of 6 workers labeled "vip-a"; 20% of partitions carry that label.
+# Both vip-a workers are killed (no_restart) at t=20s/22s, leaving the
+# label's pool fully empty for the rest of the run. Asserts (via the
+# coordinator's final gate + LabelAffinityOracle):
+#   - the run completes with zero ownership_violations / snapshot_overlaps
+#     (standard invariants, unaffected by labels)
+#   - the strict positive-proof gate (chaos.expect_label_spill, wired in
+#     main.go) requires ChaosProofMetrics.LabelSpills() > 0 across the
+#     fleet: at least one partition actually spilled from the dead vip-a
+#     pool to the unlabeled/shared fallback. Empirically 100% reliable
+#     across every trial run — IncrementLabelSpill always fires once the
+#     pool is confirmed empty.
+#
+# label_spill_grace=8s keeps the run short while still exercising a real
+# park->spill transition (default production value is 60s; scenario
+# configs shorten timers the same way chaos_stableid_tiny_pool.yaml
+# shortens WorkerIDTTL).
+#
+# HISTORICAL NOTE (finding, now fixed — see task-9-report.md and
+# task-9b-report.md for the full investigation): tuning runs for this
+# scenario originally found the label_affinity_violations==0 assertion
+# flaky (~40-50% failure) regardless of label_spill_grace's value, with
+# every failure landing right at the grace boundary
+# (age=X.05s > grace=Xs). Root cause: LabelAffinityOracle.Check()
+# (test/simulation/internal/coordinator/oracles.go) originally compared
+# directly against label_spill_grace with no allowance for the shipped
+# label-assignment feature's own documented "rebalance / handoff" phase
+# (see docs/LABELS.md's worst-case-stall formula: heartbeat-TTL detection
+# + confirmation + LabelSpillGrace + rebalance/handoff) — the normal
+# debounce and two-phase handoff/processing-gate latency any reassignment
+# already pays before its effect is externally observable via
+# AssignmentReports. This was NOT a production bug (internal/assignment/
+# labels_state.go's 50ms scheduling-margin constant works exactly as
+# designed); the gap was in the oracle's threshold model. Fixed in Task 9b
+# by adding LabelAffinityOracle.labelAffinitySettleAllowance (2s, additive
+# on top of label_spill_grace) — verified 8/8 reliable across empirical
+# trials after the fix.
+
+simulation:
+  duration: 90s
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 20
+  message_rate_per_partition: 2
+  distribution: uniform
+  labeled_subsets:
+    - label: vip-a
+      start: 0
+      end: 4 # 20% of partitions
+
+producers:
+  count: 2
+
+workers:
+  count: 6
+  assignment_strategy: WeightedConsistentHash
+  processing_delay:
+    min: 1ms
+    max: 5ms
+  ack_wait: 20s
+  unlabeled_partition_policy: shared
+  label_spill_grace: 8s
+  labels:
+    worker-0: [vip-a]
+    worker-1: [vip-a]
+
+chaos:
+  enabled: true
+  interval: "3600s-3601s" # no random chaos; deterministic scheduled pair only
+  events: []
+  min_workers: 4
+  expect_label_spill: true
+  scheduled_events:
+    - at: 20s
+      event: worker_crash
+      params:
+        target_worker: worker-0
+        no_restart: true
+    - at: 22s
+      event: worker_crash
+      params:
+        target_worker: worker-1
+        no_restart: true
+
+coordinator:
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 45s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/label_relabel_storm.yaml
+++ b/test/simulation/configs/label_relabel_storm.yaml
@@ -1,0 +1,126 @@
+# Gap 5 — repeated label-flap storm, isolating fingerprint/coalescing
+# durability from the concurrent-rebalance racing gap 3 already covers.
+#
+# 20 label_heartbeat_takeover events on the same worker (worker-0) at 2s
+# intervals (well under any rebalance-settling window), no concurrent
+# leader-flap chaos. Proves:
+#   - fingerprint durability survives repeated flapping (not just the one
+#     restart the existing stress test covers)
+#   - pendingLabelRecheck stays BOUNDED under the storm: it does not keep
+#     growing after the storm ends, and does not multiply per-partition or
+#     per-tick (see EMPIRICAL FINDINGS below for what "bounded" turned out
+#     to mean here in practice).
+#
+# TOPOLOGY, READ BEFORE "fixing" this back to a single vip-a carrier:
+#
+# worker-1 also carries vip-a, permanently (never touched by chaos), so the
+# vip-a pool always has >= 1 live carrier even while worker-0 is flapped to
+# vip-b. The first draft of this scenario declared vip-a on worker-0 ALONE
+# — every flap to vip-b then emptied the vip-a pool FLEET-WIDE (worker-0
+# was the only carrier), which is Gap 2's pool-outage/spill mechanic
+# (already covered by label_pool_outage_spill.yaml), not Gap 5's isolated
+# fingerprint/coalescing mechanic this scenario targets. Empirically this
+# made every flap a "first observation of a disruptive condition" in
+# calculator.go's deriveRebalanceAssignments — each one independently
+# earning its own deferred-then-confirmed pair of successful
+# RecordRebalanceAttempt("label_recheck", true) calls (spec §8.3's
+# guaranteed-second-observation dance) — producing 28 recheck runs from 20
+# events (1.4x) instead of the isolated single-worker-relabel behavior the
+# scenario name promises. Giving vip-a a second, non-flapping carrier
+# (mirroring label_tight_takeover_churn.yaml's 6-worker/3-vip-a-carrier
+# ratio, scaled down) keeps every flap a benign roster change within an
+# already-populated pool.
+#
+# EMPIRICAL FINDINGS (5/5 local runs after the topology fix, identical
+# every time — see task-12-report.md for the full trace):
+#
+#   label_rechecks_run = 19 (of 20 events), stable with zero variance.
+#
+# This is NOT the "typically 1-3 per drain-tick window" heavy-coalescing
+# outcome an earlier draft of this comment predicted. At this scenario's
+# 2s event cadence, this small (4-worker, 16-partition) harness's
+# label_recheck rebalance completes well before the next event arrives —
+# there is essentially no still-in-flight run for a new signal to
+# coalesce against, so the healthy baseline is close to one successful
+# recheck PER triggering event, not a compressed handful. The gate's real
+# value is proving the count does not keep growing during the ~40s of
+# quiet after the last scheduled event (it doesn't, 5/5 runs) — a stuck
+# pendingLabelRecheck flag or a drain tick that re-fires after it should
+# have cleared would show up as growth there, not as a raw count near 20.
+# main.go's checkLabelRelabelStormGate ceiling is
+# relabel_storm_event_count * 3 / 2 (30 for this scenario): ~58% headroom
+# over the observed 19, while still catching a regression that pushes
+# back toward "more than one successful rerun per triggering event" (the
+# ~1.4x this scenario itself measured under the pre-fix topology above).
+
+simulation:
+  duration: 90s
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 16
+  message_rate_per_partition: 2
+  distribution: uniform
+  labeled_subsets:
+    - label: vip-a
+      start: 0
+      end: 4
+
+producers:
+  count: 1
+
+workers:
+  count: 4
+  assignment_strategy: WeightedConsistentHash
+  processing_delay:
+    min: 1ms
+    max: 5ms
+  ack_wait: 15s
+  unlabeled_partition_policy: shared
+  label_spill_grace: 8s
+  labels:
+    worker-0: [vip-a]
+    worker-1: [vip-a]
+
+chaos:
+  enabled: true
+  interval: "3600s-3601s"
+  events: []
+  min_workers: 3
+  relabel_storm_event_count: 20
+  scheduled_events:
+    - {at: 10s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 12s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 14s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 16s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 18s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 20s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 22s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 24s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 26s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 28s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 30s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 32s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 34s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 36s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 38s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 40s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 42s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 44s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+    - {at: 46s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-b]}}
+    - {at: 48s,  event: label_heartbeat_takeover, params: {target_worker: worker-0, new_labels: [vip-a]}}
+
+coordinator:
+  gap_aging: 45s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 30s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/configs/label_tight_takeover_churn.yaml
+++ b/test/simulation/configs/label_tight_takeover_churn.yaml
@@ -1,0 +1,122 @@
+# Gap 3 (flagship) — concurrent label-change vs. in-flight rebalance/election.
+#
+# Repeatedly rewrites worker-2's live heartbeat entry with a different
+# label set (label_heartbeat_takeover) while background leader-flap chaos
+# (leader_failure / network_disconnect_leader, chaos_gate.yaml's pattern)
+# runs concurrently, so the relabel genuinely races an in-flight
+# rebalance/election rather than landing in a quiet window.
+#
+# Positive-proof gate (main.go scenarioHasLabelHeartbeatTakeover strict
+# check): label_change_triggers must be > 0, or the run fails even with
+# zero oracle violations — a primitive that silently missed the live key
+# must not pass by accident.
+#
+# The schedule's final event (165s) cures worker-2 back to its TRUE config
+# label (vip-a), mirroring every prior mismatch->cure pair (30s apart) in
+# this schedule. Without a trailing cure, the LAST mismatch (135s, vip-b)
+# has no scheduled event to trigger an immediate re-check, so clearing it
+# depends entirely on production's real spill/rebalance completing within
+# spillGrace+settleAllowance (30s) while concurrent leader-failure chaos is
+# also running — empirically this took 35-42s in 3/8 runs (Task 10d's
+# 8-run baseline against the original 5-event schedule), exceeding the
+# threshold and firing a spurious violation. Every OTHER mismatch in this
+# schedule is followed by a scheduled cure at the same 30s cadence and
+# never violated once across that same 8-run baseline (0/32 pair-instances)
+# — because LabelAffinityOracle.SetLiveLabelOverride (see oracles.go)
+# triggers an immediate re-check in the same critical section as the
+# override update, so a scheduled cure always resolves before any
+# unrelated Check() call can observe a stale, aged mismatch. Adding a 6th
+# event at the same cadence gives the final mismatch the identical
+# protection the other four already have, instead of relying on a real
+# production rebalance to win a race against concurrent chaos.
+#
+# Run under -race (see task-10-report.md for the exact build/run commands
+# and empirical trial results; task-10d-report.md for the trailing-cure
+# fix and its own empirical verification).
+
+simulation:
+  duration: 3m
+  mode: all-in-one
+
+nats:
+  mode: embedded
+
+partitions:
+  count: 24
+  message_rate_per_partition: 3
+  distribution: uniform
+  labeled_subsets:
+    - label: vip-a
+      start: 0
+      end: 6
+
+producers:
+  count: 2
+
+workers:
+  count: 6
+  assignment_strategy: WeightedConsistentHash
+  processing_delay:
+    min: 5ms
+    max: 20ms
+  ack_wait: 20s
+  unlabeled_partition_policy: shared
+  label_spill_grace: 10s
+  labels:
+    worker-0: [vip-a]
+    worker-1: [vip-a]
+    worker-2: [vip-a]
+
+chaos:
+  enabled: true
+  # Background leader-flap noise, chaos_gate.yaml's pattern.
+  interval: "15s-25s"
+  min_workers: 4
+  max_workers: 8
+  events:
+    - leader_failure
+    - network_disconnect_leader
+    - worker_pause
+  scheduled_events:
+    - at: 15s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-2
+        new_labels: [vip-b]
+    - at: 45s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-2
+        new_labels: [vip-a]
+    - at: 75s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-2
+        new_labels: [vip-b]
+    - at: 105s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-2
+        new_labels: [vip-a]
+    - at: 135s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-2
+        new_labels: [vip-b]
+    - at: 165s
+      event: label_heartbeat_takeover
+      params:
+        target_worker: worker-2
+        new_labels: [vip-a]
+
+coordinator:
+  gap_aging: 60s
+  slo:
+    enable_catch_up: true
+    catch_up_deadline: 45s
+    catch_up_percent: 99
+    absence_threshold: 5s
+
+metrics:
+  prometheus:
+    enabled: false

--- a/test/simulation/internal/config/config.go
+++ b/test/simulation/internal/config/config.go
@@ -68,6 +68,41 @@ type PartitionsConfig struct {
 	MessageRatePerPartition float64       `yaml:"message_rate_per_partition"` // Messages per second per partition
 	Distribution            string        `yaml:"distribution"`               // "uniform", "exponential"
 	Weights                 WeightsConfig `yaml:"weights"`
+
+	// LabeledSubsets declares label assignment for contiguous partition
+	// index ranges. Partitions not covered by any subset are unlabeled
+	// (Label == ""). Ranges must not overlap and must stay within
+	// [0, Count). Mirrors WeightsConfig's declarative-range style but for
+	// label routing hints (types.Partition.Label) instead of processing
+	// weight.
+	LabeledSubsets []LabeledPartitionSubset `yaml:"labeled_subsets"`
+}
+
+// LabeledPartitionSubset declares a Label for the half-open partition
+// index range [Start, End).
+type LabeledPartitionSubset struct {
+	Label string `yaml:"label"`
+	Start int    `yaml:"start"`
+	End   int    `yaml:"end"`
+}
+
+// ExpandLabels flattens LabeledSubsets into a []string of length Count,
+// indexed by partition ID, defaulting to "" (unlabeled) for indices not
+// covered by any subset. Mirrors how producer.WeightGenerator.GenerateWeights
+// flattens WeightsConfig into a []int64 of the same length — see
+// cmd/simulation/main.go's weight-generation block immediately before the
+// worker-creation loop.
+func (pc PartitionsConfig) ExpandLabels() []string {
+	labels := make([]string, pc.Count)
+	for _, s := range pc.LabeledSubsets {
+		for i := s.Start; i < s.End && i < pc.Count; i++ {
+			if i >= 0 {
+				labels[i] = s.Label
+			}
+		}
+	}
+
+	return labels
 }
 
 // WeightsConfig configures partition weight distributions.
@@ -151,6 +186,24 @@ type WorkersConfig struct {
 	// tiny-pool scenarios. Keyed by sim worker ID (e.g. "worker-0").
 	// Workers not listed inherit the cluster-wide defaults.
 	PerWorker map[string]PerWorkerConfig `yaml:"per_worker"`
+
+	// Labels declares the fixed label set for specific workers, keyed by
+	// sim worker ID (e.g. "worker-0") exactly like PerWorker. Workers not
+	// listed are unlabeled. Rides into parti.Config.WorkerLabels at
+	// construction time (worker.go:NewWorker) — labels are fixed for a
+	// worker's lifetime, matching the production contract.
+	Labels map[string][]string `yaml:"labels"`
+
+	// UnlabeledPartitionPolicy mirrors parti.Config.UnlabeledPartitionPolicy
+	// ("dedicated" or "shared"). Applied cluster-wide to every worker.
+	// Empty defers to parti.DefaultConfig()'s own default ("dedicated").
+	UnlabeledPartitionPolicy string `yaml:"unlabeled_partition_policy"`
+
+	// LabelSpillGrace mirrors parti.Config.LabelSpillGrace: how long a
+	// label's worker pool must be continuously empty before its
+	// partitions spill to the fallback ladder. Applied cluster-wide.
+	// Zero defers to parti.DefaultConfig()'s own default (60s).
+	LabelSpillGrace time.Duration `yaml:"label_spill_grace"`
 }
 
 // PerWorkerConfig configures per-worker StableID pool overrides. Each
@@ -320,6 +373,25 @@ type ChaosConfig struct {
 	// events are usually preferred; this is only for faults that must be
 	// active before the initial worker Start path.
 	Faults FaultsConfig `yaml:"faults"`
+
+	// ExpectLabelSpill, when true, arms the strict positive-proof gate
+	// asserting at least one partition actually spilled from a labeled
+	// pool to the unlabeled fallback (types.LabelMetrics.IncrementLabelSpill).
+	// Opt-in so ordinary scenarios with labeled partitions that never fully
+	// lose a pool aren't affected.
+	ExpectLabelSpill bool `yaml:"expect_label_spill"`
+
+	// ExpectLabelEmergencyCarveout, when true, arms the strict positive-
+	// proof gate asserting at least one emergency-carve-out claim
+	// (types.CalculatorMetrics.RecordEmergencyRebalance) occurred during
+	// the run. Opt-in so ordinary burst-kill scenarios aren't affected.
+	ExpectLabelEmergencyCarveout bool `yaml:"expect_label_emergency_carveout"`
+
+	// RelabelStormEventCount records how many label_heartbeat_takeover
+	// scheduled_events this scenario fires, so main.go's positive-proof
+	// gate can assert LabelRechecksRun stayed bounded (coalesced) rather
+	// than scaling linearly with event count. 0 disables the storm gate.
+	RelabelStormEventCount int `yaml:"relabel_storm_event_count"`
 }
 
 // FaultsConfig configures startup-armed fault injection.

--- a/test/simulation/internal/config/validation.go
+++ b/test/simulation/internal/config/validation.go
@@ -120,6 +120,11 @@ func validateConfig(cfg *Config) error { //nolint:cyclop,gocyclo
 		}
 	}
 
+	// Validate label topology (labels/label_spill_grace/labeled_subsets).
+	if err := validateLabelConfig(cfg); err != nil {
+		return err
+	}
+
 	// Validate coordinator
 	if cfg.Coordinator.ValidationWindow <= 0 {
 		return errors.New("validation window must be positive")
@@ -187,6 +192,57 @@ func validateConfig(cfg *Config) error { //nolint:cyclop,gocyclo
 		}
 		if cfg.Checkpoint.Path == "" {
 			return errors.New("checkpoint path cannot be empty")
+		}
+	}
+
+	return nil
+}
+
+// validateLabelConfig validates label-related configuration fields:
+// workers.unlabeled_partition_policy, workers.label_spill_grace,
+// workers.labels worker-ID references, and partitions.labeled_subsets
+// ranges and overlaps.
+func validateLabelConfig(cfg *Config) error {
+	if cfg.Workers.UnlabeledPartitionPolicy != "" &&
+		cfg.Workers.UnlabeledPartitionPolicy != "dedicated" && cfg.Workers.UnlabeledPartitionPolicy != "shared" {
+		return fmt.Errorf("invalid workers.unlabeled_partition_policy: %s (must be dedicated or shared)",
+			cfg.Workers.UnlabeledPartitionPolicy)
+	}
+	if cfg.Workers.LabelSpillGrace < 0 {
+		return errors.New("workers.label_spill_grace cannot be negative")
+	}
+	for workerID := range cfg.Workers.Labels {
+		idx := -1
+		if _, err := fmt.Sscanf(workerID, "worker-%d", &idx); err != nil || idx < 0 || idx >= cfg.Workers.Count {
+			return fmt.Errorf("workers.labels references unknown worker ID %q (cluster has workers.count=%d)",
+				workerID, cfg.Workers.Count)
+		}
+	}
+	for _, s := range cfg.Partitions.LabeledSubsets {
+		if s.Label == "" {
+			return errors.New("partitions.labeled_subsets entry has empty label")
+		}
+		if s.Start < 0 || s.End <= s.Start {
+			return fmt.Errorf("partitions.labeled_subsets entry for label %q has invalid range [%d, %d)",
+				s.Label, s.Start, s.End)
+		}
+		if s.End > cfg.Partitions.Count {
+			return fmt.Errorf("partitions.labeled_subsets entry for label %q range [%d, %d) exceeds partitions.count=%d",
+				s.Label, s.Start, s.End, cfg.Partitions.Count)
+		}
+	}
+
+	// Check for overlapping ranges among LabeledSubsets.
+	for i := 0; i < len(cfg.Partitions.LabeledSubsets); i++ {
+		for j := i + 1; j < len(cfg.Partitions.LabeledSubsets); j++ {
+			s1 := cfg.Partitions.LabeledSubsets[i]
+			s2 := cfg.Partitions.LabeledSubsets[j]
+			// Ranges [s1.Start, s1.End) and [s2.Start, s2.End) overlap if
+			// NOT (s1.End <= s2.Start OR s2.End <= s1.Start).
+			if s1.End > s2.Start && s2.End > s1.Start {
+				return fmt.Errorf("partitions.labeled_subsets entries for labels %q [%d, %d) and %q [%d, %d) overlap",
+					s1.Label, s1.Start, s1.End, s2.Label, s2.Start, s2.End)
+			}
 		}
 	}
 

--- a/test/simulation/internal/config/validation_test.go
+++ b/test/simulation/internal/config/validation_test.go
@@ -167,3 +167,210 @@ func TestValidate_AckWaitNonPositive_Rejects(t *testing.T) {
 		t.Fatalf("expected ack_wait validation error; got %v", err)
 	}
 }
+
+func TestValidateConfig_LabeledSubsetOutOfRange(t *testing.T) {
+	t.Parallel()
+	cfg := minimalValidConfig()
+	cfg.Partitions.Count = 10
+	cfg.Partitions.LabeledSubsets = []LabeledPartitionSubset{
+		{Label: "vip-a", Start: 8, End: 12}, // End exceeds Count
+	}
+	applyDefaults(cfg)
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for labeled_subsets range exceeding partitions.count")
+	}
+}
+
+func TestValidateConfig_LabeledSubsetInvalidRange(t *testing.T) {
+	t.Parallel()
+	cfg := minimalValidConfig()
+	cfg.Partitions.Count = 10
+	cfg.Partitions.LabeledSubsets = []LabeledPartitionSubset{
+		{Label: "vip-a", Start: 5, End: 3}, // Start >= End
+	}
+	applyDefaults(cfg)
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for labeled_subsets start >= end")
+	}
+}
+
+func TestValidateConfig_LabelsUnknownWorkerID(t *testing.T) {
+	t.Parallel()
+	cfg := minimalValidConfig()
+	cfg.Workers.Count = 3
+	cfg.Workers.Labels = map[string][]string{
+		"worker-9": {"vip-a"}, // out of range for Count=3 (worker-0..worker-2)
+	}
+	applyDefaults(cfg)
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for workers.labels referencing an out-of-range worker ID")
+	}
+}
+
+func TestValidateConfig_LabelsAndSubsets_Valid(t *testing.T) {
+	t.Parallel()
+	cfg := minimalValidConfig()
+	cfg.Workers.Count = 3
+	cfg.Workers.Labels = map[string][]string{"worker-0": {"vip-a"}}
+	cfg.Partitions.Count = 10
+	cfg.Partitions.LabeledSubsets = []LabeledPartitionSubset{{Label: "vip-a", Start: 0, End: 2}}
+	applyDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("expected valid config, got error: %v", err)
+	}
+}
+
+func TestPartitionsConfig_ExpandLabels(t *testing.T) {
+	t.Parallel()
+	pc := PartitionsConfig{
+		Count: 5,
+		LabeledSubsets: []LabeledPartitionSubset{
+			{Label: "vip-a", Start: 1, End: 3},
+		},
+	}
+	got := pc.ExpandLabels()
+	want := []string{"", "vip-a", "vip-a", "", ""}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestValidateConfig_UnlabeledPartitionPolicy tests validation of the
+// unlabeled_partition_policy field.
+func TestValidateConfig_UnlabeledPartitionPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		policy  string
+		wantErr bool
+	}{
+		{"empty_string_passes", "", false},
+		{"dedicated_passes", "dedicated", false},
+		{"shared_passes", "shared", false},
+		{"invalid_bogus", "bogus", true},
+		{"invalid_random", "random", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := minimalValidConfig()
+			cfg.Workers.UnlabeledPartitionPolicy = tc.policy
+			applyDefaults(cfg)
+			err := validateConfig(cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for policy %q, got nil", tc.policy)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for policy %q, got: %v", tc.policy, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfig_LabelSpillGrace tests validation of the label_spill_grace field.
+func TestValidateConfig_LabelSpillGrace(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		grace   time.Duration
+		wantErr bool
+	}{
+		{"zero_passes", 0, false},
+		{"positive_passes", 5 * time.Second, false},
+		{"negative_fails", -1 * time.Second, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := minimalValidConfig()
+			cfg.Workers.LabelSpillGrace = tc.grace
+			applyDefaults(cfg)
+			err := validateConfig(cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for grace %s, got nil", tc.grace)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for grace %s, got: %v", tc.grace, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfig_LabeledSubsetsNonOverlapping tests that non-overlapping
+// ranges pass validation, including adjacent ranges (half-open ranges touching
+// at the boundary is NOT an overlap).
+func TestValidateConfig_LabeledSubsetsNonOverlapping(t *testing.T) {
+	t.Parallel()
+	cfg := minimalValidConfig()
+	cfg.Partitions.Count = 10
+	cfg.Partitions.LabeledSubsets = []LabeledPartitionSubset{
+		{Label: "vip-a", Start: 0, End: 5},
+		{Label: "vip-b", Start: 5, End: 8}, // Touching boundary, not overlapping
+	}
+	applyDefaults(cfg)
+	err := validateConfig(cfg)
+	if err != nil {
+		t.Fatalf("expected no error for non-overlapping adjacent ranges, got: %v", err)
+	}
+}
+
+// TestValidateConfig_LabeledSubsetsOverlapping tests that overlapping ranges
+// are rejected, regardless of whether the labels are the same or different.
+func TestValidateConfig_LabeledSubsetsOverlapping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		subsets []LabeledPartitionSubset
+		wantErr bool
+	}{
+		{
+			"different_labels_overlap",
+			[]LabeledPartitionSubset{
+				{Label: "vip-a", Start: 0, End: 5},
+				{Label: "vip-b", Start: 3, End: 8}, // Overlaps with vip-a
+			},
+			true,
+		},
+		{
+			"same_label_overlap",
+			[]LabeledPartitionSubset{
+				{Label: "vip-a", Start: 0, End: 5},
+				{Label: "vip-a", Start: 3, End: 8}, // Overlaps with first vip-a
+			},
+			true,
+		},
+		{
+			"multiple_non_overlapping",
+			[]LabeledPartitionSubset{
+				{Label: "vip-a", Start: 0, End: 2},
+				{Label: "vip-b", Start: 2, End: 5},
+				{Label: "vip-c", Start: 5, End: 8},
+			},
+			false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := minimalValidConfig()
+			cfg.Partitions.Count = 10
+			cfg.Partitions.LabeledSubsets = tc.subsets
+			applyDefaults(cfg)
+			err := validateConfig(cfg)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error for overlapping ranges, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}

--- a/test/simulation/internal/coordinator/chaos.go
+++ b/test/simulation/internal/coordinator/chaos.go
@@ -73,6 +73,28 @@ const (
 	// (claimer.go:362-369), driving claimLostShutdown.
 	BucketPeerTakeoverEvent ChaosEvent = "bucket_peer_takeover"
 
+	// LabelHeartbeatTakeoverEvent directly rewrites a live worker's
+	// heartbeat KV entry with a different label set, preserving every
+	// other field (Timestamp refreshed to now). This deterministically
+	// exercises the "tight takeover" fingerprint-mismatch branch
+	// (internal/assignment/worker_monitor.go:checkLabelChange) — a
+	// heartbeat PUT landing on a STILL-LIVE key with different labels and
+	// no interceding DELETE. Modeled on BucketPeerTakeoverEvent's
+	// direct-KV-rewrite pattern applied to the heartbeat bucket instead of
+	// the stableid bucket. All-in-one mode only; process-mode dispatch
+	// logs and skips (no cross-process KV probe handle available there).
+	//
+	// Unlike a kill+respawn approach (investigated and rejected — the
+	// stableid stale-takeover path requires waiting past a staleness
+	// threshold that always exceeds the heartbeat key's own shorter TTL,
+	// so a respawn can never land on a still-live key), this primitive
+	// writes directly to the heartbeat bucket without touching the
+	// stableid claim or killing any worker process — the target worker
+	// keeps running, unaware its own heartbeat key was just overwritten by
+	// a "hostile" actor. This is deliberately the SAME shape of event a
+	// misbehaving or compromised peer could produce.
+	LabelHeartbeatTakeoverEvent ChaosEvent = "label_heartbeat_takeover"
+
 	// WatcherStallEvent simulates a stalled KV watcher on the partition
 	// source bucket WITHOUT dropping the NATS connection. Implementation:
 	// repeatedly deletes the ephemeral JetStream consumers backing the
@@ -419,6 +441,16 @@ func (cc *ChaosController) generateEventParams(event ChaosEvent) map[string]any 
 		// Default target_worker "random" — handler picks a live worker.
 		params["target_worker"] = "random"
 
+	case LabelHeartbeatTakeoverEvent:
+		// Default target_worker "random" — handler picks the first live
+		// labeled worker. new_labels defaults to a distinct singleton set
+		// so a random-cadence fire still produces a genuine
+		// fingerprint mismatch against a typical labeled worker; scenarios
+		// (e.g. label_tight_takeover_churn.yaml) override both via the YAML
+		// scheduled_events params.
+		params["target_worker"] = "random"
+		params["new_labels"] = []string{"vip-takeover"}
+
 	case StableIDTinyPoolRespawnEvent:
 		// Default target_role "" — scenario-driven via InjectEventNow.
 		// The handler will look up the role's WorkerID* overrides from
@@ -590,6 +622,8 @@ func (e ChaosEvent) String() string {
 		return "Bucket Recreate"
 	case BucketPeerTakeoverEvent:
 		return "Bucket Peer Takeover"
+	case LabelHeartbeatTakeoverEvent:
+		return "Label Heartbeat Takeover (tight-takeover fingerprint-mismatch branch)"
 	case StableIDClaimStealEvent:
 		return "StableID Claim Steal (alias of bucket_peer_takeover)"
 	case StableIDTinyPoolRespawnEvent:

--- a/test/simulation/internal/coordinator/coordinator.go
+++ b/test/simulation/internal/coordinator/coordinator.go
@@ -29,14 +29,33 @@ type Coordinator struct {
 	dup DupTracer
 
 	// assignment tracking
-	assignmentsCh       chan AssignmentReport
-	stoppedWorkersCh    chan string // signals a worker goroutine has permanently stopped
-	startLatenciesCh    chan StartLatencyReport
-	workerAssignments   map[string]map[int]struct{}
+	assignmentsCh     chan AssignmentReport
+	stoppedWorkersCh  chan string // signals a worker goroutine has permanently stopped
+	startLatenciesCh  chan StartLatencyReport
+	workerAssignments map[string]map[int]struct{}
+	// workerAssignMu guards workerAssignments against the one cross-goroutine
+	// reader (startWorkerCatchUp, called from the received-messages goroutine
+	// via processCatchUpActivity). The assignment-drain goroutine
+	// (processAssignments / processWorkerAssignmentTracker) is the sole writer
+	// and always REPLACES a worker's inner set wholesale (never mutates a
+	// published inner map in place), so the reader may snapshot under RLock and
+	// use the result unlocked. Same-goroutine reads inside the writer skip the
+	// lock (identical discipline to prevOwnersMu). Added after -race (via
+	// label_tight_takeover_churn.yaml, Task 10b) caught startWorkerCatchUp
+	// reading workerAssignments unsynchronized against the writer's map assign.
+	workerAssignMu      sync.RWMutex
 	prevGlobalAssigned  map[int]struct{}
 	prevPartitionOwners map[int]string // partitionID -> workerID for previous snapshot
-	activeOwners        map[int]string // partitionID -> workerID based on actual processing reports
-	ownersMu            sync.RWMutex   // guards activeOwners
+	// prevOwnersMu guards prevPartitionOwners. processAssignments is the
+	// sole writer and always replaces the whole map (never mutates it in
+	// place after publishing), so the lock only needs to protect the
+	// pointer swap/read, not a deep copy. Added after -race (via
+	// label_tight_takeover_churn.yaml, Task 10) caught printOwnershipAudit
+	// (called from PrintReport's ticker goroutine) reading this field
+	// unsynchronized against processAssignments' own goroutine writing it.
+	prevOwnersMu sync.RWMutex
+	activeOwners map[int]string // partitionID -> workerID based on actual processing reports
+	ownersMu     sync.RWMutex   // guards activeOwners
 
 	// ownership-violation evidence: bounded slice of cross-worker same-seq
 	// observations. Surfaced verbatim in FailureReport.OwnershipViolations.
@@ -135,6 +154,7 @@ type Coordinator struct {
 	snapshotOverlap *SnapshotOverlapClassifier
 	leaderUniq      *LeaderUniquenessWatcher
 	stateReconcile  *StateReconcileWatcher
+	labelAffinity   *LabelAffinityOracle
 
 	// Phase 1: bucket-lifecycle chaos oracle. Lazy-initialized in
 	// EnableShutdownOracles so callers that already use Phase 0 oracles
@@ -390,11 +410,14 @@ func (c *Coordinator) MarkChaosStarted() {
 	}
 }
 
-// EnableShutdownOracles constructs the three foundation oracles (snapshot-overlap,
-// leader-uniqueness, state-reconcile) and attaches them to the coordinator.
-// Must be called BEFORE coord.Start(). Idempotent — subsequent calls are no-ops.
-// registry is the GoroutineRegistry that maps worker IDs to *worker.Worker objects.
-func (c *Coordinator) EnableShutdownOracles(registry *GoroutineRegistry) {
+// EnableShutdownOracles constructs the foundation oracles (snapshot-overlap,
+// leader-uniqueness, state-reconcile, label-affinity, ...) and attaches them
+// to the coordinator. Must be called BEFORE coord.Start(). Idempotent —
+// subsequent calls are no-ops. registry is the GoroutineRegistry that maps
+// worker IDs to *worker.Worker objects. partitionLabels/spillGrace configure
+// the label-affinity oracle; pass nil/0 when the scenario has no labeled
+// partitions (all-in-one-only — process mode always passes nil/0).
+func (c *Coordinator) EnableShutdownOracles(registry *GoroutineRegistry, partitionLabels map[int]string, spillGrace time.Duration) {
 	if c.snapshotOverlap != nil {
 		return
 	}
@@ -404,6 +427,7 @@ func (c *Coordinator) EnableShutdownOracles(registry *GoroutineRegistry) {
 	c.degradedReasonOracle = NewDegradedReasonOracle()
 	c.sourceConvergence = NewSourceConvergenceOracle()
 	c.claimLossOrdering = NewClaimLossOrderingOracle()
+	c.labelAffinity = NewLabelAffinityOracle(partitionLabels, spillGrace, registry)
 	// Install a state sampler so ObserveRevocation can distinguish a
 	// poll-cadence race (legitimate backfill) from a true Stop-before-
 	// revoke ordering bug. The sampler reads the same registry the
@@ -581,6 +605,25 @@ func (c *Coordinator) GetSnapshotOverlapCount() int64 {
 		return 0
 	}
 	return c.snapshotOverlap.ViolationCount()
+}
+
+// GetLabelAffinityViolations returns the total label-affinity violations
+// detected by the oracle. Returns 0 if EnableShutdownOracles was never
+// called or the scenario has no labeled partitions.
+func (c *Coordinator) GetLabelAffinityViolations() int64 {
+	if c.labelAffinity == nil {
+		return 0
+	}
+	return c.labelAffinity.ViolationCount()
+}
+
+// LabelAffinityOracle returns the oracle, or nil if EnableShutdownOracles
+// was never called or the scenario has no labeled partitions. Callers
+// (chaos dispatch handlers that rewrite a worker's heartbeat KV entry
+// directly, e.g. label_heartbeat_takeover) use this to register a live
+// label override via SetLiveLabelOverride.
+func (c *Coordinator) LabelAffinityOracle() *LabelAffinityOracle {
+	return c.labelAffinity
 }
 
 // GetDoubleLeaderObservations returns the total (pre-chaos) double-leader
@@ -877,8 +920,17 @@ func (c *Coordinator) startWorkerCatchUp(workerID string) {
 		c.catchMu.Unlock()
 		return
 	}
-	// Build partition backlog snapshot
-	assigned := c.workerAssignments[workerID]
+	// Build partition backlog snapshot. workerAssignments is owned by the
+	// assignment-drain goroutine; snapshot this worker's partition IDs under
+	// workerAssignMu (the writer replaces the inner set wholesale) so the
+	// per-partition tracker work below runs off a private copy, unlocked.
+	c.workerAssignMu.RLock()
+	assignedSet := c.workerAssignments[workerID]
+	assigned := make([]int, 0, len(assignedSet))
+	for pid := range assignedSet {
+		assigned = append(assigned, pid)
+	}
+	c.workerAssignMu.RUnlock()
 	rec := &workerRecoveryContext{
 		startedAt:     time.Now(),
 		deadline:      c.catchUpDeadline,
@@ -887,7 +939,7 @@ func (c *Coordinator) startWorkerCatchUp(workerID string) {
 	}
 	var totalBacklog int64
 	var oldestHoleAge time.Duration
-	for pid := range assigned {
+	for _, pid := range assigned {
 		sent, received := c.tracker.GetPartitionState(pid)
 		lag := sent - received
 		if lag > 0 {
@@ -1193,7 +1245,16 @@ func (c *Coordinator) SlowStartExceedances() (initial, takeover int) {
 
 // printOwnershipAudit compares active owners vs assigned owners and prints mismatch stats.
 func (c *Coordinator) printOwnershipAudit(activeSnapshot map[int]string) {
-	if len(c.prevPartitionOwners) == 0 || len(activeSnapshot) == 0 {
+	// Snapshot the map reference under lock rather than holding the lock
+	// for the whole function: processAssignments (the sole writer) always
+	// replaces the whole map rather than mutating it in place, so a local
+	// reference captured under RLock is safe to range over unlocked
+	// afterward — no other goroutine will ever mutate this specific map
+	// instance once published.
+	c.prevOwnersMu.RLock()
+	prevPartitionOwners := c.prevPartitionOwners
+	c.prevOwnersMu.RUnlock()
+	if len(prevPartitionOwners) == 0 || len(activeSnapshot) == 0 {
 		return
 	}
 	mismatches := 0
@@ -1205,7 +1266,7 @@ func (c *Coordinator) printOwnershipAudit(activeSnapshot map[int]string) {
 	}
 	samples := make([]sample, 0, 10)
 	for pid, active := range activeSnapshot {
-		if assigned, ok := c.prevPartitionOwners[pid]; ok {
+		if assigned, ok := prevPartitionOwners[pid]; ok {
 			checked++
 			if assigned == active {
 				aligned++
@@ -1729,7 +1790,9 @@ func (c *Coordinator) processWorkerAssignmentTracker(ctx context.Context) {
 			for _, p := range ar.Partitions {
 				set[p] = struct{}{}
 			}
+			c.workerAssignMu.Lock()
 			c.workerAssignments[ar.WorkerID] = set
+			c.workerAssignMu.Unlock()
 			c.rebuildOwnerSnapshotLocked()
 			// Forward to the Phase 4 ordering oracle so its assignment
 			// snapshot tracks live state (otherwise its
@@ -1762,10 +1825,15 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 			if _, had := c.workerAssignments[wid]; !had {
 				continue
 			}
+			c.workerAssignMu.Lock()
 			delete(c.workerAssignments, wid)
+			c.workerAssignMu.Unlock()
 			c.rebuildOwnerSnapshotLocked()
 			if c.snapshotOverlap != nil {
 				c.snapshotOverlap.ForgetWorker(wid)
+			}
+			if c.labelAffinity != nil {
+				c.labelAffinity.ForgetWorker(wid)
 			}
 			if c.baselineLocked && c.totalPartitions > 0 {
 				fresh := make(map[int]string, c.totalPartitions)
@@ -1776,7 +1844,9 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 						}
 					}
 				}
+				c.prevOwnersMu.Lock()
 				c.prevPartitionOwners = fresh
+				c.prevOwnersMu.Unlock()
 			}
 		case sl := <-c.startLatenciesCh:
 			// Classify by the caller-provided cohort flag. Earlier versions
@@ -1810,7 +1880,9 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 					set[p] = struct{}{}
 				}
 			}
+			c.workerAssignMu.Lock()
 			c.workerAssignments[ar.WorkerID] = set
+			c.workerAssignMu.Unlock()
 			c.rebuildOwnerSnapshotLocked()
 
 			// Phase 3: check long-disconnect reassignment expectations on
@@ -1821,6 +1893,10 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 			if c.snapshotOverlap != nil {
 				c.snapshotOverlap.IngestAssignment(ar.WorkerID, ar.Partitions)
 				c.snapshotOverlap.Check(time.Now())
+			}
+			if c.labelAffinity != nil {
+				c.labelAffinity.IngestAssignment(ar.WorkerID, ar.Partitions)
+				c.labelAffinity.Check(time.Now())
 			}
 			if c.stateReconcile != nil {
 				c.stateReconcile.RecordAssignment(ar.WorkerID, ar.Partitions, time.Now())
@@ -1860,7 +1936,10 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 					c.metricsCollector.SetLocalityRatio(1.0)
 				}
 				c.prevGlobalAssigned = global
+				c.prevOwnersMu.Lock()
 				c.prevPartitionOwners = make(map[int]string, len(global))
+				c.prevOwnersMu.Unlock()
+
 				continue
 			}
 
@@ -1878,7 +1957,9 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 				c.metricsCollector.SetUnassignedPartitions(0)
 				c.metricsCollector.SetLocalityRatio(1.0)
 				c.prevGlobalAssigned = global
+				c.prevOwnersMu.Lock()
 				c.prevPartitionOwners = make(map[int]string, len(global))
+				c.prevOwnersMu.Unlock()
 				continue
 			}
 			if needWaitForWorkers && time.Since(c.firstAssignmentAt) >= c.baselineLockTimeout {
@@ -1937,7 +2018,9 @@ func (c *Coordinator) processAssignments(ctx context.Context) { //nolint:gocyclo
 			}
 
 			c.prevGlobalAssigned = global
+			c.prevOwnersMu.Lock()
 			c.prevPartitionOwners = currentOwners
+			c.prevOwnersMu.Unlock()
 
 			// If recovering, check exit conditions: all partitions assigned & disorder depth zero.
 			if c.recoveryActive && unassigned == 0 && c.tracker.GetDisorderDepth() == 0 {

--- a/test/simulation/internal/coordinator/goroutine_registry.go
+++ b/test/simulation/internal/coordinator/goroutine_registry.go
@@ -90,6 +90,31 @@ func (r *GoroutineRegistry) MarkInactive(id string) {
 	}
 }
 
+// MarkInactiveObj marks a goroutine inactive ONLY if the currently-registered
+// object for id is still obj — an incarnation guard for a worker goroutine
+// deactivating itself on exit.
+//
+// The bug this closes: on a crash+restart (Cancel → MarkInactive → Restart),
+// Restart re-registers a FRESH object for the same id and sets it Active=true.
+// The OLD goroutine's deferred cleanup then calls to deactivate id — but by
+// then the registry entry is the successor object. An unconditional
+// MarkInactive(id) here would flip the live successor to Active=false, making
+// it vanish from GetByType while it is still running and processing (observed
+// as a labeled worker reading empty labels / an unresolvable stable ID in the
+// label-takeover-churn scenario under -race). Guarding on obj identity means a
+// stale predecessor's cleanup is a no-op and only the current incarnation can
+// deactivate itself. The intentional chaos-side MarkInactive(id) in the
+// crash handler stays unconditional: it fires before Restart, when the current
+// object IS the one being crashed.
+func (r *GoroutineRegistry) MarkInactiveObj(id string, obj any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info, exists := r.goroutines[id]; exists && info.Obj == obj {
+		info.Active = false
+	}
+}
+
 // Restart calls the Start callback for the given goroutine ID if available and marks it active.
 // If no Start callback is set, this is a no-op.
 func (r *GoroutineRegistry) Restart(ctx context.Context, id string) {

--- a/test/simulation/internal/coordinator/goroutine_registry_test.go
+++ b/test/simulation/internal/coordinator/goroutine_registry_test.go
@@ -1,0 +1,71 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+)
+
+// markerObj is a distinct heap object used to stand in for two successive
+// *worker.Worker incarnations registered under the same id.
+type markerObj struct{ n int }
+
+// TestGoroutineRegistry_MarkInactiveObj_GuardsAgainstStaleClobber reproduces
+// the crash+restart registry clobber that produced the label_tight_takeover_churn
+// flakiness: a crashed worker's deferred cleanup deactivating the fresh
+// successor that Restart already re-registered and re-activated. It asserts the
+// incarnation-guarded MarkInactiveObj leaves the live successor active, while an
+// unconditional MarkInactive would (and here does) clobber it.
+func TestGoroutineRegistry_MarkInactiveObj_GuardsAgainstStaleClobber(t *testing.T) {
+	reg := NewGoroutineRegistry()
+	v1 := &markerObj{1}
+	v2 := &markerObj{2}
+	noop := func(context.Context) {}
+
+	// Initial incarnation.
+	reg.Register("worker-0", WorkerGoroutine, func() {}, noop, v1)
+
+	// Chaos crash: mark inactive, then Restart re-registers a fresh incarnation
+	// and re-activates it (mirrors handleLeaderGoroutineFailure + Restart).
+	reg.MarkInactive("worker-0")
+	reg.Register("worker-0", WorkerGoroutine, func() {}, noop, v2)
+
+	// The OLD (v1) goroutine's deferred cleanup now fires. With the guarded
+	// call it must be a no-op because the registered object is the successor v2.
+	reg.MarkInactiveObj("worker-0", v1)
+
+	live := reg.GetByType(WorkerGoroutine)
+	if len(live) != 1 {
+		t.Fatalf("stale v1 cleanup clobbered the live successor: got %d active workers, want 1", len(live))
+	}
+	if live[0].Obj != any(v2) {
+		t.Fatalf("active worker Obj = %v, want the successor v2", live[0].Obj)
+	}
+
+	// The current incarnation can still deactivate itself on its own exit.
+	reg.MarkInactiveObj("worker-0", v2)
+	if got := reg.GetByType(WorkerGoroutine); len(got) != 0 {
+		t.Fatalf("current incarnation failed to deactivate itself: %d active, want 0", len(got))
+	}
+}
+
+// TestGoroutineRegistry_MarkInactive_UnconditionalClobbers documents the exact
+// bug: the unconditional MarkInactive(id) that the worker goroutines used to
+// call would deactivate the live successor after a restart. This is why the
+// worker-goroutine cleanup path was switched to the guarded MarkInactiveObj;
+// the chaos crash handler keeps using unconditional MarkInactive on purpose.
+func TestGoroutineRegistry_MarkInactive_UnconditionalClobbers(t *testing.T) {
+	reg := NewGoroutineRegistry()
+	v1 := &markerObj{1}
+	v2 := &markerObj{2}
+	noop := func(context.Context) {}
+
+	reg.Register("worker-0", WorkerGoroutine, func() {}, noop, v1)
+	reg.MarkInactive("worker-0")
+	reg.Register("worker-0", WorkerGoroutine, func() {}, noop, v2)
+
+	// Unconditional deactivation clobbers the live successor v2.
+	reg.MarkInactive("worker-0")
+	if got := reg.GetByType(WorkerGoroutine); len(got) != 0 {
+		t.Fatalf("expected the unconditional clobber to hide the live successor, got %d active", len(got))
+	}
+}

--- a/test/simulation/internal/coordinator/ipc_smoke.go
+++ b/test/simulation/internal/coordinator/ipc_smoke.go
@@ -291,3 +291,18 @@ func (o *ProcessWorkerObserver) SetClaimLostObserved() {
 	}
 	o.claimLost.Store(true)
 }
+
+// WorkerLabels always returns nil in process mode. Process-mode label
+// plumbing is out of scope (no IPC frame carries labels today — see
+// LabelAffinityOracle's doc comment); this stub exists solely so
+// ProcessWorkerObserver continues to satisfy WorkerObserver after the
+// interface gained this method. LabelAffinityOracle skips process-mode
+// workers as a result (all-in-one mode only, matching this plan's scope).
+// Implements WorkerObserver.
+func (o *ProcessWorkerObserver) WorkerLabels() []string {
+	if o == nil {
+		return nil
+	}
+
+	return nil
+}

--- a/test/simulation/internal/coordinator/oracles.go
+++ b/test/simulation/internal/coordinator/oracles.go
@@ -32,6 +32,12 @@ type WorkerObserver interface {
 	// watchClaimLostShutdowns to distinguish real claim-loss shutdowns
 	// from graceful Stop transitions (both terminate in StateShutdown).
 	ClaimLostObserved() bool
+	// WorkerLabels returns the worker's currently-configured label set (may
+	// be empty/nil). In all-in-one mode this reflects the live manager's
+	// resolved labels, which can change across a respawn under the same
+	// sim worker ID. In process mode this always returns nil (process-mode
+	// label plumbing is out of scope — see LabelAffinityOracle doc).
+	WorkerLabels() []string
 }
 
 // workerStateStable is the int value of parti.StateStable / types.StateStable.
@@ -223,6 +229,290 @@ func (c *SnapshotOverlapClassifier) Check(now time.Time) {
 // ViolationCount returns the total number of overlap violations detected.
 func (c *SnapshotOverlapClassifier) ViolationCount() int64 {
 	return c.violations.Load()
+}
+
+// ---------------------------------------------------------------------------
+// Label-affinity oracle
+// ---------------------------------------------------------------------------
+
+// LabelAffinityOracle fires when a labeled partition's current owner does
+// not carry that label for longer than spillGrace PLUS a settle allowance
+// (see labelAffinitySettleAllowance below) — EXCEPT when the required label
+// has zero live carriers anywhere in the fleet, in which case the mismatch
+// is the documented permanent terminal spill state and is exempt (see
+// checkLocked's doc comment for the full Task 11b rationale).
+// partitionLabels is static
+// (fixed at construction from the scenario's
+// config.PartitionsConfig.LabeledSubsets — partition labels never change at
+// runtime in this harness); worker labels ARE allowed to change at runtime
+// (a respawn under the same sim worker ID can carry a different config-time
+// label set), so worker labels are read live from the registry on every
+// Check(), not cached. A SEPARATE mechanism, liveLabelOverrides (see
+// SetLiveLabelOverride), covers the label_heartbeat_takeover chaos
+// primitive specifically: that primitive rewrites a worker's heartbeat KV
+// entry directly without touching its Manager/Config at all, so the
+// registry read alone can never observe it.
+//
+// Mirrors SnapshotOverlapClassifier's structure and locking discipline. It
+// diverges from SnapshotOverlapClassifier.Check on one point:
+// SnapshotOverlapClassifier compares directly against graceWindow with no
+// added slack, but LabelAffinityOracle adds labelAffinitySettleAllowance on
+// top of spillGrace, because docs/LABELS.md's own worst-case-stall formula
+// documents a distinct "rebalance / handoff" phase AFTER LabelSpillGrace
+// elapses — see labelAffinitySettleAllowance's doc comment.
+type LabelAffinityOracle struct {
+	mu sync.Mutex
+
+	partitionLabels map[int]string // partition -> required label; static
+	spillGrace      time.Duration
+	// settleAllowance is added to spillGrace before a park-window mismatch
+	// counts as a violation. Defaults to labelAffinitySettleAllowance;
+	// overridable only by tests in this package (via direct field
+	// assignment) so grace-window unit tests can run with a
+	// near-zero allowance instead of waiting out multiple real seconds.
+	settleAllowance time.Duration
+	registry        *GoroutineRegistry
+
+	partitionOwner map[int]string    // partition -> current owning worker ID
+	parkedSince    map[int]time.Time // partition -> when affinity was first observed missing
+	violations     atomic.Int64
+
+	// liveLabelOverrides holds the KV-published label set for worker IDs
+	// whose heartbeat entry was rewritten out-of-band by the
+	// label_heartbeat_takeover chaos primitive. See SetLiveLabelOverride.
+	liveLabelOverrides map[string][]string
+}
+
+// labelAffinitySettleAllowance is added to spillGrace before a park-window
+// mismatch counts as a violation. It accounts for the "rebalance / handoff"
+// phase docs/LABELS.md's worst-case-stall formula documents as a SEPARATE,
+// expected time component after LabelSpillGrace elapses — the normal
+// debounce and two-phase handoff / processing-gate latency any reassignment
+// already pays before its effect is externally observable via
+// AssignmentReports. This is NOT compensating for a production bug; it is
+// the oracle correctly modeling the shipped feature's own documented
+// contract, which was omitted in this oracle's first implementation (Task 6)
+// and caught by Task 9's flaky dry-runs (~40-50% failure, all with the
+// signature `age=X.05s > grace=Xs` — right at the boundary).
+//
+// Widened from 2s to 20s during Task 11's investigation
+// (label_emergency_carveout.yaml): a burst-kill large enough to plausibly
+// include the CURRENT LEADER can force a leader failover concurrently with
+// the labeled pool emptying. The new leader's calculator only gets its
+// first chance to observe (and start parking) the empty pool after its own
+// post-takeover stabilization window plus election overhead — Task 11's
+// investigation observed vip-a partitions unowned for 25-28s under a
+// concurrent leader failover, which elapses BEFORE LabelSpillGrace even
+// starts counting down for that pool. The original 2s only budgeted for
+// ordinary handoff/debounce latency on an already-stable leader, not a full
+// leader re-election. This is, again, not compensating for a production
+// bug: a brand-new leader legitimately cannot act on a topology it has not
+// yet observed.
+//
+// This is a single shared constant across every LabelAffinityOracle
+// instance, so widening it for Task 11's failover case also widens the
+// tolerance for every other scenario. It retroactively broke Task 10's
+// flagship scenario (label_tight_takeover_churn.yaml): that scenario's
+// last scheduled relabel event landed too close to the run's own shutdown
+// to leave enough buffer for the new, wider threshold to clear — fixed as
+// Task 10c (a scenario-YAML timing adjustment, not a further oracle
+// change). If a future scenario needs an even larger allowance, prefer
+// giving that scenario's own LabelAffinityOracle instance a per-instance
+// override (the settleAllowance field is already unexported-but-settable
+// within this package) over bumping this shared default again.
+const labelAffinitySettleAllowance = 20 * time.Second
+
+// NewLabelAffinityOracle constructs an oracle. partitionLabels is typically
+// built once from config.PartitionsConfig.ExpandLabels() filtered to non-""
+// entries. registry may be nil only in unit tests that manage worker
+// lifetimes without live goroutines.
+func NewLabelAffinityOracle(partitionLabels map[int]string, spillGrace time.Duration, registry *GoroutineRegistry) *LabelAffinityOracle {
+	return &LabelAffinityOracle{
+		partitionLabels:    partitionLabels,
+		spillGrace:         spillGrace,
+		settleAllowance:    labelAffinitySettleAllowance,
+		registry:           registry,
+		partitionOwner:     make(map[int]string),
+		parkedSince:        make(map[int]time.Time),
+		liveLabelOverrides: make(map[string][]string),
+	}
+}
+
+// IngestAssignment records workerID's latest full partition-ownership
+// snapshot. Replaces any prior ownership this worker held wholesale —
+// mirrors SnapshotOverlapClassifier.IngestAssignment's replace-not-merge
+// semantics. Safe to call from any goroutine.
+func (o *LabelAffinityOracle) IngestAssignment(workerID string, partitions []int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for p, owner := range o.partitionOwner {
+		if owner == workerID {
+			delete(o.partitionOwner, p)
+		}
+	}
+	for _, p := range partitions {
+		o.partitionOwner[p] = workerID
+	}
+}
+
+// ForgetWorker drops all ownership entries attributed to workerID. Call when
+// a worker permanently stops so its stale ownership doesn't linger. Also
+// drops any liveLabelOverride recorded for workerID, so a later respawn
+// under the same sim ID starts from a clean (registry-derived) label read
+// rather than inheriting a stale KV-tamper record from a prior incarnation.
+func (o *LabelAffinityOracle) ForgetWorker(workerID string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for p, owner := range o.partitionOwner {
+		if owner == workerID {
+			delete(o.partitionOwner, p)
+		}
+	}
+	delete(o.liveLabelOverrides, workerID)
+}
+
+// SetLiveLabelOverride records workerID's CURRENT KV-published label set,
+// so Check() uses it in place of the registry-derived (Manager/Config)
+// labels WorkerObserver.WorkerLabels() would otherwise return for that
+// worker. The label_heartbeat_takeover chaos primitive rewrites a worker's
+// heartbeat KV entry directly, bypassing its own Manager/Config entirely
+// (deliberately — see label_chaos.go's handleLabelHeartbeatTakeover doc
+// comment); WorkerObserver.WorkerLabels() reflects the manager's own
+// resolved config and can never observe that out-of-band tamper. Without
+// this override, a partition legitimately routed by production to a
+// registry-config-unlabeled worker via a live heartbeat relabel would
+// present as a PERMANENT, unresolvable affinity mismatch to Check(): the
+// registry-derived label for that worker never changes, so the mismatch
+// can never clear no matter how long spillGrace+settleAllowance allows.
+//
+// Pass a nil or empty slice to model a revert to unlabeled.
+//
+// Also triggers an immediate re-check (using time.Now(), in the same
+// critical section as the override update) so a relabel that CURES a
+// previously-parked mismatch is observed right away instead of waiting for
+// the next unrelated Check() call. Without this, a relabel that cures a
+// mismatch WITHOUT also forcing a fresh partition assignment (no
+// AssignmentReport arrives to drive the normal Check() call path) would
+// leave the stale parkedSince clock running from the ORIGINAL mismatch
+// onset; a later Check() triggered by some unrelated event could then find
+// now.Sub(originalOnset) > threshold and fire a violation for a mismatch
+// that was actually cured long ago.
+func (o *LabelAffinityOracle) SetLiveLabelOverride(workerID string, labels []string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.liveLabelOverrides[workerID] = append([]string(nil), labels...)
+	o.checkLocked(time.Now())
+}
+
+// Check evaluates every labeled partition's current owner against that
+// owner's LIVE labels (read from the registry, not cached — see type doc),
+// with any recorded liveLabelOverrides (see SetLiveLabelOverride) taking
+// precedence over the registry read for the workers they name. A partition
+// whose owner lacks the required label enters a park window; if the
+// mismatch persists past spillGrace+settleAllowance, it counts as a
+// violation and the park window resets (mirrors SnapshotOverlapClassifier's
+// one-violation-per-grace-window-span semantics, not
+// one-violation-per-Check-call). The settleAllowance addition tolerates the
+// documented rebalance/handoff phase that follows spillGrace before a spill
+// decision becomes externally observable — see labelAffinitySettleAllowance.
+// A partition whose required label has zero live carriers fleet-wide is
+// exempt from violations entirely — see checkLocked's doc comment (Task 11b).
+func (o *LabelAffinityOracle) Check(now time.Time) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.checkLocked(now)
+}
+
+// checkLocked is Check's per-partition evaluation loop, factored out so
+// SetLiveLabelOverride can trigger an immediate re-check in the SAME
+// critical section as its override-map update (see SetLiveLabelOverride's
+// doc comment for why that matters). Caller MUST already hold o.mu.
+//
+// Fleet-wide-empty exemption (Task 11b): a labeled partition whose required
+// label has ZERO live carriers anywhere in the fleet is EXEMPT from
+// violations. Rationale — such a mismatch is not the avoidable kind the
+// oracle exists to catch (an eligible worker exists but isn't being used);
+// it is the CORRECT, PERMANENT terminal state docs/LABELS.md documents:
+// when every worker carrying a label has left the fleet, the label's
+// partitions legitimately spill to an unlabeled fallback worker and stay
+// there until a carrier rejoins. No worker anywhere can make such a
+// partition affine again, so the old "current owner carries the label" exit
+// condition can never be satisfied — without this exemption the oracle would
+// re-fire a violation every spillGrace+settleAllowance window for the rest of
+// the run (observed while re-verifying label_emergency_carveout.yaml, whose
+// design deliberately empties the vip-a pool fleet-wide). The exemption is
+// recomputed fresh from liveLabels on every call (NOT a sticky latch), so the
+// instant an eligible carrier reappears the mismatch becomes avoidable again
+// and is re-checked normally — with a fresh park window, because the exempt
+// branch clears parkedSince (see below). label_pool_outage_spill.yaml exhibits
+// the same fleet-wide-empty condition (both vip-a workers killed) and is
+// covered by the same exemption.
+func (o *LabelAffinityOracle) checkLocked(now time.Time) {
+	liveLabels := make(map[string][]string)
+	if o.registry != nil {
+		for _, info := range o.registry.GetByType(WorkerGoroutine) {
+			if wo, ok := info.Obj.(WorkerObserver); ok {
+				liveLabels[info.ID] = wo.WorkerLabels()
+			}
+		}
+	}
+	for workerID, override := range o.liveLabelOverrides {
+		liveLabels[workerID] = override
+	}
+
+	// Build the set of labels currently carried by at least one live worker
+	// (registry-derived plus any liveLabelOverrides), once per call rather
+	// than re-scanning per partition. A required label absent from this set
+	// has zero carriers fleet-wide and is exempt (see doc comment above).
+	labelHasCarrier := make(map[string]bool)
+	for _, labels := range liveLabels {
+		for _, l := range labels {
+			labelHasCarrier[l] = true
+		}
+	}
+
+	for partition, requiredLabel := range o.partitionLabels {
+		owner, hasOwner := o.partitionOwner[partition]
+		affine := hasOwner && slices.Contains(liveLabels[owner], requiredLabel)
+		if affine {
+			delete(o.parkedSince, partition)
+			continue
+		}
+
+		// Fleet-wide-empty exemption: no live worker carries requiredLabel,
+		// so this mismatch is the documented permanent terminal spill state,
+		// not an avoidable one. Treat it like the affine case — clear any
+		// park clock and skip. Clearing parkedSince (rather than leaving it
+		// running) means that if an eligible carrier later reappears, the
+		// park window restarts from that moment and the ensuing reassignment
+		// gets a full spillGrace+settleAllowance budget before any violation
+		// counts — avoiding a spurious violation fired off a stale clock the
+		// instant the pool becomes non-empty again.
+		if !labelHasCarrier[requiredLabel] {
+			delete(o.parkedSince, partition)
+			continue
+		}
+
+		since, wasParked := o.parkedSince[partition]
+		if !wasParked {
+			o.parkedSince[partition] = now
+			continue
+		}
+		threshold := o.spillGrace + o.settleAllowance
+		if now.Sub(since) > threshold {
+			log.Printf("[LabelAffinityOracle] VIOLATION partition=%d required=%s owner=%q ownerLabels=%v age=%v > grace=%v+settle=%v",
+				partition, requiredLabel, owner, liveLabels[owner], now.Sub(since).Truncate(time.Millisecond), o.spillGrace, o.settleAllowance)
+			o.violations.Add(1)
+			o.parkedSince[partition] = now
+		}
+	}
+}
+
+// ViolationCount returns the total number of label-affinity violations
+// detected.
+func (o *LabelAffinityOracle) ViolationCount() int64 {
+	return o.violations.Load()
 }
 
 // ---------------------------------------------------------------------------

--- a/test/simulation/internal/coordinator/oracles_test.go
+++ b/test/simulation/internal/coordinator/oracles_test.go
@@ -291,14 +291,381 @@ type stubWorker struct {
 	state          int // raw int so we don't import parti here
 	stableWorkerID string
 	claimLost      bool
+	labels         []string
 }
 
 func (s *stubWorker) IsLeader() bool          { return s.leader }
 func (s *stubWorker) WorkerStateInt() int     { return s.state }
 func (s *stubWorker) StableWorkerID() string  { return s.stableWorkerID }
 func (s *stubWorker) ClaimLostObserved() bool { return s.claimLost }
+func (s *stubWorker) WorkerLabels() []string  { return s.labels }
 
 // stateStableValue mirrors parti.StateStable (== 4 per types/state.go).
 // Hardcoded to avoid a circular import: coordinator_test → worker → coordinator.
 const stateStableValue = 4
 const stateWaitingAssignmentValue = 3
+
+// ---------------------------------------------------------------------------
+// Label-affinity oracle
+// ---------------------------------------------------------------------------
+
+func TestLabelAffinityOracle_NoViolationWhenOwnerHasLabel(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, 5*time.Second, registry)
+	o.IngestAssignment("worker-A", []int{0})
+	o.Check(time.Now())
+
+	if v := o.ViolationCount(); v != 0 {
+		t.Errorf("expected 0 violations, got %d", v)
+	}
+}
+
+func TestLabelAffinityOracle_ViolationAfterGraceWhenOwnerLacksLabel(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil}) // owns the partition, unlabeled
+	// worker-B is a standing eligible vip-a carrier that owns nothing. It keeps
+	// vip-a non-empty fleet-wide so the mismatch is AVOIDABLE (an eligible
+	// worker exists but isn't being used) — i.e. the case the oracle exists to
+	// catch — rather than the Task 11b fleet-wide-empty terminal state, which
+	// is exempt. Without it, a lone unlabeled owner would be exempt and no
+	// violation would fire, defeating this boundary test.
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	grace := 20 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	// This test exercises the spillGrace boundary itself, not the settle
+	// allowance (that's covered by
+	// TestLabelAffinityOracle_NoViolationWithinSettleAllowanceAfterGrace
+	// below). Override the production settleAllowance
+	// (labelAffinitySettleAllowance) down to 0 so a millisecond-scale sleep
+	// can still cross the effective threshold without the test taking
+	// multiple real seconds.
+	o.settleAllowance = 0
+	o.IngestAssignment("worker-A", []int{0})
+
+	// First Check(): enters the park/grace window, no violation yet.
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v != 0 {
+		t.Fatalf("expected 0 violations on first check (still in grace), got %d", v)
+	}
+
+	// After grace: violation fires.
+	time.Sleep(grace + 15*time.Millisecond)
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v == 0 {
+		t.Error("expected a violation after the grace window elapsed with no affine owner")
+	}
+}
+
+// TestLabelAffinityOracle_NoViolationWithinSettleAllowanceAfterGrace verifies
+// the fix this task adds: a mismatch that has outlived spillGrace but not yet
+// spillGrace+settleAllowance must NOT count as a violation (the "rebalance /
+// handoff" phase docs/LABELS.md's worst-case-stall formula documents as a
+// separate, expected phase after LabelSpillGrace elapses). A prior version of
+// LabelAffinityOracle.Check compared directly against spillGrace with no
+// added slack, which flagged violations inside this exact window.
+func TestLabelAffinityOracle_NoViolationWithinSettleAllowanceAfterGrace(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil}) // owns the partition, unlabeled
+	// Standing eligible vip-a carrier (owns nothing) — keeps vip-a non-empty so
+	// the mismatch is avoidable and the settle-allowance boundary is genuinely
+	// exercised rather than short-circuited by the Task 11b fleet-wide-empty
+	// exemption. See TestLabelAffinityOracle_ViolationAfterGraceWhenOwnerLacksLabel.
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	grace := 20 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	// Use a short, deterministic settle allowance for the test instead of the
+	// production labelAffinitySettleAllowance value so this test runs in
+	// milliseconds while still exercising the exact same comparison logic.
+	o.settleAllowance = 100 * time.Millisecond
+	o.IngestAssignment("worker-A", []int{0})
+
+	o.Check(time.Now()) // enters park/grace window
+
+	// Past spillGrace (20ms) but well within spillGrace+settleAllowance
+	// (120ms): must NOT violate. Pre-fix behavior compared directly against
+	// spillGrace and would have flagged this as a violation.
+	time.Sleep(60 * time.Millisecond)
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v != 0 {
+		t.Fatalf("expected 0 violations while within grace+settleAllowance (age~60ms, threshold=120ms), got %d", v)
+	}
+
+	// Past spillGrace+settleAllowance (120ms total): violation fires.
+	time.Sleep(80 * time.Millisecond) // cumulative age ~140ms > 120ms threshold
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v == 0 {
+		t.Error("expected a violation once spillGrace+settleAllowance elapsed with no affine owner")
+	}
+}
+
+func TestLabelAffinityOracle_NoViolationWithinGraceWindow(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})
+	// Standing eligible vip-a carrier (owns nothing) so the mismatch is
+	// avoidable — this test proves the WITHIN-grace path (park set, not yet
+	// violated), which the Task 11b fleet-wide-empty exemption would otherwise
+	// mask if vip-a had no carrier at all.
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	grace := 1 * time.Hour // long enough that this test can't outlast it
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	o.IngestAssignment("worker-A", []int{0})
+	o.Check(time.Now())
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v != 0 {
+		t.Errorf("expected 0 violations while still within the grace/park window, got %d", v)
+	}
+}
+
+func TestLabelAffinityOracle_RecoveryClearsParkState(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})
+	// Standing eligible vip-a carrier (owns nothing): keeps vip-a non-empty so
+	// the FIRST Check genuinely parks the mismatch (rather than being exempted
+	// by Task 11b's fleet-wide-empty rule), so this test truly exercises
+	// "recovery clears a SET park state" and not merely "an affine worker
+	// yields zero violations".
+	registry.Register("worker-C", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	grace := 15 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	o.IngestAssignment("worker-A", []int{0})
+	o.Check(time.Now()) // enters park (vip-a non-empty via worker-C, so not exempt)
+
+	// A now-affine worker takes over before grace elapses.
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+	o.IngestAssignment("worker-B", []int{0})
+	o.ForgetWorker("worker-A")
+	o.Check(time.Now())
+
+	time.Sleep(grace + 15*time.Millisecond)
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v != 0 {
+		t.Errorf("expected 0 violations after an affine worker took over before grace elapsed, got %d", v)
+	}
+}
+
+// TestLabelAffinityOracle_SetLiveLabelOverrideTriggersImmediateRecheck
+// reproduces the Task 10d bug: SetLiveLabelOverride used to update the
+// override bookkeeping without ever calling Check(), so relabel events that
+// CURE and then re-introduce a mismatch — without any intervening
+// AssignmentReport / Check() call — never reset the parkedSince clock. A
+// later, unrelated Check() call would then compute the mismatch's "age"
+// against the ORIGINAL (much older) onset instead of the true onset of the
+// current mismatch, and could fire a violation purely from that stale
+// clock even though the live mismatch had only just re-started and was
+// still well within spillGrace+settleAllowance. This mirrors the empirical
+// diagnostic run that found a violation reported at age=127.7s spanning two
+// full curing relabel events with zero intervening assignment-report
+// activity.
+//
+// Sequence: park a mismatch at T0 -> CURE via SetLiveLabelOverride at T1
+// (no Check() in between) -> UN-CURE via SetLiveLabelOverride at T2 (no
+// Check() in between) -> Check() at T3, chosen so that (T3-T2) is
+// comfortably under threshold (the current mismatch, if timed correctly,
+// should not violate yet) but (T3-T0) is comfortably OVER threshold (the
+// stale clock, if left unreset, would incorrectly violate).
+//
+// With the fix, both SetLiveLabelOverride calls (T1 cure, T2 un-cure)
+// immediately re-check in the same critical section as the override
+// update: T1 observes affine and clears parkedSince; T2 observes the
+// renewed mismatch and re-parks it fresh at T2. Check() at T3 then
+// correctly measures the age from T2, sees it under threshold, and fires
+// no violation. Before the fix, SetLiveLabelOverride never re-checks, so
+// parkedSince is still T0 when Check() runs at T3, and the stale
+// (T3-T0) age incorrectly exceeds the threshold, firing a spurious
+// violation for a mismatch that had actually only just resumed.
+func TestLabelAffinityOracle_SetLiveLabelOverrideTriggersImmediateRecheck(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	// worker-A's registry-derived labels are unlabeled and never change —
+	// mirrors the label_heartbeat_takeover primitive, which rewrites a
+	// worker's heartbeat KV entry directly without touching its
+	// Manager/Config, so the registry read alone can never observe either
+	// the cure or the later un-cure; SetLiveLabelOverride is the only
+	// signal for both.
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})
+	// worker-B is a standing eligible vip-a carrier that owns nothing. It keeps
+	// vip-a non-empty fleet-wide for the whole test so the Task 11b
+	// fleet-wide-empty exemption never applies — otherwise the T2 un-cure
+	// (worker-A reverts to unlabeled with no other carrier) would leave vip-a
+	// with zero carriers and the exemption, not the parkedSince-reset this test
+	// is asserting, would be what keeps T3's count at zero. With worker-B
+	// present the mismatch stays avoidable and this test isolates the Task 10d
+	// immediate-recheck behavior exactly as intended.
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	grace := 20 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	o.settleAllowance = 40 * time.Millisecond // threshold = grace+settle = 60ms
+	o.IngestAssignment("worker-A", []int{0})
+
+	// T0: park the mismatch (worker-A owns partition 0 but lacks "vip-a").
+	o.Check(time.Now())
+
+	// T1 (T1-T0 ~= 25ms): CURE via a live label override. No Check() call
+	// happens between T0 and T1.
+	time.Sleep(25 * time.Millisecond)
+	o.SetLiveLabelOverride("worker-A", []string{"vip-a"})
+
+	// T2 (T2-T0 ~= 50ms): UN-CURE — revert the override, re-introducing the
+	// mismatch. No Check() call happens between T1 and T2.
+	time.Sleep(25 * time.Millisecond)
+	o.SetLiveLabelOverride("worker-A", nil)
+
+	// T3 (T3-T2 ~= 20ms, well under the 60ms threshold; T3-T0 ~= 70ms, well
+	// over the 60ms threshold): an unrelated Check() call, as would happen
+	// from some other event in the real coordinator.
+	time.Sleep(20 * time.Millisecond)
+	o.Check(time.Now())
+
+	if v := o.ViolationCount(); v != 0 {
+		t.Errorf("expected 0 violations: the current mismatch (since T2, ~20ms old) is well within grace+settleAllowance (60ms); "+
+			"a violation here means parkedSince was not reset by SetLiveLabelOverride's cure/un-cure, got %d", v)
+	}
+}
+
+func TestLabelAffinityOracle_UnlabeledPartitionNeverChecked(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})
+
+	o := NewLabelAffinityOracle(map[int]string{}, 10*time.Millisecond, registry) // no labeled partitions at all
+	o.IngestAssignment("worker-A", []int{0, 1, 2})
+	time.Sleep(20 * time.Millisecond)
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v != 0 {
+		t.Errorf("expected 0 violations when no partition carries a label, got %d", v)
+	}
+}
+
+// TestLabelAffinityOracle_NoViolationWhenLabelFleetWideEmpty proves the Task
+// 11b exemption: when a labeled partition's owner lacks the required label AND
+// no live worker anywhere in the fleet carries that label (the label's entire
+// pool is permanently gone), the mismatch is the documented, PERMANENT terminal
+// spill state (docs/LABELS.md "Parking and spill": a labeled partition whose
+// pool has gone completely empty legitimately spills to an unlabeled fallback
+// worker) — NOT an avoidable mismatch awaiting eventual correction. There is no
+// worker anywhere that could ever make the partition affine again, so the
+// oracle must NOT keep re-firing a violation every threshold window forever.
+//
+// Pre-fix this test FAILS: the oracle parks the mismatch and, once
+// spillGrace+settleAllowance elapses, fires a violation because its only exit
+// condition was "the current owner carries the label," which can never become
+// true once the label has zero carriers fleet-wide.
+func TestLabelAffinityOracle_NoViolationWhenLabelFleetWideEmpty(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	// worker-A owns the labeled partition but does NOT carry vip-a, and NO
+	// other live worker carries vip-a either — the label's pool is fleet-wide
+	// empty (mirrors label_pool_outage_spill / label_emergency_carveout after
+	// every vip-a worker has been permanently killed).
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})
+
+	grace := 20 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	o.settleAllowance = 0 // exercise the spillGrace boundary directly (see sibling tests)
+	o.IngestAssignment("worker-A", []int{0})
+
+	// First Check(): observes the mismatch; the exemption suppresses it.
+	o.Check(time.Now())
+	// Advance well past spillGrace+settleAllowance and check repeatedly — a
+	// non-exempt mismatch would fire (and re-fire) here.
+	time.Sleep(grace + 15*time.Millisecond)
+	o.Check(time.Now())
+	o.Check(time.Now())
+
+	if v := o.ViolationCount(); v != 0 {
+		t.Errorf("expected 0 violations: vip-a has no live carrier fleet-wide, so the mismatch is the "+
+			"documented permanent terminal spill state, not an avoidable mismatch; got %d", v)
+	}
+}
+
+// TestLabelAffinityOracle_ViolationWhenEligibleWorkerExists proves the Task 11b
+// exemption does NOT mask a REAL, avoidable mismatch. Here an eligible worker
+// (worker-B) DOES carry vip-a — so the label's pool is NOT fleet-wide empty —
+// yet the partition is owned by an unlabeled worker (worker-A). An eligible
+// worker exists and simply isn't being used: this is exactly the mismatch the
+// oracle exists to catch, and the fleet-wide-empty exemption must NOT suppress
+// it. (This test passes both pre- and post-fix; it guards the exemption's
+// lower bound.)
+func TestLabelAffinityOracle_ViolationWhenEligibleWorkerExists(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})               // owns partition, unlabeled
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}}) // eligible, unused
+
+	grace := 20 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	o.settleAllowance = 0
+	o.IngestAssignment("worker-A", []int{0})
+
+	o.Check(time.Now())
+	time.Sleep(grace + 15*time.Millisecond)
+	o.Check(time.Now())
+
+	if v := o.ViolationCount(); v == 0 {
+		t.Error("expected a violation: an eligible vip-a worker (worker-B) exists but the partition is owned by " +
+			"an unlabeled worker — an avoidable mismatch the exemption must not suppress")
+	}
+}
+
+// TestLabelAffinityOracle_ExemptionIsStateBasedNotSticky proves the exemption
+// is recomputed fresh on every Check() from the current liveLabels, with no
+// sticky "once exempt, always exempt" latch. It starts fleet-wide empty (no
+// violation fires even past threshold), then an eligible vip-a worker appears
+// (the pool becomes non-empty) while the partition's owner still lacks the
+// label; after advancing past threshold again, a violation NOW fires. The
+// re-entry to normal checking falls out naturally from checkLocked rebuilding
+// liveLabels every call and resetting parkedSince during the exempt phase, so
+// the freshly-avoidable mismatch gets a full threshold window before it counts.
+//
+// Pre-fix this test FAILS at phase 1 (the fleet-wide-empty mismatch fires a
+// violation because there is no exemption yet).
+func TestLabelAffinityOracle_ExemptionIsStateBasedNotSticky(t *testing.T) {
+	t.Parallel()
+	registry := NewGoroutineRegistry()
+	// Phase 1 setup: worker-A owns partition 0, lacks vip-a, and no worker
+	// anywhere carries vip-a — fleet-wide empty.
+	registry.Register("worker-A", WorkerGoroutine, func() {}, nil, &stubWorker{labels: nil})
+
+	grace := 20 * time.Millisecond
+	o := NewLabelAffinityOracle(map[int]string{0: "vip-a"}, grace, registry)
+	o.settleAllowance = 0
+	o.IngestAssignment("worker-A", []int{0})
+
+	// Phase 1: fleet-wide empty — exempt, no violation even past threshold.
+	o.Check(time.Now())
+	time.Sleep(grace + 15*time.Millisecond)
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v != 0 {
+		t.Fatalf("phase 1: expected 0 violations while vip-a is fleet-wide empty, got %d", v)
+	}
+
+	// Phase 2: an eligible vip-a worker appears (pool no longer empty). The
+	// partition's owner (worker-A) still lacks the label, so the mismatch is
+	// now avoidable. The exemption must stop applying immediately, and the
+	// park clock restarts fresh from this observation.
+	registry.Register("worker-B", WorkerGoroutine, func() {}, nil, &stubWorker{labels: []string{"vip-a"}})
+
+	o.Check(time.Now()) // re-parks fresh (exemption no longer applies)
+	if v := o.ViolationCount(); v != 0 {
+		t.Fatalf("phase 2: expected 0 violations immediately after the eligible worker appears "+
+			"(fresh park window), got %d — a stale park clock leaked across the exempt phase", v)
+	}
+	time.Sleep(grace + 15*time.Millisecond)
+	o.Check(time.Now())
+	if v := o.ViolationCount(); v == 0 {
+		t.Error("phase 2: expected a violation once an eligible vip-a worker exists but the partition " +
+			"remains owned by an unlabeled worker past the threshold")
+	}
+}

--- a/test/simulation/internal/metrics/collector.go
+++ b/test/simulation/internal/metrics/collector.go
@@ -15,6 +15,14 @@ import (
 type Collector struct {
 	// Protects cached assignment metrics reads/writes
 	assignMu sync.RWMutex
+	// Protects the manual histogram-statistics sum/count pairs and the
+	// cached system/worker gauges below, all written from one goroutine
+	// (the periodic system-metrics ticker / worker/consumer callbacks) and
+	// read from another (PrintReport's ticker). Found via -race under
+	// label_tight_takeover_churn.yaml (Task 10): this scenario's
+	// leader-flap chaos plus 6 concurrent workers is the first workload to
+	// exercise this collector with real concurrency under -race.
+	statsMu sync.Mutex
 	// Message counters (per-partition)
 	messagesSentTotal        *prometheus.CounterVec
 	messagesReceivedTotal    *prometheus.CounterVec
@@ -962,7 +970,9 @@ func (a resolverMetricsAdapter) IncReconcileRescue() {
 //   - count: Number of active workers
 func (c *Collector) SetWorkersActive(count int) {
 	c.workersActive.Set(float64(count))
+	c.statsMu.Lock()
 	c.cachedActiveWorkers = count
+	c.statsMu.Unlock()
 }
 
 // RecordPartitionsPerWorker records the partition count for a worker.
@@ -971,8 +981,10 @@ func (c *Collector) SetWorkersActive(count int) {
 //   - count: Number of partitions assigned to the worker
 func (c *Collector) RecordPartitionsPerWorker(count int) {
 	c.partitionsPerWorker.Observe(float64(count))
+	c.statsMu.Lock()
 	c.partitionsPerWorkerSum += float64(count)
 	c.partitionsPerWorkerCount++
+	c.statsMu.Unlock()
 }
 
 // RecordRebalanceDuration records a rebalancing operation duration.
@@ -981,8 +993,10 @@ func (c *Collector) RecordPartitionsPerWorker(count int) {
 //   - duration: Duration of the rebalancing operation
 func (c *Collector) RecordRebalanceDuration(duration time.Duration) {
 	c.workerRebalanceDuration.Observe(duration.Seconds())
+	c.statsMu.Lock()
 	c.rebalanceDurationSum += duration.Seconds()
 	c.rebalanceDurationCount++
+	c.statsMu.Unlock()
 }
 
 // RecordMessageProcessingDuration records message processing duration.
@@ -991,8 +1005,10 @@ func (c *Collector) RecordRebalanceDuration(duration time.Duration) {
 //   - duration: Processing duration
 func (c *Collector) RecordMessageProcessingDuration(duration time.Duration) {
 	c.messageProcessingDuration.Observe(duration.Seconds())
+	c.statsMu.Lock()
 	c.processingDurationSum += duration.Seconds()
 	c.processingDurationCount++
+	c.statsMu.Unlock()
 }
 
 // RecordProcessingError records a message processing error.
@@ -1025,8 +1041,10 @@ func (c *Collector) SetPartitionWeight(partitionID int, weight int64) {
 func (c *Collector) UpdateSystemMetrics(goroutines int, memoryBytes uint64) {
 	c.goroutinesActive.Set(float64(goroutines))
 	c.memoryUsageBytes.Set(float64(memoryBytes))
+	c.statsMu.Lock()
 	c.cachedGoroutines = goroutines
 	c.cachedMemoryBytes = memoryBytes
+	c.statsMu.Unlock()
 }
 
 // GetSystemMetrics returns current system metrics.
@@ -1035,6 +1053,8 @@ func (c *Collector) UpdateSystemMetrics(goroutines int, memoryBytes uint64) {
 //   - int: Number of active goroutines
 //   - float64: Memory usage in MiB
 func (c *Collector) GetSystemMetrics() (int, float64) {
+	c.statsMu.Lock()
+	defer c.statsMu.Unlock()
 	memoryMiB := float64(c.cachedMemoryBytes) / (1024 * 1024)
 	return c.cachedGoroutines, memoryMiB
 }
@@ -1044,6 +1064,8 @@ func (c *Collector) GetSystemMetrics() (int, float64) {
 // Returns:
 //   - int: Number of active workers
 func (c *Collector) GetActiveWorkers() int {
+	c.statsMu.Lock()
+	defer c.statsMu.Unlock()
 	return c.cachedActiveWorkers
 }
 
@@ -1056,6 +1078,8 @@ func (c *Collector) GetActiveWorkers() int {
 //
 // Note: These are manually tracked averages, updated with each observation.
 func (c *Collector) GetAggregatedMetrics() (avgPartitions float64, avgRebalance float64, avgLatency float64) {
+	c.statsMu.Lock()
+	defer c.statsMu.Unlock()
 	if c.partitionsPerWorkerCount > 0 {
 		avgPartitions = c.partitionsPerWorkerSum / float64(c.partitionsPerWorkerCount)
 	}

--- a/test/simulation/internal/worker/chaos_proof_metrics.go
+++ b/test/simulation/internal/worker/chaos_proof_metrics.go
@@ -1,0 +1,105 @@
+// Package worker's ChaosProofMetrics gives label chaos scenarios a
+// race-free way to positively prove four code paths actually fired,
+// rather than inferring it from the absence of oracle violations (which
+// can pass vacuously if the chaos primitive silently took a different,
+// already-tested path — e.g. a relabel landing on an expired heartbeat
+// key instead of a live one). All four signals are already public
+// production API reachable through parti.WithMetrics; this file adds no
+// new hooks to internal/assignment or the root parti package. Pattern
+// copied from test/integration/assignment/label_policy_test.go's
+// recordingLabelMetrics.
+package worker
+
+import (
+	"sync/atomic"
+
+	imetrics "github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/types"
+)
+
+// ChaosProofMetrics embeds internal/metrics.NopMetrics (satisfying the full
+// types.MetricsCollector surface with no-ops) and overrides exactly the
+// four methods this plan's chaos scenarios need to positively prove:
+//   - IncrementLabelChangeTrigger: the worker-monitor's tight-takeover
+//     fingerprint-mismatch callback fired (internal/assignment/worker_monitor.go
+//     checkLabelChange -> calculator.go's SetOnLabelChange registration).
+//   - RecordEmergencyRebalance: the calculator's emergency carve-out claim
+//     succeeded (internal/assignment/calculator.go claimEmergency).
+//   - RecordRebalanceAttempt filtered to reason=="label_recheck", success:
+//     monitorLabelRecheck actually won its CAS/claim and ran a rebalance
+//     (as opposed to merely setting the internal, unobservable
+//     pendingLabelRecheck flag).
+//   - IncrementLabelSpill: a partition spilled from its labeled pool to an
+//     unlabeled fallback worker (used to prove a whole-label-pool-outage
+//     scenario actually triggered a spill, not just that no violation was
+//     observed).
+type ChaosProofMetrics struct {
+	*imetrics.NopMetrics
+
+	labelChangeTriggers atomic.Int64
+	emergencyClaims     atomic.Int64
+	labelRechecksRun    atomic.Int64
+	labelSpills         atomic.Int64
+}
+
+var (
+	_ types.MetricsCollector = (*ChaosProofMetrics)(nil)
+	_ types.LabelMetrics     = (*ChaosProofMetrics)(nil)
+)
+
+// NewChaosProofMetrics constructs a zeroed collector.
+func NewChaosProofMetrics() *ChaosProofMetrics {
+	return &ChaosProofMetrics{NopMetrics: imetrics.NewNop()}
+}
+
+// IncrementLabelChangeTrigger implements types.LabelMetrics.
+func (m *ChaosProofMetrics) IncrementLabelChangeTrigger() {
+	m.labelChangeTriggers.Add(1)
+}
+
+// LabelChangeTriggers returns the count of tight-takeover fingerprint-change
+// callbacks observed.
+func (m *ChaosProofMetrics) LabelChangeTriggers() int64 {
+	return m.labelChangeTriggers.Load()
+}
+
+// RecordEmergencyRebalance implements types.CalculatorMetrics. The
+// disappearedWorkers argument is discarded — this collector only needs the
+// call count, not the magnitude.
+func (m *ChaosProofMetrics) RecordEmergencyRebalance(_ int) {
+	m.emergencyClaims.Add(1)
+}
+
+// EmergencyClaims returns the count of successful emergency-carve-out
+// claims observed.
+func (m *ChaosProofMetrics) EmergencyClaims() int64 {
+	return m.emergencyClaims.Load()
+}
+
+// RecordRebalanceAttempt implements types.CalculatorMetrics. Only
+// successful attempts with reason "label_recheck" increment
+// LabelRechecksRun; every other reason/outcome is discarded.
+func (m *ChaosProofMetrics) RecordRebalanceAttempt(reason string, success bool) {
+	if reason == "label_recheck" && success {
+		m.labelRechecksRun.Add(1)
+	}
+}
+
+// LabelRechecksRun returns the count of coalesced label-recheck rebalances
+// that actually ran (as opposed to being requested/coalesced away).
+func (m *ChaosProofMetrics) LabelRechecksRun() int64 {
+	return m.labelRechecksRun.Load()
+}
+
+// IncrementLabelSpill implements types.LabelMetrics. The label argument is
+// discarded — this collector only needs the total spill count, not a
+// per-label breakdown.
+func (m *ChaosProofMetrics) IncrementLabelSpill(_ string) {
+	m.labelSpills.Add(1)
+}
+
+// LabelSpills returns the total count of partitions that spilled from a
+// labeled pool to an unlabeled fallback worker, across all labels.
+func (m *ChaosProofMetrics) LabelSpills() int64 {
+	return m.labelSpills.Load()
+}

--- a/test/simulation/internal/worker/chaos_proof_metrics_test.go
+++ b/test/simulation/internal/worker/chaos_proof_metrics_test.go
@@ -1,0 +1,65 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+func TestChaosProofMetrics_SatisfiesInterfaces(t *testing.T) {
+	t.Parallel()
+	var (
+		_ types.MetricsCollector = (*ChaosProofMetrics)(nil)
+		_ types.LabelMetrics     = (*ChaosProofMetrics)(nil)
+	)
+}
+
+func TestChaosProofMetrics_CountersStartAtZero(t *testing.T) {
+	t.Parallel()
+	m := NewChaosProofMetrics()
+	if m.LabelChangeTriggers() != 0 || m.EmergencyClaims() != 0 || m.LabelRechecksRun() != 0 || m.LabelSpills() != 0 {
+		t.Fatalf("expected all counters to start at 0, got %d/%d/%d/%d",
+			m.LabelChangeTriggers(), m.EmergencyClaims(), m.LabelRechecksRun(), m.LabelSpills())
+	}
+}
+
+func TestChaosProofMetrics_IncrementLabelSpill(t *testing.T) {
+	t.Parallel()
+	m := NewChaosProofMetrics()
+	m.IncrementLabelSpill("vip-a")
+	m.IncrementLabelSpill("vip-a")
+	m.IncrementLabelSpill("vip-b")
+	if got := m.LabelSpills(); got != 3 {
+		t.Errorf("LabelSpills() = %d, want 3 (total across all labels)", got)
+	}
+}
+
+func TestChaosProofMetrics_IncrementLabelChangeTrigger(t *testing.T) {
+	t.Parallel()
+	m := NewChaosProofMetrics()
+	m.IncrementLabelChangeTrigger()
+	m.IncrementLabelChangeTrigger()
+	if got := m.LabelChangeTriggers(); got != 2 {
+		t.Errorf("LabelChangeTriggers() = %d, want 2", got)
+	}
+}
+
+func TestChaosProofMetrics_RecordEmergencyRebalance(t *testing.T) {
+	t.Parallel()
+	m := NewChaosProofMetrics()
+	m.RecordEmergencyRebalance(3)
+	if got := m.EmergencyClaims(); got != 1 {
+		t.Errorf("EmergencyClaims() = %d, want 1 (call count, not the disappeared-worker count)", got)
+	}
+}
+
+func TestChaosProofMetrics_RecordRebalanceAttempt_FiltersToLabelRecheckSuccess(t *testing.T) {
+	t.Parallel()
+	m := NewChaosProofMetrics()
+	m.RecordRebalanceAttempt("label_recheck", false) // failed attempt: must not count
+	m.RecordRebalanceAttempt("cold_start", true)     // wrong reason: must not count
+	m.RecordRebalanceAttempt("label_recheck", true)  // the one that counts
+	if got := m.LabelRechecksRun(); got != 1 {
+		t.Errorf("LabelRechecksRun() = %d, want 1", got)
+	}
+}

--- a/test/simulation/internal/worker/worker.go
+++ b/test/simulation/internal/worker/worker.go
@@ -37,12 +37,42 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
+// buildPartitions constructs the static partition slice a worker's source
+// is seeded with. weights and labels are parallel arrays indexed by
+// partition ID; both default when shorter than count — weight defaults to
+// 1 (matching the strategy's own default-weight convention), label
+// defaults to "" (unlabeled). Factored out of NewWorker so it's testable
+// without a live NATS connection.
+func buildPartitions(count int, weights []int64, labels []string) []types.Partition {
+	partitions := make([]types.Partition, count)
+	for i := 0; i < count; i++ {
+		weight := int64(1)
+		if i < len(weights) {
+			weight = weights[i]
+		}
+		label := ""
+		if i < len(labels) {
+			label = labels[i]
+		}
+		partitions[i] = types.Partition{
+			Keys:   []string{fmt.Sprintf("%d", i)},
+			Weight: weight,
+			Label:  label,
+		}
+	}
+
+	return partitions
+}
+
 type Worker struct {
 	id      string
 	nc      *nats.Conn
 	js      jetstream.JetStream
 	cfg     *parti.Config
 	manager *parti.Manager
+	// chaosProof captures positive-proof counters for label chaos
+	// scenarios (see chaos_proof_metrics.go). Always non-nil.
+	chaosProof *ChaosProofMetrics
 	// updater is the manager-driven consumer updater. Holds the same instance
 	// as `dynamic` but typed as the parti interface for WithWorkerConsumerUpdater.
 	updater parti.WorkerConsumerUpdater
@@ -55,10 +85,20 @@ type Worker struct {
 	startLatencyCh      chan<- coordinator.StartLatencyReport
 	metricsCollector    *metrics.Collector
 	logger              types.Logger
-	currentPartitions   int // Track current partition count for metrics
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	started             atomic.Bool // Prevents multiple Start() calls
+	// currentPartitions tracks the current partition count for metrics.
+	// atomic because handleAssignmentChanged (its sole writer) can run
+	// concurrently on itself: Manager.invokeHook dispatches each
+	// OnAssignmentChanged call on its own goroutine with no
+	// cross-invocation serialization, and the direct assignment watcher
+	// and the debounced commit watcher (manager_assignment.go) can each
+	// fire around the same instant — most commonly during a leader
+	// failover. Found via -race under the label_relabel_storm scenario
+	// (see task-12-report.md); reproduced by
+	// TestHandleAssignmentChanged_ConcurrentInvocationRace.
+	currentPartitions atomic.Int32
+	ctx               context.Context
+	cancel            context.CancelFunc
+	started           atomic.Bool // Prevents multiple Start() calls
 
 	// first-assignment latency tracking: captures the delay between Start()
 	// being called and the first OnAssignmentChanged with a non-empty set.
@@ -147,12 +187,15 @@ func (w *Worker) GetProcessingMultiplier() int {
 
 // Config configures a worker.
 type Config struct {
-	ID                  string
-	NC                  *nats.Conn
-	JS                  jetstream.JetStream
-	JetStreamWrapper    func(jetstream.JetStream) jetstream.JetStream
-	PartitionCount      int
-	PartitionWeights    []int64
+	ID               string
+	NC               *nats.Conn
+	JS               jetstream.JetStream
+	JetStreamWrapper func(jetstream.JetStream) jetstream.JetStream
+	PartitionCount   int
+	PartitionWeights []int64
+	// PartitionLabels is a parallel array to PartitionWeights, indexed by
+	// partition ID. "" (or out-of-range) means unlabeled.
+	PartitionLabels     []string
 	AssignmentStrategy  string
 	ProcessingDelayMin  time.Duration
 	ProcessingDelayMax  time.Duration
@@ -220,6 +263,24 @@ type Config struct {
 	WorkerIDMax    int
 	WorkerIDTTL    time.Duration
 
+	// WorkerLabels is this worker's fixed label set. Empty means
+	// unlabeled. Rides into parti.Config.WorkerLabels — see NewWorker.
+	WorkerLabels []string
+	// ChaosProof, when non-nil, is reused as this worker's positive-proof
+	// metrics collector instead of allocating a fresh one. The all-in-one
+	// restart path passes the SAME instance across every respawn of a given
+	// sim worker ID so label-chaos counters (e.g. LabelChangeTriggers) that
+	// increment on whichever incarnation was leader at detection time survive
+	// a subsequent crash+respawn of that worker. Nil (the default) allocates a
+	// fresh collector, preserving prior single-lifetime behavior.
+	ChaosProof *ChaosProofMetrics
+	// UnlabeledPartitionPolicy mirrors parti.Config.UnlabeledPartitionPolicy.
+	// Empty defers to parti.DefaultConfig()'s own default.
+	UnlabeledPartitionPolicy string
+	// LabelSpillGrace mirrors parti.Config.LabelSpillGrace. Zero defers to
+	// parti.DefaultConfig()'s own default.
+	LabelSpillGrace time.Duration
+
 	// RevocationReportCh receives a RevocationReport each time the manager
 	// drives a zero-partition UpdateWorkerConsumer call (Phase 4 ordering
 	// oracle). The signal is needed because OnAssignmentChanged does NOT
@@ -264,17 +325,7 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop,gocyclo // dispatc
 		cfg.ID, cfg.PartitionCount, cfg.AssignmentStrategy, cfg.EnforceExclusiveConsumption, cfg.HandlerConcurrency, cfg.ConsumerBatchSize)
 
 	// Create partition source
-	partitions := make([]types.Partition, cfg.PartitionCount)
-	for i := 0; i < cfg.PartitionCount; i++ {
-		weight := int64(1)
-		if i < len(cfg.PartitionWeights) {
-			weight = cfg.PartitionWeights[i]
-		}
-		partitions[i] = types.Partition{
-			Keys:   []string{fmt.Sprintf("%d", i)},
-			Weight: weight,
-		}
-	}
+	partitions := buildPartitions(cfg.PartitionCount, cfg.PartitionWeights, cfg.PartitionLabels)
 
 	// The partition source is constructed AFTER the Worker struct (below)
 	// so the WithLeadershipProbe closure can capture &worker for the
@@ -320,6 +371,18 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop,gocyclo // dispatc
 	if cfg.WorkerIDTTL != 0 {
 		partiCfg.WorkerIDTTL = cfg.WorkerIDTTL
 	}
+	// Label topology: override-if-set semantics, same idiom as the
+	// WorkerID* block above. Empty/zero values leave parti.DefaultConfig()'s
+	// own defaults in place.
+	if len(cfg.WorkerLabels) > 0 {
+		partiCfg.WorkerLabels = cfg.WorkerLabels
+	}
+	if cfg.UnlabeledPartitionPolicy != "" {
+		partiCfg.UnlabeledPartitionPolicy = cfg.UnlabeledPartitionPolicy
+	}
+	if cfg.LabelSpillGrace != 0 {
+		partiCfg.LabelSpillGrace = cfg.LabelSpillGrace
+	}
 	// Enable two-phase handoff only when exclusive consumption is requested.
 	// This publishes ownership claims to KV so the Processing Gate can enforce exclusivity.
 	partiCfg.EnableTwoPhaseHandoff = cfg.EnforceExclusiveConsumption
@@ -336,12 +399,17 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop,gocyclo // dispatc
 	// Default is 30s which is too long for fast testing
 	partiCfg.ColdStartWindow = 10 * time.Second
 
+	// Reuse a caller-provided collector across respawns when supplied (see
+	// Config.ChaosProof); otherwise allocate a fresh one.
+	chaosProof := resolveChaosProof(cfg.ChaosProof)
+
 	// Create worker struct first so we can reference it in hooks
 	worker := &Worker{
 		id:                     cfg.ID,
 		nc:                     cfg.NC,
 		js:                     cfg.JS,
 		cfg:                    &partiCfg,
+		chaosProof:             chaosProof,
 		processingDelayMin:     cfg.ProcessingDelayMin,
 		processingDelayMax:     cfg.ProcessingDelayMax,
 		coordinatorReportCh:    cfg.CoordinatorReportCh,
@@ -349,7 +417,6 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop,gocyclo // dispatc
 		startLatencyCh:         cfg.StartLatencyCh,
 		metricsCollector:       cfg.MetricsCollector,
 		logger:                 logger,
-		currentPartitions:      0,
 		handlerConcurrency:     cfg.HandlerConcurrency,
 		consumerBatchSize:      cfg.ConsumerBatchSize,
 		isInitialCohort:        cfg.IsInitialCohort,
@@ -570,7 +637,8 @@ func NewWorker(cfg Config) (*Worker, error) { //nolint:cyclop,gocyclo // dispatc
 	manager, err := parti.NewManager(&partiCfg, js, partitionSource, assignmentStrategy,
 		parti.WithLogger(logger),
 		parti.WithHooks(hooks),
-		parti.WithWorkerConsumerUpdater(worker.updater))
+		parti.WithWorkerConsumerUpdater(worker.updater),
+		parti.WithMetrics(chaosProof))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %w", err)
 	}
@@ -678,9 +746,9 @@ func (w *Worker) Start(ctx context.Context) error {
 // handleAssignmentChanged updates metrics on assignment changes.
 func (w *Worker) handleAssignmentChanged(ctx context.Context, oldSet, newSet []types.Partition) error {
 	start := time.Now()
-	w.currentPartitions = len(newSet)
+	w.currentPartitions.Store(int32(len(newSet))) //nolint:gosec // len(newSet) is a partition count, far below int32 range
 	if w.metricsCollector != nil {
-		w.metricsCollector.RecordPartitionsPerWorker(w.currentPartitions)
+		w.metricsCollector.RecordPartitionsPerWorker(int(w.currentPartitions.Load()))
 		w.metricsCollector.RecordRebalanceDuration(time.Since(start))
 	}
 
@@ -941,6 +1009,22 @@ func (w *Worker) StableWorkerID() string {
 	return w.manager.WorkerID()
 }
 
+// ChaosProof returns this worker's positive-proof metrics collector.
+func (w *Worker) ChaosProof() *ChaosProofMetrics {
+	return w.chaosProof
+}
+
+// resolveChaosProof returns cp when non-nil (reused across respawns) or a
+// freshly-allocated collector otherwise. Extracted from NewWorker to keep that
+// constructor within the revive statement-count budget.
+func resolveChaosProof(cp *ChaosProofMetrics) *ChaosProofMetrics {
+	if cp != nil {
+		return cp
+	}
+
+	return NewChaosProofMetrics()
+}
+
 // DegradedReason returns the most recently cached degraded reason captured by
 // the OnDegraded hook, or "" if the worker has not entered degraded mode.
 func (w *Worker) DegradedReason() string {
@@ -959,6 +1043,16 @@ func (w *Worker) DegradedReason() string {
 // Implements coordinator.WorkerObserver.
 func (w *Worker) ClaimLostObserved() bool {
 	return w.claimLostObserved.Load()
+}
+
+// WorkerLabels returns the manager's resolved label set, or nil if the
+// manager is nil or the worker is unlabeled.
+// Implements coordinator.WorkerObserver.
+func (w *Worker) WorkerLabels() []string {
+	if w.manager == nil {
+		return nil
+	}
+	return w.manager.WorkerLabels()
 }
 
 // handleError is the OnError hook implementation. It captures

--- a/test/simulation/internal/worker/worker_assignment_hook_test.go
+++ b/test/simulation/internal/worker/worker_assignment_hook_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -185,5 +186,49 @@ func TestHandleAssignmentChanged_CancellationDoesNotWedge(t *testing.T) {
 		// Pass — handler returned without wedging.
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("handleAssignmentChanged wedged after ctx cancellation")
+	}
+}
+
+// TestHandleAssignmentChanged_ConcurrentInvocationRace reproduces a data
+// race found empirically while running the label_relabel_storm scenario
+// under -race (see task-12-report.md). Root cause: Manager.invokeHook
+// (manager.go) dispatches every hook invocation on its own goroutine with
+// no cross-invocation serialization, and two independent watch sessions —
+// the direct assignment watcher and the debounced commit watcher
+// (manager_assignment.go) — can each fire OnAssignmentChanged around the
+// same instant, most commonly while a leader failover causes both
+// sessions to re-observe a change together. handleAssignmentChanged wrote
+// w.currentPartitions as a plain int with no synchronization, so two
+// concurrent invocations raced on the same memory address. Production
+// code is not at fault: fire-and-forget concurrent hook dispatch is
+// invokeHook's documented, intentional contract — the callback owns its
+// own thread-safety.
+//
+// Fails under `go test -race` before the atomic.Int32 fix (two
+// unsynchronized writes to currentPartitions); passes after. The
+// assertion is a sanity check that the final value is one of the
+// concurrently-written lengths (never torn/impossible) — the race
+// detector's own verdict is the load-bearing check.
+func TestHandleAssignmentChanged_ConcurrentInvocationRace(t *testing.T) {
+	w := &Worker{
+		id:  "test-worker",
+		ctx: context.Background(),
+	}
+
+	const goroutines = 50
+	const maxLen = 5
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			newSet := make([]types.Partition, i%maxLen+1)
+			_ = w.handleAssignmentChanged(context.Background(), nil, newSet)
+		}()
+	}
+	wg.Wait()
+
+	if got := int(w.currentPartitions.Load()); got < 1 || got > maxLen {
+		t.Fatalf("currentPartitions = %d, want a value in [1,%d] (one of the concurrently-written lengths)", got, maxLen)
 	}
 }

--- a/test/simulation/internal/worker/worker_labels_test.go
+++ b/test/simulation/internal/worker/worker_labels_test.go
@@ -1,0 +1,44 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// TestNewWorker_StampsPartitionLabels verifies that PartitionLabels (parallel
+// to the existing PartitionWeights array) gets copied onto each constructed
+// types.Partition.Label, defaulting to "" for indices beyond the slice —
+// mirroring PartitionWeights' out-of-range default-to-1 behavior exactly.
+func TestNewWorker_StampsPartitionLabels(t *testing.T) {
+	t.Parallel()
+	// NewWorker requires a live NATS connection to go further than the
+	// partition-construction loop; this test only needs to prove the loop
+	// logic. Extract it as a standalone helper so it's testable without a
+	// NATS server. See Step 3 below — buildPartitions is a new unexported
+	// helper factored out of NewWorker's existing inline loop.
+	got := buildPartitions(3, nil, []string{"vip-a", "", "vip-b"})
+	want := []types.Partition{
+		{Keys: []string{"0"}, Weight: 1, Label: "vip-a"},
+		{Keys: []string{"1"}, Weight: 1, Label: ""},
+		{Keys: []string{"2"}, Weight: 1, Label: "vip-b"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Label != want[i].Label || got[i].Weight != want[i].Weight || got[i].Keys[0] != want[i].Keys[0] {
+			t.Errorf("index %d: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestNewWorker_PartitionLabelsShorterThanCount verifies default-to-""
+// out-of-range behavior, mirroring PartitionWeights' default-to-1.
+func TestNewWorker_PartitionLabelsShorterThanCount(t *testing.T) {
+	t.Parallel()
+	got := buildPartitions(3, nil, []string{"vip-a"})
+	if got[1].Label != "" || got[2].Label != "" {
+		t.Errorf("expected out-of-range partitions to default to unlabeled, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds label-awareness to the `test/simulation` chaos harness so it can exercise the production label-based partition assignment feature (shipped separately, v2.9.0) under real concurrent chaos — the specific bug class (concurrent multi-actor races) this project's history shows unit/integration tests cannot catch, but extended `-race` simulation has repeatedly caught for other features.

- Scenario config gains a declarative label topology (worker/partition label declarations, `UnlabeledPartitionPolicy`/`LabelSpillGrace` passthroughs), wired through worker construction.
- New `ChaosProofMetrics` collector so a scenario can positively prove its target mechanism fired, rather than merely inferring it from the absence of violations (which can pass vacuously).
- New `label_heartbeat_takeover` chaos primitive: directly rewrites a live worker's heartbeat KV entry to deterministically exercise the "tight takeover" fingerprint-mismatch branch — no test anywhere previously reached it. A hard-kill+respawn approach was investigated and rejected (the stableid stale-takeover path can never land on a still-live key).
- New `LabelAffinityOracle` invariant: fires when a labeled partition's owner doesn't carry the required label past its grace window; accepts live overrides from the heartbeat-takeover primitive; exempts the documented, permanent terminal state of a fleet-wide label loss.
- Four chaos scenarios: pool-outage/spill, concurrent tight-takeover relabeling (flagship), emergency carve-out under concurrent instability, and relabel-storm coalescing durability.

Along the way, `-race` under sustained chaos load surfaced several genuine pre-existing data races in the harness's own bookkeeping (never in the production library, which this PR touches only via one additive `Manager.WorkerLabels()` getter) — each fixed with a reproducer test.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean
- [x] `make lint` — 0 issues
- [x] `make pre-pr` (lint + full unit suite + full integration suite, both `-race`) — all gates passed
- [x] Each of the 4 new scenarios independently verified with 8+ consecutive clean full-length `-race` runs (20-30+ total runs each across tuning/diagnosis)
- [x] Cross-scenario regression checks after every shared-oracle change (`LabelAffinityOracle` went through 3 rounds of hardening, each re-verified against all sibling scenarios)
- [x] Final whole-branch review: zero Critical/Important issues, "ready to merge"