### PR TITLE
feat(perf-rig): churn schedule, E2/E4 matrix cells, cgroup cpu/mem capture

### DIFF
--- a/test/perf-measurement/cmd/harness/churn.go
+++ b/test/perf-measurement/cmd/harness/churn.go
@@ -1,0 +1,273 @@
+// Churn schedule — rig-only measurement plumbing for perf-measurement
+// experiment E4 (rebalance burst anatomy). See
+// docs/research/load-overhead-research-and-pprof-plan-v1.md §5 E4/E5.
+//
+// When Options.ChurnWorkerIdx >= 0, Run (main.go) launches
+// runChurnSchedule as a background goroutine right after the capture
+// window opens: after a fixed idle plateau it performs
+// Options.ChurnWaves repetitions of kill worker -> wait convergence ->
+// re-add worker -> wait convergence, writing each phase transition's
+// wall-clock timestamp to <output-dir>/churn-waves.csv so a post-hoc
+// pass can slice rpc_counts.csv into per-wave windows.
+//
+// This file is throwaway rig tooling for one measurement campaign — it
+// does not touch any library package, only cmd/harness's own
+// WorkerHandle/StartWorker/WaitStableAll primitives.
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/arloliu/parti/v2"
+)
+
+// workerSet is a mutex-protected view over the harness's worker
+// handles. The plain []*WorkerHandle slice built in Run is sufficient
+// for every pre-existing code path (all of which run either before the
+// churn goroutine starts or after it has been joined via
+// Run's churnWG.Wait()), but the churn goroutine replaces one element
+// (the killed-then-restarted worker's handle) concurrently with the
+// capture loop's per-tick AggregateSnapshots read of the same slice.
+// workerSet is the smallest synchronization that makes that safe.
+type workerSet struct {
+	mu      sync.RWMutex
+	workers []*WorkerHandle
+}
+
+// newWorkerSet wraps an existing worker slice. The caller must not
+// mutate the backing array directly afterward — only through the
+// returned workerSet's methods.
+func newWorkerSet(workers []*WorkerHandle) *workerSet {
+	return &workerSet{workers: workers}
+}
+
+// Snapshot returns a shallow copy of the current handle list, safe for
+// the caller to range over without holding any lock.
+func (ws *workerSet) Snapshot() []*WorkerHandle {
+	ws.mu.RLock()
+	defer ws.mu.RUnlock()
+	out := make([]*WorkerHandle, len(ws.workers))
+	copy(out, ws.workers)
+
+	return out
+}
+
+// Get returns the handle whose .idx == idx, or nil if not present.
+func (ws *workerSet) Get(idx int) *WorkerHandle {
+	ws.mu.RLock()
+	defer ws.mu.RUnlock()
+	for _, w := range ws.workers {
+		if w.idx == idx {
+			return w
+		}
+	}
+
+	return nil
+}
+
+// Replace swaps the handle whose .idx == idx for wh. No-op if idx is
+// not found (should not happen — the idx space is fixed at startup and
+// the churn schedule only ever replaces an index it already read via
+// Get).
+func (ws *workerSet) Replace(idx int, wh *WorkerHandle) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	for i, w := range ws.workers {
+		if w.idx == idx {
+			ws.workers[i] = wh
+			return
+		}
+	}
+}
+
+// churnWaveEvent is one row of churn-waves.csv.
+type churnWaveEvent struct {
+	Wave      int
+	Phase     string // "kill" | "post_kill_stable" | "readd" | "post_readd_stable" | "wave_failed"
+	At        time.Time
+	LeaderIdx int // -1 if no in-process worker currently holds leadership
+	Note      string
+}
+
+// churnWaveWriter appends churnWaveEvents to <outputDir>/churn-waves.csv,
+// flushing after every row so a truncated run still leaves usable
+// partial data — matches the rest of the rig's crash-safety posture
+// (e.g. the streamed rpc_counts.csv).
+type churnWaveWriter struct {
+	f *os.File
+	w *csv.Writer
+}
+
+func newChurnWaveWriter(outputDir string) (*churnWaveWriter, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir output dir: %w", err)
+	}
+	f, err := os.Create(filepath.Join(outputDir, "churn-waves.csv"))
+	if err != nil {
+		return nil, fmt.Errorf("create churn-waves.csv: %w", err)
+	}
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"wave", "phase", "t_unix_ns", "t_rfc3339", "leader_idx", "note"}); err != nil {
+		_ = f.Close()
+
+		return nil, fmt.Errorf("write churn-waves.csv header: %w", err)
+	}
+	w.Flush()
+
+	return &churnWaveWriter{f: f, w: w}, nil
+}
+
+// Write appends ev and flushes immediately.
+func (cw *churnWaveWriter) Write(ev churnWaveEvent) {
+	_ = cw.w.Write([]string{
+		fmt.Sprintf("%d", ev.Wave),
+		ev.Phase,
+		fmt.Sprintf("%d", ev.At.UnixNano()),
+		ev.At.UTC().Format(time.RFC3339Nano),
+		fmt.Sprintf("%d", ev.LeaderIdx),
+		ev.Note,
+	})
+	cw.w.Flush()
+}
+
+// Close flushes and closes the underlying file. Best-effort: errors are
+// dropped, matching the rig's other best-effort teardown paths.
+func (cw *churnWaveWriter) Close() {
+	cw.w.Flush()
+	_ = cw.f.Close()
+}
+
+// runChurnSchedule executes o.ChurnWaves repetitions of
+// kill -> converge -> re-add -> converge against the worker at index
+// o.ChurnWorkerIdx, after an initial o.ChurnPlateau idle wait. It is
+// designed to run as a single background goroutine started right after
+// the capture window opens (captureStart) and joined (via a
+// sync.WaitGroup) before Run proceeds past the capture loop.
+//
+// ctx bounds the ENTIRE schedule with a hard ceiling the caller derives
+// independently of the harness's outer signal context (see Run's
+// churnCtx construction) — a stuck convergence wait must not hang the
+// harness process indefinitely. Each per-wave convergence wait
+// additionally has its own o.ChurnConvergeTimeout budget; a wave whose
+// convergence check exceeds that budget is logged to the CSV as
+// "wave_failed" (via a non-empty Note on the relevant phase row) and the
+// schedule proceeds to the next wave — it does not retry.
+func runChurnSchedule(
+	ctx context.Context,
+	o Options,
+	cfg parti.Config,
+	ws *workerSet,
+	lt *LeaderTracker,
+	errLog io.Writer,
+) {
+	cww, err := newChurnWaveWriter(o.OutputDir)
+	if err != nil {
+		fmt.Fprintf(errLog, "churn: failed to open churn-waves.csv: %v (schedule aborted)\n", err)
+
+		return
+	}
+	defer cww.Close()
+
+	idx := o.ChurnWorkerIdx
+	fmt.Fprintf(errLog, "churn: schedule starting — worker=%d waves=%d plateau=%s converge_timeout=%s\n",
+		idx, o.ChurnWaves, o.ChurnPlateau, o.ChurnConvergeTimeout)
+
+	if err := sleepCtx(ctx, o.ChurnPlateau); err != nil {
+		fmt.Fprintf(errLog, "churn: aborted during idle plateau: %v\n", err)
+
+		return
+	}
+
+	leaderAt := func() int {
+		if i, ok := lt.Current(); ok {
+			return i
+		}
+
+		return -1
+	}
+
+	for wave := 1; wave <= o.ChurnWaves; wave++ {
+		target := ws.Get(idx)
+		if target == nil {
+			fmt.Fprintf(errLog, "churn: wave %d: worker %d not found — aborting schedule\n", wave, idx)
+			cww.Write(churnWaveEvent{Wave: wave, Phase: "wave_failed", At: time.Now(), LeaderIdx: leaderAt(), Note: "worker not found"})
+
+			return
+		}
+
+		// --- kill ---
+		killAt := time.Now()
+		stopCtx, stopCancel := context.WithTimeout(ctx, 30*time.Second)
+		stopErr := target.Stop(stopCtx)
+		stopCancel()
+		cww.Write(churnWaveEvent{Wave: wave, Phase: "kill", At: killAt, LeaderIdx: leaderAt(), Note: errString(stopErr)})
+		if stopErr != nil {
+			fmt.Fprintf(errLog, "churn: wave %d: kill worker %d: %v (continuing — worker is down regardless)\n", wave, idx, stopErr)
+		}
+
+		// --- wait convergence: remaining (non-killed) workers Stable ---
+		remaining := remainingWorkers(ws.Snapshot(), idx)
+		cErr := WaitStableAll(remaining, o.ChurnConvergeTimeout)
+		postKillAt := time.Now()
+		cww.Write(churnWaveEvent{Wave: wave, Phase: "post_kill_stable", At: postKillAt, LeaderIdx: leaderAt(), Note: errString(cErr)})
+		if cErr != nil {
+			fmt.Fprintf(errLog, "churn: wave %d: post-kill convergence timed out: %v\n", wave, cErr)
+		}
+
+		// --- re-add ---
+		readdAt := time.Now()
+		newWH, startErr := StartWorker(ctx, idx, o, cfg, lt)
+		if startErr != nil {
+			fmt.Fprintf(errLog, "churn: wave %d: re-add worker %d FAILED: %v — schedule aborted\n", wave, idx, startErr)
+			cww.Write(churnWaveEvent{Wave: wave, Phase: "wave_failed", At: readdAt, LeaderIdx: leaderAt(), Note: "re-add failed: " + startErr.Error()})
+
+			return
+		}
+		ws.Replace(idx, newWH)
+		cww.Write(churnWaveEvent{Wave: wave, Phase: "readd", At: readdAt, LeaderIdx: leaderAt(), Note: ""})
+
+		// --- wait convergence: ALL workers (incl. re-added) Stable ---
+		all := ws.Snapshot()
+		cErr2 := WaitStableAll(all, o.ChurnConvergeTimeout)
+		postReaddAt := time.Now()
+		cww.Write(churnWaveEvent{Wave: wave, Phase: "post_readd_stable", At: postReaddAt, LeaderIdx: leaderAt(), Note: errString(cErr2)})
+		if cErr2 != nil {
+			fmt.Fprintf(errLog, "churn: wave %d: post-readd convergence timed out: %v\n", wave, cErr2)
+		}
+
+		fmt.Fprintf(errLog, "churn: wave %d complete — kill=%s post_kill=%s readd=%s post_readd=%s\n",
+			wave, killAt.Format(time.RFC3339), postKillAt.Format(time.RFC3339), readdAt.Format(time.RFC3339), postReaddAt.Format(time.RFC3339))
+	}
+
+	fmt.Fprintf(errLog, "churn: schedule complete (%d waves)\n", o.ChurnWaves)
+}
+
+// remainingWorkers returns all handles in all except the one whose
+// .idx == excludeIdx.
+func remainingWorkers(all []*WorkerHandle, excludeIdx int) []*WorkerHandle {
+	out := make([]*WorkerHandle, 0, len(all))
+	for _, w := range all {
+		if w.idx != excludeIdx {
+			out = append(out, w)
+		}
+	}
+
+	return out
+}
+
+// errString returns "" for a nil error and err.Error() otherwise, so
+// churn-waves.csv's note column is empty on the happy path.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return err.Error()
+}

