### PR TITLE
fix(perf-rig): readiness-gated captures, last_seq write rates, full jsz reachability

### DIFF
--- a/test/perf-measurement/RUNBOOK.md
+++ b/test/perf-measurement/RUNBOOK.md
@@ -443,6 +443,8 @@ Each run lands in `results/run-NNN-<cell>-N<N>-rep<r>/`:
 run-meta.yaml       pre-run sidecar (seed, position, cell, N, rep, flags)
 manifest.yaml       harness metadata; presence = CSV complete
 rpc_counts.csv      per-tick JetStream RPC counters
+harness.log         harness stdout+stderr (backgrounded; see "Capture-window
+                    readiness gate" below). Not written for M1.0 control runs.
 cgroup_io.raw       cgroup v2 io.stat (primary IOPS source)
 cgroup_cpumem.raw   cgroup v2 cpu.stat usage_usec + memory.current (NATS CPU/RSS; load mode)
 iostat.raw          host-level cross-check
@@ -453,6 +455,32 @@ aggregated.csv      produced by the aggregator after each run
 
 The campaign summary is written to `results/campaign-manifest.yaml`.
 
+### Capture-window readiness gate
+
+For every non-control cell, `run-matrix.sh` starts the harness binary in
+the background and does **not** start the external capture scripts
+(`cgroup_io.raw` / `iostat.raw` / `jsz.raw` / `node_exporter.prom`) until
+the harness signals steady-state — every worker has reached `StateStable`
+(workers provisioned, assignments settled). Before this fix, captures
+started on a fixed wall-clock offset regardless of cluster state; at
+N>=2000 the harness was often still provisioning at that point, so
+"idle steady-state" captures actually measured provisioning churn.
+
+The signal is the harness's `/ready` HTTP endpoint (`cmd/harness/ready.go`,
+enabled via `--ready-addr`, off by default outside `run-matrix.sh`):
+503 until `WaitStableAll` succeeds, 200 forever after. `run-matrix.sh`'s
+`wait_for_ready` polls it every 2 s, bounded by `--ready-timeout-secs`
+(default 1800 s — a ceiling, not a fixed wait; it returns the instant
+`/ready` reports 200). If the harness process exits on its own, or the
+timeout elapses, the run is aborted as FAILED with `failed.txt` written —
+captures are **never** started against an unready cluster. Capture
+*duration* is unchanged: once gated captures start, they still run for
+`--warmup-secs + --capture-secs`, matching the harness's own remaining
+lifecycle from that point (warmup -> capture -> exit).
+
+M1.0 control runs (no harness) are unaffected — there is no cluster to
+gate on, so captures start immediately as before.
+
 ### Failure artifacts
 
 If a run fails, the script writes one or more sentinel files alongside the
@@ -460,7 +488,7 @@ run artifacts:
 
 | File | Meaning |
 |---|---|
-| `failed.txt` | Harness binary exited non-zero. |
+| `failed.txt` | Harness binary exited non-zero, or the readiness gate failed (see `harness.log` and the "readiness gate" stderr line for which). |
 | `capture-failed.txt` | A mandatory capture file was missing or empty at run end. |
 | `aggregate-failed.txt` | The aggregator step exited non-zero. |
 
@@ -631,6 +659,7 @@ running `analyze.py`.
 | Aggregator divergence > 5 % | Host background I/O inflated iostat totals. | Ensure no concurrent disk-intensive workloads during capture. If persistent, set `--max-disagreement-pct 10` only for the affected run; flag it in `notes.md`. |
 | `MDE_slope ≥ 0.167` at Gate 3 | Rig too noisy to detect H1 signal. | Identify and eliminate host noise sources. Re-run M1.0. Do not proceed to the knob matrix until the gate passes. |
 | Harness `Run` returns "degraded" | A parti worker entered the degraded state during warmup. | Transient; re-run. If persistent, check NATS cluster health (`make reset`) and network stability. |
+| `failed.txt` says "readiness gate failed" | Cluster never reached `StateStable` within `--ready-timeout-secs` (default 1800s), or the harness process exited before signaling readiness. | Check `harness.log` in the run dir for the underlying cause (e.g. a `WaitStableAll` timeout). If N is large enough that provisioning legitimately needs longer than the default, raise `--ready-timeout-secs`. |
 
 ---
 

--- a/test/perf-measurement/cmd/aggregate/main_test.go
+++ b/test/perf-measurement/cmd/aggregate/main_test.go
@@ -115,8 +115,14 @@ func (f fixtureSpec) materialize(t *testing.T, dir string) {
 					streamJSON.WriteString(",")
 				}
 				first = false
