### PR TITLE
feat: v2.9.1 label follow-up APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.9.1] - 2026-07-10
+
+Label follow-up APIs that remove the workaround code label consumers were
+writing against v2.9.0: a validator so callers can reject a bad label at their
+own API boundary, a label-preserving write primitive, a batch validator, an
+embeddable no-op metrics base, and a way to actually reach immediate spill. All
+additive except one intentional error-text change (below); with zero labels
+anywhere in the fleet, assignment output is unchanged from every prior release.
+
+### Added
+
+- **`types.ValidateLabel(s string) error`** — validates a single partition or
+  worker label against the library's own rules (at most 64 bytes, no `.`, no
+  ASCII whitespace; the empty string is valid). `Partition.Validate` and the
+  worker-label normalizer now delegate to it, so a consumer can validate a label
+  at its own API boundary with zero risk of the rules drifting.
+- **`types.ValidatePartitions(ps []types.Partition) error`** — runs the exact
+  per-partition `Validate` plus `CanonicalID` duplicate check the `source.NatsKV`
+  write path performs (same first-error order and messages), so a consumer can
+  reject a malformed batch at its boundary with a precise message instead of a
+  generic error from inside a write.
+- **`types.MergeLabels(current, intents) ([]types.Partition, []string, error)`**
+  — a label-preserving write primitive keyed on `Partition.ID()`: a `nil` intent
+  clears a label, a non-`nil` intent sets it, an absent id is left unchanged, and
+  every unmentioned label is preserved. Hand the result to `source.Modify`
+  instead of hand-rolling an inherit/set/clear CAS closure. Returns the unmatched
+  ids (so a caller can reject a typo'd id) and **fails closed** on an `ID()`
+  collision rather than guessing which partition to relabel.
+- **`types.NopMetrics`** — an exported composite no-op satisfying the full
+  `types.MetricsCollector` and its optional `types.LabelMetrics` extension. Embed
+  it and override only the methods you care about (e.g. the label gauges for a
+  health endpoint) instead of stubbing the whole eight-interface surface.
+- **`parti.WithLabelSpillGrace(d time.Duration)`** — overrides
+  `Config.LabelSpillGrace`, and is the only way to reach immediate spill
+  (`d == 0`): the non-pointer config field silently re-defaults an explicit `0`
+  to `60s`. The option wins over the config field (mirroring `WithWorkerLabels`)
+  and rejects a negative duration at `NewManager` with an error wrapping
+  `types.ErrInvalidConfig`.
+
+### Changed
+
+- **Label validation error text is now uniform.** The partition-label and
+  worker-label validators previously produced different messages (`partition
+  label ...` vs `worker label ...`); both now surface `types.ValidateLabel`'s
+  canonical `label ...` wording. This is an error-**text** change only — no API
+  or behavior change, no change to which labels are accepted or rejected. Code
+  that matched on the old per-caller prefixes should match on the shared text.
+
+### Docs
+
+- `docs/LABELS.md`: the VIP promotion workflow now uses `MergeLabels`; a new
+  "Validating at your API boundary" note covers `ValidateLabel` /
+  `ValidatePartitions`; a "Label observability without a metrics pipeline"
+  subsection shows an in-memory collector embedding `types.NopMetrics` with the
+  leader-only caveat spelled out; and the spill-grace section documents reaching
+  immediate spill via `WithLabelSpillGrace`.
+
 ## [v2.9.0] - 2026-07-08
 
 Label-based partition assignment: pin a subset of partitions to a dedicated

--- a/config.go
+++ b/config.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/arloliu/fuda"
+	"github.com/arloliu/parti/v2/types"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -639,14 +639,8 @@ func normalizeWorkerLabels(labels []string) ([]string, error) {
 		if l == "" {
 			return nil, errors.New("worker label cannot be empty")
 		}
-		if len(l) > 64 {
-			return nil, fmt.Errorf("worker label exceeds 64 bytes: %q", l)
-		}
-		if strings.Contains(l, ".") {
-			return nil, fmt.Errorf("worker label contains invalid character '.': %q", l)
-		}
-		if strings.ContainsAny(l, " \t\n\r") {
-			return nil, fmt.Errorf("worker label contains whitespace: %q", l)
+		if err := types.ValidateLabel(l); err != nil {
+			return nil, err
 		}
 		if _, dup := seen[l]; dup {
 			continue

--- a/config_labels_test.go
+++ b/config_labels_test.go
@@ -1,11 +1,39 @@
 package parti
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/arloliu/parti/v2/types"
 	"github.com/stretchr/testify/require"
 )
+
+// TestWorkerAndPartitionLabelRulesAgree guards against the charset/length
+// rules drifting between Partition.Validate and normalizeWorkerLabels now that
+// both delegate to types.ValidateLabel. Every non-empty label that one path
+// rejects, the other must reject too (the empty string is excluded: it is
+// valid for a partition but forbidden for a worker label).
+func TestWorkerAndPartitionLabelRulesAgree(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"vip",                   // valid on both
+		"gpu-batch_2",           // valid on both
+		"a.b",                   // dot
+		"a b",                   // space
+		"a\tb",                  // tab
+		strings.Repeat("x", 64), // exactly at cap, valid
+		strings.Repeat("x", 65), // over cap
+	}
+	for _, label := range cases {
+		partErr := types.Partition{Keys: []string{"k"}, Label: label}.Validate()
+		_, workerErr := normalizeWorkerLabels([]string{label})
+		require.Equal(t, partErr != nil, workerErr != nil,
+			"partition and worker label validity must agree for %q (partErr=%v workerErr=%v)",
+			label, partErr, workerErr)
+	}
+}
 
 func TestConfig_WorkerLabelsNormalization(t *testing.T) {
 	t.Parallel()

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -25,6 +25,7 @@
     - [Worker labels](#worker-labels)
     - [Assignment policy (fleet-uniform)](#assignment-policy-fleet-uniform)
   - [The VIP promotion workflow](#the-vip-promotion-workflow)
+    - [Validating at your API boundary](#validating-at-your-api-boundary)
   - [Assignment flow](#assignment-flow)
     - [Leader: one rebalance pass](#leader-one-rebalance-pass)
     - [Worker: applying a commit](#worker-applying-a-commit)
@@ -38,6 +39,7 @@
     - [Deployment topology](#deployment-topology)
     - [Rolling updates](#rolling-updates)
   - [What operators see](#what-operators-see)
+    - [Label observability without a metrics pipeline](#label-observability-without-a-metrics-pipeline)
   - [Gotchas](#gotchas)
 
 ---
@@ -188,12 +190,29 @@ deployment; assignment *policy* is not.
 | Field | Default | Description |
 |---|---|---|
 | `UnlabeledPartitionPolicy` | `"dedicated"` | `"dedicated"`: unlabeled partitions go to unlabeled workers only, falling back to all workers when no unlabeled worker is live. `"shared"`: unlabeled partitions go to any worker, labeled or not. |
-| `LabelSpillGrace` | `60s` | How long a label's worker pool must be continuously empty before its partitions spill to the fallback ladder. `0` spills immediately. |
+| `LabelSpillGrace` | `60s` | How long a label's worker pool must be continuously empty before its partitions spill to the fallback ladder. See the note below for reaching immediate spill. |
 
 ```yaml
 unlabeledPartitionPolicy: dedicated
 labelSpillGrace: 60s
 ```
+
+**Immediate spill (`0`) is set via the option, not the config field.**
+`LabelSpillGrace` is a non-pointer duration with a `60s` default, so an explicit
+`labelSpillGrace: 0` cannot be told apart from the zero value and is re-defaulted
+back to `60s`. To spill on the first rebalance that finds a pool empty, pass the
+functional option, which preserves the difference between unset and `0`:
+
+```go
+mgr, err := parti.NewManager(cfg, js, src, strategy,
+    parti.WithLabelSpillGrace(0)) // 0 ⇒ immediate spill; wins over Config.LabelSpillGrace
+```
+
+The option overrides `Config.LabelSpillGrace` (mirroring `WithWorkerLabels` vs
+`Config.WorkerLabels`) and rejects a negative duration at `NewManager` with an
+error wrapping `types.ErrInvalidConfig`. Prefer a grace well below the class's
+latency SLO over `0` unless instant spill is genuinely wanted — see
+[Parking and spill](#parking-and-spill).
 
 With zero labels anywhere in the fleet (no labeled partitions, no labeled
 workers), the whole pipeline degenerates to today's single
@@ -210,24 +229,83 @@ In production the partition list normally lives in the `source.NatsKV`
 source (see [Strategies & Sources](STRATEGIES.md#natskv-source)). Promoting
 or demoting a partition is a **full-list rewrite** through the existing
 update path — there is no targeted "patch one partition's label" API.
-`source.NatsKV.Modify` does a CAS-fenced read-modify-write, which is the
-natural fit:
+`source.NatsKV.Modify` does a CAS-fenced read-modify-write, and
+`types.MergeLabels` computes the relabeled list — keyed on `Partition.ID()`, it
+sets, clears, or leaves each partition's label alone without disturbing keys or
+weight, and preserves every label the incoming intents don't mention (so a
+weight-only projection can't silently demote a pool — see
+[rollout rule #2](#rollout-rules)).
+
+Validate the intents at your API boundary **before** calling `Modify`.
+`Modify`'s closure has signature `func([]Partition) []Partition` — it cannot
+return an error, so a rejection (a typo'd id, or an ambiguous `ID()` collision)
+must be surfaced out here, against the current list, where it is a 400-class
+caller error rather than a silent no-op that still CAS-writes:
 
 ```go
 // kv obtained as in the NatsKV Source guide (docs/STRATEGIES.md).
 src := source.NewNatsKV(kv, "partitions", logger)
 
-// Promote "tenant-acme" to the vip pool.
-err := src.Modify(ctx, func(partitions []types.Partition) []types.Partition {
-    for i := range partitions {
-        if partitions[i].ID() == "tenant-acme" {
-            partitions[i].Label = "vip"
-        }
+// Promote "tenant-acme" to vip and demote "tenant-legacy" to unlabeled.
+vip := "vip"
+intents := map[string]*string{
+    "tenant-acme":   &vip, // set
+    "tenant-legacy": nil,  // clear (back to unlabeled)
+}
+
+// 1. Reject bad intents at the boundary, before any write.
+current, err := src.List(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+if _, unmatched, mErr := types.MergeLabels(current, intents); mErr != nil {
+    log.Fatalf("ambiguous relabel: %v", mErr) // ID() collision → 400
+} else if len(unmatched) > 0 {
+    log.Fatalf("unknown partition ids: %v", unmatched) // typo → 404
+}
+
+// 2. Apply under CAS. Modify re-reads the authoritative list, so MergeLabels
+//    runs again on it; step 1 already rejected bad intents, and the closure
+//    returns the list untouched on the rare in-flight structural change rather
+//    than writing a partial result.
+err = src.Modify(ctx, func(partitions []types.Partition) []types.Partition {
+    merged, _, mErr := types.MergeLabels(partitions, intents)
+    if mErr != nil {
+        return partitions // safety: never write a nil/partial list
     }
-    return partitions
+    return merged
 })
 if err != nil {
     log.Fatal(err)
+}
+```
+
+`MergeLabels` **fails closed** on an `ID()` collision: `ID()` dash-joins a
+partition's keys and is not collision-safe, so an intent that matches more than
+one partition returns an error rather than guessing which to relabel. It does
+**not** validate label values — pair it with `ValidateLabel` at your boundary
+(next section).
+
+### Validating at your API boundary
+
+If you accept relabel or partition-list edits from an operator API, validate the
+inputs at that boundary so a bad request returns an actionable `InvalidArgument`
+naming the offender, instead of surfacing as a generic error from deep inside a
+write. The rules have one home in `types`, so there is no drift risk from
+mirroring them:
+
+```go
+// Reject a bad label value before it reaches MergeLabels / the write path.
+if err := types.ValidateLabel(newLabel); err != nil {
+    return fmt.Errorf("invalid label %q: %w", newLabel, err) // 400 at your API
+}
+
+// Reject a malformed full-list write (dup ids, bad keys, bad labels) up front.
+// ValidatePartitions runs the exact per-partition Validate + CanonicalID dup
+// check the write performs, so the boundary check predicts what the write
+// rejects — including which index/id collided.
+if err := types.ValidatePartitions(next); err != nil {
+    return fmt.Errorf("invalid partition set: %w", err)
 }
 ```
 
@@ -660,6 +738,61 @@ Grep for these log lines when diagnosing a labeled deployment:
 | `startup: current alias assignment is for a different incarnation; waiting for a label-correct assignment` | Warn | Same guard, at startup, on the legacy-alias path. |
 | `initial assignment deferred pending label observation confirmation` | Info | The leader's first rebalance after startup saw a disruptive label observation and is waiting for the automatic second (confirming) observation before acting. |
 | `label recheck requested` | Debug | The leader's label re-check timer or a label-change signal woke the rebalance path (with a `reason` field). Useful for confirming the grace-expiry or confirmation timers are actually firing. |
+
+### Label observability without a metrics pipeline
+
+You don't need a Prometheus (or other) `MetricsCollector` to see label state. A
+small in-memory collector that embeds `types.NopMetrics` and overrides only the
+`LabelMetrics` methods gives you a live snapshot to read from your own health
+endpoint. `NopMetrics` supplies no-ops for every other `MetricsCollector`
+method, so this is all the code:
+
+```go
+// labelSnapshot exposes parked counts / pool sizes / spill totals over your
+// own /healthz.
+type labelSnapshot struct {
+    types.NopMetrics // no-ops for the entire MetricsCollector surface
+    mu     sync.Mutex
+    parked map[string]int // per-label parked partitions (gauge)
+    pool   map[string]int // per-label eligible workers (gauge)
+    spills map[string]int // per-label cumulative spill events (counter)
+}
+
+func newLabelSnapshot() *labelSnapshot {
+    return &labelSnapshot{
+        parked: map[string]int{}, pool: map[string]int{}, spills: map[string]int{},
+    }
+}
+
+// Override the LabelMetrics methods you care about. The gauges are recomputed
+// every rebalance, and an absent label is zeroed in the same pass, so the maps
+// never go stale; IncrementLabelSpill is a monotonic counter, so accumulate it.
+// Every override takes the lock because these methods are called from the
+// manager's internal goroutines while your health handler reads concurrently.
+func (s *labelSnapshot) RecordParkedPartitions(label string, count int) {
+    s.mu.Lock(); defer s.mu.Unlock()
+    s.parked[label] = count
+}
+func (s *labelSnapshot) RecordLabelPoolSize(label string, workers int) {
+    s.mu.Lock(); defer s.mu.Unlock()
+    s.pool[label] = workers
+}
+func (s *labelSnapshot) IncrementLabelSpill(label string) {
+    s.mu.Lock(); defer s.mu.Unlock()
+    s.spills[label]++
+}
+
+// Wire it in, then read s under its lock from your health handler.
+snap := newLabelSnapshot()
+mgr, err := parti.NewManager(cfg, js, src, strategy, parti.WithMetrics(snap))
+```
+
+**Leader-only caveat.** These gauges are computed by the leader's calculator, so
+a per-pod collector shows data **only on the pod that is currently leader**;
+every follower's snapshot stays empty, and a leader that steps down zeroes the
+gauges it was reporting. Point operators at the leader's endpoint (or aggregate
+across pods and read whichever is non-empty) — "are any `vip` partitions parked
+right now?" is only answerable on the leader.
 
 ## Gotchas
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,8 +1,18 @@
 package parti
 
 import (
+	"time"
+
 	"github.com/arloliu/parti/v2/internal/assignment"
 )
+
+// LabelSpillGraceForTest returns the Manager's resolved (post-option) copy of
+// Config.LabelSpillGrace — the value startCalculator passes to the calculator.
+// Exposed via export_test.go so cross-package tests can assert the
+// WithLabelSpillGrace override without making the config copy public.
+func LabelSpillGraceForTest(m *Manager) time.Duration {
+	return m.cfg.LabelSpillGrace
+}
 
 // CalculatorForTest returns the Manager's internal *assignment.Calculator
 // when one is wired (i.e., the manager is the leader and startCalculator

--- a/manager.go
+++ b/manager.go
@@ -436,6 +436,20 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 		opt(options)
 	}
 
+	// WithLabelSpillGrace overrides Config.LabelSpillGrace (already defaulted by
+	// SetDefaults above). Applied here — after the options loop, before cfg is
+	// copied into the Manager — so the copy carries the override, and so an
+	// explicit 0 (immediate spill) survives instead of being re-defaulted to
+	// 60s. The negative guard mirrors the config field's gte=0 validation, which
+	// the option path bypasses because Option cannot return an error.
+	if options.labelSpillGrace != nil {
+		if *options.labelSpillGrace < 0 {
+			return nil, fmt.Errorf("WithLabelSpillGrace: %w: must be >= 0, got %s",
+				types.ErrInvalidConfig, *options.labelSpillGrace)
+		}
+		cfg.LabelSpillGrace = *options.labelSpillGrace // may be 0 ⇒ immediate spill
+	}
+
 	metricsCollector := options.metrics
 	if metricsCollector == nil {
 		metricsCollector = metrics.NewNop()

--- a/manager_label_spillgrace_test.go
+++ b/manager_label_spillgrace_test.go
@@ -1,0 +1,93 @@
+package parti_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLabelSpillGrace_ConfigZeroIsUnreachable is the verify-first reproducer for
+// Gap 1: on a non-pointer Config field, an explicit LabelSpillGrace = 0 cannot
+// be distinguished from the zero value, so NewManager's SetDefaults call
+// re-defaults it to 60s. This documents the v2.9.0 behavior that
+// WithLabelSpillGrace exists to work around.
+func TestLabelSpillGrace_ConfigZeroIsUnreachable(t *testing.T) {
+	t.Parallel()
+
+	cfg := parti.Config{LabelSpillGrace: 0}
+	require.NoError(t, parti.SetDefaults(&cfg))
+	require.Equal(t, 60*time.Second, cfg.LabelSpillGrace,
+		"explicit config 0 is coerced back to the 60s default (the bug WithLabelSpillGrace fixes)")
+}
+
+// TestWithLabelSpillGrace_Override asserts the option resolves onto the
+// Manager's config copy — the value startCalculator hands the calculator —
+// including the immediate-spill 0 that the config field cannot express.
+func TestWithLabelSpillGrace_Override(t *testing.T) {
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	src := source.NewStatic(testutil.CreateTestPartitions(3))
+
+	newMgr := func(t *testing.T, opts ...parti.Option) *parti.Manager {
+		t.Helper()
+		cfg := testutil.IntegrationTestConfig()
+		cfg.LabelSpillGrace = 0 // config 0 would otherwise re-default to 60s
+		mgr, err := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(), opts...)
+		require.NoError(t, err)
+		return mgr
+	}
+
+	t.Run("no option keeps the 60s default", func(t *testing.T) {
+		t.Parallel()
+		mgr := newMgr(t)
+		require.Equal(t, 60*time.Second, parti.LabelSpillGraceForTest(mgr),
+			"without the option, config 0 stays coerced to 60s")
+	})
+
+	t.Run("zero reaches immediate spill", func(t *testing.T) {
+		t.Parallel()
+		mgr := newMgr(t, parti.WithLabelSpillGrace(0))
+		require.Equal(t, time.Duration(0), parti.LabelSpillGraceForTest(mgr),
+			"WithLabelSpillGrace(0) makes an immediate spill reachable")
+	})
+
+	t.Run("positive value wins over config", func(t *testing.T) {
+		t.Parallel()
+		mgr := newMgr(t, parti.WithLabelSpillGrace(30*time.Second))
+		require.Equal(t, 30*time.Second, parti.LabelSpillGraceForTest(mgr))
+	})
+}
+
+// TestWithLabelSpillGrace_NegativeRejected asserts the negative guard mirrors
+// the config field's gte=0 validation, returning a wrapped ErrInvalidConfig
+// naming the option.
+func TestWithLabelSpillGrace_NegativeRejected(t *testing.T) {
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	cfg := testutil.IntegrationTestConfig()
+	src := source.NewStatic(testutil.CreateTestPartitions(3))
+
+	_, err = parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(),
+		parti.WithLabelSpillGrace(-time.Second))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, types.ErrInvalidConfig), "must wrap ErrInvalidConfig")
+	require.Contains(t, err.Error(), "WithLabelSpillGrace", "message must name the option")
+}

--- a/nop_metrics_embed_test.go
+++ b/nop_metrics_embed_test.go
@@ -1,0 +1,56 @@
+package parti_test
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2"
+	"github.com/arloliu/parti/v2/internal/testutil"
+	"github.com/arloliu/parti/v2/source"
+	"github.com/arloliu/parti/v2/strategy"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// labelParkCollector is the observability-without-a-pipeline pattern from
+// docs/LABELS.md: embed types.NopMetrics for a complete no-op base and override
+// only the LabelMetrics method(s) of interest.
+type labelParkCollector struct {
+	types.NopMetrics
+	parked map[string]int
+}
+
+func (c *labelParkCollector) RecordParkedPartitions(label string, count int) {
+	c.parked[label] = count
+}
+
+// Compile-time proof that embedding NopMetrics is enough to satisfy the full
+// collector plus the optional label extension with a single overridden method.
+var (
+	_ types.MetricsCollector = (*labelParkCollector)(nil)
+	_ types.LabelMetrics     = (*labelParkCollector)(nil)
+)
+
+func TestNopMetrics_EmbedAndWire(t *testing.T) {
+	t.Parallel()
+
+	nc, cleanup := testutil.StartEmbeddedNATS(t)
+	t.Cleanup(cleanup)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	coll := &labelParkCollector{parked: map[string]int{}}
+
+	cfg := testutil.IntegrationTestConfig()
+	src := source.NewStatic(testutil.CreateTestPartitions(3))
+	mgr, err := parti.NewManager(&cfg, js, src, strategy.NewConsistentHash(), parti.WithMetrics(coll))
+	require.NoError(t, err, "a NopMetrics-embedding collector must wire into WithMetrics")
+	require.NotNil(t, mgr)
+
+	// The overridden method records; the inherited no-ops are safe to call.
+	coll.RecordParkedPartitions("vip", 4)
+	coll.RecordLabelPoolSize("vip", 0) // inherited no-op
+	coll.IncrementLabelSpill("vip")    // inherited no-op
+	coll.RecordActiveWorkers(2)        // inherited no-op from a non-label sub-interface
+	require.Equal(t, map[string]int{"vip": 4}, coll.parked)
+}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package parti
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Option configures a Manager with optional dependencies.
 type Option func(*managerOptions)
@@ -20,6 +23,13 @@ type managerOptions struct {
 	// NewManager, because Option cannot return an error.
 	workerLabels    []string
 	workerLabelsSet bool
+
+	// labelSpillGrace carries the value supplied via WithLabelSpillGrace. A nil
+	// pointer means "unset" (use Config.LabelSpillGrace / the 60s default); a
+	// non-nil pointer overrides it, including an explicit 0 that the config
+	// field cannot express. Validated in NewManager, because Option cannot
+	// return an error.
+	labelSpillGrace *time.Duration
 }
 
 // WithElectionAgent sets a custom election agent.
@@ -124,6 +134,32 @@ func WithWorkerLabels(labels ...string) Option {
 	return func(o *managerOptions) {
 		o.workerLabels = labels
 		o.workerLabelsSet = true
+	}
+}
+
+// WithLabelSpillGrace sets how long a label's worker pool must be continuously
+// empty before its partitions spill to unlabeled fallback workers, overriding
+// Config.LabelSpillGrace.
+//
+// Use this to reach an immediate spill (d == 0): Config.LabelSpillGrace is a
+// non-pointer duration with a 60s default, so an explicit 0 in the config is
+// silently re-defaulted to 60s and cannot be configured. This option preserves
+// the difference between "unset" and "0", so WithLabelSpillGrace(0) yields a
+// grace of 0 (spill on the first rebalance that finds the pool empty).
+//
+// The option wins over Config.LabelSpillGrace, mirroring the WithWorkerLabels
+// vs Config.WorkerLabels precedence. A negative duration causes NewManager to
+// return an error wrapping types.ErrInvalidConfig, matching the config field's
+// gte=0 rule.
+//
+// Parameters:
+//   - d: Spill grace duration (>= 0; 0 means immediate spill)
+//
+// Returns:
+//   - Option: Functional option for NewManager
+func WithLabelSpillGrace(d time.Duration) Option {
+	return func(o *managerOptions) {
+		o.labelSpillGrace = &d
 	}
 }
 

--- a/source/nats_kv.go
+++ b/source/nats_kv.go
@@ -1310,22 +1310,21 @@ func partitionsEqual(a, b []types.Partition) bool {
 // alias the returned data — this protects the encode→KV-write window against
 // concurrent caller mutations.
 func validateAndDedupe(partitions []types.Partition) ([]types.Partition, error) {
-	seen := make(map[string]struct{}, len(partitions))
-	result := make([]types.Partition, 0, len(partitions))
+	// types.ValidatePartitions runs the exact per-partition Validate + CanonicalID
+	// duplicate check (same first-error order and message strings) that this
+	// function used inline, so callers see an identical error surface.
+	if err := types.ValidatePartitions(partitions); err != nil {
+		return nil, err
+	}
+
+	// The set is now known valid and duplicate-free; deep-copy each partition's
+	// Keys so callers cannot alias the returned data during the encode→write window.
+	result := make([]types.Partition, len(partitions))
 	for i, p := range partitions {
-		if err := p.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid partition at index %d: %w", i, err)
-		}
-		cid := p.CanonicalID()
-		if _, dup := seen[cid]; dup {
-			return nil, fmt.Errorf("duplicate partition at index %d (canonical_id=%q)", i, cid)
-		}
-		seen[cid] = struct{}{}
-		// Deep-copy Keys to protect the encode→write window against caller mutation.
 		cp := p // struct-value copy preserves Weight, Label, and future fields
 		cp.Keys = make([]string, len(p.Keys))
 		copy(cp.Keys, p.Keys)
-		result = append(result, cp)
+		result[i] = cp
 	}
 
 	return result, nil

--- a/source/nats_kv_dedup_test.go
+++ b/source/nats_kv_dedup_test.go
@@ -12,6 +12,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestValidateAndDedupe_ErrorSurface is a golden-diff of the write path's
+// validation error strings. validateAndDedupe now delegates to
+// types.ValidatePartitions; these assertions pin the exact messages a caller
+// of Update/Modify sees so the delegation cannot silently change the surface.
+func TestValidateAndDedupe_ErrorSurface(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid set deep-copies keys", func(t *testing.T) {
+		t.Parallel()
+		in := []types.Partition{{Keys: []string{"a"}, Weight: 3, Label: "vip"}}
+		out, err := validateAndDedupe(in)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		require.Equal(t, in[0], out[0])
+		// Mutating the input Keys must not affect the returned copy.
+		in[0].Keys[0] = "mutated"
+		require.Equal(t, "a", out[0].Keys[0], "returned Keys must not alias the input")
+	})
+
+	t.Run("invalid partition", func(t *testing.T) {
+		t.Parallel()
+		_, err := validateAndDedupe([]types.Partition{{Keys: []string{"ok"}}, {Keys: []string{"bad.key"}}})
+		require.EqualError(t, err,
+			`invalid partition at index 1: partition key at index 0 contains invalid character '.' (dots are reserved separators): "bad.key"`)
+	})
+
+	t.Run("duplicate CanonicalID", func(t *testing.T) {
+		t.Parallel()
+		_, err := validateAndDedupe([]types.Partition{{Keys: []string{"same"}}, {Keys: []string{"same"}}})
+		require.EqualError(t, err, `duplicate partition at index 1 (canonical_id="4:same")`)
+	})
+}
+
 // TestNatsKV_Watch_StaleEventIgnored is a deterministic reproducer for the
 // CI flake in TestNatsKV_Watch_Deduplication: under load, a watcher event
 // for an earlier KV revision can drain from watcher.Updates() *after* a

--- a/types/labels.go
+++ b/types/labels.go
@@ -1,0 +1,89 @@
+package types
+
+import (
+	"fmt"
+	"slices"
+)
+
+// MergeLabels returns a deep copy of current with each partition's Label
+// adjusted by intents, keyed on Partition.ID():
+//
+//   - intents[id] == nil  ⇒ clear the label ("")
+//   - intents[id] == &s   ⇒ set the label to s
+//   - id absent           ⇒ label unchanged
+//
+// It is the label-preserving primitive for a writer that rebuilds its partition
+// list from a source that does not carry labels: instead of hand-writing a CAS
+// Modify closure that re-derives inherit/set/clear semantics (and risks silently
+// stripping every label), the writer computes the new list with MergeLabels and
+// hands the result straight to source.Modify.
+//
+// The second return is the sorted list of ids that appear in intents but not in
+// current (unmatched). Callers reject these at their own boundary — for example
+// returning a not-found for a typo'd id — instead of silently no-op'ing.
+//
+// MergeLabels fails closed on an ID() collision. Partition.ID() dash-joins Keys
+// and is NOT collision-safe: Keys ["a-b","c"] and ["a","b-c"] both yield
+// "a-b-c" (the write path dedupes on CanonicalID precisely because of this). If
+// an intent's id matches MORE THAN ONE partition in current, MergeLabels returns
+// a non-nil error and nil slices — it never guesses which partition to relabel.
+// A collided partition that no intent targets is copied through untouched (no
+// error), so a collision only matters when a caller actually tries to relabel
+// through the ambiguous id.
+//
+// current is not mutated; the returned partitions deep-copy each Keys slice, so
+// the result shares no backing array with current and is safe to mutate or hand
+// to source.Modify. MergeLabels does NOT validate label values — pair it with
+// ValidateLabel at the caller's boundary; source.validateAndDedupe backstops at
+// write time.
+func MergeLabels(current []Partition, intents map[string]*string) ([]Partition, []string, error) {
+	// Index current by ID(); keep every matching index so a collision (an id
+	// mapping to >1 partition) is detectable rather than silently resolved.
+	idx := make(map[string][]int, len(current))
+	for i := range current {
+		id := current[i].ID()
+		idx[id] = append(idx[id], i)
+	}
+
+	// First pass: classify each intent's id. Collision on a TARGETED id fails
+	// closed before any result is produced; an id absent from current is
+	// unmatched. This runs before the copy so an error returns nil slices.
+	var unmatched []string
+	for id := range intents {
+		switch n := len(idx[id]); {
+		case n == 0:
+			unmatched = append(unmatched, id)
+		case n > 1:
+			return nil, nil, fmt.Errorf(
+				"MergeLabels: intent id %q matches %d partitions whose key tuples collide on ID(); refusing to guess which to relabel",
+				id, n)
+		}
+	}
+
+	// Deep-copy current so neither the caller's slice nor its Keys backing
+	// arrays are mutated, and the result is safe to hand to source.Modify.
+	result := make([]Partition, len(current))
+	for i := range current {
+		cp := current[i]
+		cp.Keys = make([]string, len(current[i].Keys))
+		copy(cp.Keys, current[i].Keys)
+		result[i] = cp
+	}
+
+	// Second pass: apply each unambiguously matched intent to its one partition.
+	for id, val := range intents {
+		is := idx[id]
+		if len(is) != 1 {
+			continue // unmatched (0) recorded above; collision (>1) already errored
+		}
+		if val == nil {
+			result[is[0]].Label = "" // clear
+		} else {
+			result[is[0]].Label = *val // set
+		}
+	}
+
+	slices.Sort(unmatched)
+
+	return result, unmatched, nil
+}

--- a/types/labels_test.go
+++ b/types/labels_test.go
@@ -1,0 +1,167 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeLabels_SetClearAbsent(t *testing.T) {
+	t.Parallel()
+
+	current := []types.Partition{
+		{Keys: []string{"a"}, Weight: 1, Label: "gold"},
+		{Keys: []string{"b"}, Weight: 2},
+		{Keys: []string{"c"}, Weight: 3, Label: "vip"},
+	}
+
+	got, unmatched, err := types.MergeLabels(current, map[string]*string{
+		"a": new("vip"), // set (overwrite existing)
+		"c": nil,        // clear
+		// "b" absent ⇒ unchanged
+	})
+	require.NoError(t, err)
+	require.Empty(t, unmatched)
+
+	require.Equal(t, "vip", got[0].Label, "a set to vip")
+	require.Equal(t, "", got[1].Label, "b unchanged (empty)")
+	require.Equal(t, "", got[2].Label, "c cleared")
+	// Non-label fields preserved.
+	require.Equal(t, int64(1), got[0].Weight)
+	require.Equal(t, []string{"c"}, got[2].Keys)
+}
+
+func TestMergeLabels_UnknownIDUnmatched(t *testing.T) {
+	t.Parallel()
+
+	current := []types.Partition{{Keys: []string{"a"}}}
+
+	got, unmatched, err := types.MergeLabels(current, map[string]*string{
+		"zzz": new("vip"),
+		"aaa": nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "no partition added for unknown ids")
+	require.Equal(t, "", got[0].Label)
+	require.Equal(t, []string{"aaa", "zzz"}, unmatched, "unmatched ids returned sorted")
+}
+
+func TestMergeLabels_EmptyAndNilIntents(t *testing.T) {
+	t.Parallel()
+
+	current := []types.Partition{
+		{Keys: []string{"a"}, Label: "gold"},
+		{Keys: []string{"b", "sub"}, Weight: 5},
+	}
+
+	for _, name := range []string{"nil", "empty"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var intents map[string]*string
+			if name == "empty" {
+				intents = map[string]*string{}
+			}
+			got, unmatched, err := types.MergeLabels(current, intents)
+			require.NoError(t, err)
+			require.Empty(t, unmatched)
+			require.Equal(t, current, got, "deep-equal copy of current")
+
+			// Even with no intents applied, the result must deep-copy Keys so a
+			// caller cannot mutate current through the returned slice.
+			require.NotSame(t, &current[0].Keys[0], &got[0].Keys[0],
+				"Keys must not share a backing array with current")
+			got[0].Keys[0] = "mutated"
+			require.Equal(t, "a", current[0].Keys[0], "mutating result must not touch current")
+		})
+	}
+}
+
+func TestMergeLabels_CollisionOutranksUnmatched(t *testing.T) {
+	t.Parallel()
+
+	// current holds the ID() collision pair plus a normal partition.
+	current := []types.Partition{
+		{Keys: []string{"a-b", "c"}},
+		{Keys: []string{"a", "b-c"}},
+		{Keys: []string{"solo"}},
+	}
+
+	// Intents carry BOTH a collided-id target and an unmatched id. The
+	// fail-closed collision must win: error + nil slices, regardless of the
+	// unmatched id also present.
+	got, unmatched, err := types.MergeLabels(current, map[string]*string{
+		"a-b-c": new("vip"), // ambiguous collision
+		"typo":  new("vip"), // unmatched
+	})
+	require.Error(t, err)
+	require.Nil(t, got, "collision returns nil partitions")
+	require.Nil(t, unmatched, "collision returns nil unmatched, not the typo slice")
+}
+
+func TestMergeLabels_DoesNotValidateLabelValues(t *testing.T) {
+	t.Parallel()
+
+	// MergeLabels is mechanical: it does not run ValidateLabel. An invalid
+	// label value is applied as-is; the caller validates at its boundary and the
+	// write path backstops. This pins that contract.
+	current := []types.Partition{{Keys: []string{"a"}}}
+	got, unmatched, err := types.MergeLabels(current, map[string]*string{"a": new("has space")})
+	require.NoError(t, err)
+	require.Empty(t, unmatched)
+	require.Equal(t, "has space", got[0].Label, "invalid label value applied verbatim, not rejected")
+	require.Error(t, types.ValidateLabel(got[0].Label), "the applied value is indeed invalid")
+}
+
+func TestMergeLabels_NoAliasing(t *testing.T) {
+	t.Parallel()
+
+	current := []types.Partition{{Keys: []string{"a", "b"}, Label: "gold"}}
+
+	got, _, err := types.MergeLabels(current, map[string]*string{"a-b": new("vip")})
+	require.NoError(t, err)
+
+	// Mutating the result must not touch current — no shared Keys backing array,
+	// and the label change stayed on the copy.
+	got[0].Keys[0] = "mutated"
+	require.Equal(t, "a", current[0].Keys[0], "current Keys must not alias result")
+	require.Equal(t, "gold", current[0].Label, "current Label must be unchanged")
+
+	// And mutating current after the call must not touch the result.
+	current[0].Label = "changed"
+	require.Equal(t, "vip", got[0].Label, "result must not alias current")
+}
+
+func TestMergeLabels_CollisionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// The repo's pinned ID() collision pair: both produce ID() "a-b-c".
+	collided := []types.Partition{
+		{Keys: []string{"a-b", "c"}},
+		{Keys: []string{"a", "b-c"}},
+	}
+	require.Equal(t, collided[0].ID(), collided[1].ID())
+
+	t.Run("intent targets collided id ⇒ error, nil slices", func(t *testing.T) {
+		t.Parallel()
+		got, unmatched, err := types.MergeLabels(collided, map[string]*string{"a-b-c": new("vip")})
+		require.Error(t, err)
+		require.Nil(t, got)
+		require.Nil(t, unmatched)
+		require.Contains(t, err.Error(), "a-b-c")
+	})
+
+	t.Run("intent does not target collided id ⇒ no error, collided pass through", func(t *testing.T) {
+		t.Parallel()
+		current := append([]types.Partition{{Keys: []string{"other"}}}, collided...)
+		got, unmatched, err := types.MergeLabels(current, map[string]*string{"other": new("vip")})
+		require.NoError(t, err)
+		require.Empty(t, unmatched)
+		require.Equal(t, "vip", got[0].Label, "targeted partition relabeled")
+		// Both collided partitions copied through untouched.
+		require.Equal(t, "", got[1].Label)
+		require.Equal(t, "", got[2].Label)
+		require.Equal(t, []string{"a-b", "c"}, got[1].Keys)
+		require.Equal(t, []string{"a", "b-c"}, got[2].Keys)
+	})
+}

--- a/types/nop_metrics.go
+++ b/types/nop_metrics.go
@@ -1,0 +1,264 @@
+package types
+
+// NopMetrics is an exported composite no-op that satisfies the full
+// MetricsCollector interface and its optional LabelMetrics extension, with
+// every method discarding its argument.
+//
+// It exists to be embedded. MetricsCollector is a union of eight
+// domain-focused sub-interfaces, so a consumer that only cares about a few
+// signals — say the label gauges — would otherwise have to stub dozens of
+// unrelated methods. Embed NopMetrics and override just the methods you need.
+// Overrides must guard any shared state themselves: the manager calls collector
+// methods from internal goroutines, so a health reader running concurrently
+// needs the same lock (see the runnable example in docs/LABELS.md):
+//
+//	type labelCollector struct {
+//	    types.NopMetrics // supplies no-ops for every other method
+//	    mu               sync.Mutex
+//	    parked           map[string]int
+//	}
+//
+//	func (c *labelCollector) RecordParkedPartitions(label string, count int) {
+//	    c.mu.Lock()
+//	    defer c.mu.Unlock()
+//	    c.parked[label] = count
+//	}
+//
+//	mgr, _ := parti.NewManager(cfg, js, src, strategy, parti.WithMetrics(&labelCollector{...}))
+//
+// The zero value is ready to use. NopMetrics' own methods are non-blocking and
+// safe for concurrent use, matching the MetricsCollector contract.
+type NopMetrics struct{}
+
+// Compile-time assertions that NopMetrics satisfies the collector interface and
+// its optional label extension.
+var (
+	_ MetricsCollector = (*NopMetrics)(nil)
+	_ LabelMetrics     = (*NopMetrics)(nil)
+)
+
+// ManagerMetrics implementation
+
+// RecordStateTransition discards the state transition metric.
+func (NopMetrics) RecordStateTransition(_ /* from */, _ /* to */ State, _ /* duration */ float64) {
+}
+
+// RecordLeadershipChange discards the leadership change metric.
+func (NopMetrics) RecordLeadershipChange(_ /* newLeader */ string) {}
+
+// RecordDegradedDuration discards the degraded mode duration metric.
+func (NopMetrics) RecordDegradedDuration(_ /* duration */ float64) {}
+
+// SetDegradedMode discards the degraded mode status metric.
+func (NopMetrics) SetDegradedMode(_ /* degraded */ float64) {}
+
+// SetCacheAge discards the cache age metric.
+func (NopMetrics) SetCacheAge(_ /* age */ float64) {}
+
+// SetAlertLevel discards the alert level metric.
+func (NopMetrics) SetAlertLevel(_ /* level */ int) {}
+
+// IncrementAlertEmitted discards the alert emission counter.
+func (NopMetrics) IncrementAlertEmitted(_ /* level */ string) {}
+
+// RecordApplyAttempt discards the apply-attempt counter.
+func (NopMetrics) RecordApplyAttempt(_ /* workerID */ string, _ /* version */ int64) {}
+
+// RecordHandoffRemovalPending discards the handoff-removal-pending counter.
+func (NopMetrics) RecordHandoffRemovalPending(_ /* workerID */ string) {}
+
+// CalculatorMetrics implementation
+
+// RecordRebalanceDuration discards the rebalance duration metric.
+func (NopMetrics) RecordRebalanceDuration(_ /* duration */ float64, _ /* reason */ string) {}
+
+// RecordRebalanceAttempt discards the rebalance attempt metric.
+func (NopMetrics) RecordRebalanceAttempt(_ /* reason */ string, _ /* success */ bool) {}
+
+// RecordPartitionCount discards the partition count metric.
+func (NopMetrics) RecordPartitionCount(_ /* count */ int) {}
+
+// RecordKVOperationDuration discards the KV operation duration metric.
+func (NopMetrics) RecordKVOperationDuration(_ /* operation */ string, _ /* duration */ float64) {}
+
+// RecordStateChangeDropped discards the state change dropped metric.
+func (NopMetrics) RecordStateChangeDropped() {}
+
+// RecordEmergencyRebalance discards the emergency rebalance metric.
+func (NopMetrics) RecordEmergencyRebalance(_ /* disappearedWorkers */ int) {}
+
+// RecordWorkerChange discards the worker topology change metric.
+func (NopMetrics) RecordWorkerChange(_ /* added */, _ /* removed */ int) {}
+
+// RecordOrphanedPartitions discards the orphaned partitions metric.
+func (NopMetrics) RecordOrphanedPartitions(_ /* count */ int) {}
+
+// RecordActiveWorkers discards the active workers metric.
+func (NopMetrics) RecordActiveWorkers(_ /* count */ int) {}
+
+// RecordCacheUsage discards the cache usage metric.
+func (NopMetrics) RecordCacheUsage(_ /* cacheType */ string, _ /* age */ float64) {}
+
+// IncrementCacheFallback discards the cache fallback counter.
+func (NopMetrics) IncrementCacheFallback(_ /* reason */ string) {}
+
+// WorkerMetrics implementation
+
+// RecordHeartbeat discards the heartbeat metric.
+func (NopMetrics) RecordHeartbeat(_ /* workerID */ string, _ /* success */ bool) {}
+
+// AssignmentMetrics implementation
+
+// RecordAssignmentChange discards the assignment change metric.
+func (NopMetrics) RecordAssignmentChange(_ /* added */, _ /* removed */ int, _ /* version */ int64) {
+}
+
+// PublisherMetrics implementation
+
+// IncrementPayloadsCreated discards the payloads-created counter.
+func (NopMetrics) IncrementPayloadsCreated() {}
+
+// IncrementPayloadsReused discards the payloads-reused counter.
+func (NopMetrics) IncrementPayloadsReused() {}
+
+// ObservePayloadBytesWritten discards the payload bytes-written histogram.
+func (NopMetrics) ObservePayloadBytesWritten(_ /* bytes */ int) {}
+
+// ObserveCommitBytesWritten discards the commit bytes-written histogram.
+func (NopMetrics) ObserveCommitBytesWritten(_ /* bytes */ int) {}
+
+// IncrementBatchAborted discards the batch-aborted counter.
+func (NopMetrics) IncrementBatchAborted(_ /* reason */ string) {}
+
+// IncrementAliasBarrierFailed discards the alias-barrier-failed counter.
+func (NopMetrics) IncrementAliasBarrierFailed() {}
+
+// IncrementAliasVisibleUncommitted discards the alias-visible-uncommitted counter.
+func (NopMetrics) IncrementAliasVisibleUncommitted() {}
+
+// IncrementCommitAborts discards the commit-aborts counter.
+func (NopMetrics) IncrementCommitAborts() {}
+
+// GCMetrics implementation
+
+// IncrementPayloadDeleteErrors discards the payload-delete-errors counter.
+func (NopMetrics) IncrementPayloadDeleteErrors() {}
+
+// AuditMetrics implementation
+
+// RecordAuditCounts discards the audit classification gauge.
+func (NopMetrics) RecordAuditCounts(_ /* fullyApplied */, _ /* behind */, _ /* unverifiable */ int) {
+}
+
+// RecordWorkerBehind discards the behind-worker observation.
+func (NopMetrics) RecordWorkerBehind(_ /* workerID */ string, _ /* commitVersion */ int64) {}
+
+// RecordAuditEscalationSkipped discards the escalation-skipped counter.
+func (NopMetrics) RecordAuditEscalationSkipped(_ /* reason */, _ /* workerID */ string) {}
+
+// RecordStaleLeaderRejected discards the stale-leader rejection counter.
+func (NopMetrics) RecordStaleLeaderRejected() {}
+
+// RecordStaleSnapshotStoreDropped discards the stale-snapshot-Store gate counter.
+func (NopMetrics) RecordStaleSnapshotStoreDropped() {}
+
+// RecordCommitPayloadMissing discards the malformed-commit counter.
+func (NopMetrics) RecordCommitPayloadMissing() {}
+
+// RecordPayloadFetchError discards the payload-fetch error counter.
+func (NopMetrics) RecordPayloadFetchError() {}
+
+// RecordPayloadDecompressError discards the payload-decompress error counter.
+func (NopMetrics) RecordPayloadDecompressError() {}
+
+// RecordPayloadDecodeError discards the payload-decode error counter.
+func (NopMetrics) RecordPayloadDecodeError() {}
+
+// RecordPayloadHashMismatch discards the payload hash-mismatch counter.
+func (NopMetrics) RecordPayloadHashMismatch() {}
+
+// RecordSetDigestMismatch discards the set-digest mismatch counter.
+func (NopMetrics) RecordSetDigestMismatch() {}
+
+// WorkerConsumerMetrics implementation
+
+// IncrementWorkerConsumerControlRetry discards the control-plane retry counter.
+func (NopMetrics) IncrementWorkerConsumerControlRetry(_ /* op */ string) {}
+
+// RecordWorkerConsumerRetryBackoff discards the backoff duration observation.
+func (NopMetrics) RecordWorkerConsumerRetryBackoff(_ /* op */ string, _ /* seconds */ float64) {}
+
+// SetWorkerConsumerSubjectsCurrent discards the gauge set.
+func (NopMetrics) SetWorkerConsumerSubjectsCurrent(_ /* count */ int) {}
+
+// IncrementWorkerConsumerSubjectChange discards subject change increments.
+func (NopMetrics) IncrementWorkerConsumerSubjectChange(_ /* kind */ string, _ /* count */ int) {}
+
+// IncrementWorkerConsumerGuardrailViolation discards guardrail violation increments.
+func (NopMetrics) IncrementWorkerConsumerGuardrailViolation(_ /* kind */ string) {}
+
+// IncrementWorkerConsumerSubjectThresholdWarning discards threshold warning increments.
+func (NopMetrics) IncrementWorkerConsumerSubjectThresholdWarning() {}
+
+// RecordWorkerConsumerUpdate discards update result increments.
+func (NopMetrics) RecordWorkerConsumerUpdate(_ /* result */ string) {}
+
+// ObserveWorkerConsumerUpdateLatency discards latency observations.
+func (NopMetrics) ObserveWorkerConsumerUpdateLatency(_ /* seconds */ float64) {}
+
+// IncrementWorkerConsumerIteratorRestart discards iterator restart increments.
+func (NopMetrics) IncrementWorkerConsumerIteratorRestart(_ /* reason */ string) {}
+
+// IncrementWorkerConsumerIteratorEscalation discards iterator escalation increments.
+func (NopMetrics) IncrementWorkerConsumerIteratorEscalation(_ /* reason */ string) {}
+
+// SetWorkerConsumerConsecutiveIteratorFailures discards consecutive failure gauge updates.
+func (NopMetrics) SetWorkerConsumerConsecutiveIteratorFailures(_ /* count */ int) {}
+
+// SetWorkerConsumerHealthStatus discards health status updates.
+func (NopMetrics) SetWorkerConsumerHealthStatus(_ /* healthy */ bool) {}
+
+// IncrementWorkerConsumerRecreationAttempt discards recreation attempt increments.
+func (NopMetrics) IncrementWorkerConsumerRecreationAttempt(_ /* reason */ string) {}
+
+// RecordWorkerConsumerRecreation discards recreation outcome increments.
+func (NopMetrics) RecordWorkerConsumerRecreation(_ /* result */ string, _ /* reason */ string) {}
+
+// ObserveWorkerConsumerRecreationDuration discards recreation duration observations.
+func (NopMetrics) ObserveWorkerConsumerRecreationDuration(_ /* seconds */ float64) {}
+
+// IncrementWorkerConsumerPullSuppressed discards pull suppression increments.
+func (NopMetrics) IncrementWorkerConsumerPullSuppressed(_ /* reason */ string) {}
+
+// LabelMetrics implementation (optional extension interface)
+
+// RecordLabelPoolSize discards the per-label worker pool size gauge.
+func (NopMetrics) RecordLabelPoolSize(_ /* label */ string, _ /* workers */ int) {}
+
+// RecordParkedPartitions discards the per-label parked-partition count gauge.
+func (NopMetrics) RecordParkedPartitions(_ /* label */ string, _ /* count */ int) {}
+
+// IncrementLabelSpill discards the label-spill counter.
+func (NopMetrics) IncrementLabelSpill(_ /* label */ string) {}
+
+// IncrementLabelChangeTrigger discards the label-change-triggered-rebalance counter.
+func (NopMetrics) IncrementLabelChangeTrigger() {}
+
+// IncrementLabelIncarnationReject discards the stale-incarnation label rejection counter.
+func (NopMetrics) IncrementLabelIncarnationReject() {}
+
+// IncrementUnlabeledFallback discards the unlabeled-fallback counter.
+func (NopMetrics) IncrementUnlabeledFallback() {}
+
+// ConsumerCreateThrottleObserver implementation (optional sidecar).
+//
+// These two methods are not part of MetricsCollector; they let an embedded
+// NopMetrics also satisfy the internal consumer-create throttle observer that
+// the durable helper type-asserts for, so a collector embedding NopMetrics
+// gets a complete no-op base with no extra stubbing.
+
+// IncrementConsumerCreateThrottled discards the consumer-create throttle counter.
+func (NopMetrics) IncrementConsumerCreateThrottled() {}
+
+// ObserveConsumerCreateThrottleWait discards the throttle wait observation.
+func (NopMetrics) ObserveConsumerCreateThrottleWait(_ /* seconds */ float64) {}

--- a/types/partition.go
+++ b/types/partition.go
@@ -55,16 +55,31 @@ func (p Partition) Validate() error {
 		}
 	}
 
-	if p.Label != "" {
-		if len(p.Label) > 64 {
-			return fmt.Errorf("partition label exceeds 64 bytes: %q", p.Label)
-		}
-		if strings.Contains(p.Label, ".") {
-			return fmt.Errorf("partition label contains invalid character '.': %q", p.Label)
-		}
-		if strings.ContainsAny(p.Label, " \t\n\r") {
-			return fmt.Errorf("partition label contains whitespace: %q", p.Label)
-		}
+	return ValidateLabel(p.Label)
+}
+
+// ValidateLabel reports whether s is a valid partition or worker label,
+// returning a descriptive error when it is not. The empty string is valid (an
+// unlabeled partition); callers that forbid empty labels — such as the
+// worker-label set — must reject "" themselves before delegating here.
+//
+// Rules: at most 64 bytes, no '.', and no ASCII whitespace (" \t\n\r"). The
+// 64-byte limit is a byte length, not a rune count, matching the partition-key
+// rules; a multi-byte rune counts as its encoded byte length.
+//
+// ValidateLabel is the single home for the label charset/length rules:
+// Partition.Validate and the worker-label normalizer both delegate to it, so a
+// consumer can validate a label at its own API boundary with zero risk of the
+// rules drifting from the library.
+func ValidateLabel(s string) error {
+	if len(s) > 64 {
+		return fmt.Errorf("label exceeds 64 bytes: %q", s)
+	}
+	if strings.Contains(s, ".") {
+		return fmt.Errorf("label contains invalid character '.': %q", s)
+	}
+	if strings.ContainsAny(s, " \t\n\r") {
+		return fmt.Errorf("label contains whitespace: %q", s)
 	}
 
 	return nil

--- a/types/partition.go
+++ b/types/partition.go
@@ -85,6 +85,36 @@ func ValidateLabel(s string) error {
 	return nil
 }
 
+// ValidatePartitions checks a whole partition set the way the NatsKV write path
+// does, returning the first problem found so a caller can reject a malformed
+// batch at its own API boundary — with a precise message naming the offending
+// index and colliding id — instead of letting it surface as a generic error
+// from deep inside a write.
+//
+// It makes a single left-to-right pass: at each index it runs Partition.Validate
+// and then checks that partition's CanonicalID against the ids already seen. The
+// order matters — an earlier duplicate outranks a later invalid partition — and
+// it mirrors the write path byte for byte, so the boundary check predicts
+// exactly what the write will reject. Duplicate detection keys on CanonicalID
+// (not ID), because that is what the write path dedupes on.
+//
+// ValidatePartitions neither mutates nor dedupes ps; it only validates.
+func ValidatePartitions(ps []Partition) error {
+	seen := make(map[string]struct{}, len(ps))
+	for i, p := range ps {
+		if err := p.Validate(); err != nil {
+			return fmt.Errorf("invalid partition at index %d: %w", i, err)
+		}
+		cid := p.CanonicalID()
+		if _, dup := seen[cid]; dup {
+			return fmt.Errorf("duplicate partition at index %d (canonical_id=%q)", i, cid)
+		}
+		seen[cid] = struct{}{}
+	}
+
+	return nil
+}
+
 // SubjectKey returns the canonical subject identifier for the partition formed by
 // joining the Keys with a dot ("."). This is used for subject templating and
 // JetStream FilterSubjects construction.

--- a/types/partition_label_test.go
+++ b/types/partition_label_test.go
@@ -43,6 +43,50 @@ func TestPartitionLabel_Validate(t *testing.T) {
 	require.NoError(t, valid(strings.Repeat("x", 64)), "exactly 64 bytes ok")
 }
 
+func TestValidateLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		label   string
+		wantErr bool
+	}{
+		{"empty is valid", "", false},
+		{"simple", "vip", false},
+		{"charset ok", "gpu-batch_2", false},
+		{"exactly 64 bytes", strings.Repeat("x", 64), false},
+		{"over 64 bytes", strings.Repeat("x", 65), true},
+		{"multibyte over 64 bytes", strings.Repeat("é", 33), true}, // 66 bytes, 33 runes
+		{"dot", "a.b", true},
+		{"space", "a b", true},
+		{"tab", "a\tb", true},
+		{"newline", "a\nb", true},
+		{"carriage return", "a\rb", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := types.ValidateLabel(tt.label)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	// Partition.Validate delegates its label rules to ValidateLabel: a label
+	// that ValidateLabel rejects must also fail Partition.Validate, and the
+	// surfaced error must be the shared ValidateLabel error verbatim.
+	for _, bad := range []string{"a.b", "a b", strings.Repeat("x", 65)} {
+		want := types.ValidateLabel(bad)
+		require.Error(t, want)
+		got := types.Partition{Keys: []string{"k"}, Label: bad}.Validate()
+		require.EqualError(t, got, want.Error(),
+			"Partition.Validate must surface the ValidateLabel error for %q", bad)
+	}
+}
+
 func TestPartitionLabel_JSONRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/types/partition_test.go
+++ b/types/partition_test.go
@@ -205,6 +205,111 @@ func BenchmarkPartitionHashID(b *testing.B) {
 }
 
 // BenchmarkPartitionIDJoinHash measures strings.Join then HashString for comparison.
+func TestValidatePartitions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid set", func(t *testing.T) {
+		t.Parallel()
+		ps := []Partition{
+			{Keys: []string{"a"}},
+			{Keys: []string{"b"}, Label: "vip"},
+			{Keys: []string{"c", "d"}},
+		}
+		require.NoError(t, ValidatePartitions(ps))
+	})
+
+	t.Run("empty and nil", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidatePartitions(nil))
+		require.NoError(t, ValidatePartitions([]Partition{}))
+	})
+
+	t.Run("invalid partition names index", func(t *testing.T) {
+		t.Parallel()
+		ps := []Partition{
+			{Keys: []string{"ok"}},
+			{Keys: []string{"bad.key"}},
+		}
+		err := ValidatePartitions(ps)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid partition at index 1")
+	})
+
+	t.Run("empty-key partition", func(t *testing.T) {
+		t.Parallel()
+		err := ValidatePartitions([]Partition{{Keys: nil}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid partition at index 0")
+	})
+
+	t.Run("bad label delegates to ValidateLabel", func(t *testing.T) {
+		t.Parallel()
+		err := ValidatePartitions([]Partition{{Keys: []string{"a"}, Label: "has space"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid partition at index 0")
+		require.Contains(t, err.Error(), "label contains whitespace")
+	})
+
+	t.Run("duplicate CanonicalID names the id", func(t *testing.T) {
+		t.Parallel()
+		ps := []Partition{
+			{Keys: []string{"a"}},
+			{Keys: []string{"a"}}, // same CanonicalID
+		}
+		err := ValidatePartitions(ps)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate partition at index 1")
+		require.Contains(t, err.Error(), ps[0].CanonicalID())
+	})
+
+	t.Run("dedupe keys on CanonicalID not ID", func(t *testing.T) {
+		t.Parallel()
+		// The ID()-collision pair ("a-b-c" both) has distinct CanonicalIDs, so
+		// it is NOT a duplicate: ValidatePartitions must accept it, matching the
+		// write path's CanonicalID dedupe.
+		ps := []Partition{
+			{Keys: []string{"a-b", "c"}},
+			{Keys: []string{"a", "b-c"}},
+		}
+		require.Equal(t, ps[0].ID(), ps[1].ID())
+		require.NoError(t, ValidatePartitions(ps))
+	})
+
+	t.Run("mixed failure: earlier duplicate outranks later invalid", func(t *testing.T) {
+		t.Parallel()
+		// index 0 valid, index 1 duplicates it, index 2 is invalid. The single
+		// left-to-right pass must return the duplicate at index 1 and never
+		// reach the invalid at index 2. A two-pass (validate-all-then-detect)
+		// shape would flip this to the index-2 invalid error.
+		ps := []Partition{
+			{Keys: []string{"a"}},
+			{Keys: []string{"a"}},       // duplicate at index 1
+			{Keys: []string{"bad.key"}}, // invalid at index 2
+		}
+		err := ValidatePartitions(ps)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate partition at index 1")
+		require.NotContains(t, err.Error(), "index 2")
+	})
+
+	t.Run("same index: Validate runs before the duplicate check", func(t *testing.T) {
+		t.Parallel()
+		// index 1 has the same CanonicalID as index 0 (labels are ID-blind) AND
+		// an invalid label. The single pass must run Validate() first at index 1
+		// and report the invalid label, not the duplicate — pinning per-index
+		// ordering, not just cross-index ordering.
+		ps := []Partition{
+			{Keys: []string{"a"}},
+			{Keys: []string{"a"}, Label: "bad label"}, // dup CanonicalID + invalid label
+		}
+		err := ValidatePartitions(ps)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid partition at index 1")
+		require.Contains(t, err.Error(), "label contains whitespace")
+		require.NotContains(t, err.Error(), "duplicate")
+	})
+}
+
 func BenchmarkPartitionIDJoinHash(b *testing.B) {
 	parts := []Partition{
 		{Keys: []string{"topic", "p", "0"}},


### PR DESCRIPTION
## Summary

Additive label follow-up APIs for **v2.9.1**, driven by the fdc-kernel integration gaps in `tmp/v2.9.1-followup-gaps-from-fdc-integration.md`. Each removes workaround code label consumers were writing against v2.9.0. With zero labels anywhere in the fleet, assignment output is unchanged from every prior release. Everything is additive except one intentional error-text change (below).

Plan of record: `tmp/v2.9.1-label-followups-plan-v2.md` (decisions locked).

## What's in it (6 scope-pure, bisectable commits)

1. **`types.ValidateLabel(s) error`** — one home for the label charset/length rules (≤64 bytes, no `.`, no ASCII whitespace; `""` valid). `Partition.Validate` and `normalizeWorkerLabels` delegate to it, so a consumer can validate a label at its own boundary with zero drift risk.
2. **`types.ValidatePartitions(ps) error`** — runs the exact per-partition `Validate` + `CanonicalID` dup-check the write path performs (single left-to-right pass; earlier duplicate outranks later invalid). `source.validateAndDedupe` refactored to reuse it, error surface byte-identical (golden-diff test).
3. **`types.MergeLabels(current, intents) ([]Partition, []string, error)`** — label-preserving merge keyed on `Partition.ID()`: set / clear / leave-unchanged, preserving unmentioned labels. Returns unmatched ids (reject typos at the boundary) and **fails closed** on an `ID()` collision rather than guessing which partition to relabel. Deep-copies; never mutates `current`.
4. **`parti.WithLabelSpillGrace(d)`** — makes immediate spill (`0`) reachable. `Config.LabelSpillGrace` is a non-pointer field, so an explicit `0` is silently re-defaulted to `60s`; the option preserves unset-vs-`0`. Negative → `NewManager` error wrapping `types.ErrInvalidConfig`.
5. **`types.NopMetrics`** — exported composite no-op satisfying the full `MetricsCollector` + `LabelMetrics`; the embeddable base a consumer needs to build a small label collector without stubbing eight sub-interfaces.
6. **Docs + CHANGELOG** — `docs/LABELS.md` MergeLabels promotion workflow, boundary-validation guidance, and a "label observability without a metrics pipeline" subsection (leader-only caveat); v2.9.1 CHANGELOG section.

### Intentional change (not additive)

Label validation error text is now uniform: the partition-label and worker-label validators previously produced different messages (`partition label …` vs `worker label …`); both now surface `ValidateLabel`'s canonical `label …` wording. Error-**text** only — no API/behavior change, no change to which labels are accepted. Documented in the CHANGELOG.

## Testing

- `make pre-pr` green (lint + unit `-race` + integration `-race`).
- Verify-first reproducer pins the v2.9.0 `LabelSpillGrace=0` coercion before the fix.
- Golden-diff test pins the `validateAndDedupe` error strings across the refactor.
- MergeLabels tests: set/clear/absent, unmatched, deep-copy/no-alias, collision fail-closed (repo's pinned pair), collision-outranks-unmatched, does-not-validate-label-values.
- Cross-model post-impl review (Codex, read-only): P0 none, core implementations confirmed correct; its 2 P1 + 3 P2 doc/test-coverage findings are all addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