--- a/test/perf-measurement/cmd/harness/harness.go
+++ b/test/perf-measurement/cmd/harness/harness.go
@@ -104,6 +104,23 @@ type Options struct {
 	// capture-window start on cluster steady-state instead of a fixed
 	// wall-clock offset.
 	ReadyAddr string
+
+	// --- E4 churn schedule (rig-only, see churn.go) ---
+
+	// ChurnWorkerIdx is the 0-based worker index the churn schedule
+	// repeatedly kills and re-adds during the capture window; -1
+	// disables the schedule entirely (default; zero overhead).
+	ChurnWorkerIdx int
+	// ChurnWaves is the number of kill->converge->re-add repetitions.
+	ChurnWaves int
+	// ChurnPlateau is the idle wait after the capture window opens
+	// before wave 1's kill, giving a clean idle-state tail for
+	// pre-wave comparison.
+	ChurnPlateau time.Duration
+	// ChurnConvergeTimeout bounds how long the schedule waits, per
+	// phase (post-kill and post-re-add), for the cluster to report
+	// Stable before logging that phase as failed and moving on.
+	ChurnConvergeTimeout time.Duration
 }
 
 // PartitionSourceBucket is the JetStream-KV bucket the harness creates
@@ -769,6 +786,10 @@ type ManifestOptions struct {
 	MaxAckPending         int     `yaml:"maxAckPending"`
 	AckWait               string  `yaml:"ackWait"`
 	StartupBudget         string  `yaml:"startupBudget"`
+	ChurnWorkerIdx        int     `yaml:"churnWorkerIdx"`
+	ChurnWaves            int     `yaml:"churnWaves"`
+	ChurnPlateau          string  `yaml:"churnPlateau"`
+	ChurnConvergeTimeout  string  `yaml:"churnConvergeTimeout"`
 }
 
 // ManifestStream records the storage class confirmed by