-				fmt.Fprintf(&streamJSON, `{"name":"%s","state":{"messages":%d,"bytes":%d}}`,
-					name, sp.msgsPer5s*uint64(p), sp.bytesPer5s*uint64(p))
+				// last_seq is set equal to the cumulative messages count:
+				// the fixture models a stream with no per-subject
+				// retention eviction, so live count and cumulative
+				// sequence number grow together (unlike a real parti KV
+				// bucket under History=1 — see jszStreamState godoc).
+				// ParseJSZ reads last_seq (not messages) for JSZSample.Msgs.
+				fmt.Fprintf(&streamJSON, `{"name":"%s","state":{"messages":%d,"bytes":%d,"last_seq":%d}}`,
+					name, sp.msgsPer5s*uint64(p), sp.bytesPer5s*uint64(p), sp.msgsPer5s*uint64(p))
 			}
 			streamJSON.WriteString(`]`)
 			fmt.Fprintf(&b, `{"t_unix_ns":%d,"node":"localhost:8222","endpoint":"jsz","body":{"account_details":[{"stream_detail":%s}]}}`+"\n",

--- a/test/perf-measurement/cmd/harness/harness.go
+++ b/test/perf-measurement/cmd/harness/harness.go
@@ -97,6 +97,13 @@ type Options struct {
 	PprofAddr            string // bind address for the net/http/pprof debug listener; "" disables it (default: disabled)
 	BlockProfileRate     int    // runtime.SetBlockProfileRate; 0 disables block profiling (default)
 	MutexProfileFraction int    // runtime.SetMutexProfileFraction; 0 disables mutex profiling (default)
+
+	// ReadyAddr is the bind address for the /ready readiness endpoint
+	// (see ready.go); "" disables it (default: disabled). run-matrix.sh
+	// sets this on every harness invocation so it can gate the external
+	// capture-window start on cluster steady-state instead of a fixed
+	// wall-clock offset.
+	ReadyAddr string
 }
 
 // PartitionSourceBucket is the JetStream-KV bucket the harness creates

--- a/test/perf-measurement/cmd/harness/main.go
+++ b/test/perf-measurement/cmd/harness/main.go
@@ -94,6 +94,8 @@ func parseFlags(args []string) (Options, error) {
 		pprofAddr            = fs.String("pprof-addr", "", "bind address for the net/http/pprof debug listener (e.g. 127.0.0.1:6060); empty disables it (default)")
 		blockProfileRate     = fs.Int("block-profile-rate", 0, "runtime.SetBlockProfileRate; 0 disables block profiling (default; zero steady-state overhead)")
 		mutexProfileFraction = fs.Int("mutex-profile-fraction", 0, "runtime.SetMutexProfileFraction; 0 disables mutex profiling (default; zero steady-state overhead)")
+
+		readyAddr = fs.String("ready-addr", "", "bind address for the /ready readiness endpoint (e.g. 127.0.0.1:6061); empty disables it (default). Polled by run-matrix.sh to gate the external capture-window start on cluster steady-state (workers Stable) instead of a fixed wall-clock offset.")
 	)
 
 	if err := fs.Parse(args); err != nil {
@@ -148,6 +150,7 @@ func parseFlags(args []string) (Options, error) {
 		PprofAddr:             *pprofAddr,
 		BlockProfileRate:      *blockProfileRate,
 		MutexProfileFraction:  *mutexProfileFraction,
+		ReadyAddr:             *readyAddr,
 	}, nil
 }
 
@@ -204,6 +207,18 @@ func Run(ctx context.Context, o Options, errLog io.Writer) error {
 			return fmt.Errorf("start pprof listener: %w", perr)
 		}
 		defer shutdownPprofListener(pprofSrv)
+	}
+
+	// Readiness listener starts early (before provisioning) so a poller
+	// sees 503 from t=0 rather than a connection-refused race; it flips
+	// to 200 once WaitStableAll succeeds below (Step 6).
+	readyTracker := NewReadyTracker()
+	if o.ReadyAddr != "" {
+		readySrv, rerr := StartReadyListener(ctx, o.ReadyAddr, readyTracker)
+		if rerr != nil {
+			return fmt.Errorf("start ready listener: %w", rerr)
+		}
+		defer shutdownReadyListener(readySrv)
 	}
 
 	// Step 1: setup NATS + wrapper. The setup wrapper is intentionally
@@ -279,6 +294,11 @@ func Run(ctx context.Context, o Options, errLog io.Writer) error {
 	if err := WaitStableAll(workers, o.StartupBudget); err != nil {
 		return fmt.Errorf("wait stable: %w", err)
 	}
+	// Flip readiness the instant the cluster reaches steady state — this
+	// is the exact signal run-matrix.sh's capture-window gate (Item 1)
+	// waits on, so it must fire as early as possible, before the
+	// queue-consumer / producer / warmup steps below.
+	readyTracker.SetReady()
 
 	// Step 6b: now that the cluster is Stable, start any Queue-mode consumers
 	// (StartWorker no longer does this, since it no longer blocks on Stable).

--- a/test/perf-measurement/cmd/harness/ready.go
+++ b/test/perf-measurement/cmd/harness/ready.go
@@ -1,0 +1,111 @@
+// Readiness signalling for run-matrix.sh (Item 1: capture-window
+// gating). Independent of the profiling plumbing in pprof.go — see
+// StartReadyListener's godoc for why the two listeners are separate.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// ReadyTracker reports whether the harness cluster has reached its
+// initial steady state — every worker StateStable per WaitStableAll
+// (main.go Step 6), i.e. workers provisioned and assignments settled.
+// It starts not-ready and is flipped exactly once, right before the
+// warmup sleep begins.
+//
+// run-matrix.sh polls this (via StartReadyListener's /ready endpoint)
+// before starting the external capture scripts (cgroup/iostat/jsz/
+// node_exporter), so a capture window never starts while the cluster
+// is still provisioning — a fixed wall-clock capture start landed
+// inside provisioning at N>=2000, contaminating "idle steady-state"
+// captures with provisioning churn (see RUNBOOK.md and run-matrix.sh's
+// wait_for_ready).
+type ReadyTracker struct {
+	ready atomic.Bool
+}
+
+// NewReadyTracker returns a tracker in the not-ready state.
+func NewReadyTracker() *ReadyTracker { return &ReadyTracker{} }
+
+// SetReady flips the tracker to ready. Idempotent; safe to call at
+// most once in normal operation (main.go calls it right after
+// WaitStableAll succeeds).
+func (rt *ReadyTracker) SetReady() { rt.ready.Store(true) }
+
+// IsReady reports whether SetReady has been called.
+func (rt *ReadyTracker) IsReady() bool { return rt.ready.Load() }
+
+// readyHandler serves 200 "ready\n" once rt is ready, 503 "not
+// ready\n" otherwise. Polled by run-matrix.sh's wait_for_ready.
+func readyHandler(rt *ReadyTracker) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if !rt.IsReady() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready\n"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready\n"))
+	}
+}
+
+// StartReadyListener starts a minimal HTTP server bound to addr
+// exposing only /ready (see readyHandler), fed by rt.
+//
+// This is intentionally a SEPARATE listener from StartPprofListener
+// (pprof.go) rather than another handler bundled onto the same mux:
+// readiness gating is needed on every run-matrix.sh run, while the
+// pprof listener stays opt-in (--pprof-addr empty by default) for
+// dedicated profiling sessions. Tying /ready to --pprof-addr would
+// force an operator to always enable the pprof listener just to get
+// readiness gating, or require run-matrix.sh to always pass
+// --pprof-addr — conflating two independent concerns for no benefit,
+// since a bare HTTP listener with a single trivial handler carries no
+// measurable steady-state overhead of its own.
+//
+// addr should be a localhost or rig-network-only address (e.g.
+// "127.0.0.1:6061" — chosen to avoid colliding with the NATS cluster's
+// own host-mapped ports 4222/6060/8222+ in docker-compose.yaml). This
+// listener has no authentication.
+//
+// The returned *http.Server is already serving in a background
+// goroutine; the caller is responsible for closing it (e.g. via
+// shutdownReadyListener) when the harness run ends.
+func StartReadyListener(ctx context.Context, addr string, rt *ReadyTracker) (*http.Server, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ready", readyHandler(rt))
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen %q: %w", addr, err)
+	}
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		// ErrServerClosed is the expected return from Close(); nothing
+		// useful to do with any other error from a background debug
+		// listener, so it is intentionally dropped (matches
+		// StartPprofListener's identical background-goroutine pattern).
+		_ = srv.Serve(ln)
+	}()
+
+	return srv, nil
+}
+
+// shutdownReadyListener mirrors shutdownPprofListener's bounded grace
+// window (see that function's godoc for the rationale — SIGINT already
+// cancels the caller's context, so this uses its own timeout instead).
+func shutdownReadyListener(srv *http.Server) {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
+}