@@ -822,6 +843,10 @@ func buildManifestOptions(o Options) ManifestOptions {
 		MaxAckPending:         o.MaxAckPending,
 		AckWait:               o.AckWait.String(),
 		StartupBudget:         o.StartupBudget.String(),
+		ChurnWorkerIdx:        o.ChurnWorkerIdx,
+		ChurnWaves:            o.ChurnWaves,
+		ChurnPlateau:          o.ChurnPlateau.String(),
+		ChurnConvergeTimeout:  o.ChurnConvergeTimeout.String(),
 	}
 }
 

--- a/test/perf-measurement/cmd/harness/main.go
+++ b/test/perf-measurement/cmd/harness/main.go
@@ -96,10 +96,18 @@ func parseFlags(args []string) (Options, error) {
 		mutexProfileFraction = fs.Int("mutex-profile-fraction", 0, "runtime.SetMutexProfileFraction; 0 disables mutex profiling (default; zero steady-state overhead)")
 
 		readyAddr = fs.String("ready-addr", "", "bind address for the /ready readiness endpoint (e.g. 127.0.0.1:6061); empty disables it (default). Polled by run-matrix.sh to gate the external capture-window start on cluster steady-state (workers Stable) instead of a fixed wall-clock offset.")
+
+		churnWorkerIdx       = fs.Int("churn-worker-idx", -1, "rig-only E4 churn schedule: 0-based worker index to repeatedly kill/re-add during the capture window; -1 disables the schedule (default)")
+		churnWaves           = fs.Int("churn-waves", 3, "rig-only E4 churn schedule: number of kill->converge->re-add repetitions")
+		churnPlateau         = fs.Duration("churn-plateau", 90*time.Second, "rig-only E4 churn schedule: idle wait after capture-window start before wave 1's kill")
+		churnConvergeTimeout = fs.Duration("churn-converge-timeout", 120*time.Second, "rig-only E4 churn schedule: per-phase budget for the cluster to reach Stable after a kill or a re-add; a wave that exceeds this is logged as wave_failed and the schedule continues to the next wave")
 	)
 
 	if err := fs.Parse(args); err != nil {
 		return Options{}, err
+	}
+	if *churnWorkerIdx >= *workers {
+		return Options{}, fmt.Errorf("--churn-worker-idx=%d out of range for --workers=%d", *churnWorkerIdx, *workers)
 	}
 
 	kvSt, err := ParseStorage(*kvStorage)
@@ -151,6 +159,11 @@ func parseFlags(args []string) (Options, error) {
 		BlockProfileRate:      *blockProfileRate,
 		MutexProfileFraction:  *mutexProfileFraction,
 		ReadyAddr:             *readyAddr,
+
+		ChurnWorkerIdx:       *churnWorkerIdx,
+		ChurnWaves:           *churnWaves,
+		ChurnPlateau:         *churnPlateau,
+		ChurnConvergeTimeout: *churnConvergeTimeout,
 	}, nil
 }
 
@@ -360,6 +373,63 @@ func Run(ctx context.Context, o Options, errLog io.Writer) error {
 	ResetAll(workers)
 	captureStart := time.Now()
 
+	// Churn schedule (E4 rebalance-burst anatomy, rig-only — see
+	// churn.go). Disabled unless --churn-worker-idx >= 0 (default -1).
+	// The schedule runs as a background goroutine for the remainder of
+	// the capture window; churnCtx gives it a hard ceiling independent
+	// of the outer signal context so a stuck convergence wait cannot
+	// hang the harness process indefinitely. ws, when non-nil, is the
+	// live worker view the capture loop and the post-loop status checks
+	// below must read through instead of the plain `workers` slice,
+	// because the churn goroutine replaces one element (the
+	// killed-then-restarted worker's handle) concurrently with the
+	// capture loop's per-tick reads of the same slice.
+	var ws *workerSet
+	var churnWG sync.WaitGroup
+	churnCancel := func() {}
+	if o.ChurnWorkerIdx >= 0 {
+		ws = newWorkerSet(workers)
+		ceiling := o.ChurnPlateau + time.Duration(o.ChurnWaves)*2*o.ChurnConvergeTimeout + 2*time.Minute
+		var churnCtx context.Context
+		churnCtx, churnCancel = context.WithTimeout(ctx, ceiling)
+		churnWG.Add(1)
+		go func() {
+			defer churnWG.Done()
+			runChurnSchedule(churnCtx, o, cfg, ws, leaderTracker, errLog)
+		}()
+	}
+	defer churnCancel()
+
+	// captureWorkers returns the worker list the capture loop should
+	// read at this instant: the live churn-updated view when the
+	// schedule is active, otherwise the plain (never-mutated) workers
+	// slice.
+	captureWorkers := func() []*WorkerHandle {
+		if ws != nil {
+			return ws.Snapshot()
+		}
+
+		return workers
+	}
+
+	// statusWorkers returns the worker list the run-level degraded gate
+	// should evaluate: captureWorkers() minus the actively-churned
+	// index. The churned worker legitimately cycles through
+	// StateShutdown -> (new instance) -> StateStable as a deliberate
+	// part of the E4 experiment; churn-waves.csv (via runChurnSchedule's
+	// wave_failed notes) is the authoritative signal for whether ITS
+	// transitions converged in time. The run-level gate below still
+	// aborts the run on any UNEXPECTED degraded transition among every
+	// other worker.
+	statusWorkers := func() []*WorkerHandle {
+		cw := captureWorkers()
+		if o.ChurnWorkerIdx >= 0 {
+			return remainingWorkers(cw, o.ChurnWorkerIdx)
+		}
+
+		return cw
+	}
+
 	// Arm the in-window interval on every recorder and the producer at the
 	// real capture start, both in CLOCK_MONOTONIC, so delivery is compared
 	// against in-window sends (NOT total Sent, which spans warmup+capture).
@@ -413,7 +483,7 @@ func Run(ctx context.Context, o Options, errLog io.Writer) error {
 	// Emit an initial snapshot at t=0 of the capture window so
 	// downstream tooling can see a row even if the capture is
 	// truncated.
-	if err := writeSnapshot(w, time.Now(), workers); err != nil {
+	if err := writeSnapshot(w, time.Now(), captureWorkers()); err != nil {
 		return err
 	}
 
@@ -444,28 +514,43 @@ captureLoop:
 			// cannot commit the partial CSV the run produces no
 			// final CSV and we must not write a manifest either
 			// (artifact-completeness contract).
-			if serr := writeSnapshot(w, time.Now(), workers); serr != nil {
+			if serr := writeSnapshot(w, time.Now(), captureWorkers()); serr != nil {
 				fmt.Fprintf(errLog, "interrupt: final snapshot: %v\n", serr)
 			}
 			if cerr := commitCSV(); cerr != nil {
 				fmt.Fprintf(errLog, "interrupt: csv commit failed, no manifest written: %v\n", cerr)
 				return cerr
 			}
+			// Join the churn goroutine (no-op if it was never started)
+			// and refresh workers to the live view before cleanup runs
+			// so a re-added worker's manager/consumer is actually
+			// stopped, not leaked.
+			churnWG.Wait()
+			if ws != nil {
+				workers = ws.Snapshot()
+			}
 
 			return finishRun(o, cfg, workers, started, "interrupted", ctx.Err())
 		case t := <-ticker.C:
-			if err := writeSnapshot(w, t, workers); err != nil {
+			if err := writeSnapshot(w, t, captureWorkers()); err != nil {
 				return err
 			}
 			// Mid-run degraded gate: if any worker has logged a
 			// degraded transition or is no longer Stable, abort with
 			// status=degraded so the manifest accurately records the
-			// failure mode.
-			if status, derr := DecideRunStatus(workers); derr != nil {
+			// failure mode. statusWorkers() excludes the actively-churned
+			// worker (see its doc comment) so the deliberate E4
+			// kill/re-add cycle never trips this gate.
+			if status, derr := DecideRunStatus(statusWorkers()); derr != nil {
 				if cerr := commitCSV(); cerr != nil {
 					fmt.Fprintf(errLog, "degraded: csv commit failed, no manifest written: %v\n", cerr)
 					return cerr
 				}
+				churnWG.Wait()
+				if ws != nil {
+					workers = ws.Snapshot()
+				}
+
 				return finishRun(o, cfg, workers, started, status, derr)
 			}
 			if !t.Before(captureDeadline) {
@@ -474,8 +559,18 @@ captureLoop:
 		}
 	}
 
+	// Join the churn goroutine (no-op if it was never started) and
+	// refresh workers to the live (post-churn) view before every
+	// downstream step below — the final degraded check, latency
+	// collection, and the deferred cleanup() must all act on the
+	// currently-running handles, not the pre-churn ones.
+	churnWG.Wait()
+	if ws != nil {
+		workers = ws.Snapshot()
+	}
+
 	// Final post-capture degraded check, then commit CSV and manifest.
-	status, derr := DecideRunStatus(workers)
+	status, derr := DecideRunStatus(statusWorkers())
 
 	if o.Load {
 		// Drain: let in-flight in-window messages arrive before reading

--- a/test/perf-measurement/scripts/run-e4.sh
+++ b/test/perf-measurement/scripts/run-e4.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# run-e4.sh — Drives one E4 (rebalance burst anatomy) cell: readiness-gated
+# capture, a churn schedule (kill->converge->re-add x N, see cmd/harness's
+# --churn-* flags / churn.go), and — for cells with --profiles — the E5
+# client-side profile set (idle window + one wave, 30s CPU + heap + mutex).
+#
+# One-off measurement-session script (S3 brief), not part of the
+# reusable run-matrix.sh cell loop: E4/E5's profile-capture choreography
+# (poll churn-waves.csv for a wave boundary, fire pprof captures at the
+# right instant) doesn't fit run_one's generic per-cell shape, so this
+# script duplicates run-matrix.sh's readiness-gate + capture-start
+# pattern for a single cell rather than extending run_one's control flow
+# for every other cell too. See RUNBOOK.md / docs/research/
+# load-overhead-research-and-pprof-plan-v1.md §5 E4/E5 for the
+# experiment definitions.
+#
+# Usage:
+#   run-e4.sh --cell E4.b --n 2000 --workers 50 --churn-worker-idx 49 \
+#             --warmup-secs 60 --capture-secs 1200 --churn-plateau 90s \
+#             --churn-converge-timeout 150s --output-dir results/s3-e4/E4.b \
+#             [--profiles]
+#
+# All rig runs are synchronous, blocking, foreground calls — this script
+# does not background itself and does not return until the harness
+# process (and the capture/aggregate tail) has completed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RIG_DIR="$(dirname "$SCRIPT_DIR")"
+
+HARNESS_BIN="${RIG_DIR}/cmd/harness/harness"
+if [[ -x "${RIG_DIR}/cmd/aggregate/aggregate" ]]; then
+    AGGREGATE_BIN="${RIG_DIR}/cmd/aggregate/aggregate"
+else
+    AGGREGATE_BIN="aggregate"
+fi
+
+CONTAINERS_R3="perf-nats-1,perf-nats-2,perf-nats-3"
+NATS_MONITOR_R3="localhost:8222,localhost:8223,localhost:8224"
+
+READY_ADDR="127.0.0.1:6061"
+# 16060, not the harness default 6060 — this host already has some
+# unrelated process bound to 6060 system-wide (confirmed via `ss -tln`
+# before this campaign); avoids a bind-in-use abort.
+PPROF_ADDR="127.0.0.1:16060"
+READY_TIMEOUT_SECS=1800
+
+CELL="" N="" WORKERS="" CHURN_IDX="" WARMUP_SECS=60 CAPTURE_SECS=600
+CHURN_WAVES=3 CHURN_PLATEAU="90s" CHURN_CONVERGE_TIMEOUT="150s"
+OUTPUT_DIR="" DO_PROFILES=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cell) CELL="$2"; shift 2 ;;
+        --n) N="$2"; shift 2 ;;
+        --workers) WORKERS="$2"; shift 2 ;;
+        --churn-worker-idx) CHURN_IDX="$2"; shift 2 ;;
+        --churn-waves) CHURN_WAVES="$2"; shift 2 ;;
+        --churn-plateau) CHURN_PLATEAU="$2"; shift 2 ;;
+        --churn-converge-timeout) CHURN_CONVERGE_TIMEOUT="$2"; shift 2 ;;
+        --warmup-secs) WARMUP_SECS="$2"; shift 2 ;;
+        --capture-secs) CAPTURE_SECS="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --profiles) DO_PROFILES=true; shift ;;
+        *) echo "run-e4.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+for req in CELL N WORKERS CHURN_IDX OUTPUT_DIR; do
+    if [[ -z "${!req}" ]]; then
+        echo "run-e4.sh: --${req,,} is required" >&2
+        exit 1
+    fi
+done
+
+RUN_DIR="${RIG_DIR}/${OUTPUT_DIR}"
+mkdir -p "$RUN_DIR"
+
+echo "=== E4 cell ${CELL}  N=${N} workers=${WORKERS} churn_idx=${CHURN_IDX} profiles=${DO_PROFILES} ==="
+echo "  run dir: ${RUN_DIR}"
+
+# shellcheck source=_capture_lib.sh
+source "${SCRIPT_DIR}/_capture_lib.sh"
+CAPTURE_PIDS=() CAPTURE_NAMES=() CAPTURE_RCS=()
+trap 'echo "run-e4.sh: signal received — stopping captures and exiting" >&2; stop_captures; exit 130' INT TERM
+
+echo "  resetting rig (replicas=3)..."
+PERF_RIG_NATS_REPLICAS=3 make -C "$RIG_DIR" reset
+
+HARNESS_LOG="${RUN_DIR}/harness.log"
+echo "  starting harness; waiting for readiness (timeout ${READY_TIMEOUT_SECS}s)..."
+
+HARNESS_ARGS=(
+    --n="$N" --workers="$WORKERS" --replicas=3
+    --two-phase=true --consumer-mode=dynamic --consumer-memory-storage
+    --warmup="${WARMUP_SECS}s" --capture-window="${CAPTURE_SECS}s"
+    --rpc-dump-interval=1s
+    --output-dir="$RUN_DIR"
+    --ready-addr="$READY_ADDR"
+    --pprof-addr="$PPROF_ADDR"
+    --churn-worker-idx="$CHURN_IDX" --churn-waves="$CHURN_WAVES"
+    --churn-plateau="$CHURN_PLATEAU" --churn-converge-timeout="$CHURN_CONVERGE_TIMEOUT"
+)
+if [[ "$DO_PROFILES" == "true" ]]; then
+    # Non-zero only for the cells that actually capture profiles — a
+    # normal (non-profiled) harness run pays zero block/mutex overhead
+    # (see cmd/harness/main.go flag docs).
+    HARNESS_ARGS+=(--block-profile-rate=10000 --mutex-profile-fraction=1)
+fi
+
+PERF_RIG_RUN_INDEX="s3-e4-${CELL}" \
+PERF_RIG_NATS_IMAGE="${PERF_RIG_NATS_IMAGE:-nats:2.12.6}" \
+    "$HARNESS_BIN" "${HARNESS_ARGS[@]}" > "$HARNESS_LOG" 2>&1 &
+HARNESS_PID=$!
+
+if ! wait_for_ready "$READY_ADDR" "$READY_TIMEOUT_SECS" "$HARNESS_PID"; then
+    echo "  readiness gate FAILED — see ${HARNESS_LOG}" >&2
+    kill "$HARNESS_PID" 2>/dev/null || true
+    wait "$HARNESS_PID" 2>/dev/null || true
+    echo "readiness gate failed" > "${RUN_DIR}/failed.txt"
+    exit 1
+fi
+echo "  cluster ready — starting captures..."
+
+CAPTURE_TOTAL=$(( WARMUP_SECS + CAPTURE_SECS + 60 )) # +60s slack over the harness's own window
+bash "${SCRIPT_DIR}/capture-cgroup-io.sh" --output "${RUN_DIR}/cgroup_io.raw" --duration "$CAPTURE_TOTAL" --containers "$CONTAINERS_R3" &
+CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("cgroup-io")
+bash "${SCRIPT_DIR}/capture-iostat.sh" --output "${RUN_DIR}/iostat.raw" --duration "$CAPTURE_TOTAL" &
+CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("iostat")
+bash "${SCRIPT_DIR}/capture-jsz.sh" --output "${RUN_DIR}/jsz.raw" --duration "$CAPTURE_TOTAL" --nats-nodes "$NATS_MONITOR_R3" --jsz-detail &
+CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("jsz")
+if curl -sf --max-time 2 http://localhost:9100/metrics >/dev/null 2>&1; then
+    bash "${SCRIPT_DIR}/capture-node-exporter.sh" --output "${RUN_DIR}/node_exporter.prom" --duration "$CAPTURE_TOTAL" &
+    CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("node-exporter")
+else
+    printf '# node_exporter unavailable at run start; stub for aggregator presence check\n' > "${RUN_DIR}/node_exporter.prom"
+fi
+echo "  captures started (PIDs: ${CAPTURE_PIDS[*]})"
+
+# ---------------------------------------------------------------------------
+# E5 profile capture (only when --profiles was passed): idle window profile
+# BEFORE wave 1, wave profile DURING wave 2. Runs as a background subshell so
+# it never blocks the harness wait below; PROFILE_PID is joined explicitly
+# after the harness exits so this script doesn't return early with a profile
+# capture still in flight.
+# ---------------------------------------------------------------------------
+PROFILE_PID=""
+if [[ "$DO_PROFILES" == "true" ]]; then
+    (
+        PLOG="${RUN_DIR}/profile-log.txt"
+        capture_set() {
+            local tag="$1"
+            local t0 t1 leader_before leader_after
+            t0="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+            curl -s --max-time 3 "http://${PPROF_ADDR}/leader" -o "${RUN_DIR}/${tag}-leader-before.json" || true
+            leader_before="$(cat "${RUN_DIR}/${tag}-leader-before.json" 2>/dev/null || echo '{}')"
+            # heap/mutex are point-in-time snapshots (mutex is CUMULATIVE
+            # since process start / last fraction change, not windowed —
+            # see the s3-verdict methodology note); fire them right as the
+            # 30s CPU capture starts so all three roughly share one instant.
+            curl -s --max-time 10 "http://${PPROF_ADDR}/debug/pprof/heap" -o "${RUN_DIR}/${tag}-heap.pprof" &
+            local heap_pid=$!
+            curl -s --max-time 10 "http://${PPROF_ADDR}/debug/pprof/mutex" -o "${RUN_DIR}/${tag}-mutex.pprof" &
+            local mutex_pid=$!
+            curl -s --max-time 40 "http://${PPROF_ADDR}/debug/pprof/profile?seconds=30" -o "${RUN_DIR}/${tag}-cpu.pprof"
+            wait "$heap_pid" "$mutex_pid" 2>/dev/null || true
+            t1="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+            curl -s --max-time 3 "http://${PPROF_ADDR}/leader" -o "${RUN_DIR}/${tag}-leader-after.json" || true
+            leader_after="$(cat "${RUN_DIR}/${tag}-leader-after.json" 2>/dev/null || echo '{}')"
+            printf '%s: window=[%s,%s] leader_before=%s leader_after=%s\n' "$tag" "$t0" "$t1" "$leader_before" "$leader_after" >> "$PLOG"
+        }
+
+        # Wait for the harness's capture window (and churn schedule) to
+        # actually start: churn-waves.csv is created (header written)
+        # the instant runChurnSchedule launches, i.e. right at
+        # captureStart (after warmup) — a more reliable sync signal than
+        # guessing warmup+epsilon from this script.
+        cw_csv="${RUN_DIR}/churn-waves.csv"
+        for _ in $(seq 1 600); do
+            [[ -s "$cw_csv" ]] && break
+            sleep 1
+        done
+        if [[ ! -s "$cw_csv" ]]; then
+            echo "profile-capture: churn-waves.csv never appeared — aborting profile capture" >> "${RUN_DIR}/profile-log.txt"
+            exit 0
+        fi
+
+        # --- idle profile: fire immediately, lands inside the plateau ---
+        capture_set "idle"
+
+        # --- wave profile: poll for wave 2's kill row, then fire ---
+        for _ in $(seq 1 600); do
+            if grep -q '^2,kill,' "$cw_csv" 2>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+        if grep -q '^2,kill,' "$cw_csv" 2>/dev/null; then
+            capture_set "wave2"
+        else
+            echo "profile-capture: wave 2 kill event never observed within poll budget — no wave profile captured" >> "$PLOG"
+        fi
+    ) &
+    PROFILE_PID=$!
+fi
+
+echo "  waiting for harness (pid ${HARNESS_PID}) to complete — this is a synchronous, blocking, foreground wait..."
+HARNESS_RC=0
+wait "$HARNESS_PID" || HARNESS_RC=$?
+echo "  harness exited rc=${HARNESS_RC}"
+
+if [[ -n "$PROFILE_PID" ]]; then
+    echo "  joining profile-capture subshell (pid ${PROFILE_PID})..."
+    wait "$PROFILE_PID" || true
+fi
+
+echo "  stopping captures..."
+stop_captures
+
+if ! verify_captures "$RUN_DIR"; then
+    echo "  run FAILED (capture verify) — see ${RUN_DIR}/capture-failed.txt" >&2
+    exit 1
+fi
+
+if [[ "$HARNESS_RC" -ne 0 ]]; then
+    printf 'harness exit code %d\n' "$HARNESS_RC" > "${RUN_DIR}/failed.txt"
+    echo "  run FAILED (harness_rc=${HARNESS_RC})" >&2
+    exit 1
+fi
+
+echo "  aggregating..."
+if ! "$AGGREGATE_BIN" --run-dir "$RUN_DIR"; then
+    echo "  aggregate FAILED" >&2
+    echo "aggregate exited non-zero" > "${RUN_DIR}/aggregate-failed.txt"
+    exit 1
+fi
+
+echo "  run OK: ${RUN_DIR}"