--- a/test/perf-measurement/cmd/harness/ready_test.go
+++ b/test/perf-measurement/cmd/harness/ready_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadyTracker_NotReadyInitially locks the zero-value contract: a
+// freshly constructed tracker reports not-ready until SetReady is called.
+func TestReadyTracker_NotReadyInitially(t *testing.T) {
+	rt := NewReadyTracker()
+	require.False(t, rt.IsReady())
+}
+
+// TestReadyTracker_BecomesReady covers the one-shot flip.
+func TestReadyTracker_BecomesReady(t *testing.T) {
+	rt := NewReadyTracker()
+	rt.SetReady()
+	require.True(t, rt.IsReady())
+}
+
+// TestReadyHandler_ReportsState exercises the /ready HTTP handler's own
+// branching: 503 before SetReady, 200 after.
+func TestReadyHandler_ReportsState(t *testing.T) {
+	rt := NewReadyTracker()
+	h := readyHandler(rt)
+
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	rt.SetReady()
+	rec = httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestStartReadyListener_ServesReadyOverHTTP is an end-to-end check of
+// the actual listener (not just the handler in isolation): a real HTTP
+// GET against the bound address must observe the 503->200 transition,
+// matching exactly what run-matrix.sh's wait_for_ready polls for. Binds
+// an explicit loopback port (rather than ":0") so the test can make
+// real HTTP requests without needing to recover an ephemeral port from
+// the net.Listener, which StartReadyListener does not expose.
+func TestStartReadyListener_ServesReadyOverHTTP(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rt := NewReadyTracker()
+	const addr = "127.0.0.1:16061" // arbitrary unused port for the test
+	srv, err := StartReadyListener(ctx, addr, rt)
+	require.NoError(t, err)
+	defer shutdownReadyListener(srv)
+
+	url := "http://" + addr + "/ready"
+
+	get := func() int {
+		resp, err := http.Get(url) //nolint:gosec,noctx // test-only, fixed loopback URL
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+
+	require.Eventually(t, func() bool {
+		return get() == http.StatusServiceUnavailable
+	}, 2*time.Second, 10*time.Millisecond, "listener must serve 503 before SetReady")
+
+	rt.SetReady()
+
+	require.Eventually(t, func() bool {
+		return get() == http.StatusOK
+	}, 2*time.Second, 10*time.Millisecond, "listener must serve 200 after SetReady")
+}

--- a/test/perf-measurement/docker/docker-compose.yaml
+++ b/test/perf-measurement/docker/docker-compose.yaml
@@ -28,10 +28,17 @@
 #     docker compose --profile r3 up -d                            # M2.C tuning
 #   docker compose --profile r5 up -d                              # 5-node cluster
 #
-# Only nats-1 exposes host ports (4222 client, 8222 monitoring, 6060
-# profiling) so the harness can connect via a single URL
-# (nats://localhost:4222) and capture scripts can reach server-side
-# CPU/heap/goroutine profiles at http://localhost:6060/debug/pprof/.
+# Only nats-1 exposes the client port (4222) so the harness always
+# connects via a single URL (nats://localhost:4222), and only nats-1
+# exposes the profiling port (6060) for server-side CPU/heap/goroutine
+# profiles at http://localhost:6060/debug/pprof/.
+#
+# Monitoring ports (8222) ARE exposed on every node (nats-1..nats-5, one
+# distinct host port each) so capture-jsz.sh's --jsz-detail meta-leader
+# poll can reach whichever node currently holds JetStream meta-leadership
+# — meta-leadership can move to any node, and a detail poll aimed only at
+# nats-1 silently returns nothing once leadership moves off it. See
+# scripts/capture-jsz.sh header + scripts/run-matrix.sh NATS_MONITOR_R3/R5.
 
 services:
   nats-1:
@@ -61,6 +68,8 @@ services:
     command: ["-c", "/etc/nats/nats-server.conf"]
     environment:
       - SERVER_NAME=nats-2
+    ports:
+      - "8223:8222"   # monitoring port (meta-leader detail capture; see nats-1 note above)
     volumes:
       - ${PERF_RIG_NATS_CONFIG:-./nats-server.conf}:/etc/nats/nats-server.conf:ro
       - ${PERF_RIG_DIR:-./data}/perf-nats-2:/data
@@ -76,6 +85,8 @@ services:
     command: ["-c", "/etc/nats/nats-server.conf"]
     environment:
       - SERVER_NAME=nats-3
+    ports:
+      - "8224:8222"   # monitoring port (meta-leader detail capture; see nats-1 note above)
     volumes:
       - ${PERF_RIG_NATS_CONFIG:-./nats-server.conf}:/etc/nats/nats-server.conf:ro
       - ${PERF_RIG_DIR:-./data}/perf-nats-3:/data
@@ -91,6 +102,8 @@ services:
     command: ["-c", "/etc/nats/nats-server.conf"]
     environment:
       - SERVER_NAME=nats-4
+    ports:
+      - "8225:8222"   # monitoring port (meta-leader detail capture; see nats-1 note above)
     volumes:
       - ${PERF_RIG_NATS_CONFIG:-./nats-server.conf}:/etc/nats/nats-server.conf:ro
       - ${PERF_RIG_DIR:-./data}/perf-nats-4:/data
@@ -106,6 +119,8 @@ services:
     command: ["-c", "/etc/nats/nats-server.conf"]
     environment:
       - SERVER_NAME=nats-5
+    ports:
+      - "8226:8222"   # monitoring port (meta-leader detail capture; see nats-1 note above)
     volumes:
       - ${PERF_RIG_NATS_CONFIG:-./nats-server.conf}:/etc/nats/nats-server.conf:ro
       - ${PERF_RIG_DIR:-./data}/perf-nats-5:/data

--- a/test/perf-measurement/internal/aggregate/jsz.go
+++ b/test/perf-measurement/internal/aggregate/jsz.go
@@ -10,8 +10,11 @@ import (
 	"slices"
 )
 
-// JSZSample is one snapshot of a single stream's cumulative
-// (messages, bytes) at one jsz poll tick.
+// JSZSample is one snapshot of a single stream's cumulative write
+// count (Msgs) and current byte footprint (Bytes) at one jsz poll
+// tick. Msgs is sourced from the stream's `last_seq` (see
+// jszStreamState), NOT its `messages` (live count) — see that type's
+// godoc for why the distinction matters.
 type JSZSample struct {
 	TUnixNs int64
 	Stream  string
@@ -38,9 +41,27 @@ type jszLine struct {
 }
 
 // jszStreamState is the per-stream message/byte state in a /jsz body.
+//
+// Messages is the stream's LIVE message count after retention limits
+// are applied — for a parti KV bucket (History=1, MaxMsgsPerSubject=1)
+// this settles at the key population (e.g. one key per worker for the
+// heartbeat bucket) and stops changing once the cluster is steady,
+// even though the bucket keeps being overwritten at its configured
+// cadence: each Put on an existing key evicts the prior revision, so
+// live count is flat. Using Messages to derive a write-rate therefore
+// silently reports 0 for any KV bucket whose key set has stabilized —
+// this was the root cause of the empty stream_msgs_*/stream_bytes_*
+// columns observed in early campaign runs (results/s1-e1, s2-e8).
+//
+// LastSeq is the cumulative count of every message ever appended to
+// the stream, including ones since evicted by a per-subject retention
+// limit — it keeps climbing under the exact same in-place-overwrite
+// traffic that leaves Messages flat, and is the correct source for a
+// write-rate metric. See ParseJSZ / JSZSample.
 type jszStreamState struct {
 	Messages uint64 `json:"messages"`
 	Bytes    uint64 `json:"bytes"`
+	LastSeq  uint64 `json:"last_seq"`
 }
 
 // jszStreamDetail is one stream entry under an account's stream_detail.
@@ -190,8 +211,9 @@ func parseJSZReader(r io.Reader) ([]JSZSample, error) {
 				out = append(out, JSZSample{
 					TUnixNs: l.TUnixNs,
 					Stream:  sd.Name,
-					Msgs:    sd.State.Messages,
-					Bytes:   sd.State.Bytes,
+					// last_seq, not messages — see jszStreamState godoc.
+					Msgs:  sd.State.LastSeq,
+					Bytes: sd.State.Bytes,
 				})
 			}
 		}

--- a/test/perf-measurement/internal/aggregate/jsz_test.go
+++ b/test/perf-measurement/internal/aggregate/jsz_test.go
@@ -1,0 +1,88 @@
+package aggregate
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseJSZ_UsesLastSeqNotLiveMessageCount is a reproducer for the
+// empty stream_msgs_* / stream_bytes_* columns observed in real
+// S1/S2 campaign runs (results/s1-e1, results/s2-e8): every parti KV
+// bucket (heartbeat, stableid, election, handoff, ...) uses History=1,
+// so JetStream evicts a key's prior revision on every Put — the
+// bucket's LIVE `state.messages` count settles at the key population
+// (e.g. one key per worker) and stops changing once the cluster is
+// steady, even though the bucket keeps being written at the
+// configured cadence. `state.last_seq`, by contrast, is the
+// cumulative count of every message the stream has ever appended
+// (including ones since evicted by the per-subject retention limit)
+// and keeps climbing.
+//
+// The fixture below reproduces the exact shape observed in
+// results/s1-e1/run-005-E1.b-N2000-rep1/jsz.raw for KV_parti-heartbeat:
+// messages pinned at 50 (= worker count) while last_seq climbs 50,
+// 100, 150 across three 5s polls.
+//
+// Before the fix, ParseJSZ read `messages`, so JSZSample.Msgs was
+// [50,50,50] and JSZRates derived a MsgsRate of 0 at every tick —
+// the "empty" column the operator observed. After the fix, ParseJSZ
+// reads `last_seq`, JSZSample.Msgs is [50,100,150], and JSZRates
+// derives a nonzero rate.
+func TestParseJSZ_UsesLastSeqNotLiveMessageCount(t *testing.T) {
+	const ndjson = `{"t_unix_ns":1000000000,"node":"localhost:8222","endpoint":"jsz","body":{"account_details":[{"stream_detail":[{"name":"KV_parti-heartbeat","state":{"messages":50,"bytes":11676,"last_seq":50}}]}]}}
+{"t_unix_ns":6000000000,"node":"localhost:8222","endpoint":"jsz","body":{"account_details":[{"stream_detail":[{"name":"KV_parti-heartbeat","state":{"messages":50,"bytes":11677,"last_seq":100}}]}]}}
+{"t_unix_ns":11000000000,"node":"localhost:8222","endpoint":"jsz","body":{"account_details":[{"stream_detail":[{"name":"KV_parti-heartbeat","state":{"messages":50,"bytes":11676,"last_seq":150}}]}]}}
+`
+
+	samples, err := parseJSZReader(strings.NewReader(ndjson))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 3 {
+		t.Fatalf("expected 3 samples, got %d", len(samples))
+	}
+
+	wantMsgs := []uint64{50, 100, 150}
+	for i, s := range samples {
+		if s.Msgs != wantMsgs[i] {
+			t.Fatalf("sample[%d].Msgs = %d, want %d (last_seq, not the flat live-message count 50)", i, s.Msgs, wantMsgs[i])
+		}
+	}
+
+	rates := JSZRates(samples)
+	if len(rates) == 0 {
+		t.Fatal("JSZRates produced no rows for a stream with growing last_seq")
+	}
+	var sawNonZero bool
+	for _, r := range rates {
+		if r.MsgsRate != 0 {
+			sawNonZero = true
+			// 50 messages / 5s = 10 msgs/s for both poll gaps.
+			if r.MsgsRate != 10 {
+				t.Fatalf("MsgsRate = %v, want 10 (Δlast_seq=50 / Δt=5s)", r.MsgsRate)
+			}
+		}
+	}
+	if !sawNonZero {
+		t.Fatal("MsgsRate was 0 at every tick — regressed to reading the flat live-message count instead of last_seq")
+	}
+}
+
+// TestParseJSZ_MissingLastSeqDefaultsToZero documents the fallback for a
+// /jsz response that (for whatever server-version reason) omits
+// last_seq: ParseJSZ must not panic or misparse, it just reports 0 —
+// same as any other omitted uint64 JSON field.
+func TestParseJSZ_MissingLastSeqDefaultsToZero(t *testing.T) {
+	const ndjson = `{"t_unix_ns":1000000000,"node":"localhost:8222","endpoint":"jsz","body":{"account_details":[{"stream_detail":[{"name":"perf-rig-data","state":{"messages":0,"bytes":0}}]}]}}
+`
+	samples, err := parseJSZReader(strings.NewReader(ndjson))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("expected 1 sample, got %d", len(samples))
+	}
+	if samples[0].Msgs != 0 {
+		t.Fatalf("Msgs = %d, want 0", samples[0].Msgs)
+	}
+}

--- a/test/perf-measurement/scripts/_capture_lib.sh
+++ b/test/perf-measurement/scripts/_capture_lib.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # _capture_lib.sh — Shared capture-lifecycle helpers for run-matrix.sh.
 #
-# Sourced by run-matrix.sh and by test/scripts/test-capture-failure.sh.
-# Do not execute directly.
+# Sourced by run-matrix.sh and by scripts/test-capture-failure.sh and
+# scripts/test-readiness-gate.sh. Do not execute directly.
 #
 # Globals exported (caller must declare these as arrays before sourcing):
 #   CAPTURE_PIDS  — PIDs of background capture processes.
@@ -62,4 +62,41 @@ verify_captures() {
         return 1
     fi
     return 0
+}
+
+# wait_for_ready READY_ADDR TIMEOUT_SECS HARNESS_PID — poll the harness's
+# /ready endpoint (cmd/harness/ready.go) every 2s until it reports 200,
+# the harness process exits on its own, or TIMEOUT_SECS elapses.
+#
+# This is run-matrix.sh's capture-window readiness gate (RUNBOOK.md
+# "Capture-window readiness gate"): run_one starts the harness in the
+# background and calls this BEFORE starting the external capture
+# scripts, so a capture window never starts while the cluster is still
+# provisioning (workers/assignments not yet settled) — a fixed
+# wall-clock capture start landed inside provisioning at N>=2000.
+#
+# Returns 0 once /ready reports 200. Returns 1 (with a stderr message)
+# if the harness process exits before becoming ready, or if
+# TIMEOUT_SECS elapses first — the caller must never start captures on
+# a non-zero return.
+wait_for_ready() {
+    local ready_addr="$1" timeout_secs="$2" harness_pid="$3"
+    local poll_interval=2
+    local waited=0
+
+    while true; do
+        if ! kill -0 "$harness_pid" 2>/dev/null; then
+            echo "  readiness gate: harness process (pid ${harness_pid}) exited before signaling readiness" >&2
+            return 1
+        fi
+        if curl -sf --max-time 2 "http://${ready_addr}/ready" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [[ "$waited" -ge "$timeout_secs" ]]; then
+            echo "  readiness gate: timed out after ${timeout_secs}s waiting for http://${ready_addr}/ready" >&2
+            return 1
+        fi
+        sleep "$poll_interval"
+        waited=$(( waited + poll_interval ))
+    done
 }

--- a/test/perf-measurement/scripts/capture-jsz.sh
+++ b/test/perf-measurement/scripts/capture-jsz.sh
@@ -37,6 +37,16 @@
 # corrupt an ndjson line in the primary capture. Detail lines carry endpoint
 # "jsz-detail" for self-description even though they never reach OUTPUT.
 #
+# Reachability requirement: this generalizes correctly only for nodes whose
+# monitoring port is reachable from wherever this script runs — meta-leadership
+# can land on any --nats-nodes entry, not just the first. run-matrix.sh's
+# NATS_MONITOR_R3/R5 pass every cluster node's host-mapped monitoring port
+# (see docker/docker-compose.yaml: nats-1:8222, nats-2:8223, nats-3:8224,
+# nats-4:8225, nats-5:8226) for exactly this reason. Passing a --nats-nodes
+# list that omits a node means detail silently goes missing (WARN, not fatal)
+# whenever leadership is on the omitted node — check the WARN rate in the
+# capture log before trusting a --jsz-detail run's coverage.
+#
 # Output format (one JSON object per line):
 #   {"t_unix_ns": <unix_ns>, "node": "<host:port>", "endpoint": "jsz|varz", "body": {...}}
 # With --jsz-detail, <OUTPUT>.detail additionally receives:

--- a/test/perf-measurement/scripts/run-matrix.sh
+++ b/test/perf-measurement/scripts/run-matrix.sh
@@ -57,6 +57,24 @@ WARMUP_SECS=300     # 5 min
 CAPTURE_SECS=600    # 10 min
 CAPTURE_TOTAL=$(( WARMUP_SECS + CAPTURE_SECS ))
 
+# Readiness-gate timeout (seconds; Item 1 fix — see wait_for_ready and
+# start_captures below). This is a CEILING, not a fixed wait:
+# wait_for_ready returns the instant /ready reports 200, so a generous
+# default costs nothing on a fast cold-start (same philosophy as the
+# harness's own defaultStartupBudget in cmd/harness/harness.go). Default
+# covers the largest scheduled cell today (E1.c, N=10000 ->
+# defaultStartupBudget = max(120s, 10000*120ms) = 1200s) plus headroom
+# for process/NATS-connect overhead; raise it for a campaign with a
+# larger N or a slower host.
+READY_TIMEOUT_SECS=1800   # 30 min
+
+# Harness readiness endpoint (see cmd/harness/ready.go). Fixed: only one
+# harness process runs at a time (see cmd/harness/pprof.go's topology
+# note), so a single well-known port is sufficient. 6061 is chosen to
+# avoid colliding with the NATS cluster's host-mapped ports
+# (4222/6060/8222+ — see docker/docker-compose.yaml).
+READY_ADDR="127.0.0.1:6061"
+
 # ---------------------------------------------------------------------------
 # Cell definitions.
 #
@@ -199,6 +217,16 @@ Options:
                       §M1 matrix uses 300 s (the default).
   --capture-secs N    Per-run capture window in seconds (default: 600 = 10 min).
                       Tier 0 typically uses 60-120 s.
+  --ready-timeout-secs N
+                      Bounded wait (seconds) for the harness's /ready signal
+                      before a run is aborted as FAILED (default: 1800 = 30
+                      min). This gates when external captures (cgroup/iostat/
+                      jsz/node_exporter) start: run-matrix.sh never starts
+                      them until the cluster reports steady-state, so a run
+                      never silently captures provisioning churn as "idle".
+                      Raise this for cells with N well above 10000 (the
+                      harness's own defaultStartupBudget scales with N; see
+                      RUNBOOK.md).
   --results-dir PATH  Parent directory for per-run subdirs (default: results/).
   --dry-run           Print the full randomised schedule and exit without
                       running the rig.
@@ -233,6 +261,7 @@ while [[ $# -gt 0 ]]; do
         --n-values)    N_VALUES_ARG="$2"; shift 2 ;;
         --warmup-secs) WARMUP_SECS="$2"; shift 2 ;;
         --capture-secs) CAPTURE_SECS="$2"; shift 2 ;;