--- a/test/perf-measurement/scripts/run-matrix.sh
+++ b/test/perf-measurement/scripts/run-matrix.sh
@@ -156,6 +156,18 @@ _def_cell E1.a  3 "512"   "--two-phase=true --consumer-mode=dynamic --consumer-m
 _def_cell E1.b  3 "2000"  "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=50"
 _def_cell E1.c  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100"
 
+# E2   Pull-floor ablation — Cell 100/10000 (W=100, P=10000), idle + load
+#      (X=200 msg/s), --fetch-timeout 5s vs 30s, --batch-size 1 (pinned
+#      default, passed explicitly for self-documentation). See
+#      docs/research/load-overhead-research-and-pprof-plan-v1.md §5 E2.
+#      Load arms add --load --per-worker-rate=2 (k=2, W=100 ⇒ aggregate
+#      X = k·W = 200 msg/s) on the same production diagonal cell as
+#      E1.c/E8.c/E4.c.
+_def_cell E2.1  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100 --fetch-timeout=5s --batch-size=1"
+_def_cell E2.2  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100 --fetch-timeout=30s --batch-size=1"
+_def_cell E2.3  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100 --fetch-timeout=5s --batch-size=1 --load --per-worker-rate=2"
+_def_cell E2.4  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100 --fetch-timeout=30s --batch-size=1 --load --per-worker-rate=2"
+
 # E8   Sweep W-fold scaling isolation — fixed P=2000, W swept. NOTE: the
 #      measured steady-state forced-full sweep period is ~19-33 min (S2-E8,
 #      2026-07-16), not the nominal 10 min — 900s idle windows may catch
@@ -164,6 +176,23 @@ _def_cell E1.c  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-m
 _def_cell E8.a  3 "2000"  "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=10"
 _def_cell E8.b  3 "2000"  "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=50"
 _def_cell E8.c  3 "2000"  "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100"
+
+# E4   Rebalance burst anatomy — production arm, diagonal cells, plus the
+#      rig-only churn schedule (cmd/harness --churn-worker-idx/--churn-waves/
+#      --churn-plateau/--churn-converge-timeout — see cmd/harness/churn.go):
+#      kill the LAST worker index -> wait convergence -> re-add -> wait
+#      convergence, x3 waves, after an idle plateau. --churn-worker-idx is
+#      workers-1 for each cell (a fixed, reproducible target across waves).
+#      NOTE: these cells are documented here for the matrix's cell-catalogue
+#      convention, but the S3 measurement session drove them through the
+#      dedicated scripts/run-e4.sh, not this file's run_one loop — run_one
+#      has no hook for E5's mid-run pprof-capture choreography (idle-window
+#      profile before wave 1, wave profile during wave 2; see run-e4.sh's
+#      header comment). Running these flags through run_one directly would
+#      execute the churn schedule but skip the E5 profile captures.
+_def_cell E4.a  3 "512"   "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=10 --churn-worker-idx=9 --churn-waves=3 --churn-plateau=60s --churn-converge-timeout=90s"
+_def_cell E4.b  3 "2000"  "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=50 --churn-worker-idx=49 --churn-waves=3 --churn-plateau=90s --churn-converge-timeout=150s"
+_def_cell E4.c  3 "10000" "--two-phase=true --consumer-mode=dynamic --consumer-memory-storage --workers=100 --churn-worker-idx=99 --churn-waves=3 --churn-plateau=90s --churn-converge-timeout=180s"
 
 # ---------------------------------------------------------------------------
 # Plan 02 — NATS server-side tuning cells (M2.x).