+        --ready-timeout-secs) READY_TIMEOUT_SECS="$2"; shift 2 ;;
         --reps)        REPS="$2";        shift 2 ;;
         --results-dir) RESULTS_DIR="$2"; shift 2 ;;
         --dry-run)     DRY_RUN=true;     shift ;;
@@ -256,6 +285,10 @@ if ! [[ "$WARMUP_SECS" =~ ^[0-9]+$ ]] || [[ "$WARMUP_SECS" -lt 5 ]]; then
 fi
 if ! [[ "$CAPTURE_SECS" =~ ^[0-9]+$ ]] || [[ "$CAPTURE_SECS" -lt 10 ]]; then
     echo "run-matrix.sh: --capture-secs must be an integer >= 10, got: $CAPTURE_SECS" >&2
+    exit 1
+fi
+if ! [[ "$READY_TIMEOUT_SECS" =~ ^[0-9]+$ ]] || [[ "$READY_TIMEOUT_SECS" -lt 10 ]]; then
+    echo "run-matrix.sh: --ready-timeout-secs must be an integer >= 10, got: $READY_TIMEOUT_SECS" >&2
     exit 1
 fi
 # Recompute total now that user overrides have landed.
@@ -488,8 +521,8 @@ write_campaign_manifest "$CAMPAIGN_START" 0 "$TOTAL_RUNS"
 
 # ---------------------------------------------------------------------------
 # Track background capture PIDs; clean them up on signal or exit.