@@ -566,6 +595,20 @@ start_captures() {
         --containers "$containers" &
     CAPTURE_PIDS+=($!)
     CAPTURE_NAMES+=("cgroup-io")
+
+    # cgroup-cpumem — per-container CPU cores + RSS (needed by CPU-delta
+    # cells, e.g. E2's pull-floor ablation; see internal/aggregate's
+    # ParseCgroupCPUMem/CPUMemDeltas and cmd/fitmodel's cellCPUMem for the
+    # established extraction convention). Same container list as cgroup-io.
+    # Not in verify_captures' mandatory-file list — a failure here still
+    # surfaces via CAPTURE_RCS (capture-failed.txt), matching how
+    # run-armb-matrix.sh treats this same capture.
+    bash "${SCRIPT_DIR}/capture-cgroup-cpumem.sh" \
+        --output "${run_dir}/cgroup_cpumem.raw" \
+        --duration "$duration" \
+        --containers "$containers" &
+    CAPTURE_PIDS+=($!)
+    CAPTURE_NAMES+=("cgroup-cpumem")
 
     # iostat — secondary cross-check.
     bash "${SCRIPT_DIR}/capture-iostat.sh" \

--- a/test/perf-measurement/scripts/run-matrix.sh
+++ b/test/perf-measurement/scripts/run-matrix.sh
@@ -498,6 +498,14 @@ fi
 mkdir -p "$RESULTS_DIR"
 SCHEDULE_FILE="${RESULTS_DIR}/schedule.tsv"
 
+# A schedule is pre-registered evidence — never silently clobber one left
+# by an earlier invocation into the same RESULTS_DIR; move it aside first.
+if [[ -f "$SCHEDULE_FILE" ]]; then
+    backup="${SCHEDULE_FILE}.$(date -u +%Y%m%dT%H%M%SZ).bak"
+    mv "$SCHEDULE_FILE" "$backup"
+    echo "run-matrix.sh: existing schedule.tsv preserved as ${backup}" >&2
+fi
+
 {
     echo "# run-matrix.sh  seed=${SEED}  reps=${REPS}  total_runs=${TOTAL_RUNS}"
     echo "# generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
Measurement-rig tooling accumulated during the rebalance-anatomy (E4) and pull-floor (E2) sessions, plus one driver hardening fix. Rig-only: no library surface is touched (all changes under `test/perf-measurement/`).

- **cmd/harness/churn.go** — opt-in kill→converge→re-add churn schedule (`--churn-worker-idx/-waves/-plateau/-converge-timeout`, default off). Phase timestamps land in `churn-waves.csv` for per-wave slicing of `rpc_counts.csv`. A mutex-protected `workerSet` view keeps the capture loop safe against the schedule's concurrent worker-handle replacement; the run-level degraded gate exempts only the deliberately churned index.
- **scripts/run-e4.sh** — dedicated churn-cell driver hosting the mid-run pprof choreography (idle profile before wave 1, wave profile during wave 2) that `run_one` can't.
- **run-matrix.sh** — E2 pull-floor ablation cells (FetchTimeout 5s vs 30s, idle + load arms), E4 cell catalogue entries, and a `cgroup-cpumem` capture alongside `cgroup-io` for CPU-delta cells.
- **run-matrix.sh fix** — an existing `schedule.tsv` is preserved as a timestamped `.bak` instead of being silently overwritten by a re-invocation into the same results directory.

Validation: `go build`/`go vet` on `./cmd/... ./internal/...` clean; `golangci-lint run` 0 issues; `bash -n` on both scripts. The churn tooling ran 12+ E4 measurement runs and the E2 cells 4 runs on this exact code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3evmLZovmtfQK4Zb5B7WF