-# stop_captures / verify_captures live in _capture_lib.sh so the test
-# harness can source them independently.
+# stop_captures / verify_captures / wait_for_ready live in _capture_lib.sh
+# so the test harness can source them independently.
 # ---------------------------------------------------------------------------
 CAPTURE_PIDS=()
 CAPTURE_NAMES=()
@@ -572,6 +605,10 @@ start_captures() {
     fi
 }
 
+# wait_for_ready lives in _capture_lib.sh (sourced above) so the test
+# harness can drive it independently of the rest of this script — see
+# that file for its contract.
+
 # ---------------------------------------------------------------------------
 # run_one — execute a single scheduled entry.
 #
@@ -641,15 +678,17 @@ run_one() {
         return 1
     fi
 
-    # Start captures.
-    start_captures "$run_dir" "$replicas" "$CAPTURE_TOTAL"
-    echo "  captures started (PIDs: ${CAPTURE_PIDS[*]:-none})"
-
     local harness_rc=0
     local control_start=""
+    local readiness_failed=false
+    local harness_pid=""
 
     if [[ "$is_control" == "true" ]]; then
-        # M1.0 — no harness; just let captures run for the full window.
+        # M1.0 — no harness, so there is no cluster to gate on; captures
+        # start immediately and run for the full window, same as before
+        # the Item 1 fix.
+        start_captures "$run_dir" "$replicas" "$CAPTURE_TOTAL"
+        echo "  captures started (PIDs: ${CAPTURE_PIDS[*]:-none})"
         # Record start time now so the window is accurate even if stop
         # or verify takes extra time.
         control_start="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -657,8 +696,16 @@ run_one() {
         sleep "$CAPTURE_TOTAL" || true
         echo "  M1.0 capture window complete."
     else
-        # Run the harness binary.
-        echo "  running harness (--n=${n} ${flags})..."
+        # Run the harness binary in the background so its lifecycle
+        # (provisioning -> Stable -> warmup -> capture) can run concurrently
+        # with polling its readiness signal (Item 1 fix): external captures
+        # must not start until the cluster reports steady-state, never on a
+        # fixed wall-clock offset that can land inside provisioning at
+        # N>=2000. Duration semantics are unchanged — once captures start
+        # they still run for CAPTURE_TOTAL (warmup + capture), the same as
+        # the harness's own remaining lifecycle from this point.
+        local harness_log="${run_dir}/harness.log"
+        echo "  starting harness (--n=${n} ${flags}); waiting for readiness (timeout ${READY_TIMEOUT_SECS}s)..."
         PERF_RIG_RUN_INDEX="${pos}" \
         PERF_RIG_NATS_IMAGE="${PERF_RIG_NATS_IMAGE:-nats:2.12.6}" \
         PERF_RIG_NATS_IMAGE_DIGEST="${PERF_RIG_NATS_IMAGE_DIGEST:-}" \
@@ -667,17 +714,38 @@ run_one() {
                 --output-dir="$run_dir" \
                 --warmup="${WARMUP_SECS}s" \
                 --capture-window="${CAPTURE_SECS}s" \
+                --ready-addr="$READY_ADDR" \
                 $flags \
-            || harness_rc=$?
+                > "$harness_log" 2>&1 &
+        harness_pid=$!
 
+        if wait_for_ready "$READY_ADDR" "$READY_TIMEOUT_SECS" "$harness_pid"; then
+            echo "  cluster ready — starting captures..."
+            start_captures "$run_dir" "$replicas" "$CAPTURE_TOTAL"
+            echo "  captures started (PIDs: ${CAPTURE_PIDS[*]:-none})"
+        else
+            echo "  readiness gate FAILED — never starting captures against an unready cluster (see ${harness_log})" >&2
+            readiness_failed=true
+            kill "$harness_pid" 2>/dev/null || true
+        fi
+
+        wait "$harness_pid" 2>/dev/null || harness_rc=$?
         if [[ "$harness_rc" -ne 0 ]]; then
             echo "  harness exited with code ${harness_rc}" >&2
         fi
     fi
 
-    # Stop captures regardless of harness outcome.
+    # Stop captures regardless of harness outcome. Safe even when the
+    # readiness gate failed before start_captures ran: CAPTURE_PIDS is
+    # empty in that case and stop_captures is then a no-op.
     echo "  stopping captures..."
     stop_captures
+
+    if [[ "$readiness_failed" == "true" ]]; then
+        printf 'readiness gate failed (harness_rc=%d); see harness.log\n' "$harness_rc" > "${run_dir}/failed.txt"
+        echo "  run FAILED (readiness gate); continuing campaign."
+        return 1
+    fi
 
     if [[ "$harness_rc" -ne 0 ]]; then
         printf 'harness exit code %d\n' "$harness_rc" > "${run_dir}/failed.txt"

--- a/test/perf-measurement/scripts/run-matrix.sh
+++ b/test/perf-measurement/scripts/run-matrix.sh
@@ -41,9 +41,16 @@ fi
 CONTAINERS_R3="perf-nats-1,perf-nats-2,perf-nats-3"
 CONTAINERS_R5="perf-nats-1,perf-nats-2,perf-nats-3,perf-nats-4,perf-nats-5"
 
-# Monitoring endpoint for capture-jsz.sh.
-NATS_MONITOR_R3="localhost:8222"
-NATS_MONITOR_R5="localhost:8222"   # single ingress; route discovery handles the rest
+# Monitoring endpoints for capture-jsz.sh — one per cluster node, host
+# ports per docker/docker-compose.yaml (nats-1:8222, nats-2:8223, ...).
+# capture-jsz.sh polls every listed node each lean tick and, with
+# --jsz-detail, resolves whichever one currently reports itself as
+# JetStream meta-leader (meta-leadership can move to any node) for the
+# expensive per-consumer/raft detail poll. Passing only nats-1 here would
+# silently starve --jsz-detail of leader detail whenever leadership moves
+# off nats-1.
+NATS_MONITOR_R3="localhost:8222,localhost:8223,localhost:8224"
+NATS_MONITOR_R5="localhost:8222,localhost:8223,localhost:8224,localhost:8225,localhost:8226"
 
 # Warmup and capture window durations (seconds).
 WARMUP_SECS=300     # 5 min
@@ -506,11 +513,13 @@ start_captures() {
     CAPTURE_PIDS=()
     CAPTURE_NAMES=()
 
-    local containers
+    local containers nats_monitor
     if [[ "$replicas" -eq 5 ]]; then
         containers="$CONTAINERS_R5"
+        nats_monitor="$NATS_MONITOR_R5"
     else
         containers="$CONTAINERS_R3"
+        nats_monitor="$NATS_MONITOR_R3"
     fi
 
     # Mandatory capture prerequisites were validated by preflight; here
@@ -542,7 +551,7 @@ start_captures() {
     bash "${SCRIPT_DIR}/capture-jsz.sh" \
         --output "${run_dir}/jsz.raw" \
         --duration "$duration" \
-        --nats-nodes "$NATS_MONITOR_R3" \
+        --nats-nodes "$nats_monitor" \
         "${jsz_extra[@]}" &
     CAPTURE_PIDS+=($!)
     CAPTURE_NAMES+=("jsz")

--- a/test/perf-measurement/scripts/test-readiness-gate.sh
+++ b/test/perf-measurement/scripts/test-readiness-gate.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# test-readiness-gate.sh — Bash-level smoke test for the Item 1 fix:
+# run-matrix.sh's wait_for_ready capture-window readiness gate
+# (scripts/_capture_lib.sh).
+#
+# Exercises wait_for_ready against a real HTTP listener (a tiny Python
+# stand-in for cmd/harness/ready.go's /ready endpoint — see ready_test.go
+# for the Go-side unit tests of the actual handler) and real background
+# processes standing in for the harness PID, so the three outcomes the
+# gate must distinguish are proven end-to-end without needing the full
+# docker rig:
+#
+#   1. Cluster becomes ready before the timeout -> gate returns 0 promptly.
+#   2. The "harness" process exits before ever becoming ready -> gate
+#      returns 1 promptly (does not wait out the full timeout).
+#   3. The cluster never becomes ready -> gate returns 1 once the timeout
+#      elapses (bounded wait, loud failure — never silently proceeds).
+#
+# Run with: bash test/perf-measurement/scripts/test-readiness-gate.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=_capture_lib.sh
+source "${SCRIPT_DIR}/_capture_lib.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; (( PASS++ )) || true; }
+fail() { echo "  FAIL: $1" >&2; (( FAIL++ )) || true; }
+
+MOCK_PORT=17061
+MOCK_PID=""
+
+# start_mock_ready STATUS_CODE — serve STATUS_CODE for every GET on
+# MOCK_PORT until stop_mock_ready is called.
+start_mock_ready() {
+    local status="$1"
+    python3 -c '
+import http.server, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(int(sys.argv[2]))
+        self.end_headers()
+    def log_message(self, *a):
+        pass
+http.server.HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+' "$MOCK_PORT" "$status" &
+    MOCK_PID=$!
+    # Give the listener a moment to bind before the first poll.
+    sleep 0.3
+}
+
+stop_mock_ready() {
+    if [[ -n "$MOCK_PID" ]]; then
+        kill "$MOCK_PID" 2>/dev/null || true
+        wait "$MOCK_PID" 2>/dev/null || true
+        MOCK_PID=""
+    fi
+}
+
+cleanup() {
+    stop_mock_ready
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1 — cluster ready immediately: wait_for_ready must return 0 without
+# waiting out the timeout.
+# ---------------------------------------------------------------------------
+echo "=== Test 1: ready immediately -> returns 0 promptly ==="
+start_mock_ready 200
+sleep 30 &
+harness_pid=$!
+
+start_ts=$(date +%s)
+if wait_for_ready "127.0.0.1:${MOCK_PORT}" 20 "$harness_pid"; then
+    pass "wait_for_ready returned 0 when /ready reports 200"
+else
+    fail "wait_for_ready returned non-zero when /ready reports 200"
+fi
+elapsed=$(( $(date +%s) - start_ts ))
+if [[ "$elapsed" -le 5 ]]; then
+    pass "returned promptly (${elapsed}s), did not wait out the 20s timeout"
+else
+    fail "took ${elapsed}s to notice an already-ready /ready endpoint"
+fi
+
+kill "$harness_pid" 2>/dev/null || true
+wait "$harness_pid" 2>/dev/null || true
+stop_mock_ready
+
+# ---------------------------------------------------------------------------
+# Test 2 — harness process exits before becoming ready: wait_for_ready
+# must return 1 as soon as it notices, not wait out the full timeout.
+# No mock server is started at all (connection refused on every poll),
+# standing in for a harness that died before ever starting its listener.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 2: harness exits early -> returns 1 promptly ==="
+( sleep 0.5 ) &
+harness_pid=$!
+
+start_ts=$(date +%s)
+if ! wait_for_ready "127.0.0.1:${MOCK_PORT}" 30 "$harness_pid" 2>/tmp/readiness-gate-test2.stderr; then
+    pass "wait_for_ready returned non-zero when the harness process died"
+else
+    fail "wait_for_ready returned 0 despite the harness process dying"
+fi
+elapsed=$(( $(date +%s) - start_ts ))
+if [[ "$elapsed" -le 10 ]]; then
+    pass "returned promptly (${elapsed}s), did not wait out the 30s timeout"
+else
+    fail "took ${elapsed}s to notice the harness process had died"
+fi
+if grep -q "exited before signaling readiness" /tmp/readiness-gate-test2.stderr; then
+    pass "stderr names the harness-exited cause"
+else
+    fail "stderr did not name the harness-exited cause: $(cat /tmp/readiness-gate-test2.stderr)"
+fi
+rm -f /tmp/readiness-gate-test2.stderr
+
+# ---------------------------------------------------------------------------
+# Test 3 — cluster never becomes ready: wait_for_ready must return 1 once
+# the bounded timeout elapses, never silently returning success.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 3: never ready -> bounded timeout, returns 1 ==="
+start_mock_ready 503
+sleep 30 &
+harness_pid=$!
+
+start_ts=$(date +%s)
+if ! wait_for_ready "127.0.0.1:${MOCK_PORT}" 5 "$harness_pid" 2>/tmp/readiness-gate-test3.stderr; then
+    pass "wait_for_ready returned non-zero after the timeout elapsed"
+else
+    fail "wait_for_ready returned 0 despite /ready never reporting 200"
+fi
+elapsed=$(( $(date +%s) - start_ts ))
+if [[ "$elapsed" -ge 4 ]]; then
+    pass "waited out the bounded timeout (${elapsed}s >= 4s) rather than giving up early"
+else
+    fail "returned before the timeout elapsed (${elapsed}s), gate is not bounded correctly"
+fi
+if grep -q "timed out after 5s" /tmp/readiness-gate-test3.stderr; then
+    pass "stderr names the timeout cause"
+else
+    fail "stderr did not name the timeout cause: $(cat /tmp/readiness-gate-test3.stderr)"
+fi
+rm -f /tmp/readiness-gate-test3.stderr
+
+kill "$harness_pid" 2>/dev/null || true
+wait "$harness_pid" 2>/dev/null || true
+stop_mock_ready
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Three measurement-rig defects found during the S1/S2 idle-baseline sessions:

- **Readiness-gated capture start** — capture windows previously started at a fixed early offset and, at N≥2000 partitions, landed inside provisioning, contaminating "idle steady-state" numbers. The harness now exposes a `/ready` endpoint (flips after `WaitStableAll`) with `--ready-addr`/`--ready-timeout-secs`, and `run-matrix.sh` gates `start_captures` on it with a bounded wait that aborts the cell as FAILED rather than silently capturing. Verified with a bash-mock suite (8/8) plus a live smoke cell showing a real ~44s provisioning-to-ready gap before captures began.
- **Stream write-rate columns were all zero** — parti's History=1 KV buckets keep `state.messages` flat after provisioning while `state.last_seq` keeps climbing; the aggregator now derives write rates from `last_seq`. Reproducer test fails on the old parser; re-aggregating an existing S2 run dir turns the previously empty columns nonzero.
- **jsz meta-leader detail unreachable off nats-1** — each NATS node's monitoring port is now mapped to a distinct host port (8222–8226) and `run-matrix.sh` passes every node to `capture-jsz.sh` (also fixes jsz always using the R3 monitor list under R5 cells). The meta-leader resolution logic was already generic; reachability was the gap.

## Validation
- Perf-module Go tests green (`./cmd/... ./internal/...`), aggregator reproducer RED→GREEN.
- Root `make lint` and perf-module golangci-lint: 0 issues.
- Live 3-node rig smoke for items 1 and 3.

## Notes
- `--ready-timeout-secs` defaults to 1800s (global, not per-N-scaled) — cells far above N≈14000 need an explicit override (documented in RUNBOOK.md).
- New loopback-only host port mappings 8223–8226 change the "only nats-1 is exposed" topology assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3evmLZovmtfQK4Zb5B7WF