### PR TITLE
v2.10.0: load-overhead hardening — leader-gated sweeps, six correctness fixes, pull-loop tuning knobs

### DIFF
--- a/.agents/rules/300-testing.md
+++ b/.agents/rules/300-testing.md
@@ -47,7 +47,10 @@ When adding a monitor goroutine on a ticker (e.g. `monitorBucketEpochs`,
 focused concurrency stress test under `test/integration/<package>/`:
 
 - Start a small real cluster (embedded NATS, 2-3 worker managers).
-- Configure the monitor at aggressive cadence (e.g. `OperationTimeout=10ms`).
+- Configure the monitor at aggressive cadence via the knob that drives its
+  ticker (e.g. `BucketEpochProbeInterval=10ms` for `monitorBucketEpochs`;
+  `OperationTimeout` only bounds per-operation deadlines, not the epoch-fence
+  cadence).
 - Drive concurrent KV traffic against the buckets the monitor probes for ~5s.
 - Assert no race-detector triggers (`go test -race ...`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.10.0] - 2026-07-17
+
+A hardening and load-overhead release driven by a measurement campaign against
+the perf rig (W≤100 workers, P≤10,000 partitions, R=3). Six pre-existing bugs
+found by the campaign's review discipline are fixed, the leader now gates
+periodic claim sweeps (removing the largest idle KV-read multiplier), and two
+new knobs let large deployments cut idle pull-loop CPU without giving up
+detection latency. All changes are additive or strictly-tightening; no public
+API is removed or changed incompatibly.
+
+### Added
+
+- **`parti.WithBucketEpochProbeInterval(d)` / `Config.BucketEpochProbeInterval`**
+  — configures the epoch-fence monitor's bucket-recreation probe period
+  (default 10s, previously hardcoded to OperationTimeout). Lower it for faster
+  bucket-swap detection or raise it to shave idle KV reads on very large fleets.
+- **`consumer.WithPullHeartbeatCap(d)` / `PullHeartbeatCap` on every consumer
+  config** — bounds the derived pull heartbeat (normally `FetchTimeout/2`)
+  independently of `FetchTimeout`, so raising `FetchTimeout` to cut idle
+  pull-request churn (measured: ~0.77 idle / ~1.13 loaded CPU cores saved at
+  P=10,000 going 5s→30s, with P99 delivery latency improved) no longer
+  stretches deleted-consumer detection. `0` (default) disables the cap; a
+  nonzero value must be within nats.go's `PullHeartbeat` validity range
+  [500ms, 30s]. See the new "Tuning at high partition counts" section in
+  `docs/SCALING.md`.
+- **Leader-gated claim sweeps** — the periodic (ticker-origin) claim sweep now
+  runs only on the leader, with followers keeping a phase-staggered ~5-minute
+  backstop so a wedged or absent leader can never leave expired claims
+  unswept. Apply-origin and startup sweeps are unchanged (every worker). At
+  W=100 this removes ~99% of steady-state sweep-driven KV reads. Orphan-claim
+  reaping is additionally fenced against stale leadership samples
+  (generation-checked, revision-conditioned deletes), so a deposed leader's
+  in-flight sweep can never delete a claim the new leader considers live.
+
+### Fixed
+
+- **Assignment continuity across coalesced versions** — the prepare phase
+  diffs against the worker's last *committed* assignment, and retry/stash
+  coalescing routinely leaves that more than one version behind the incoming
+  one. Across such a gap, a partition that transited another owner and
+  returned (A→B→A) looked unchanged and was silently skipped — leaving the
+  worker permanently gated off the partition — and a claim reaped during a
+  missed removal/re-add was never recreated. Any non-adjacent version
+  transition now fails open into a full prepare walk. This is an explicitly
+  partial repair: equal-Version authority divergence and cross-worker claim
+  staleness are documented open hazards (pinned by tests) deferred to a
+  claim-level commit-identity fence project.
+- **Assignment payload fetch failures are retried** — a commit whose payload
+  fetch or verification failed was silently dropped; the worker sat on its
+  stale assignment until the next unrelated commit. Fetch failures now enter
+  the same bounded-backoff retry loop an apply failure uses, coalescing to the
+  newest target.
+- **Shared accepted-target fence across the retry loops** — the apply-retry
+  and (new) fetch-retry loops each track their own in-flight target; without a
+  shared fence, a slow retry could apply a target that a sibling loop's newer
+  accepted target had superseded — with a removal-guard bypass and, combined
+  with the continuity fail-open, a cross-worker claim steal in the worst
+  interleaving. Both delivery gates now raise a monotonic highest-accepted
+  (Version, LeaderRevision) fence that the apply pipeline checks before any
+  coordinator work.
+- **Lost wakeup in the assignment retry loops** — a retry stashed in the
+  window between a retry loop's final empty-stash check and its exit flag
+  clearing was stranded forever. Both loops now re-check the stash after
+  deactivating and re-activate themselves (context-guarded to avoid a
+  shutdown-time respawn loop).
+- **Payload GC vs. adoption race** — the commit-payload garbage collector
+  could delete a payload that a concurrent publish was adopting (reusing),
+  producing a commit referencing purged data. Adoption now CAS-touches the
+  payload to a fresh revision before finalizing, and GC's delete is
+  revision-conditioned, so whichever side lands first wins deterministically
+  and the loser retries cleanly.
+- **Orphan-claim reaping grace across reappearance** — a claim owner that
+  disappeared, reappeared (re-vouched), then disappeared again kept its
+  original orphan clock, so the reaper could delete the claim without a full
+  fresh grace window. Reappearance now resets the clock.
+- **Heartbeat scan reads are deadline-bounded** — the worker monitor's
+  heartbeat scan could stall indefinitely on a degraded KV; per-key reads now
+  run under a per-pass deadline.
+- **`FetchTimeout` above 60s no longer breaks pull consumers** — the derived
+  pull heartbeat (`FetchTimeout/2`) had no ceiling, and nats.go rejects an
+  explicit heartbeat above 30s, so any `FetchTimeout > 60s` made every
+  iterator creation fail and the pull loop spin in a restart/warn cycle
+  forever. The derivation is now clamped to nats.go's [500ms, 30s] validity
+  range at every derivation site (all four consumer engines and the perf rig's
+  calibrate tool).
+
+### Documentation
+
+- New **"Tuning at high partition counts"** section in `docs/SCALING.md`:
+  measured FetchTimeout guidance, the PullHeartbeatCap pairing (first
+  missed-heartbeat signal vs confirmed burst-threshold recovery), and the
+  leader-audit cadence note.
+- `docs/API_REFERENCE.md` gains the `WithPullHeartbeatCap` row.
+
 ## [v2.9.1] - 2026-07-10
 
 Label follow-up APIs that remove the workaround code label consumers were

--- a/config.go
+++ b/config.go
@@ -471,6 +471,21 @@ type Config struct {
 	// Recommended: 10 seconds.
 	OperationTimeout time.Duration `yaml:"operationTimeout" default:"10s" validate:"gt=0"`
 
+	// BucketEpochProbeInterval is how often the bucket-epoch fence (see
+	// monitorBucketEpochs) polls each Parti-owned KV bucket for a
+	// wipe-and-recreate event. This was previously coupled to
+	// OperationTimeout — the same knob that bounds every individual KV
+	// operation's deadline — so changing one unintentionally changed the
+	// other. This field decouples the probe cadence from that deadline.
+	// Default 10s preserves the prior default behavior for deployments
+	// that left OperationTimeout at its own 10s default; deployments that
+	// TUNED OperationTimeout and relied on the old coupled cadence must set
+	// this field to their previous OperationTimeout value to preserve it.
+	// The per-probe deadline is still OperationTimeout (see
+	// probeBucketCreated); this field controls only how often a probe pass
+	// runs.
+	BucketEpochProbeInterval time.Duration `yaml:"bucketEpochProbeInterval" default:"10s" validate:"gt=0"`
+
 	// ElectionTimeout is the maximum time to wait for leader election to complete.
 	// Also drives leader lease renewal frequency (ElectionTimeout/3). Longer values
 	// reduce KV write load at the cost of slower failover detection.

--- a/config_test.go
+++ b/config_test.go
@@ -221,6 +221,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, 10*time.Second, cfg.PlannedScaleWindow)
 	require.Equal(t, 0.5, cfg.RestartDetectionRatio)
 	require.Equal(t, 10*time.Second, cfg.OperationTimeout)
+	require.Equal(t, 10*time.Second, cfg.BucketEpochProbeInterval)
 	require.Equal(t, 10*time.Second, cfg.ElectionTimeout)
 	require.Equal(t, 60*time.Second, cfg.StartupTimeout)
 	require.Equal(t, 10*time.Second, cfg.ShutdownTimeout)
@@ -236,24 +237,27 @@ func TestSetDefaults(t *testing.T) {
 		require.Equal(t, 999, cfg.WorkerIDMax)
 		require.Equal(t, 75*time.Second, cfg.WorkerIDTTL)
 		require.Equal(t, 10*time.Second, cfg.RebalanceCooldown)
+		require.Equal(t, 10*time.Second, cfg.BucketEpochProbeInterval,
+			"unset BucketEpochProbeInterval defaults to 10s, preserving the prior OperationTimeout-coupled behavior")
 	})
 
 	t.Run("preserves custom values", func(t *testing.T) {
 		cfg := Config{
-			WorkerIDPrefix:        "custom",
-			WorkerIDMin:           10,
-			WorkerIDMax:           200,
-			WorkerIDTTL:           60 * time.Second,
-			HeartbeatInterval:     5 * time.Second,
-			HeartbeatTTL:          15 * time.Second,
-			ColdStartWindow:       45 * time.Second,
-			PlannedScaleWindow:    20 * time.Second,
-			RestartDetectionRatio: 0.7,
-			OperationTimeout:      20 * time.Second,
-			ElectionTimeout:       10 * time.Second,
-			StartupTimeout:        60 * time.Second,
-			ShutdownTimeout:       20 * time.Second,
-			RebalanceCooldown:     15 * time.Second,
+			WorkerIDPrefix:           "custom",
+			WorkerIDMin:              10,
+			WorkerIDMax:              200,
+			WorkerIDTTL:              60 * time.Second,
+			HeartbeatInterval:        5 * time.Second,
+			HeartbeatTTL:             15 * time.Second,
+			ColdStartWindow:          45 * time.Second,
+			PlannedScaleWindow:       20 * time.Second,
+			RestartDetectionRatio:    0.7,
+			OperationTimeout:         20 * time.Second,
+			BucketEpochProbeInterval: 90 * time.Second,
+			ElectionTimeout:          10 * time.Second,
+			StartupTimeout:           60 * time.Second,
+			ShutdownTimeout:          20 * time.Second,
+			RebalanceCooldown:        15 * time.Second,
 		}
 		require.NoError(t, SetDefaults(&cfg))
 
@@ -268,6 +272,8 @@ func TestSetDefaults(t *testing.T) {
 		require.Equal(t, 20*time.Second, cfg.PlannedScaleWindow)
 		require.Equal(t, 0.7, cfg.RestartDetectionRatio)
 		require.Equal(t, 20*time.Second, cfg.OperationTimeout)
+		require.Equal(t, 90*time.Second, cfg.BucketEpochProbeInterval,
+			"a custom BucketEpochProbeInterval, distinct from OperationTimeout, must survive SetDefaults unchanged")
 		require.Equal(t, 10*time.Second, cfg.ElectionTimeout)
 		require.Equal(t, 60*time.Second, cfg.StartupTimeout)
 		require.Equal(t, 20*time.Second, cfg.ShutdownTimeout)

--- a/consumer/broadcast.go
+++ b/consumer/broadcast.go
@@ -131,6 +131,7 @@ func NewBroadcast(
 			MaxDeliver:        o.maxDeliver,
 			BatchSize:         o.batchSize,
 			FetchTimeout:      o.fetchTimeout,
+			PullHeartbeatCap:  o.pullHeartbeatCap,
 			MaxWaiting:        o.maxWaiting,
 			MaxAckPending:     o.maxAckPending,
 			InactiveThreshold: o.inactiveThreshold,
@@ -165,6 +166,7 @@ func NewBroadcast(
 		MaxDeliver:        cfg.MaxDeliver,
 		BatchSize:         cfg.BatchSize,
 		FetchTimeout:      cfg.FetchTimeout,
+		PullHeartbeatCap:  cfg.PullHeartbeatCap,
 		MaxWaiting:        cfg.MaxWaiting,
 		MaxAckPending:     cfg.MaxAckPending,
 		InactiveThreshold: cfg.InactiveThreshold,
@@ -268,6 +270,10 @@ func (c *BroadcastConfig) Validate() error {
 	}
 
 	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
+		return err
+	}
+
+	if err := validatePullHeartbeatCap(c.PullHeartbeatCap); err != nil {
 		return err
 	}
 

--- a/consumer/broadcast_test.go
+++ b/consumer/broadcast_test.go
@@ -67,6 +67,34 @@ func TestBroadcastConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
 				return cfg.Validate()
 			},
 		},
+		{
+			name: "PullHeartbeatCap below 500ms floor",
+			fn: func() error {
+				cfg := BroadcastConfig{
+					StreamName:     "S",
+					ConsumerPrefix: "pfx",
+					FilterSubject:  "s.>",
+					CommonConfig:   CommonConfig{PullHeartbeatCap: 499 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "PullHeartbeatCap above 30s ceiling",
+			fn: func() error {
+				cfg := BroadcastConfig{
+					StreamName:     "S",
+					ConsumerPrefix: "pfx",
+					FilterSubject:  "s.>",
+					CommonConfig:   CommonConfig{PullHeartbeatCap: 31 * time.Second},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/consumer/common.go
+++ b/consumer/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arloliu/fuda"
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/types"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -75,6 +76,25 @@ type CommonConfig struct {
 	//
 	// Default: 5s.
 	FetchTimeout time.Duration `default:"5s" validate:"gt=0"`
+
+	// PullHeartbeatCap optionally bounds the derived nats.go PullHeartbeat
+	// value used by the consumer's pull loop. The heartbeat is normally
+	// FetchTimeout/2, clamped to nats.go's PullHeartbeat validity range
+	// [500ms, 30s]; when PullHeartbeatCap > 0 the derived heartbeat is
+	// further capped to this value.
+	//
+	// The heartbeat drives missed-heartbeat detection: nats.go's
+	// ErrNoHeartbeat fires at roughly 2x the heartbeat, which is how a
+	// deleted durable consumer is detected. Raising FetchTimeout to reduce
+	// idle pull-request churn also raises the derived heartbeat and
+	// therefore that detection latency; this cap bounds it independent of
+	// FetchTimeout.
+	//
+	// 0 (default) disables the cap: the heartbeat stays FetchTimeout/2,
+	// capped only at 30s. A nonzero value outside [500ms, 30s] (nats.go's
+	// PullHeartbeat bounds) is rejected at construction with
+	// ErrInvalidConfig. See [WithPullHeartbeatCap].
+	PullHeartbeatCap time.Duration `validate:"gte=0"`
 
 	// MaxWaiting is the maximum number of outstanding pull requests allowed.
 	//
@@ -175,7 +195,11 @@ func (c *CommonConfig) Validate() error {
 		return err
 	}
 
-	return validateFetchTimeoutFloor(c.FetchTimeout)
+	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
+		return err
+	}
+
+	return validatePullHeartbeatCap(c.PullHeartbeatCap)
 }
 
 // validateFetchTimeoutFloor enforces NATS's 1s PullExpiry minimum. Each
@@ -186,6 +210,24 @@ func (c *CommonConfig) Validate() error {
 func validateFetchTimeoutFloor(ft time.Duration) error {
 	if ft < time.Second {
 		return fmt.Errorf("%w: FetchTimeout must be at least 1s (NATS PullExpiry floor), got %v", ErrInvalidConfig, ft)
+	}
+
+	return nil
+}
+
+// validatePullHeartbeatCap enforces nats.go's PullHeartbeat validity range
+// [500ms, 30s] (jetstream_options.go configureConsume/configureMessages,
+// nats.go v1.52.0) on a nonzero PullHeartbeatCap. Zero is always accepted:
+// it means "no cap", not "zero heartbeat". Each consumer config's Validate
+// calls this directly, mirroring validateFetchTimeoutFloor above.
+func validatePullHeartbeatCap(heartbeatCap time.Duration) error {
+	if heartbeatCap == 0 {
+		return nil
+	}
+	if heartbeatCap < natsutil.MinPullHeartbeat || heartbeatCap > natsutil.MaxPullHeartbeat {
+		return fmt.Errorf(
+			"%w: PullHeartbeatCap must be 0 (disabled) or within [500ms, 30s] (nats.go PullHeartbeat range), got %v",
+			ErrInvalidConfig, heartbeatCap)
 	}
 
 	return nil

--- a/consumer/common_test.go
+++ b/consumer/common_test.go
@@ -170,3 +170,24 @@ func TestCommonConfig_FetchTimeout_FloorIsOneSecond(t *testing.T) {
 	cfg = CommonConfig{FetchTimeout: time.Second}
 	require.NoError(t, cfg.Validate(), "FetchTimeout == 1s is the boundary and must pass")
 }
+
+// TestCommonConfig_PullHeartbeatCap_Bounds pins CommonConfig.Validate's
+// PullHeartbeatCap boundary directly (the shared home every consumer type's
+// Validate ultimately mirrors): 0 always passes, [500ms, 30s] passes, and
+// anything outside that nonzero range fails.
+func TestCommonConfig_PullHeartbeatCap_Bounds(t *testing.T) {
+	cfg := CommonConfig{FetchTimeout: time.Second, PullHeartbeatCap: 0}
+	require.NoError(t, cfg.Validate(), "0 (disabled) must pass")
+
+	cfg = CommonConfig{FetchTimeout: time.Second, PullHeartbeatCap: 499 * time.Millisecond}
+	require.Error(t, cfg.Validate(), "PullHeartbeatCap below the 500ms nats.go PullHeartbeat floor must fail validation")
+
+	cfg = CommonConfig{FetchTimeout: time.Second, PullHeartbeatCap: 500 * time.Millisecond}
+	require.NoError(t, cfg.Validate(), "PullHeartbeatCap == 500ms is the boundary and must pass")
+
+	cfg = CommonConfig{FetchTimeout: time.Second, PullHeartbeatCap: 30 * time.Second}
+	require.NoError(t, cfg.Validate(), "PullHeartbeatCap == 30s is the boundary and must pass")
+
+	cfg = CommonConfig{FetchTimeout: time.Second, PullHeartbeatCap: 31 * time.Second}
+	require.Error(t, cfg.Validate(), "PullHeartbeatCap above the 30s nats.go PullHeartbeat ceiling must fail validation")
+}

--- a/consumer/dynamic.go
+++ b/consumer/dynamic.go
@@ -377,6 +377,7 @@ func NewDynamic(
 			MaxDeliver:        o.maxDeliver,
 			BatchSize:         o.batchSize,
 			FetchTimeout:      o.fetchTimeout,
+			PullHeartbeatCap:  o.pullHeartbeatCap,
 			MaxWaiting:        o.maxWaiting,
 			MaxAckPending:     o.maxAckPending,
 			InactiveThreshold: o.inactiveThreshold,
@@ -436,6 +437,7 @@ func NewDynamic(
 		MaxDeliver:                  cfg.MaxDeliver,
 		BatchSize:                   cfg.BatchSize,
 		FetchTimeout:                cfg.FetchTimeout,
+		PullHeartbeatCap:            cfg.PullHeartbeatCap,
 		MaxWaiting:                  cfg.MaxWaiting,
 		MaxAckPending:               cfg.MaxAckPending,
 		InactiveThreshold:           cfg.InactiveThreshold,
@@ -715,6 +717,10 @@ func (c *DynamicConfig) Validate() error {
 	}
 
 	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
+		return err
+	}
+
+	if err := validatePullHeartbeatCap(c.PullHeartbeatCap); err != nil {
 		return err
 	}
 

--- a/consumer/dynamic_test.go
+++ b/consumer/dynamic_test.go
@@ -124,6 +124,66 @@ func TestDynamic_ConsumerOptions_AppliedToLiveConsumer(t *testing.T) {
 	require.True(t, found, "no per-partition consumer was created under the dynopt_worker prefix")
 }
 
+// TestDynamic_FetchTimeoutAbove60s_ReceivesMessages proves the
+// WithFetchTimeout/PullHeartbeatCap wiring reaches the live pull loop
+// end-to-end for Dynamic: before the derived heartbeat was bounded to
+// nats.go's 30s PullHeartbeat maximum, FetchTimeout above 60s made every
+// iterator-creation attempt fail and no message was ever delivered.
+func TestDynamic_FetchTimeoutAbove60s_ReceivesMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	streamName := "DYN_HB90"
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     streamName,
+		Subjects: []string{"dynhb90.>"},
+	})
+	require.NoError(t, err)
+
+	processed := make(chan struct{}, 1)
+	handler := consumer.MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error {
+		select {
+		case processed <- struct{}{}:
+		default:
+		}
+
+		return nil
+	})
+
+	dyn, err := consumer.NewDynamic(
+		js,
+		streamName,
+		"dynhb90_worker",
+		"dynhb90.{{.PartitionID}}",
+		handler,
+		consumer.WithFetchTimeout(90*time.Second),
+		consumer.WithPullHeartbeatCap(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer func() { _ = dyn.Stop(ctx) }()
+
+	err = dyn.Update(ctx, "worker-0", []types.Partition{{Keys: []string{"p0"}}})
+	require.NoError(t, err)
+
+	_, err = js.Publish(ctx, "dynhb90.p0", []byte("test"))
+	require.NoError(t, err)
+
+	select {
+	case <-processed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for message processing; iterator creation likely rejected by nats.go (heartbeat above 30s ceiling)")
+	}
+}
+
 // TestDynamicConfig_Validate_WrapsErrInvalidConfig verifies that every
 // validation failure in NewDynamic / DynamicConfig.Validate is reachable
 // via errors.Is(err, consumer.ErrInvalidConfig).
@@ -172,6 +232,34 @@ func TestDynamicConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
 					StreamName:      "S",
 					ConsumerPrefix:  "bad prefix!",
 					SubjectTemplate: "s.{{partition}}",
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "PullHeartbeatCap below 500ms floor",
+			fn: func() error {
+				cfg := consumer.DynamicConfig{
+					StreamName:      "S",
+					ConsumerPrefix:  "pfx",
+					SubjectTemplate: "s.{{partition}}",
+					CommonConfig:    consumer.CommonConfig{PullHeartbeatCap: 499 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "PullHeartbeatCap above 30s ceiling",
+			fn: func() error {
+				cfg := consumer.DynamicConfig{
+					StreamName:      "S",
+					ConsumerPrefix:  "pfx",
+					SubjectTemplate: "s.{{partition}}",
+					CommonConfig:    consumer.CommonConfig{PullHeartbeatCap: 31 * time.Second},
 				}
 				_ = cfg.SetDefaults()
 

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -157,6 +157,7 @@ type options struct {
 	maxDeliver        int
 	batchSize         int
 	fetchTimeout      time.Duration
+	pullHeartbeatCap  time.Duration
 	maxWaiting        int
 	maxAckPending     int
 	inactiveThreshold time.Duration
@@ -377,6 +378,27 @@ func WithFetchTimeout(d time.Duration) Option {
 		if d > 0 {
 			o.fetchTimeout = d
 		}
+	})
+}
+
+// WithPullHeartbeatCap bounds the derived nats.go PullHeartbeat value used by
+// the consumer's pull loop. The heartbeat is normally FetchTimeout/2, clamped
+// to nats.go's PullHeartbeat validity range [500ms, 30s]; when d > 0, the
+// derived heartbeat is further capped to d.
+//
+// The heartbeat drives missed-heartbeat detection: nats.go's ErrNoHeartbeat
+// fires at roughly 2x the heartbeat, which is how a deleted durable consumer
+// is detected. Raising FetchTimeout to reduce idle pull-request churn also
+// raises the derived heartbeat and therefore that detection latency; this
+// cap bounds it independent of FetchTimeout.
+//
+// 0 (default) disables the cap: the heartbeat stays FetchTimeout/2, capped
+// only at 30s — this is the behavior with the option unset. A nonzero d
+// outside [500ms, 30s] (nats.go's PullHeartbeat bounds) is rejected at
+// construction with ErrInvalidConfig.
+func WithPullHeartbeatCap(d time.Duration) Option {
+	return universalOpt(func(o *options) {
+		o.pullHeartbeatCap = d
 	})
 }
 

--- a/consumer/pull_heartbeat_test.go
+++ b/consumer/pull_heartbeat_test.go
@@ -1,0 +1,74 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	partitesting "github.com/arloliu/parti/v2/partitest"
+)
+
+// TestValidatePullHeartbeatCap pins the accept/reject boundary shared by every
+// consumer type's Validate path: 0 (disabled) is always accepted; a nonzero
+// value is accepted only within nats.go's PullHeartbeat range [500ms, 30s].
+func TestValidatePullHeartbeatCap(t *testing.T) {
+	tests := []struct {
+		name         string
+		heartbeatCap time.Duration
+		wantErr      bool
+	}{
+		{"zero disables", 0, false},
+		{"499ms below floor", 499 * time.Millisecond, true},
+		{"500ms at floor", 500 * time.Millisecond, false},
+		{"2s mid-range", 2 * time.Second, false},
+		{"30s at ceiling", 30 * time.Second, false},
+		{"31s above ceiling", 31 * time.Second, true},
+		{"negative", -time.Second, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePullHeartbeatCap(tt.heartbeatCap)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidConfig)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestQueue_IteratorFactoryInjection_TakesPrecedenceOverPullHeartbeatCap pins
+// that a caller-supplied IteratorFactory still wins over the
+// PullHeartbeatCap-derived default at the Queue seam — the same precedence
+// rule proven at the internal/durable seam.
+func TestQueue_IteratorFactoryInjection_TakesPrecedenceOverPullHeartbeatCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel: injected factory called")
+	injected := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		return nil, sentinel
+	}
+
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	q, err := NewQueue(js, "S", "c", "s.>", handler,
+		WithPullHeartbeatCap(2*time.Second),
+		WithIteratorFactory(injected),
+	)
+	require.NoError(t, err)
+
+	_, err = q.iterFactory(nil, 1, 30*time.Second)
+	require.ErrorIs(t, err, sentinel, "custom IteratorFactory must take precedence over the PullHeartbeatCap-derived default")
+}

--- a/consumer/queue.go
+++ b/consumer/queue.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/recovery"
 	"github.com/arloliu/parti/v2/jsutil"
 	"github.com/arloliu/parti/v2/types"
@@ -169,6 +170,10 @@ func (c *QueueConfig) Validate() error {
 		return err
 	}
 
+	if err := validatePullHeartbeatCap(c.PullHeartbeatCap); err != nil {
+		return err
+	}
+
 	if !jsutil.IsValidConsumerName(c.ConsumerName) {
 		return fmt.Errorf("%w: consumer name %q contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)", ErrInvalidConfig, c.ConsumerName)
 	}
@@ -222,6 +227,7 @@ func NewQueue(
 			MaxDeliver:        o.maxDeliver,
 			BatchSize:         o.batchSize,
 			FetchTimeout:      o.fetchTimeout,
+			PullHeartbeatCap:  o.pullHeartbeatCap,
 			MaxWaiting:        o.maxWaiting,
 			MaxAckPending:     o.maxAckPending,
 			InactiveThreshold: o.inactiveThreshold,
@@ -244,7 +250,7 @@ func NewQueue(
 
 	iterFactory := cfg.IteratorFactory
 	if iterFactory == nil {
-		iterFactory = defaultIterFactory
+		iterFactory = makeDefaultIterFactory(cfg.PullHeartbeatCap)
 	}
 
 	return &Queue{
@@ -265,14 +271,19 @@ func NewQueue(
 	}, nil
 }
 
-// defaultIterFactory creates a messages iterator with heartbeat and expiry.
-func defaultIterFactory(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
-	heartbeat := max(expiry/2, 100*time.Millisecond)
-	return cons.Messages(
-		jetstream.PullMaxMessages(batch),
-		jetstream.PullExpiry(expiry),
-		jetstream.PullHeartbeat(heartbeat),
-	)
+// makeDefaultIterFactory returns the default messages iterator factory, with
+// PullHeartbeat derived by natsutil.DerivePullHeartbeat from the expiry
+// passed at call time and heartbeatCap fixed at construction time.
+func makeDefaultIterFactory(heartbeatCap time.Duration) func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
+	return func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
+		heartbeat := natsutil.DerivePullHeartbeat(expiry, heartbeatCap)
+
+		return cons.Messages(
+			jetstream.PullMaxMessages(batch),
+			jetstream.PullExpiry(expiry),
+			jetstream.PullHeartbeat(heartbeat),
+		)
+	}
 }
 
 // Start begins consuming messages.

--- a/consumer/queue_test.go
+++ b/consumer/queue_test.go
@@ -167,6 +167,34 @@ func TestQueueConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
 				return cfg.Validate()
 			},
 		},
+		{
+			name: "PullHeartbeatCap below 500ms floor",
+			fn: func() error {
+				cfg := QueueConfig{
+					StreamName:    "TEST",
+					ConsumerName:  "ok",
+					FilterSubject: "events.>",
+					CommonConfig:  CommonConfig{PullHeartbeatCap: 499 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "PullHeartbeatCap above 30s ceiling",
+			fn: func() error {
+				cfg := QueueConfig{
+					StreamName:    "TEST",
+					ConsumerName:  "ok",
+					FilterSubject: "events.>",
+					CommonConfig:  CommonConfig{PullHeartbeatCap: 31 * time.Second},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -175,6 +203,23 @@ func TestQueueConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, errors.Is(err, ErrInvalidConfig),
 				"expected errors.Is(err, ErrInvalidConfig), got: %v", err)
+		})
+	}
+}
+
+// TestQueueConfig_Validate_PullHeartbeatCap_Accepted pins the accept side of
+// the boundary: unset (0) and every valid nonzero cap must pass.
+func TestQueueConfig_Validate_PullHeartbeatCap_Accepted(t *testing.T) {
+	for _, heartbeatCap := range []time.Duration{0, 500 * time.Millisecond, 2 * time.Second, 30 * time.Second} {
+		t.Run(heartbeatCap.String(), func(t *testing.T) {
+			cfg := QueueConfig{
+				StreamName:    "TEST",
+				ConsumerName:  "ok",
+				FilterSubject: "events.>",
+				CommonConfig:  CommonConfig{PullHeartbeatCap: heartbeatCap},
+			}
+			_ = cfg.SetDefaults()
+			require.NoError(t, cfg.Validate())
 		})
 	}
 }
@@ -794,4 +839,58 @@ func TestQueue_RecoverySnapshot_CarriesConsumerOptions(t *testing.T) {
 
 	require.False(t, qDefault.consumerConfig.MemoryStorage)
 	require.Equal(t, 0, qDefault.consumerConfig.Replicas)
+}
+
+// TestQueue_FetchTimeoutAbove60s_IteratorCreationSucceeds proves the derived
+// pull heartbeat for a raised FetchTimeout stays within nats.go's PullHeartbeat
+// validity range.
+//
+// Before the derivation was given an explicit ceiling, the heartbeat was
+// always expiry/2 with no upper bound. nats.go v1.52.0 rejects an explicit
+// PullHeartbeat outside [500ms, 30s] (jetstream_options.go configureMessages)
+// with ErrInvalidOption, so any FetchTimeout above 60s derived a heartbeat
+// above 30s and iterator creation failed on every attempt — the pull loop
+// then spun in a restart/warn cycle forever with no terminal signal.
+//
+// This calls the real iterator factory directly (bypassing the async pull
+// loop's retry/backoff, which would otherwise hide the failure behind an
+// infinite warn-and-retry cycle) against a live NATS consumer, so it exercises
+// the exact nats.go validation path a production pull loop would hit.
+func TestQueue_FetchTimeoutAbove60s_IteratorCreationSucceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      "QUEUE_HB90",
+		Subjects:  []string{"hb90.>"},
+		Retention: jetstream.LimitsPolicy,
+		Storage:   jetstream.MemoryStorage,
+		MaxMsgs:   -1,
+	})
+	require.NoError(t, err)
+
+	handler := MessageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error { return nil })
+
+	q, err := NewQueue(js, "QUEUE_HB90", "hb90-workers", "hb90.>", handler,
+		WithFetchTimeout(90*time.Second),
+	)
+	require.NoError(t, err)
+
+	cons, err := q.ensureConsumer(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = js.DeleteConsumer(ctx, "QUEUE_HB90", "hb90-workers") })
+
+	iter, err := q.iterFactory(cons, q.config.BatchSize, q.config.FetchTimeout)
+	require.NoError(t, err,
+		"iterator creation must succeed with FetchTimeout > 60s once the derived "+
+			"heartbeat is bounded to nats.go's 30s PullHeartbeat maximum")
+	iter.Stop()
 }

--- a/consumer/static.go
+++ b/consumer/static.go
@@ -152,6 +152,7 @@ func NewStatic(
 			MaxDeliver:        o.maxDeliver,
 			BatchSize:         o.batchSize,
 			FetchTimeout:      o.fetchTimeout,
+			PullHeartbeatCap:  o.pullHeartbeatCap,
 			MaxWaiting:        o.maxWaiting,
 			MaxAckPending:     o.maxAckPending,
 			InactiveThreshold: o.inactiveThreshold,
@@ -186,6 +187,7 @@ func NewStatic(
 		Partition:         cfg.Partition,
 		BatchSize:         cfg.BatchSize,
 		FetchTimeout:      cfg.FetchTimeout,
+		PullHeartbeatCap:  cfg.PullHeartbeatCap,
 		ManualAck:         cfg.ManualAck,
 		MaxDeliver:        cfg.MaxDeliver,
 		Logger:            cfg.Logger,
@@ -303,6 +305,10 @@ func (c *StaticConfig) Validate() error {
 	}
 
 	if err := validateFetchTimeoutFloor(c.FetchTimeout); err != nil {
+		return err
+	}
+
+	if err := validatePullHeartbeatCap(c.PullHeartbeatCap); err != nil {
 		return err
 	}
 

--- a/consumer/static_test.go
+++ b/consumer/static_test.go
@@ -137,6 +137,36 @@ func TestStaticConfig_Validate_WrapsErrInvalidConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "PullHeartbeatCap below 500ms floor",
+			fn: func() error {
+				cfg := StaticConfig{
+					StreamName:     "S",
+					ConsumerName:   "c",
+					SubjectPattern: "s.{{partition}}",
+					NumPartitions:  2,
+					CommonConfig:   CommonConfig{PullHeartbeatCap: 499 * time.Millisecond},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
+			name: "PullHeartbeatCap above 30s ceiling",
+			fn: func() error {
+				cfg := StaticConfig{
+					StreamName:     "S",
+					ConsumerName:   "c",
+					SubjectPattern: "s.{{partition}}",
+					NumPartitions:  2,
+					CommonConfig:   CommonConfig{PullHeartbeatCap: 31 * time.Second},
+				}
+				_ = cfg.SetDefaults()
+
+				return cfg.Validate()
+			},
+		},
+		{
 			name: "invalid subject pattern (crosses ipartition boundary)",
 			fn: func() error {
 				// Pattern with an unrecognized placeholder: the error originates in

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -944,10 +944,11 @@ type Config struct {
     RestartDetectionRatio float64       // NO-OP (orphaned, pending removal); historically classified restarts (default: 0.5)
 
     // Timeouts
-    OperationTimeout time.Duration // Timeout for KV operations (default: 10s)
-    ElectionTimeout  time.Duration // Timeout for leader election (default: 10s)
-    StartupTimeout   time.Duration // Timeout for manager startup (default: 60s)
-    ShutdownTimeout  time.Duration // Timeout for graceful shutdown (default: 10s)
+    OperationTimeout         time.Duration // Timeout for KV operations (default: 10s)
+    BucketEpochProbeInterval time.Duration // Bucket-epoch fence probe cadence, independent of OperationTimeout (default: 10s)
+    ElectionTimeout          time.Duration // Timeout for leader election (default: 10s)
+    StartupTimeout           time.Duration // Timeout for manager startup (default: 60s)
+    ShutdownTimeout          time.Duration // Timeout for graceful shutdown (default: 10s)
 
     // Assignment Configuration
     RebalanceCooldown time.Duration // Min time between rebalances (default: 10s)
@@ -2156,6 +2157,31 @@ logger, _ := zap.NewProduction()
 js, _ := jetstream.New(nc)
 mgr, err := parti.NewManager(cfg, js, src, strategy,
     parti.WithLogger(logger.Sugar()),
+)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+---
+
+### WithBucketEpochProbeInterval
+
+Overrides `Config.BucketEpochProbeInterval`, the polling cadence for the
+bucket-epoch fence (independent of `OperationTimeout`, which continues to
+bound only each individual probe's deadline). Deployments that tuned
+`OperationTimeout` and relied on the old coupled cadence should set this
+explicitly to their previous `OperationTimeout` value.
+
+```go
+func WithBucketEpochProbeInterval(d time.Duration) Option
+```
+
+**Example**:
+```go
+js, _ := jetstream.New(nc)
+mgr, err := parti.NewManager(cfg, js, src, strategy,
+    parti.WithBucketEpochProbeInterval(3*time.Second),
 )
 if err != nil {
     log.Fatal(err)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1935,6 +1935,7 @@ c, _ := consumer.NewQueue(js, "stream", "consumer", "subject.>", handler,
 | `WithMaxDeliver(n)`              | Max redelivery attempts                        |
 | `WithMaxAckPending(n)`           | Max unacked messages                           |
 | `WithFetchTimeout(duration)`     | Max wait when pulling batch                    |
+| `WithPullHeartbeatCap(duration)` | Bound deleted-consumer detection latency when `FetchTimeout` is raised (default `0`=disabled; nonzero must be in `[500ms, 30s]` or construction fails with `ErrInvalidConfig`) |
 | `WithManualAck(bool)`            | Disable auto-acknowledgement                   |
 | `WithInactiveThreshold(duration)`| Consumer cleanup threshold                     |
 | `WithRecoveryStrategy(strategy)` | Auto-recovery on unexpected consumer deletion  |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -745,6 +745,28 @@ OperationTimeout <= ElectionTimeout / 3
 At the default pair (both 10s) the warning fires; in production
 prefer something like `OperationTimeout=3s, ElectionTimeout=10s`.
 
+### BucketEpochProbeInterval
+
+The bucket-epoch fence (see [Election Bucket Storage
+Migration](#election-bucket-storage-migration) above) polls each
+Parti-owned KV bucket's stream-Created timestamp on a periodic ticker to
+detect a wipe-and-recreate event. The polling cadence is
+`BucketEpochProbeInterval` (default `10s`) — a separate knob from
+`OperationTimeout`, which continues to bound only the deadline of each
+individual probe. Previously these were the same knob, so tuning
+`OperationTimeout` down (e.g. per the guidance above) also sped up or
+slowed down epoch-fence polling as a side effect. Lower
+`BucketEpochProbeInterval` for faster wipe-and-recreate detection at the
+cost of more frequent KV status reads; the default (`10s`) matches
+`OperationTimeout`'s own default, so deployments that left
+`OperationTimeout` at its default need no changes. Deployments that TUNED
+`OperationTimeout` (e.g. to `3s`, per the guidance above) and relied on the
+old coupled cadence must explicitly set `BucketEpochProbeInterval` to
+their previous `OperationTimeout` value to preserve the old probe cadence
+— left unset, their fence cadence silently changes from that tuned value
+to the new independent `10s` default. Set it via
+`Config.BucketEpochProbeInterval` or `parti.WithBucketEpochProbeInterval`.
+
 ### NATS Cluster Maintenance
 
 When performing NATS maintenance:

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -184,6 +184,34 @@ triggers lossless rebind.
   is at the JetStream floor; this buys footprint, not speed. See the "NATS-Side
   Cost" section in [OPERATIONS.md](OPERATIONS.md).
 
+### Tuning at high partition counts
+
+Each `Dynamic` partition consumer runs its own pull loop, and each loop re-issues
+an idle pull request every `FetchTimeout`. That re-issue traffic scales with the
+partition count and becomes the dominant **idle** server CPU cost at large P —
+it is a floor you pay even with zero messages flowing.
+
+- **Raise `WithFetchTimeout` to 30s at P ≳ 2000.** Measured on the v2.10 perf
+  rig (W=100, P=10,000, R=3): moving FetchTimeout from the 5s default to 30s cut
+  server CPU by **~0.77 cores idle / ~1.13 cores under load**, with P50 delivery
+  latency flat, P99 *improved*, and delivery ratio unaffected. Values above 60s
+  also work (the derived pull heartbeat is clamped to nats.go's 30s ceiling),
+  but 30s captured the bulk of the win in measurement.
+- **Pair it with `WithPullHeartbeatCap` to keep detection fast.** The pull
+  heartbeat is derived as `FetchTimeout/2` (capped at 30s), and the first
+  missed-heartbeat signal fires at roughly 2× the heartbeat. At
+  `FetchTimeout=30s` that stretches the first signal to ~30s. Setting
+  `WithPullHeartbeatCap(5*time.Second)` holds it at ~10s; confirmed recovery
+  follows after the burst threshold (default 3 consecutive misses) plus a
+  confirmation check — still several-fold faster than the uncapped
+  30s-heartbeat equivalent. Idle heartbeats are cheap server→client pushes, so
+  the cap costs far less than the pull re-issues you removed.
+- **Leader audit cadence tracks `HeartbeatTTL`.** The leader-side apply audit
+  runs once per `HeartbeatTTL` (not separately configurable); its cost scales
+  with worker count and is negligible at the measured scales (W ≤ 100). If you
+  raise `HeartbeatTTL` for other reasons, the audit stretches with it — no
+  separate tuning is needed or possible in 2.x.
+
 ---
 
 ## Proof

--- a/internal/assignment/assignment_publisher.go
+++ b/internal/assignment/assignment_publisher.go
@@ -42,6 +42,19 @@ const (
 	aliasBarrierMaxJitter   = 50 * time.Millisecond
 )
 
+// Bounded retry budget for the payload adoption CAS-touch (step 4's
+// ErrKeyExists branch). A touch loss means a concurrent GC sweep's
+// revision-conditioned delete (commit_gc.go RunOnce) won the race against
+// this adoption's verify-back; the whole create-or-adopt step is retried
+// from scratch (see createOrAdoptPayload). This is the rare path — GC only
+// deletes payloads outside the retention window, so a same-instant adopt is
+// uncommon — so a small, fast budget is enough.
+const (
+	payloadAdoptMaxAttempts = 3
+	payloadAdoptBaseBackoff = 20 * time.Millisecond
+	payloadAdoptMaxJitter   = 20 * time.Millisecond
+)
+
 // LeaderCheckFunc is the contract for the publisher's pre-alias and post-alias
 // leadership fences (publish steps 5 and 7 of §3.5).
 //
@@ -63,6 +76,9 @@ type LeaderCheckFunc func(ctx context.Context, claimed uint64) error
 // On every Publish, the publisher:
 //  1. Writes content-addressable AssignmentPayload keys ("assignment._payload.<hex(sha256)>")
 //     via kv.Create with hash-verify on ErrKeyExists (immutable, dedupe-safe).
+//     An adopted (reused) key is CAS-touched to a fresh revision before the
+//     adoption is treated as final, fencing it against a racing GC delete
+//     (see createOrAdoptPayload).
 //  2. Reads heartbeats to classify legacy (CapAckV1=0) workers in the batch.
 //  3. Brackets the legacy alias barrier with two leadership rechecks
 //     (pre-alias and post-alias).
@@ -668,35 +684,9 @@ func (p *AssignmentPublisher) writePayloads(
 
 		setDigest := computeSetDigest(canonical)
 
-		rev, err := p.assignmentKV.Create(ctx, key, stored)
-		switch {
-		case err == nil:
-			p.metrics.IncrementPayloadsCreated()
-			p.metrics.ObservePayloadBytesWritten(len(stored))
-		case errors.Is(err, jetstream.ErrKeyExists):
-			// Verify-back: fetch the existing bytes, decompress, sha256, and
-			// compare with our hash. A mismatch is either a sha256 collision
-			// (extraordinary) or KV corruption.
-			entry, gerr := p.assignmentKV.Get(ctx, key)
-			if gerr != nil {
-				return nil, nil, fmt.Errorf("verify-back get worker=%s key=%s: %w", w, key, gerr)
-			}
-			plain, derr := gzipDecompress(entry.Value())
-			if derr != nil {
-				// Tolerate the case where some operator wrote uncompressed bytes
-				// (unlikely in production, but be defensive): treat the raw
-				// stored bytes as canonical and re-hash directly.
-				plain = entry.Value()
-			}
-			gotHash := sha256.Sum256(plain)
-			if !bytes.Equal(gotHash[:], hash[:]) {
-				return nil, nil, fmt.Errorf("%w: key=%s expected=%s got=%s",
-					types.ErrPayloadHashCollisionOrCorruption, key, hashHex, hex.EncodeToString(gotHash[:]))
-			}
-			p.metrics.IncrementPayloadsReused()
-			rev = entry.Revision()
-		default:
-			return nil, nil, fmt.Errorf("kv create payload worker=%s key=%s: %w", w, key, err)
+		rev, err := p.createOrAdoptPayload(ctx, key, hash[:], hashHex, stored)
+		if err != nil {
+			return nil, nil, fmt.Errorf("worker=%s: %w", w, err)
 		}
 
 		refs[w] = types.AssignmentPayloadRef{
@@ -709,6 +699,139 @@ func (p *AssignmentPublisher) writePayloads(
 	}
 
 	return refs, payloads, nil
+}
+
+// createOrAdoptPayload implements step 4's per-key write, closing the
+// payload-GC-vs-adoption race: GC's RunOnce (commit_gc.go) can classify a
+// payload key as an orphan and delete it based on a snapshot taken before
+// this adoption started, and the plain Create→ErrKeyExists→verify-back
+// sequence used to give GC nothing to condition on — the adopter's
+// verify-back and GC's delete were two independent operations racing on the
+// same key with no shared fencing token.
+//
+// The fix makes both sides condition on the payload key's own KV revision:
+//   - On ErrKeyExists (an existing key with matching content), this method
+//     CAS-touches the key — kv.Update with the SAME bytes at the revision
+//     just observed — before treating the adoption as final. The touch keeps
+//     the key's content identical but advances its revision AND writes a
+//     fresh entry, resetting the Created timestamp GC's age gate reads.
+//   - GC's delete arm conditions its Delete on the revision it observed
+//     (jetstream.LastRevision) instead of deleting unconditionally.
+//
+// The two pieces split the two GC-read-vs-touch orderings between them:
+//   - GC's age-gate Get happens BEFORE the touch: the touch advances the
+//     revision, so GC's conditioned delete is rejected (fencing, below).
+//   - GC's age-gate Get happens AFTER the touch: it observes a fresh entry
+//     younger than Retention, and the age gate skips the key — no delete is
+//     even attempted.
+//
+// Both orderings lean on the standing retention-lease assumption every
+// payload write (fresh Create included) already relies on: a publish
+// completes its commit CAS within Retention (default 24h) of writing the
+// key. A publish stalled longer than Retention between touch/Create and
+// commit can still lose the key to a later GC pass — that is the
+// pre-existing lease contract, not a window this fix introduces or widens.
+//
+// Whichever side's conditioned write reaches the server first wins:
+//   - If GC deletes first, this method's touch loses (nats.go maps the
+//     revision mismatch to jetstream.ErrKeyExists, the same sentinel Create
+//     returns for "key already exists" — see errors.go's shared
+//     JSErrCodeStreamWrongLastSequence mapping), and the whole
+//     create-or-adopt step is retried: the next Create attempt recreates the
+//     key since it is now genuinely absent.
+//   - If this method's touch lands first, GC's conditioned delete loses and
+//     the key survives — GC treats that as "an adopter won" and skips it
+//     (see commit_gc.go RunOnce).
+//
+// A publish therefore never commits a payload ref whose touch (or fresh
+// Create) did not succeed. The extra touch write only happens on the
+// ErrKeyExists (adoption) branch — one extra KV op per ADOPTED key per
+// publish; new payloads (the common case) pay nothing extra.
+//
+// Bounded by payloadAdoptMaxAttempts; exhausting the budget returns an error
+// that aborts the batch (the caller wraps it with worker context).
+func (p *AssignmentPublisher) createOrAdoptPayload(ctx context.Context, key string, hash []byte, hashHex string, stored []byte) (uint64, error) {
+	var lastErr error
+	for attempt := range payloadAdoptMaxAttempts {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+
+		rev, err := p.assignmentKV.Create(ctx, key, stored)
+		switch {
+		case err == nil:
+			p.metrics.IncrementPayloadsCreated()
+			p.metrics.ObservePayloadBytesWritten(len(stored))
+
+			return rev, nil
+
+		case errors.Is(err, jetstream.ErrKeyExists):
+			// Verify-back: fetch the existing bytes, decompress, sha256, and
+			// compare with our hash. A mismatch is either a sha256 collision
+			// (extraordinary) or KV corruption — not retryable.
+			entry, gerr := p.assignmentKV.Get(ctx, key)
+			if gerr != nil {
+				// The key existed a moment ago (Create lost) but is now
+				// unreadable — most likely a GC delete landed between our
+				// Create attempt and this Get. Retry the whole step: the
+				// next Create attempt either recreates the key (if the
+				// delete is durable) or observes a fresh adopter.
+				lastErr = fmt.Errorf("verify-back get key=%s: %w", key, gerr)
+				p.backoffPayloadAdoptRetry(ctx, attempt)
+
+				continue
+			}
+			plain, derr := gzipDecompress(entry.Value())
+			if derr != nil {
+				// Tolerate the case where some operator wrote uncompressed bytes
+				// (unlikely in production, but be defensive): treat the raw
+				// stored bytes as canonical and re-hash directly.
+				plain = entry.Value()
+			}
+			gotHash := sha256.Sum256(plain)
+			if !bytes.Equal(gotHash[:], hash) {
+				return 0, fmt.Errorf("%w: key=%s expected=%s got=%s",
+					types.ErrPayloadHashCollisionOrCorruption, key, hashHex, hex.EncodeToString(gotHash[:]))
+			}
+
+			// CAS-touch: write the SAME bytes back at the observed revision.
+			// This is the fencing token GC's conditioned delete competes
+			// against — see the method doc above.
+			newRev, uerr := p.assignmentKV.Update(ctx, key, entry.Value(), entry.Revision())
+			if uerr != nil {
+				if errors.Is(uerr, jetstream.ErrKeyExists) {
+					// Revision moved under us between verify-back and touch:
+					// a GC delete (or another adopter's touch) won. Our
+					// verify-back is now stale — retry the whole step.
+					lastErr = fmt.Errorf("adopt touch cas lost key=%s: %w", key, uerr)
+					p.backoffPayloadAdoptRetry(ctx, attempt)
+
+					continue
+				}
+
+				return 0, fmt.Errorf("adopt touch key=%s: %w", key, uerr)
+			}
+			p.metrics.IncrementPayloadsReused()
+
+			return newRev, nil
+
+		default:
+			return 0, fmt.Errorf("kv create payload key=%s: %w", key, err)
+		}
+	}
+
+	return 0, fmt.Errorf("payload adoption exhausted %d attempts key=%s: %w", payloadAdoptMaxAttempts, key, lastErr)
+}
+
+// backoffPayloadAdoptRetry waits a short jittered backoff between
+// createOrAdoptPayload retries, or returns early if ctx is cancelled.
+func (p *AssignmentPublisher) backoffPayloadAdoptRetry(ctx context.Context, attempt int) {
+	backoff := payloadAdoptBaseBackoff << attempt
+	jitter := jitterDuration(payloadAdoptMaxJitter)
+	select {
+	case <-ctx.Done():
+	case <-time.After(backoff + jitter):
+	}
 }
 
 // classifyLegacyWorkers reads each worker's heartbeat and returns the subset

--- a/internal/assignment/assignment_publisher_test.go
+++ b/internal/assignment/assignment_publisher_test.go
@@ -477,7 +477,10 @@ func TestPublisher_InlineSizeRegression_DoesNotApply(t *testing.T) {
 
 // TestPublisher_ErrKeyExists_VerifiedAndReused — pre-populate a payload key
 // with the exact bytes the publisher will produce; assert payloads_reused
-// increments, ref carries existing revision.
+// increments and the adoption CAS-touch advances the ref's revision past the
+// pre-existing one while leaving the stored content byte-identical (see
+// createOrAdoptPayload — the touch is the fencing token against a racing GC
+// delete).
 func TestPublisher_ErrKeyExists_VerifiedAndReused(t *testing.T) {
 	f := newPublisherFixture(t, "key-exists-reused")
 	ctx := context.Background()
@@ -507,7 +510,18 @@ func TestPublisher_ErrKeyExists_VerifiedAndReused(t *testing.T) {
 
 	c := f.readCommit(t, ctx)
 	require.Equal(t, key, c.Payloads["w1"].Key)
-	require.Equal(t, rev, c.Payloads["w1"].Revision, "ref must carry the pre-existing revision")
+	// The adoption touch (kv.Update at the verified revision) advances the
+	// key's revision; the ref must carry the POST-touch revision so the
+	// commit references the fenced state, not the pre-adoption one.
+	require.Greater(t, c.Payloads["w1"].Revision, rev,
+		"ref must carry the post-touch revision (adoption CAS-touch advances it)")
+	entry, gerr := f.assignmentKV.Get(ctx, key)
+	require.NoError(t, gerr)
+	require.Equal(t, c.Payloads["w1"].Revision, entry.Revision(),
+		"ref revision must match the live key's revision after the touch")
+	plain, derr := gzipDecompress(entry.Value())
+	require.NoError(t, derr)
+	require.Equal(t, canonical, plain, "touch must not change the stored content")
 }
 
 // TestPublisher_ErrKeyExists_HashMismatchSurfacesCollisionError — pre-populate

--- a/internal/assignment/commit_gc.go
+++ b/internal/assignment/commit_gc.go
@@ -89,10 +89,16 @@ type CommitGCConfig struct {
 //   - Non-live keys older than Retention are eligible for deletion. Failures
 //     are non-fatal and surface via the IncrementPayloadDeleteErrors metric.
 //
-// CommitGC is safe to call concurrently with Publisher.Publish: GC only writes
-// (deletes) keys it has classified as orphan; the publisher only writes keys
-// via kv.Create + verify-back, so a delete-vs-create race produces at most a
-// transient "verify failed" the publisher self-recovers from on the next pass.
+// CommitGC is safe to call concurrently with Publisher.Publish, including
+// across processes: GC's delete is conditioned on the payload key's revision
+// (jetstream.LastRevision) as observed immediately before the delete, and a
+// publish adopting an existing key (Create → ErrKeyExists → verify-back)
+// CAS-touches it to advance that same revision before treating the adoption
+// as final (see createOrAdoptPayload in assignment_publisher.go). Whichever
+// side's conditioned write reaches the server first wins deterministically:
+// a GC delete that lands first makes the adopter's touch fail and retry
+// (recreating the key), and an adopter's touch that lands first makes GC's
+// delete fail and the key survives.
 //
 // Example:
 //
@@ -293,26 +299,61 @@ func (g *CommitGC) RunOnce(ctx context.Context) error {
 		if g.cfg.Retention > 0 && now.Sub(entry.Created()) < g.cfg.Retention {
 			continue
 		}
-		// Re-check in-flight refs immediately before deleting: a publish
-		// that began AFTER the snapshot above and adopted this key via
-		// ErrKeyExists can have registered its ref in the publisher's set
-		// during the kv.Get above. The double-check closes the narrow race
-		// where step 4's verify-back happens between our snapshot and our
-		// delete.
+		// Re-check in-flight refs immediately before deleting: a
+		// same-process publish that began AFTER the snapshot above and
+		// adopted this key via ErrKeyExists can have registered its ref in
+		// the publisher's set by now. This is a best-effort fast path only
+		// — LiveRefs is process-local (invisible to a concurrent publisher
+		// in another process) and even same-process the ref is registered
+		// only after writePayloads returns, a window after the adopter's
+		// touch below has already landed. The conditioned Delete below is
+		// the actual correctness mechanism; this check just avoids the
+		// round trip for the common same-process case.
 		if g.liveRefs != nil {
 			stillLive := slices.Contains(g.liveRefs.LiveRefs(), k)
 			if stillLive {
 				continue
 			}
 		}
-		if err := kv.Delete(ctx, k); err != nil {
-			if errors.Is(err, jetstream.ErrKeyNotFound) {
+		// Conditioned delete: only remove the key if its revision still
+		// matches what we just observed above (entry.Revision()). This is
+		// the fencing token that closes the payload-GC-vs-adoption race —
+		// see createOrAdoptPayload's doc in assignment_publisher.go. If an
+		// adopter CAS-touched this key (Create→ErrKeyExists→verify-back→
+		// Update) anywhere between our Get above and this Delete, the
+		// revision no longer matches and the delete is rejected instead of
+		// silently destroying a payload a fresh commit now references. The
+		// opposite ordering — a touch landing BEFORE our Get above — is
+		// covered by the age gate, not by this condition: the touch writes a
+		// fresh entry, so the Get sees Created within Retention and skips
+		// the key entirely. Both halves assume a publish commits within
+		// Retention of its payload write (the standing retention lease;
+		// see createOrAdoptPayload's doc).
+		if err := kv.Delete(ctx, k, jetstream.LastRevision(entry.Revision())); err != nil {
+			switch {
+			case errors.Is(err, jetstream.ErrKeyNotFound):
+				// Key already gone — another GC pass (or a delete that
+				// otherwise raced ahead of us) got there first.
+				continue
+			case errors.Is(err, jetstream.ErrKeyExists):
+				// Revision-conditioned delete lost: nats.go maps a
+				// wrong-last-sequence rejection to the same sentinel Create
+				// uses for "key already exists" (both are
+				// JSErrCodeStreamWrongLastSequence). It proves only that the
+				// key's revision moved after our Get — most likely an
+				// adopter's CAS-touch, though any concurrent write to the
+				// key produces the same rejection. Either way the key is
+				// live again; skip it. Kept distinguishable from the
+				// already-deleted case above so debug logs can tell the two
+				// loser classifications apart.
+				g.logger.Debug("payload GC delete lost: revision moved after age-gate read", "key", k)
+				continue
+			default:
+				errs++
+				g.cfg.Metrics.IncrementPayloadDeleteErrors()
+				g.logger.Warn("payload GC delete failed (non-fatal)", "key", k, "error", err)
 				continue
 			}
-			errs++
-			g.cfg.Metrics.IncrementPayloadDeleteErrors()
-			g.logger.Warn("payload GC delete failed (non-fatal)", "key", k, "error", err)
-			continue
 		}
 		deletes++
 	}

--- a/internal/assignment/commit_gc_adoption_race_test.go
+++ b/internal/assignment/commit_gc_adoption_race_test.go
@@ -1,0 +1,389 @@
+package assignment
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Payload-GC-vs-adoption race (see createOrAdoptPayload in
+// assignment_publisher.go and the conditioned delete in commit_gc.go
+// RunOnce).
+//
+// The bug this closes: GC's RunOnce can classify a payload key K as an
+// orphan from a stale snapshot (computeLiveSet ran before an adopter reused
+// K), and a plain kv.Delete(K) races an adopter's Create→ErrKeyExists→
+// verify-back with NOTHING for either side to condition on. Whichever
+// interleaving wins, the loser gets no signal: GC can delete a payload a
+// fresh commit now references, or (pre-fix) an adopter can silently commit a
+// reference to a payload GC is about to delete.
+//
+// The two tests below use a KV wrapper that synchronously injects the
+// "other side" at the exact instant one side's write hits the server —
+// deterministically reproducing both orderings without relying on real
+// goroutine scheduling.
+// ============================================================================
+
+// raceInjectingKV wraps a jetstream.KeyValue and lets a test synchronously
+// run a callback the first time Delete or Update targets a specific key,
+// immediately BEFORE forwarding the call to the real KV. This is how the
+// tests below pin an exact interleaving between GC's delete arm and the
+// publisher's adoption touch inside a single goroutine: whichever
+// intercepted call is made first "happens", then the intercepted call
+// itself proceeds against server state the injected callback just changed.
+type raceInjectingKV struct {
+	jetstream.KeyValue
+	targetKey string
+
+	mu       sync.Mutex
+	fired    bool
+	onDelete func()
+	onUpdate func()
+}
+
+func (k *raceInjectingKV) Delete(ctx context.Context, key string, opts ...jetstream.KVDeleteOpt) error {
+	k.fireOnce(key, k.onDelete)
+	return k.KeyValue.Delete(ctx, key, opts...)
+}
+
+func (k *raceInjectingKV) Update(ctx context.Context, key string, value []byte, revision uint64) (uint64, error) {
+	k.fireOnce(key, k.onUpdate)
+	return k.KeyValue.Update(ctx, key, value, revision)
+}
+
+func (k *raceInjectingKV) fireOnce(key string, fn func()) {
+	if fn == nil || key != k.targetKey {
+		return
+	}
+	k.mu.Lock()
+	if k.fired {
+		k.mu.Unlock()
+		return
+	}
+	k.fired = true
+	k.mu.Unlock()
+	fn()
+}
+
+// racePayloadFixture wires a real JetStream-backed publisher whose
+// AssignmentKV is a raceInjectingKV, plus a v1-heartbeat worker "w1" and the
+// precomputed key/bytes for the payload {partition "k"} — the exact content
+// a Publish({"w1": {"k"}}) call produces, byte-for-byte, via
+// mustMarshalCanonicalPayload.
+type racePayloadFixture struct {
+	pub        *AssignmentPublisher
+	realKV     jetstream.KeyValue // unwrapped — for planting/reading state directly
+	wrapped    *raceInjectingKV
+	metrics    *countingMetrics
+	payloadKey string
+	canonical  []byte
+}
+
+func newRacePayloadFixture(t *testing.T, name string) *racePayloadFixture {
+	t.Helper()
+	ctx := t.Context()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	realKV := partitest.CreateJetStreamKV(t, nc, "race-asgn-"+name)
+	hkv := partitest.CreateJetStreamKV(t, nc, "race-hb-"+name)
+
+	hb := types.Heartbeat{
+		WorkerID:      "w1",
+		SchemaVersion: 1,
+		Capabilities:  types.CapAckV1,
+		Timestamp:     time.Now().UTC(),
+	}
+	hbData, err := json.Marshal(hb)
+	require.NoError(t, err)
+	_, err = hkv.Put(ctx, "heartbeat.w1", hbData)
+	require.NoError(t, err)
+
+	payload := types.AssignmentPayload{
+		SchemaVersion:     types.AssignmentSchemaVersion,
+		Partitions:        []types.Partition{ps("k")},
+		WorkerLabelsKnown: true,
+	}
+	canonical := mustMarshalCanonicalPayload(t, payload)
+	hash := sha256.Sum256(canonical)
+	payloadKey := "assignment._payload." + hex.EncodeToString(hash[:])
+	gz, err := gzipCompress(canonical)
+	require.NoError(t, err)
+	// Plant K as a pre-existing payload — models an old, possibly
+	// cross-process payload that predates this test's publisher instance,
+	// exactly like the reused-K scenario in the review reports.
+	_, err = realKV.Create(ctx, payloadKey, gz)
+	require.NoError(t, err)
+
+	wrapped := &raceInjectingKV{KeyValue: realKV, targetKey: payloadKey}
+	m := newCountingMetrics()
+	pub := NewAssignmentPublisher(PublisherConfig{
+		AssignmentKV:    wrapped,
+		HeartbeatKV:     hkv,
+		Prefix:          "assignment",
+		HeartbeatPrefix: "heartbeat",
+		LeaderCheckFn:   func(context.Context, uint64) error { return nil },
+		Logger:          logging.NewNop(),
+		Metrics:         m,
+	})
+
+	return &racePayloadFixture{
+		pub:        pub,
+		realKV:     realKV,
+		wrapped:    wrapped,
+		metrics:    m,
+		payloadKey: payloadKey,
+		canonical:  canonical,
+	}
+}
+
+// publishK runs the adopter's Publish call that reuses payloadKey for
+// worker "w1".
+func (f *racePayloadFixture) publishK(ctx context.Context) error {
+	return f.pub.Publish(ctx, PublishInput{
+		Workers:          []string{"w1"},
+		Assignments:      map[string][]types.Partition{"w1": {ps("k")}},
+		SourcePartitions: []types.Partition{ps("k")},
+		LeaderRevision:   1,
+	})
+}
+
+// readCommit fetches and decodes assignment._commit via the unwrapped KV.
+func (f *racePayloadFixture) readCommit(t *testing.T, ctx context.Context) *types.AssignmentCommit {
+	t.Helper()
+	entry, err := f.realKV.Get(ctx, "assignment._commit")
+	require.NoError(t, err)
+	var c types.AssignmentCommit
+	require.NoError(t, json.Unmarshal(entry.Value(), &c))
+
+	return &c
+}
+
+// TestCommitGC_PayloadAdoptionRace_AdopterTouchWins_KSurvives reproduces the
+// P0 from the review reports: GC's live-set snapshot (computeLiveSet) is
+// taken BEFORE an adopter reuses K, and K is old enough / outside the log
+// window to be classified as an orphan. Between GC's per-key Get (the
+// age-gate read whose revision the fixed delete conditions on) and GC's
+// Delete call, a full adopter Publish — Create→ErrKeyExists→verify-back→
+// touch→commit C2 — lands, referencing K.
+//
+// On parent (pre-fix) code, GC's kv.Delete(K) is unconditioned: it deletes K
+// regardless of the adopter's touch/commit, so C2 ends up referencing a
+// payload that no longer exists. This test's "K must survive" assertion
+// FAILS on parent code (RED).
+//
+// After the fix, GC's delete is conditioned on the (now stale) revision it
+// observed before the adoption landed; the conditioned delete is rejected
+// and K survives (GREEN).
+func TestCommitGC_PayloadAdoptionRace_AdopterTouchWins_KSurvives(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	f := newRacePayloadFixture(t, "adopter-wins")
+
+	// Inject: run the FULL adopter publish (which lands commit C2
+	// referencing K) at the exact instant GC's delete call reaches the
+	// server — i.e., strictly between GC's per-key Get and its Delete.
+	f.wrapped.onDelete = func() {
+		require.NoError(t, f.publishK(ctx), "adopter publish (C2) must succeed")
+	}
+
+	gc := NewCommitGC(CommitGCConfig{
+		Publisher:   f.pub,
+		Interval:    time.Hour,
+		Retention:   time.Second,
+		KeepCommits: 10,
+		// K's real Created() timestamp is "now" (planted moments ago); skew
+		// GC's clock far enough forward to clear the retention gate so K is
+		// classified as an eligible orphan at computeLiveSet time (no
+		// commit exists yet, so the live set is empty).
+		Now:     func() time.Time { return time.Now().Add(48 * time.Hour) },
+		Metrics: f.metrics,
+	})
+	require.NotNil(t, gc)
+	require.NoError(t, gc.RunOnce(ctx))
+
+	// K must survive: the adopter's touch (part of publishK, above) must
+	// have raced ahead of GC's conditioned delete.
+	_, err := f.realKV.Get(ctx, f.payloadKey)
+	require.NoError(t, err, "K must survive: adopter's touch must beat GC's conditioned delete")
+
+	// The committed C2 must actually reference the surviving K — proving
+	// this isn't a case where the commit failed silently.
+	commit := f.readCommit(t, ctx)
+	ref, ok := commit.Payloads["w1"]
+	require.True(t, ok, "C2 must reference worker w1's payload")
+	require.Equal(t, f.payloadKey, ref.Key, "C2 must reference K")
+
+	// Losing the conditioned delete is an EXPECTED-loser skip, not a delete
+	// failure: the GC must not count it toward payload delete errors.
+	require.EqualValues(t, 0, f.metrics.gcDeleteErrors.Load(),
+		"conditioned-delete loss must not count as a payload delete error")
+}
+
+// TestCommitGC_PayloadAdoptionRace_GCDeleteWins_AdopterRecreatesAndCommits
+// covers the opposite ordering named in the review: GC's delete lands
+// FIRST, strictly between the adopter's verify-back Get and its touch
+// (Update) call. The touch must lose (K is gone), the whole
+// create-or-adopt step must retry, the retry's Create must recreate K (it
+// no longer exists), and the publish must still succeed, committing a
+// reference to the recreated K.
+//
+// This exercises the real production GC delete path (via gc.RunOnce) as the
+// "GC wins" side of the race, not a hand-rolled substitute.
+func TestCommitGC_PayloadAdoptionRace_GCDeleteWins_AdopterRecreatesAndCommits(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	f := newRacePayloadFixture(t, "gc-wins")
+
+	gc := NewCommitGC(CommitGCConfig{
+		Publisher:   f.pub,
+		Interval:    time.Hour,
+		Retention:   time.Second,
+		KeepCommits: 10,
+		Now:         func() time.Time { return time.Now().Add(48 * time.Hour) },
+		Metrics:     f.metrics,
+	})
+	require.NotNil(t, gc)
+
+	// Inject: run a REAL GC sweep at the exact instant the adopter's touch
+	// (Update) reaches the server — i.e., strictly between the adopter's
+	// verify-back Get and its touch. At this point in the flow the
+	// publisher has not yet registered K in inflightRefs (writePayloads has
+	// not returned), so GC's LiveRefs fast path does not see it either —
+	// this is precisely the "verify-back-to-registration window" the
+	// review reports named as unclosed by LiveRefs alone.
+	f.wrapped.onUpdate = func() {
+		require.NoError(t, gc.RunOnce(ctx), "simulated concurrent GC sweep")
+	}
+
+	err := f.publishK(ctx)
+	require.NoError(t, err, "adopter must recover by re-creating K after losing the touch race")
+
+	// K must be present again (recreated by the retry, not the original
+	// planted key — the original was really deleted by gc.RunOnce above).
+	entry, err := f.realKV.Get(ctx, f.payloadKey)
+	require.NoError(t, err, "K must be recreated after the touch lost to GC's delete")
+	plain, derr := gzipDecompress(entry.Value())
+	require.NoError(t, derr)
+	require.Equal(t, f.canonical, plain, "recreated K must carry the same canonical content")
+
+	// The committed C2 must reference K.
+	commit := f.readCommit(t, ctx)
+	ref, ok := commit.Payloads["w1"]
+	require.True(t, ok)
+	require.Equal(t, f.payloadKey, ref.Key)
+
+	// Pin that the recovery path was a re-CREATE, not a reuse: the only
+	// successful Create the publisher's metrics observed is the retry's
+	// (the original plant used realKV.Create directly, bypassing metrics).
+	require.EqualValues(t, 1, f.metrics.payloadsCreated.Load(),
+		"exactly one successful Create: the retry after the touch lost to GC")
+	require.EqualValues(t, 0, f.metrics.payloadsReused.Load(),
+		"the touch-loses-to-delete path must NOT count as a reuse")
+}
+
+// TestPayloadAdoptionExhaustion_NoCommitWritten pins the exhaustion contract
+// of the adoption CAS loop: when every one of the payloadAdoptMaxAttempts
+// touch attempts loses its revision condition, Publish must FAIL — and,
+// critically, assignment._commit must never be written. A commit referencing
+// a payload whose adoption touch never succeeded is exactly the torn state
+// the revision-conditioned protocol exists to prevent, so the abort-before-
+// commit-CAS ordering is the load-bearing half of the fix.
+func TestPayloadAdoptionExhaustion_NoCommitWritten(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	f := newRacePayloadFixture(t, "adopt-exhaustion")
+
+	// Inject: immediately before EVERY adopter touch (Update) reaches the
+	// server, advance K's revision out-of-band via the unwrapped KV — same
+	// bytes, current revision — so the adopter's touch, conditioned on the
+	// revision from its verify-back Get, always loses. Re-arming the
+	// fire-once latch inside the callback makes the injection repeat for
+	// every retry attempt, modeling a competing writer winning every round.
+	f.wrapped.onUpdate = func() {
+		entry, gerr := f.realKV.Get(ctx, f.payloadKey)
+		require.NoError(t, gerr, "out-of-band revision bump: read current entry")
+		_, uerr := f.realKV.Update(ctx, f.payloadKey, entry.Value(), entry.Revision())
+		require.NoError(t, uerr, "out-of-band revision bump: advance revision")
+		f.wrapped.mu.Lock()
+		f.wrapped.fired = false // re-arm: the NEXT touch attempt must lose too
+		f.wrapped.mu.Unlock()
+	}
+
+	err := f.publishK(ctx)
+	require.Error(t, err, "publish must fail once adoption attempts are exhausted")
+	require.ErrorContains(t, err, "payload adoption exhausted")
+
+	// The load-bearing assertion: exhaustion aborted the publish BEFORE the
+	// commit CAS — no commit may exist referencing the never-adopted K.
+	_, gerr := f.realKV.Get(ctx, "assignment._commit")
+	require.ErrorIs(t, gerr, jetstream.ErrKeyNotFound,
+		"assignment._commit must not be written after adoption exhaustion")
+
+	// And the failed adoption must not have been counted as a successful
+	// create or reuse.
+	require.EqualValues(t, 0, f.metrics.payloadsCreated.Load())
+	require.EqualValues(t, 0, f.metrics.payloadsReused.Load())
+}
+
+// TestPayloadRevisionRace_LoserClassification pins the nats.go/JetStream
+// behavior both sides of the fix depend on: a revision-conditioned write
+// that loses a race — whether it's GC's LastRevision-conditioned Delete or
+// the adopter's revision-conditioned Update (touch) — surfaces as
+// jetstream.ErrKeyExists (nats.go maps the underlying JetStream
+// "wrong last sequence" API code, JSErrCodeStreamWrongLastSequence, to the
+// same sentinel Create uses for "key already exists"). This is NOT the same
+// classification as deleting a key that is already fully gone
+// (jetstream.ErrKeyNotFound), which both commit_gc.go's delete-arm switch
+// and the pre-existing "raced away" handling still rely on staying distinct.
+//
+// This test does not depend on the fix's application code — it is a
+// contract pin against the vendored nats.go behavior the fix's error
+// classification switches assume.
+func TestPayloadRevisionRace_LoserClassification(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	kv := partitest.CreateJetStreamKV(t, nc, "race-loser-classification")
+
+	key := "assignment._payload.deadbeef"
+	rev, err := kv.Create(ctx, key, []byte("v1"))
+	require.NoError(t, err)
+
+	// A second writer advances the key's revision — models either side
+	// (a GC delete or a concurrent adopter's touch) winning first.
+	_, err = kv.Update(ctx, key, []byte("v2"), rev)
+	require.NoError(t, err)
+
+	// A conditioned Delete against the now-stale revision (models GC's
+	// delete arm losing to an adopter's touch) must classify as
+	// ErrKeyExists, NOT ErrKeyNotFound — the key is very much still there.
+	derr := kv.Delete(ctx, key, jetstream.LastRevision(rev))
+	require.Error(t, derr)
+	require.ErrorIs(t, derr, jetstream.ErrKeyExists)
+	require.NotErrorIs(t, derr, jetstream.ErrKeyNotFound)
+
+	// A conditioned Update against the now-stale revision (models the
+	// adopter's touch losing to a GC delete that landed first) must also
+	// classify as ErrKeyExists.
+	_, uerr := kv.Update(ctx, key, []byte("v3"), rev)
+	require.Error(t, uerr)
+	require.ErrorIs(t, uerr, jetstream.ErrKeyExists)
+	require.NotErrorIs(t, uerr, jetstream.ErrKeyNotFound)
+
+	// Contrast: deleting an ALREADY-fully-deleted key stays classified as
+	// ErrKeyNotFound — the pre-existing "raced away" case GC already
+	// handled — so the two loser classifications remain distinguishable.
+	require.NoError(t, kv.Delete(ctx, key)) // unconditioned: removes latest.
+	_, gerr := kv.Get(ctx, key)
+	require.ErrorIs(t, gerr, jetstream.ErrKeyNotFound)
+}

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -156,6 +156,43 @@ type Config struct {
 	// no-op; the revision-CAS delete additionally guarantees any concurrent
 	// claim transition wins over the reaper. <= 0 disables orphan reaping.
 	OrphanGrace time.Duration
+	// SweepAuthority reports whether this worker currently holds sweep
+	// authority (in practice: parti leadership). Ticker-origin sweeps run
+	// at full cadence only when it returns true; other workers drop to
+	// the backstop cadence (see twophase.go's ticker loop). nil = every
+	// worker keeps today's full ticker cadence (fail-open default; direct
+	// constructions and tests are unchanged).
+	//
+	// CONTRACT: invoked ONLY from sampleAuthority WHILE HOLDING the
+	// coordinator's internal authMu — it must be cheap and non-blocking
+	// (the manager wires a closure over an atomic election flag), and it
+	// MUST NOT call back into the coordinator (that would be a lock
+	// cycle: sampleAuthority already holds authMu).
+	SweepAuthority func() bool
+	// SweepPhaseSeed staggers follower backstop ticks across a fleet. The
+	// manager wires fnv1a64(stableWorkerID) — hash/fnv's 64-bit FNV-1a
+	// over the worker's claimed stable ID, available before coordinator
+	// construction. The coordinator reduces it internally:
+	// phase = SweepPhaseSeed % backstopEvery. 0 (default) = phase 0;
+	// direct constructions and tests are unchanged.
+	SweepPhaseSeed uint64
+	// SweepTicks, when non-nil, replaces the internal time.NewTicker as
+	// the ticker-fire source (Start consumes this channel instead of
+	// creating a ticker). TEST-ONLY seam: production wiring never sets
+	// it. The loop uses the two-value receive — `_, ok := <-tickSrc; if
+	// !ok { return }` — so a CLOSED injected channel terminates the
+	// goroutine cleanly (test teardown) instead of hot-looping on zero
+	// values. Together with Now this makes every ticker cadence contract
+	// deterministic.
+	SweepTicks <-chan time.Time
+	// SweepObserver, when non-nil, is invoked by maybeSweepClaims's
+	// CALLERS (the ticker loop and Apply) with each attempt's origin,
+	// the authority observation for ticker-origin attempts (constant
+	// true for Apply-origin), and the returned admitted value —
+	// therefore always OUTSIDE sweepMu and authMu. Ticker and Apply
+	// attempts run concurrently, so the observer MUST be goroutine-safe
+	// and non-blocking. TEST-ONLY seam; not a metrics-interface change.
+	SweepObserver func(origin sweepOrigin, authorized, admitted bool)
 }
 
 // New returns a Coordinator implementation.
@@ -196,7 +233,7 @@ func New(cfg Config, enableTwoPhase bool) Coordinator {
 	if enableTwoPhase {
 		coord := &twoPhaseCoordinator{
 			cfg:               cfg,
-			orphanAbsentSince: make(map[string]time.Time),
+			orphanAbsentSince: make(map[string]orphanClock),
 			sweepConfirmGap:   natsutil.ScanGateDefaultConfirmGap,
 			sweepMaxSkips:     natsutil.ScanGateMaxSkippedPasses,
 		}

--- a/internal/assignment/handoff/orphan_reap_test.go
+++ b/internal/assignment/handoff/orphan_reap_test.go
@@ -289,6 +289,99 @@ func TestOrphanReap_RevisionConflictKeepsClaim(t *testing.T) {
 		"a lost delete CAS means the claim moved; the reaper must yield")
 }
 
+// errArmedGetFailure is the injected per-key read failure used to reproduce the
+// stale-absence-clock bug: a claim Get failing during a vouched reappearance
+// must not be the only path by which that pid's absence clock gets cleared.
+var errArmedGetFailure = errors.New("injected get failure")
+
+// getFailArmedStore fails the next Get for a designated partition ID once
+// arm() has been called, then reverts to passing through. Used to make a
+// single pass's per-key claim read fail for exactly one pid.
+type getFailArmedStore struct {
+	ClaimStore
+	mu     sync.Mutex
+	target string
+	armed  bool
+}
+
+func (g *getFailArmedStore) arm() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.armed = true
+}
+
+func (g *getFailArmedStore) Get(ctx context.Context, partitionID string) (Claim, uint64, error) {
+	g.mu.Lock()
+	if g.armed && partitionID == g.target {
+		g.armed = false
+		g.mu.Unlock()
+
+		return Claim{}, 0, errArmedGetFailure
+	}
+	g.mu.Unlock()
+
+	return g.ClaimStore.Get(ctx, partitionID)
+}
+
+// TestOrphanReap_ReappearanceClearsClockDespiteFailedRead pins round-3 P0-2
+// (tmp/leader-gated-sweep_v4_review.md): a stable claim's absence clock must
+// clear on any vouched pass where its pid is present in the live set, even
+// when that pass's per-key claim Get fails and sweepClaim is therefore
+// skipped for it. Before the fix, the ONLY clock-clear path lived inside
+// maybeReapOrphan's in-set branch, which a failed read never reaches, so a
+// later pass could reap using the ORIGINAL (pre-reappearance) seed instead
+// of requiring a fresh grace measured from the SECOND disappearance.
+//
+// p-gone is a co-resident claim that is never live, seeded on the same pass
+// as p-flap: it pins that the pass-level clear only deletes clocks for pids
+// actually present in that pass's live set, not the whole map (no
+// over-clearing) — it must still reap once ITS OWN grace elapses.
+func TestOrphanReap_ReappearanceClearsClockDespiteFailedRead(t *testing.T) {
+	t.Parallel()
+
+	h := newReapHarness(t, orphanTestGrace)
+	now := time.Now().UTC()
+	h.seed(stableClaim("p-flap", now))
+	h.seed(stableClaim("p-gone", now))
+	failing := &getFailArmedStore{ClaimStore: h.store, target: "p-flap"}
+	h.swapStore(t, failing)
+
+	// Both absent from the first pass: each gets an absence clock seeded at
+	// t0.
+	h.setLive()
+	h.sweep(t)
+
+	// p-flap reappears in the vouched live set, but its per-key claim read
+	// fails on this very pass: sweepClaim is skipped for it, so the fix's
+	// pass-level clear (independent of per-claim read success) is the only
+	// thing that can clear its clock here. p-gone stays absent and must be
+	// left untouched by this pass.
+	h.setLive("p-flap")
+	failing.arm()
+	h.sweep(t)
+
+	// p-flap disappears again. No sweep runs yet: whether its clock survived
+	// the reappearance pass is decided by the next vouched pass below.
+	h.setLive()
+
+	// Advance by EXACTLY grace measured from the ORIGINAL seed (t0) — enough
+	// for the pre-fix bug to reap p-flap on a stale clock, and the precise
+	// boundary at which p-gone's own reap must fire (the reap guard is
+	// strictly `< OrphanGrace`; an exact-grace advance pins that a `<=`
+	// regression would wrongly retain p-gone). The fix requires a FRESH
+	// grace for p-flap measured from the second disappearance, which this
+	// pass itself is the first vouched observation of.
+	h.advance(orphanTestGrace)
+	h.sweep(t)
+
+	require.True(t, h.claimExists(t, "p-flap"),
+		"a failed per-key read during a vouched reappearance must not leave a stale absence "+
+			"clock: the claim must survive until a FRESH grace elapses from the second disappearance")
+	require.False(t, h.claimExists(t, "p-gone"),
+		"a claim absent the whole time must still reap once its OWN grace elapses: the "+
+			"pass-level clear must not over-clear clocks for pids that never reappeared")
+}
+
 func TestOrphanReap_ZeroGraceDisables(t *testing.T) {
 	t.Parallel()
 

--- a/internal/assignment/handoff/sweep_authority_live_test.go
+++ b/internal/assignment/handoff/sweep_authority_live_test.go
@@ -1,0 +1,464 @@
+package handoff
+
+// Live-NATS proof of §4.10: no-leader healing within the I2 bound, and
+// §4.12: mixed-concurrency stress (leader full cadence + follower
+// backstops + concurrent Apply-origin claim mutation).
+//
+// The 5-minute followerBackstopTarget is a const, so real-time waiting is
+// not viable in a unit test; both proofs drive injected SweepTicks +
+// fake Now against a REAL NATS-backed claim Store, exactly like
+// sweep_gate_reap_live_test.go's convention (testing.Short() guard, no
+// build tag — this file runs as part of `make test`, not
+// `make test-integration`).
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSweepAuthorityLive_NoLeaderHealingWithinI2Bound pins §4.10:
+// N coordinators share one real NATS-backed claim bucket, ALL reporting
+// SweepAuthority=false (no leader anywhere in the fleet). A planted
+// expired-TTL prepare still heals within the I2 either-origin bound —
+// (backstopEvery+1) x SweepInterval — via the ticker's backstop cadence,
+// and the healing pass is observed as ticker-origin, UNAUTHORIZED,
+// admitted via SweepObserver — proving it was NOT healed by an
+// accidental leader running at full cadence.
+func TestSweepAuthorityLive_NoLeaderHealingWithinI2Bound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	// partitest (not internal/testutil): an in-package handoff test
+	// cannot import internal/testutil, which pulls in the root parti
+	// package that itself imports this package (cycle).
+	srv, nc := partitest.StartEmbeddedNATS(t)
+	defer func() {
+		nc.Close()
+		srv.Shutdown()
+		srv.WaitForShutdown()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const bucket = "sweep-authority-live-i2"
+	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+	store := NewNATSClaimStore(kv, "claims/")
+
+	// A sanity handle dedicated to the test's own reads — never a handle
+	// a live component owns (ListKeys spins up a throwaway ordered
+	// consumer that mutates its handle's stream state).
+	sanityKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	sanityStore := NewNATSClaimStore(sanityKV, "claims/")
+
+	// A stuck, TTL-expired prepare: the reconcile arm's expired-reset
+	// path (independent of LivePartitions/leadership) is the healing
+	// this test observes — exactly the shape a stalled two-worker
+	// handoff leaves behind.
+	seedNow := time.Now().UTC()
+	stuck := Claim{
+		PartitionID:  "p-stuck",
+		Owner:        "worker-A",
+		PendingOwner: "worker-B",
+		State:        ClaimStatePrepare,
+		Epoch:        1,
+		LastUpdated:  seedNow.Add(-time.Hour),
+		TTLSeconds:   1, // long since expired relative to LastUpdated
+	}
+	_, err = store.PutIfEpoch(ctx, "p-stuck", 0, stuck)
+	require.NoError(t, err)
+
+	const (
+		numWorkers    = 3
+		interval      = 30 * time.Second
+		backstopEvery = 10 // default: followerBackstopTarget(5m) / interval(30s)
+	)
+
+	// A single mutex-guarded fake clock shared by every coordinator: the
+	// I2 bound is expressed in tick counts, not wall-clock time, so
+	// there is no need for per-worker clock skew. Guarded (not a plain
+	// closure over a bare variable) so -race is clean regardless of
+	// exactly when each coordinator's ticker goroutine reads it.
+	clock := struct {
+		mu  sync.Mutex
+		now time.Time
+	}{now: seedNow}
+	readNow := func() time.Time {
+		clock.mu.Lock()
+		defer clock.mu.Unlock()
+
+		return clock.now
+	}
+	advanceNow := func(d time.Duration) time.Time {
+		clock.mu.Lock()
+		defer clock.mu.Unlock()
+		clock.now = clock.now.Add(d)
+
+		return clock.now
+	}
+
+	type worker struct {
+		coord  *twoPhaseCoordinator
+		ticks  chan time.Time
+		events chan sweepAuthEvent
+	}
+
+	workers := make([]*worker, numWorkers)
+	for i := range numWorkers {
+		w := &worker{ticks: make(chan time.Time), events: make(chan sweepAuthEvent, 64)}
+		coord, ok := New(Config{
+			Store:          store,
+			Now:            readNow,
+			SweepInterval:  interval,
+			SweepPhaseSeed: uint64(i), // stagger backstop ticks across the fleet
+			SweepTicks:     w.ticks,
+			SweepAuthority: func() bool { return false }, // no leader, ever
+			SweepObserver: func(origin sweepOrigin, authorized, admitted bool) {
+				w.events <- sweepAuthEvent{origin: origin, authorized: authorized, admitted: admitted}
+			},
+			MaxRetries:  3,
+			BaseBackoff: time.Millisecond,
+			MaxBackoff:  5 * time.Millisecond,
+		}, true).(*twoPhaseCoordinator)
+		require.True(t, ok)
+		w.coord = coord
+		w.coord.Start(ctx)
+		workers[i] = w
+	}
+
+	// Drive ticks in lockstep across all N coordinators, up to the I2
+	// bound (backstopEvery+1 rounds), checking for healing after each
+	// round and capturing whichever pass actually admitted.
+	var healingEvent *sweepAuthEvent
+	healed := false
+	for round := 1; round <= backstopEvery+1 && !healed; round++ {
+		advanceNow(interval)
+		for _, w := range workers {
+			select {
+			case w.ticks <- readNow():
+			case <-time.After(5 * time.Second):
+				t.Fatalf("worker did not consume round %d's tick", round)
+			}
+		}
+
+		for _, w := range workers {
+		drain:
+			for {
+				select {
+				case ev := <-w.events:
+					if ev.admitted {
+						e := ev
+						healingEvent = &e
+					}
+				default:
+					break drain
+				}
+			}
+		}
+
+		got, rev, gerr := sanityStore.Get(ctx, "p-stuck")
+		require.NoError(t, gerr)
+		if rev != 0 && got.State == ClaimStateStable {
+			healed = true
+		}
+	}
+
+	require.True(t, healed,
+		"the stuck prepare must heal within the I2 bound ((backstopEvery+1) x SweepInterval) with no leader present")
+	require.NotNil(t, healingEvent, "the healing pass must have been observed via SweepObserver")
+	require.Equal(t, sweepOriginTicker, healingEvent.origin, "healed by a TICKER pass, not an accidental leader")
+	require.False(t, healingEvent.authorized, "healed while UNAUTHORIZED — no accidental leader ran at full cadence")
+	require.True(t, healingEvent.admitted)
+}
+
+// countTickerAdmissions returns a SweepObserver that increments counter
+// for every ticker-origin ADMITTED event whose authorized value matches
+// wantAuthorized — factored into its own named function (rather than an
+// inline closure at each call site) so its branch counts against ITS
+// OWN cyclomatic complexity budget, not
+// TestSweepAuthorityLive_MixedConcurrencyStress's.
+func countTickerAdmissions(counter *atomic.Int64, wantAuthorized bool) func(origin sweepOrigin, authorized, admitted bool) {
+	return func(origin sweepOrigin, authorized, admitted bool) {
+		if origin == sweepOriginTicker && authorized == wantAuthorized && admitted {
+			counter.Add(1)
+		}
+	}
+}
+
+// liveStressCoordinatorOpts configures newLiveStressCoordinator.
+type liveStressCoordinatorOpts struct {
+	store     ClaimStore
+	now       func() time.Time
+	interval  time.Duration
+	ticks     chan time.Time
+	authority bool
+	observer  func(origin sweepOrigin, authorized, admitted bool)
+}
+
+// newLiveStressCoordinator builds and starts a two-phase coordinator for
+// TestSweepAuthorityLive_MixedConcurrencyStress — factored out to keep
+// that test's own cyclomatic complexity under the repo's lint budget.
+func newLiveStressCoordinator(t *testing.T, ctx context.Context, opts liveStressCoordinatorOpts) *twoPhaseCoordinator {
+	t.Helper()
+	authority := opts.authority
+	coord, ok := New(Config{
+		Store:          opts.store,
+		Now:            opts.now,
+		SweepInterval:  opts.interval,
+		SweepPhaseSeed: 0,
+		SweepTicks:     opts.ticks,
+		SweepAuthority: func() bool { return authority },
+		SweepObserver:  opts.observer,
+		MaxRetries:     3,
+		BaseBackoff:    time.Millisecond,
+		MaxBackoff:     5 * time.Millisecond,
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	coord.Start(ctx)
+
+	return coord
+}
+
+// TestSweepAuthorityLive_MixedConcurrencyStress pins §4.12 (review
+// finding P1-4): the minimal sufficient shape the review specified —
+// two coordinators against one embedded-NATS bucket, each with its OWN
+// production and probe KV handles (NewNATSClaimStoreWithProbe, mirroring
+// how the manager wires a dedicated probe handle in production — never
+// sharing a handle across coordinators, since kv.Status mutates shared
+// *stream state under concurrent Get/Put: the epoch-monitor race class
+// rule 300-testing.md:44 requires live-NATS stress to catch). One
+// constant-authority leader and one false-authority follower, the
+// follower's phase deterministically reaching a backstop tick; injected
+// ticks and fake time (no real 5-minute waits); ~5s of concurrent
+// Apply-origin claim mutation from both coordinators under -race;
+// SweepObserver assertions proving at least one authorized ticker
+// admission, at least one unauthorized backstop admission, and
+// overlapping Apply attempts; finishing with no deadlock and stable
+// claim convergence.
+func TestSweepAuthorityLive_MixedConcurrencyStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	srv, nc := partitest.StartEmbeddedNATS(t)
+	defer func() {
+		nc.Close()
+		srv.Shutdown()
+		srv.WaitForShutdown()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	const bucket = "sweep-authority-live-mixed-concurrency"
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: bucket})
+	require.NoError(t, err)
+
+	// Two coordinators, ONE shared bucket, each with its own dedicated
+	// production + probe handle pair — four handles total, never shared
+	// across coordinators.
+	kvA, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	probeA, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	kvB, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	probeB, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+
+	storeA := NewNATSClaimStoreWithProbe(kvA, probeA, "claims/")
+	storeB := NewNATSClaimStoreWithProbe(kvB, probeB, "claims/")
+
+	// A sanity handle dedicated to the test's own final reads — never a
+	// handle a live component owns.
+	sanityKV, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	sanityStore := NewNATSClaimStore(sanityKV, "claims/")
+
+	// A single mutex-guarded fake clock shared by both coordinators —
+	// the I2/backstop bound is expressed in tick counts, not wall-clock
+	// time.
+	clock := struct {
+		mu  sync.Mutex
+		now time.Time
+	}{now: time.Now().UTC()}
+	readNow := func() time.Time {
+		clock.mu.Lock()
+		defer clock.mu.Unlock()
+
+		return clock.now
+	}
+	advanceNow := func(d time.Duration) time.Time {
+		clock.mu.Lock()
+		defer clock.mu.Unlock()
+		clock.now = clock.now.Add(d)
+
+		return clock.now
+	}
+
+	const (
+		interval      = 30 * time.Second
+		backstopEvery = 10 // default: followerBackstopTarget(5m) / interval(30s)
+	)
+
+	ticksA := make(chan time.Time)
+	ticksB := make(chan time.Time)
+
+	// Aggregate counters, not a buffered event-history channel: under
+	// the Apply-origin stress below, SweepObserver fires on EVERY single
+	// Apply call (hundreds+ in a 5s window) — a bounded channel with
+	// nothing draining it concurrently deadlocks (the apply-loop
+	// goroutines block sending to a full channel while the only drain
+	// point waits for them to finish first). This test only needs
+	// aggregate admission counts, so atomics sidestep the problem
+	// entirely.
+	var (
+		aTickerAuthorizedAdmitted   atomic.Int64
+		bTickerUnauthorizedAdmitted atomic.Int64
+	)
+
+	coordA := newLiveStressCoordinator(t, ctx, liveStressCoordinatorOpts{
+		store: storeA, now: readNow, interval: interval, ticks: ticksA,
+		authority: true, // constant-authority leader
+		observer:  countTickerAdmissions(&aTickerAuthorizedAdmitted, true),
+	})
+	coordB := newLiveStressCoordinator(t, ctx, liveStressCoordinatorOpts{
+		store: storeB, now: readNow, interval: interval, ticks: ticksB,
+		authority: false, // false-authority follower; phase 0: deterministic backstop at tick 10
+		observer:  countTickerAdmissions(&bTickerUnauthorizedAdmitted, false),
+	})
+
+	partitions := []string{"p0", "p1", "p2", "p3"}
+	makeAssignment := func(pids ...string) types.Assignment {
+		parts := make([]types.Partition, len(pids))
+		for i, pid := range pids {
+			parts[i] = types.Partition{Keys: []string{pid}}
+		}
+
+		return types.Assignment{Version: 1, Partitions: parts}
+	}
+
+	stressCtx, stressCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer stressCancel()
+
+	var (
+		wg              sync.WaitGroup
+		inFlight        atomic.Int32
+		overlapObserved atomic.Bool
+	)
+
+	// Concurrent Apply-origin claim mutation: both coordinators toggle
+	// the SAME partition set between "acquire" and "release" as fast as
+	// they can for ~5s, contending over the shared bucket under -race —
+	// the overlapping-attempts proof the review requires.
+	applyLoop := func(coord *twoPhaseCoordinator, worker string) {
+		defer wg.Done()
+		prev := types.Assignment{}
+		acquire := false
+		for stressCtx.Err() == nil {
+			next := types.Assignment{}
+			if acquire {
+				next = makeAssignment(partitions...)
+			}
+			acquire = !acquire
+
+			if inFlight.Add(1) > 1 {
+				overlapObserved.Store(true)
+			}
+			_ = coord.Apply(stressCtx, worker, prev, next)
+			inFlight.Add(-1)
+
+			prev = next
+		}
+	}
+
+	wg.Add(2)
+	go applyLoop(coordA, "worker-A")
+	go applyLoop(coordB, "worker-B")
+
+	// Concurrently — overlapping the Apply stress above — drive ticks
+	// for both coordinators, enough rounds to guarantee coordB's
+	// deterministic backstop (tick backstopEvery, phase 0) fires at
+	// least once.
+	pushBothTicks := func() {
+		now := advanceNow(interval)
+		var tickWg sync.WaitGroup
+		tickWg.Add(2)
+		go func() {
+			defer tickWg.Done()
+			select {
+			case ticksA <- now:
+			case <-ctx.Done():
+			}
+		}()
+		go func() {
+			defer tickWg.Done()
+			select {
+			case ticksB <- now:
+			case <-ctx.Done():
+			}
+		}()
+		tickWg.Wait()
+	}
+
+	const rounds = backstopEvery + 2
+	for range rounds {
+		pushBothTicks()
+	}
+
+	wg.Wait() // the ~5s Apply stress window completes
+
+	// A few more rounds, past the Apply stress window, so the fake
+	// clock advances enough (well past the default 1-minute claim TTL)
+	// for the reconcile arm to settle any claim left mid-handoff by the
+	// contention above — the "stable claim convergence" this test must
+	// finish by asserting.
+	for range 6 {
+		pushBothTicks()
+	}
+
+	require.GreaterOrEqual(t, aTickerAuthorizedAdmitted.Load(), int64(1),
+		"the constant-authority leader must record at least one authorized ticker admission")
+	require.GreaterOrEqual(t, bTickerUnauthorizedAdmitted.Load(), int64(1),
+		"the false-authority follower must record at least one unauthorized backstop admission")
+	require.True(t, overlapObserved.Load(),
+		"the concurrent Apply-origin stress must have produced overlapping attempts")
+
+	// No deadlock: reaching this point within the outer 60s ctx already
+	// proves it. Stable claim convergence: every listed claim must have
+	// settled to stable.
+	require.Eventually(t, func() bool {
+		keys, lerr := sanityStore.ListKeys(ctx)
+		if lerr != nil {
+			return false
+		}
+		for _, k := range keys {
+			c, rev, gerr := sanityStore.Get(ctx, k)
+			if gerr != nil || rev == 0 {
+				continue
+			}
+			if c.State != ClaimStateStable {
+				return false
+			}
+		}
+
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "claims must converge to stable after the stress window")
+}

--- a/internal/assignment/handoff/sweep_authority_test.go
+++ b/internal/assignment/handoff/sweep_authority_test.go
@@ -1,0 +1,2311 @@
+package handoff
+
+// Leader-gated ticker claim sweep (SweepAuthority + follower backstop).
+// Pins tmp/leader-gated-claim-sweep-design.md (v7) §4.1-4.9. Every test
+// here is deterministic: SweepTicks + a fake Config.Now replace the real
+// ticker, SweepObserver replaces polling for the ticker's own decisions,
+// and testHookAfterVouchSnapshot pins the vouch-to-seed race window.
+// No real tickers, no time.Sleep.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// --- authHarness: drives the ticker loop deterministically ---
+
+// sweepAuthEvent is one SweepObserver invocation captured by authHarness.
+// tick is a TEST-SIDE tag (never part of the production SweepObserver
+// signature — see recvTickEvent's doc for why it exists and how it is
+// assigned race-free).
+type sweepAuthEvent struct {
+	origin     sweepOrigin
+	authorized bool
+	admitted   bool
+	tick       uint64
+}
+
+// authHarness drives the coordinator's real ticker goroutine (via
+// coord.Start) deterministically: an injected SweepTicks channel replaces
+// time.NewTicker, and a fake clock is advanced by exactly one configured
+// interval per pushed tick (mirroring the real relationship between a
+// ticker firing and elapsed wall-clock time — needed because
+// maybeSweepClaims' OWN interval throttle would otherwise absorb
+// back-to-back ticks whose Now() never advances).
+//
+// The unbuffered ticks channel is a lockstep barrier FOR THE SENDER: a
+// pushTick call blocks until the ticker goroutine is ready to receive,
+// which only happens once it has looped back to its select statement —
+// i.e. after the PREVIOUS tick's entire case body, including any
+// SweepObserver call, has finished. This lets a test push a known
+// sequence of ticks without racing the goroutine's own progress.
+//
+// It does NOT, however, make it safe to non-blockingly check "no event
+// yet" immediately after pushing a tick that is ITSELF expected to admit
+// — pushTick only proves that tick's sampleAuthority() call has
+// happened (via the sampled handshake below), not that the rest of its
+// case body — maybeSweepClaims and any SweepObserver call — has
+// finished. A stale event from an EARLIER, incorrectly-admitting
+// off-cycle tick could therefore still be sitting in `events` when a
+// naive caller checks. recvTickEvent closes this gap by tagging every
+// event with the tick sequence number that produced it (see its doc);
+// skip ticks need no interleaved checks (the `continue` path never
+// reaches the observer, so there is nothing to race against for THEM
+// specifically), but the run's FINAL (admit) tick must always be
+// consumed via recvTickEvent, never a bare FIFO recv.
+type authHarness struct {
+	store *memStore
+	coord *twoPhaseCoordinator
+
+	mu         sync.Mutex
+	now        time.Time
+	live       map[string]struct{}
+	vouch      bool
+	authorized bool
+
+	interval     time.Duration
+	ticks        chan time.Time
+	events       chan sweepAuthEvent
+	nilAuthority bool
+	// sampled is signaled by sampleAuth every time the coordinator's
+	// sampleAuthority() calls it — i.e. once per tick, unconditionally,
+	// as the very first thing that tick's processing does — carrying
+	// the tick's own sequence number (see tickSeq). pushTick waits on it
+	// (when SweepAuthority is wired at all — see nilAuthority) so a
+	// push doesn't return until the JUST-PUSHED tick's authority read
+	// has actually happened. Without this, "the tick was received" (the
+	// ticks-channel rendezvous) is NOT sufficient proof that its
+	// sampleAuthority() call already happened — a test that mutates
+	// `authorized` immediately after a push (to set up the NEXT tick's
+	// expected value) can otherwise race the CURRENT (skip) tick's own
+	// read of it.
+	sampled chan uint64
+	// tickSeq is a coordinator-lifetime monotonic counter, incremented
+	// exactly once per real tick — INSIDE sampleAuth, which runs on the
+	// SUT's own ticker goroutine — so every read anywhere else in that
+	// SAME tick's processing (in particular, the SweepObserver closure,
+	// which always runs later in the same tick's body) is race-free
+	// same-goroutine sequential access, guarded by mu only because the
+	// TEST driver goroutine also reads it (via lastTick/pushTick).
+	// lastTick records the sequence number pushTick most recently
+	// learned about, i.e. the tag any immediately-following
+	// recvTickEvent call should expect.
+	tickSeq  uint64
+	lastTick uint64
+}
+
+type authHarnessOpts struct {
+	grace        time.Duration
+	interval     time.Duration
+	phaseSeed    uint64
+	nilAuthority bool
+	// store, when non-nil, is wired as cfg.Store instead of h.store
+	// directly — e.g. a probeMemStore or counting wrapper around
+	// baseStore (for scan-gate / call-count tests). It MUST wrap the
+	// same instance passed as baseStore.
+	store ClaimStore
+	// baseStore, when non-nil, becomes h.store (seed()/claimExists()'s
+	// target) — the same underlying map `store` wraps. Ignored when
+	// store is nil.
+	baseStore *memStore
+}
+
+func newAuthHarness(t *testing.T, opts authHarnessOpts) *authHarness {
+	t.Helper()
+	if opts.interval == 0 {
+		opts.interval = 30 * time.Second
+	}
+	base := opts.baseStore
+	if base == nil {
+		base = newMemStore()
+	}
+	h := &authHarness{
+		store:        base,
+		now:          time.Now().UTC(),
+		live:         map[string]struct{}{},
+		vouch:        true,
+		authorized:   true,
+		interval:     opts.interval,
+		ticks:        make(chan time.Time),
+		events:       make(chan sweepAuthEvent, 4096),
+		nilAuthority: opts.nilAuthority,
+		sampled:      make(chan uint64),
+	}
+	cfgStore := ClaimStore(h.store)
+	if opts.store != nil {
+		cfgStore = opts.store
+	}
+
+	cfg := Config{
+		Store: cfgStore,
+		Now: func() time.Time {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+
+			return h.now
+		},
+		LivePartitions: func(context.Context) (map[string]struct{}, bool) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			out := make(map[string]struct{}, len(h.live))
+			for k := range h.live {
+				out[k] = struct{}{}
+			}
+
+			return out, h.vouch
+		},
+		OrphanGrace:    opts.grace,
+		SweepInterval:  opts.interval,
+		SweepPhaseSeed: opts.phaseSeed,
+		SweepTicks:     h.ticks,
+		SweepObserver: func(origin sweepOrigin, authorized, admitted bool) {
+			// Runs on the SUT's ticker goroutine (for ticker-origin) or the
+			// caller's own goroutine (for Apply-origin, synchronous — see
+			// recvTickEvent's doc). Reading tickSeq here is race-free for
+			// the ticker-origin case specifically: sampleAuth (same
+			// goroutine, earlier in this same tick's body) is the only
+			// writer, and Go's memory model needs no extra synchronization
+			// for same-goroutine sequential reads/writes; mu is taken only
+			// because the harness's OWN driver goroutine also reads it.
+			h.mu.Lock()
+			seq := h.tickSeq
+			h.mu.Unlock()
+			h.events <- sweepAuthEvent{origin: origin, authorized: authorized, admitted: admitted, tick: seq}
+		},
+		MaxRetries:  1,
+		BaseBackoff: time.Millisecond,
+		MaxBackoff:  2 * time.Millisecond,
+	}
+	if !opts.nilAuthority {
+		cfg.SweepAuthority = h.sampleAuth
+	}
+
+	coord, ok := New(cfg, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	h.coord = coord
+	h.coord.Start(context.Background())
+
+	return h
+}
+
+func (h *authHarness) sampleAuth() bool {
+	h.mu.Lock()
+	authorized := h.authorized
+	h.tickSeq++
+	seq := h.tickSeq
+	h.mu.Unlock()
+	// Signal AFTER reading state (and bumping tickSeq), so a pushTick
+	// caller that then mutates `authorized` cannot possibly race THIS
+	// read (see the `sampled` field doc), and so the SweepObserver call
+	// later in THIS SAME tick's body (if reached) tags its event with
+	// the tickSeq value THIS call just assigned, never a value a
+	// subsequently-pushed tick bumped to first.
+	h.sampled <- seq
+
+	return authorized
+}
+
+func (h *authHarness) setAuthorized(v bool) {
+	h.mu.Lock()
+	h.authorized = v
+	h.mu.Unlock()
+}
+
+func (h *authHarness) setLive(pids ...string) {
+	h.mu.Lock()
+	h.live = make(map[string]struct{}, len(pids))
+	for _, p := range pids {
+		h.live[p] = struct{}{}
+	}
+	h.mu.Unlock()
+}
+
+func (h *authHarness) advance(d time.Duration) {
+	h.mu.Lock()
+	h.now = h.now.Add(d)
+	h.mu.Unlock()
+}
+
+func (h *authHarness) nowVal() time.Time {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.now
+}
+
+// gen reads the coordinator's current unvouchedGen under authMu (mirrors
+// fenceHarness.gen).
+func (h *authHarness) gen() uint64 {
+	h.coord.authMu.Lock()
+	defer h.coord.authMu.Unlock()
+
+	return h.coord.unvouchedGen
+}
+
+func (h *authHarness) seed(c Claim) {
+	h.store.mu.Lock()
+	h.store.data[c.PartitionID] = c
+	h.store.rev[c.PartitionID] = 1
+	h.store.mu.Unlock()
+}
+
+// pushTick advances the fake clock by one configured interval, then
+// sends on the ticks channel (see the type doc for the barrier
+// property this establishes).
+func (h *authHarness) pushTick() {
+	h.pushTickAdvance(h.interval)
+}
+
+// pushTickAdvance is pushTick with an explicit advance, used to model a
+// tick landing less than a full interval after some other event (e.g.
+// an Apply-origin sweep) consumed the shared throttle.
+//
+// It does not return until the pushed tick's sampleAuthority() call has
+// happened (see the `sampled` field doc) — so it is safe for the caller
+// to mutate authorized-state (setAuthorized, setLive, setVouch, advance)
+// immediately afterward without racing the tick it just pushed. It also
+// records that tick's sequence number in h.lastTick, which
+// recvTickEvent uses to reject a stale event instead of silently
+// accepting it. Skipped under nilAuthority, where SweepAuthority is
+// never wired at all (a nil-authority coordinator's sampleAuthority
+// short-circuits without calling it) — nilAuthority tests never call
+// recvTickEvent (see its doc), so an unset lastTick is harmless there.
+func (h *authHarness) pushTickAdvance(d time.Duration) {
+	h.advance(d)
+	select {
+	case h.ticks <- h.nowVal():
+	case <-time.After(5 * time.Second):
+		panic("authHarness.pushTick: ticker goroutine did not consume the tick")
+	}
+	if h.nilAuthority {
+		return
+	}
+	select {
+	case seq := <-h.sampled:
+		h.mu.Lock()
+		h.lastTick = seq
+		h.mu.Unlock()
+	case <-time.After(5 * time.Second):
+		panic("authHarness.pushTick: sampleAuthority was not called for the pushed tick")
+	}
+}
+
+// recvEvent blocks for the very next SweepObserver event, FIFO, with no
+// tick-index verification. Safe ONLY for Apply-origin events: Apply
+// calls maybeSweepClaims and the observer SYNCHRONOUSLY, in the calling
+// goroutine, so by the time Apply returns its event is already sitting
+// in `events` — there is no async window for a stale event to hide in.
+// Ticker-origin events MUST use recvTickEvent instead.
+func (h *authHarness) recvEvent(t *testing.T) sweepAuthEvent {
+	t.Helper()
+	select {
+	case ev := <-h.events:
+		return ev
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a SweepObserver event")
+
+		return sweepAuthEvent{}
+	}
+}
+
+// recvTickEvent blocks for the ticker-origin SweepObserver event tagged
+// with h.lastTick — the sequence number of the tick most recently
+// confirmed via pushTick/pushTickAdvance. This is the fix for review
+// finding P1-1 (codex-r1-postimpl.md): pushTick only proves that tick's
+// sampleAuthority() call has happened, not that its maybeSweepClaims +
+// SweepObserver call has finished, so a bare FIFO recv can silently
+// dequeue a STALE event queued by an earlier, incorrectly-admitting
+// off-cycle tick — masking exactly the bug these cadence tests exist to
+// catch (see the review's 5-step false-pass sequence). Any event whose
+// tag does not match the expected tick fails the test immediately
+// instead of being accepted as "the" event.
+//
+// Once the tick-tagged event for the LAST tick pushed so far has been
+// observed, that tick's entire case body (through the SweepObserver
+// call) is PROVEN complete — the observer call is the final action
+// before the ticker goroutine loops back to select — and, since no
+// further tick has been pushed, the goroutine is now guaranteed idle.
+// This is what makes an expectNoPendingEvent call immediately
+// afterward non-racy: nothing else could still be in flight.
+func (h *authHarness) recvTickEvent(t *testing.T) sweepAuthEvent {
+	t.Helper()
+	h.mu.Lock()
+	want := h.lastTick
+	h.mu.Unlock()
+	select {
+	case ev := <-h.events:
+		require.Equal(t, sweepOriginTicker, ev.origin, "expected a ticker-origin event")
+		require.Equal(t, want, ev.tick,
+			"observer event is tagged for tick %d, not the expected tick %d — an earlier off-cycle "+
+				"tick must have incorrectly admitted and left a STALE event queued (the exact false-pass "+
+				"mode this tagging exists to catch)", ev.tick, want)
+
+		return ev
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for tick %d's SweepObserver event", want)
+
+		return sweepAuthEvent{}
+	}
+}
+
+// pushTickThenRecv pushes one tick (a full h.interval advance) and
+// returns its tick-verified event — a convenience for tests that push
+// and immediately consume one tick at a time with no batching (so no
+// staleness window exists), used by the leader-cadence fault-matrix
+// rows where every tick is individually significant.
+func (h *authHarness) pushTickThenRecv(t *testing.T) sweepAuthEvent {
+	t.Helper()
+	h.pushTick()
+
+	return h.recvTickEvent(t)
+}
+
+// pushTickThenRecvAdvance is pushTickThenRecv with an explicit advance,
+// mirroring pushTickAdvance.
+func (h *authHarness) pushTickThenRecvAdvance(t *testing.T, d time.Duration) sweepAuthEvent {
+	t.Helper()
+	h.pushTickAdvance(d)
+
+	return h.recvTickEvent(t)
+}
+
+// maybeRecvTickEvent is recvTickEvent's tolerant counterpart, for tests
+// that cannot know in advance (round by round) whether the tick they
+// just pushed is a skip or an admit — unlike recvTickEvent, which always
+// requires an event, ok is false for a genuine off-cycle skip (no event
+// is ever sent for that tick — ticks channel provably silent, per
+// runSkipThenAdmit's doc). Any event that DOES arrive within the bounded
+// window is still tag-checked against h.lastTick, so a stale event from
+// an earlier tick fails the test immediately rather than being
+// misattributed to the current one.
+func (h *authHarness) maybeRecvTickEvent(t *testing.T) (sweepAuthEvent, bool) {
+	t.Helper()
+	h.mu.Lock()
+	want := h.lastTick
+	h.mu.Unlock()
+	select {
+	case ev := <-h.events:
+		require.Equal(t, sweepOriginTicker, ev.origin, "expected a ticker-origin event")
+		require.Equal(t, want, ev.tick,
+			"observer event is tagged for tick %d, not the expected tick %d", ev.tick, want)
+
+		return ev, true
+	case <-time.After(150 * time.Millisecond):
+		return sweepAuthEvent{}, false
+	}
+}
+
+func (h *authHarness) expectNoPendingEvent(t *testing.T) {
+	t.Helper()
+	select {
+	case ev := <-h.events:
+		t.Fatalf("unexpected SweepObserver event: %+v", ev)
+	default:
+	}
+}
+
+// runSkipThenAdmit pushes skipCount ticks expected to produce NO
+// SweepObserver event, followed by one tick expected to admit; returns
+// that tick's event. Skip ticks are pushed with NO interleaved checks
+// (they are provably silent — the off-cycle path `continue`s before ever
+// reaching the observer, so there is nothing to race against); only the
+// final (admit) tick is consumed, via recvTickEvent (which rejects a
+// STALE event tagged for an earlier tick instead of silently accepting
+// it — see its doc), followed by one drain check confirming no other
+// event arrived across the whole run — so an unexpected admission
+// anywhere in the skip run either fails immediately (recvTickEvent's tag
+// mismatch, if it races ahead of the real final event) or fails via the
+// drain check (if it trails behind), even though this helper cannot name
+// which skip tick misbehaved.
+func (h *authHarness) runSkipThenAdmit(t *testing.T, skipCount int) sweepAuthEvent {
+	t.Helper()
+	for range skipCount {
+		h.pushTick()
+	}
+	h.pushTick() // the admit tick
+	ev := h.recvTickEvent(t)
+	h.expectNoPendingEvent(t)
+
+	return ev
+}
+
+// --- fenceHarness: drives sweep internals directly, synchronously ---
+
+// fenceHarness exercises the generation-fence protocol (§2.2a) and the
+// per-pass reap decision via direct, synchronous calls into the
+// coordinator's unexported methods — appropriate here because these
+// tests pin exact interleavings between a "sample" (sampleAuthority) and
+// a "pass" (a full sweep reaching maybeReapOrphan) that driving the real
+// ticker goroutine would make nondeterministic to orchestrate. In-package
+// tests calling unexported methods directly is the established pattern
+// (see reapHarness in orphan_reap_test.go, sweepGateHarness in
+// sweep_gate_test.go).
+type fenceHarness struct {
+	store *memStore
+	coord *twoPhaseCoordinator
+
+	mu         sync.Mutex
+	now        time.Time
+	live       map[string]struct{}
+	vouch      bool
+	authorized bool
+	authFn     func() bool
+}
+
+func newFenceHarness(t *testing.T, grace time.Duration) *fenceHarness {
+	t.Helper()
+
+	return newFenceHarnessCfg(t, grace, false)
+}
+
+// newFenceHarnessNilAuthority builds a harness with Config.SweepAuthority
+// left nil — the exact I1 contract under test, distinct from a harness
+// whose SweepAuthority happens to always return true.
+func newFenceHarnessNilAuthority(t *testing.T, grace time.Duration) *fenceHarness {
+	t.Helper()
+
+	return newFenceHarnessCfg(t, grace, true)
+}
+
+func newFenceHarnessCfg(t *testing.T, grace time.Duration, nilAuthority bool) *fenceHarness {
+	t.Helper()
+	h := &fenceHarness{
+		store:      newMemStore(),
+		now:        time.Now().UTC(),
+		live:       map[string]struct{}{},
+		vouch:      true,
+		authorized: true,
+	}
+	cfg := Config{
+		Store: h.store,
+		Now: func() time.Time {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+
+			return h.now
+		},
+		LivePartitions: func(context.Context) (map[string]struct{}, bool) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			out := make(map[string]struct{}, len(h.live))
+			for k := range h.live {
+				out[k] = struct{}{}
+			}
+
+			return out, h.vouch
+		},
+		OrphanGrace:   grace,
+		SweepInterval: -1, // sweep on every Apply call; the tests drive passes directly
+		MaxRetries:    1,
+		BaseBackoff:   time.Millisecond,
+		MaxBackoff:    2 * time.Millisecond,
+	}
+	if !nilAuthority {
+		cfg.SweepAuthority = h.sampleAuth
+	}
+	coord, ok := New(cfg, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	h.coord = coord
+
+	return h
+}
+
+func (h *fenceHarness) sampleAuth() bool {
+	h.mu.Lock()
+	fn := h.authFn
+	authorized := h.authorized
+	h.mu.Unlock()
+	if fn != nil {
+		return fn()
+	}
+
+	return authorized
+}
+
+func (h *fenceHarness) setAuthorized(v bool) {
+	h.mu.Lock()
+	h.authorized = v
+	h.mu.Unlock()
+}
+
+func (h *fenceHarness) setAuthFn(f func() bool) {
+	h.mu.Lock()
+	h.authFn = f
+	h.mu.Unlock()
+}
+
+// test's claim is absent from the live set), but the variadic mirrors
+// reapHarness.setLive's general API for whichever future test needs a
+// live pid.
+//
+//nolint:unparam // pids is nil at every current call site (every fence
+func (h *fenceHarness) setLive(pids ...string) {
+	h.mu.Lock()
+	h.live = make(map[string]struct{}, len(pids))
+	for _, p := range pids {
+		h.live[p] = struct{}{}
+	}
+	h.mu.Unlock()
+}
+
+func (h *fenceHarness) setVouch(v bool) {
+	h.mu.Lock()
+	h.vouch = v
+	h.mu.Unlock()
+}
+
+func (h *fenceHarness) advance(d time.Duration) {
+	h.mu.Lock()
+	h.now = h.now.Add(d)
+	h.mu.Unlock()
+}
+
+func (h *fenceHarness) seed(c Claim) {
+	h.store.mu.Lock()
+	h.store.data[c.PartitionID] = c
+	h.store.rev[c.PartitionID] = 1
+	h.store.mu.Unlock()
+}
+
+// parameterized to match reapHarness.claimExists's API.
+func (h *fenceHarness) claimExists(t *testing.T, pid string) bool {
+	t.Helper()
+	_, rev, err := h.store.Get(context.Background(), pid)
+	require.NoError(t, err)
+
+	return rev != 0
+}
+
+// pass drives one full sweep pass synchronously via Apply (sweepOriginApply
+// -> ungated, always the full body; never samples SweepAuthority).
+func (h *fenceHarness) pass(t *testing.T) {
+	t.Helper()
+	require.NoError(t, h.coord.Apply(context.Background(), "worker-1", types.Assignment{}, types.Assignment{}))
+}
+
+// swapStore replaces the coordinator's store mid-test.
+func (h *fenceHarness) swapStore(s ClaimStore) {
+	h.coord.cfg.Store = s
+}
+
+// gen reads the coordinator's current unvouchedGen under authMu.
+func (h *fenceHarness) gen() uint64 {
+	h.coord.authMu.Lock()
+	defer h.coord.authMu.Unlock()
+
+	return h.coord.unvouchedGen
+}
+
+// clockOf reads the absence-clock entry for pid, if any.
+//
+// parameterized for symmetry with claimExists and seed.
+//
+//nolint:unparam // pid is "p-gone" at every current call site; kept
+func (h *fenceHarness) clockOf(pid string) (orphanClock, bool) {
+	c, ok := h.coord.orphanAbsentSince[pid]
+
+	return c, ok
+}
+
+// ambiguousDeleteStore always returns an ambiguous (non-definitive) error
+// from Delete — modeling a client-observed timeout whose already-sent
+// request the server may or may not still apply — without ever mutating
+// the underlying store.
+type ambiguousDeleteStore struct {
+	ClaimStore
+}
+
+func (s *ambiguousDeleteStore) Delete(context.Context, string, uint64) error {
+	return context.DeadlineExceeded
+}
+
+// --- §4.1: nil-authority regression + the universal reap-arm deltas ---
+
+func TestSweepAuthority_NilAuthorityCadenceRegression(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{nilAuthority: true})
+	for range 5 {
+		h.pushTick()
+		ev := h.recvEvent(t)
+		require.Equal(t, sweepOriginTicker, ev.origin)
+		require.True(t, ev.authorized, "nil SweepAuthority must report authorized=true (fail-open default)")
+		require.True(t, ev.admitted, "nil SweepAuthority must admit every tick — today's full cadence")
+	}
+}
+
+func TestSweepAuthority_ConstantTrueMatchesNilCadence(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{})
+	h.setAuthorized(true)
+	for range 5 {
+		h.pushTick()
+		ev := h.recvTickEvent(t)
+		require.Equal(t, sweepOriginTicker, ev.origin)
+		require.True(t, ev.authorized)
+		require.True(t, ev.admitted)
+	}
+}
+
+// TestSweepAuthority_I1_ClockSeedsFromVouchSnapshotNotPassStart pins §4.1(a):
+// under nil authority, a new absence clock's timestamp equals the pass's
+// vouch snapshot time (resolveLiveSet, read AFTER ListKeys + the per-key
+// Get storm), not maybeSweepClaims' pass-start now (read before any of
+// that work). A Now() that returns a strictly later reading on each
+// successive call distinguishes the two call sites.
+func TestSweepAuthority_I1_ClockSeedsFromVouchSnapshotNotPassStart(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarnessNilAuthority(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive() // absent from the vouched set
+
+	base := h.now
+	var calls int
+	h.coord.cfg.Now = func() time.Time {
+		calls++
+
+		return base.Add(time.Duration(calls) * time.Second)
+	}
+
+	h.pass(t)
+
+	clock, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	require.Equal(t, base.Add(2*time.Second), clock.since,
+		"the absence clock must seed from the vouch snapshot (the SECOND Now() reading: pass-start is the first)")
+	require.NotEqual(t, base.Add(1*time.Second), clock.since,
+		"the absence clock must not seed from pass-start now (the FIRST Now() reading)")
+}
+
+// TestSweepAuthority_I1_AmbiguousDeleteSelfPoisonsUnderNilAuthority pins
+// §4.1(b): under nil authority, a reap delete against a stalled store
+// returns an ambiguous outcome, keeps the claim and clock, AND
+// self-poisons the generation. The discard branch — reached only via
+// this flow, since liveOK never goes false in this scenario — fires on
+// the next grace-eligible vouched pass; a later vouched pass reseeds
+// fresh; a reap fires only after a full fresh grace from that seed.
+func TestSweepAuthority_I1_AmbiguousDeleteSelfPoisonsUnderNilAuthority(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarnessNilAuthority(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive() // absent
+
+	h.pass(t) // seeds the clock at the current generation
+	before := h.gen()
+
+	h.swapStore(&ambiguousDeleteStore{ClaimStore: h.store})
+	h.advance(orphanTestGrace + time.Second)
+	h.pass(t) // grace elapsed: reaches the fence, attempts delete, ambiguous outcome
+
+	require.True(t, h.claimExists(t, "p-gone"), "an ambiguous delete outcome must keep the claim")
+	clock, ok := h.clockOf("p-gone")
+	require.True(t, ok, "an ambiguous delete outcome must keep the clock")
+	require.Equal(t, before, clock.gen, "the retained clock still carries its ORIGINAL generation")
+	require.Greater(t, h.gen(), before,
+		"an ambiguous delete outcome must self-poison the generation, even under nil SweepAuthority")
+
+	// The NEXT grace-eligible vouched pass sees the generation mismatch
+	// and discards — no reap, no reseed within that same pass.
+	h.swapStore(h.store)
+	h.pass(t)
+	require.True(t, h.claimExists(t, "p-gone"), "a discarded (stale-generation) clock must not reap")
+	_, ok = h.clockOf("p-gone")
+	require.False(t, ok, "a fence mismatch must remove the clock")
+
+	// A later freshly vouched pass seeds a new clock at the current generation.
+	h.pass(t)
+	clock2, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	require.Equal(t, h.gen(), clock2.gen)
+
+	// A reap fires only after a FULL fresh grace from that fresh seed.
+	h.advance(orphanTestGrace - time.Second)
+	h.pass(t)
+	require.True(t, h.claimExists(t, "p-gone"), "must not reap before a full fresh grace from the fresh seed")
+
+	h.advance(2 * time.Second)
+	h.pass(t)
+	require.False(t, h.claimExists(t, "p-gone"), "must reap once a full fresh grace has elapsed from the fresh seed")
+}
+
+// TestSweepAuthority_I1_UnvouchedPassClearsClocksAndAdvancesGeneration
+// pins §4.1(c): an in-pass liveOK=false still clears every clock
+// (today's behavior, unweakened) and now also advances the generation.
+// In a nil-authority flow with NO ambiguous delete, the discard path is
+// never reached (there is nothing left to discard — the wholesale clear
+// already removed it), so a normal grace-based reap still succeeds.
+func TestSweepAuthority_I1_UnvouchedPassClearsClocksAndAdvancesGeneration(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarnessNilAuthority(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive()
+
+	h.pass(t) // vouched: seeds a clock
+	_, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	genBefore := h.gen()
+
+	h.setVouch(false)
+	h.pass(t) // in-pass liveOK=false
+
+	_, ok = h.clockOf("p-gone")
+	require.False(t, ok, "an unvouched pass must clear every absence clock")
+	require.Greater(t, h.gen(), genBefore, "an unvouched vouch attempt must advance the generation")
+
+	h.setVouch(true)
+	h.pass(t) // reseeds at the current generation
+	clock, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	require.Equal(t, h.gen(), clock.gen)
+
+	h.advance(orphanTestGrace + time.Second)
+	h.pass(t)
+	require.False(t, h.claimExists(t, "p-gone"),
+		"a normal grace-based reap must succeed when the only generation-advancing cause is "+
+			"liveOK=false, never an ambiguous delete")
+}
+
+// --- §4.2: cadence table + flap storm ---
+
+// TestSweepAuthority_BackstopCadence_PhaseTable pins §4.2: under
+// authority=false, admitted passes occur ONLY on backstop ticks — the
+// smallest tick >= 1 satisfying (tick+phase) % backstopEvery == 0 — for
+// every phase value at the default interval's backstopEvery=10.
+func TestSweepAuthority_BackstopCadence_PhaseTable(t *testing.T) {
+	t.Parallel()
+
+	for phase := uint64(0); phase < 10; phase++ {
+		t.Run(fmt.Sprintf("phase=%d", phase), func(t *testing.T) {
+			t.Parallel()
+
+			h := newAuthHarness(t, authHarnessOpts{phaseSeed: phase})
+			h.setAuthorized(false)
+
+			firstAdmitTick := (10 - phase) % 10
+			if firstAdmitTick == 0 {
+				firstAdmitTick = 10
+			}
+			ev := h.runSkipThenAdmit(t, int(firstAdmitTick)-1)
+			require.Equal(t, sweepOriginTicker, ev.origin)
+			require.False(t, ev.authorized)
+			require.True(t, ev.admitted)
+		})
+	}
+}
+
+// TestSweepAuthority_FlapStorm_PreservesAbsoluteTickIndices pins §4.2:
+// cadence follows the probed authority value tick-by-tick, AND the
+// absolute backstop tick indices survive an authority flap storm
+// unchanged (the tick counter is coordinator-lifetime monotonic, never
+// reset on a transition).
+func TestSweepAuthority_FlapStorm_PreservesAbsoluteTickIndices(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{phaseSeed: 0}) // backstopEvery=10, phase=0
+	h.setAuthorized(true)
+
+	// Ticks 1..9: authorized, every tick admits.
+	for range 9 {
+		h.pushTick()
+		ev := h.recvTickEvent(t)
+		require.True(t, ev.authorized)
+		require.True(t, ev.admitted)
+	}
+
+	// Flap to unauthorized right at the phase-0 backstop boundary.
+	h.setAuthorized(false)
+	h.pushTick() // tick 10: due backstop tick — admitted despite the flap
+	ev := h.recvTickEvent(t)
+	require.False(t, ev.authorized)
+	require.True(t, ev.admitted)
+
+	// Ticks 11..19 (9 off-cycle skips): the counter must not reset across
+	// the flap, so these stay off-cycle exactly as without any flap —
+	// pushed with no interleaved checks (skip ticks are provably silent;
+	// see runSkipThenAdmit's doc for why checking in between would race).
+	for range 9 {
+		h.pushTick()
+	}
+
+	// Flap back to authorized right after: tick 20 must be the very next
+	// admitted tick. The drain check below fails if any of ticks 11..19
+	// had wrongly leaked an event too (two events queued instead of one).
+	h.setAuthorized(true)
+	h.pushTick() // tick 20
+	ev = h.recvTickEvent(t)
+	require.True(t, ev.authorized, "no stray admission before tick 20")
+	require.True(t, ev.admitted)
+	h.expectNoPendingEvent(t)
+}
+
+// --- §4.3: backstop passes engage the scan gate ---
+
+// TestSweepAuthority_BackstopPassesEngageScanGate pins §4.3: a backstop
+// pass runs the identical maybeSweepClaims body a leader's tick does —
+// scan-gated when the store can probe its position. The first backstop
+// pass (nothing latched yet) is full; a second admitted backstop pass
+// against an unchanged position is cached (no additional ListKeys).
+func TestSweepAuthority_BackstopPassesEngageScanGate(t *testing.T) {
+	t.Parallel()
+
+	base := newMemStore()
+	store := &probeMemStore{memStore: base, pos: natsutil.KVStreamPos{Created: time.Unix(1000, 0), LastSeq: 1}}
+
+	h := newAuthHarness(t, authHarnessOpts{store: store, baseStore: base})
+	h.coord.sweepConfirmGap = time.Nanosecond // must not block this deterministic test
+	c := NewInitialClaim("p1", "worker-1", h.nowVal(), time.Minute)
+	_, err := store.PutIfEpoch(context.Background(), "p1", 0, c)
+	require.NoError(t, err)
+	h.setAuthorized(false)
+
+	ev := h.runSkipThenAdmit(t, 9) // tick 10: first backstop, nothing latched -> full
+	require.True(t, ev.admitted)
+	require.EqualValues(t, 1, store.listCalls.Load())
+
+	ev = h.runSkipThenAdmit(t, 9) // tick 20: position unchanged -> cached
+	require.True(t, ev.admitted)
+	require.EqualValues(t, 1, store.listCalls.Load(),
+		"an unchanged position must engage the gate on a backstop pass too")
+}
+
+// TestSweepAuthority_BackstopPassFailsOpenOnProbeError pins §4.3: a
+// probe error inside an admitted backstop pass fails open to a full
+// pass, exactly as a leader's gated tick does.
+func TestSweepAuthority_BackstopPassFailsOpenOnProbeError(t *testing.T) {
+	t.Parallel()
+
+	base := newMemStore()
+	store := &probeMemStore{
+		memStore: base,
+		pos:      natsutil.KVStreamPos{Created: time.Unix(1000, 0), LastSeq: 1},
+		probeErr: context.DeadlineExceeded,
+	}
+
+	h := newAuthHarness(t, authHarnessOpts{store: store, baseStore: base})
+	h.coord.sweepConfirmGap = time.Nanosecond
+	c := NewInitialClaim("p1", "worker-1", h.nowVal(), time.Minute)
+	_, err := store.PutIfEpoch(context.Background(), "p1", 0, c)
+	require.NoError(t, err)
+	h.setAuthorized(false)
+
+	ev := h.runSkipThenAdmit(t, 9) // tick 10
+	require.True(t, ev.admitted)
+	require.EqualValues(t, 1, store.listCalls.Load())
+
+	ev = h.runSkipThenAdmit(t, 9) // tick 20: probe still failing -> full again
+	require.True(t, ev.admitted)
+	require.EqualValues(t, 2, store.listCalls.Load(),
+		"a probe error on a backstop pass must fail open to a full pass")
+}
+
+// TestSweepAuthority_NoProberStoreRunsFullPassesAtBackstopCadenceOnly
+// pins §4.3: a store without the prober capability, under
+// authority=false, runs full passes at backstop cadence only — never
+// every tick (that would be the pre-gate behavior), never zero (the
+// backstop cadence must keep firing).
+func TestSweepAuthority_NoProberStoreRunsFullPassesAtBackstopCadenceOnly(t *testing.T) {
+	t.Parallel()
+
+	base := newMemStore()
+	c := NewInitialClaim("p1", "worker-1", time.Now().UTC(), time.Minute)
+	_, err := base.PutIfEpoch(context.Background(), "p1", 0, c)
+	require.NoError(t, err)
+	var lists atomic.Int32
+	counting := &countingListStore{ClaimStore: base, lists: &lists}
+
+	h := newAuthHarness(t, authHarnessOpts{store: counting, baseStore: base})
+	h.setAuthorized(false)
+
+	ev := h.runSkipThenAdmit(t, 9) // tick 10: first backstop
+	require.True(t, ev.admitted)
+	require.EqualValues(t, 1, lists.Load(), "never every tick — only at the backstop tick")
+
+	ev = h.runSkipThenAdmit(t, 9) // tick 20: second backstop
+	require.True(t, ev.admitted)
+	require.EqualValues(t, 2, lists.Load(), "never zero — the backstop cadence keeps firing")
+}
+
+// --- §4.4: generation fence (all interleavings) ---
+
+// TestSweepAuthority_Fence_BasicSequencing pins §4.4(a): seed as leader;
+// one false sample; regain; the next vouched pass whose grace has
+// elapsed sees the generation mismatch and DISCARDS — no reap AND no
+// reseed within that same pass; the clock is then absent; a SUBSEQUENT
+// freshly vouched pass seeds a new clock from its own snapshot; a reap
+// may fire only after a full grace from that fresh seed. Three distinct
+// observations, asserted separately.
+func TestSweepAuthority_Fence_BasicSequencing(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive() // absent
+	h.setAuthorized(true)
+
+	h.pass(t) // leader, vouched: seeds the clock at the current generation
+	genAtSeed := h.gen()
+	require.Zero(t, genAtSeed)
+
+	// Grace elapses while still (nominally) leader.
+	h.advance(orphanTestGrace + time.Second)
+
+	// One false sample (only the ticker samples in production; a direct
+	// call here is the deterministic equivalent).
+	h.setAuthorized(false)
+	require.False(t, h.coord.sampleAuthority())
+	require.Greater(t, h.gen(), genAtSeed)
+
+	// Regain.
+	h.setAuthorized(true)
+
+	// Observation 1: the next vouched pass DISCARDS — no reap, no reseed.
+	h.pass(t)
+	require.True(t, h.claimExists(t, "p-gone"), "a discarded clock must not reap")
+
+	// Observation 2: the clock is absent afterward.
+	_, ok := h.clockOf("p-gone")
+	require.False(t, ok, "a fence mismatch must remove the clock, not re-seed it")
+
+	// Observation 3: a SUBSEQUENT freshly vouched pass seeds a new clock,
+	// and a reap fires only after a full grace measured from it.
+	h.pass(t)
+	clock, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	require.Equal(t, h.gen(), clock.gen)
+
+	h.advance(orphanTestGrace - time.Second)
+	h.pass(t)
+	require.True(t, h.claimExists(t, "p-gone"), "must not reap before a full fresh grace")
+
+	h.advance(2 * time.Second)
+	h.pass(t)
+	require.False(t, h.claimExists(t, "p-gone"), "must reap once the fresh grace has fully elapsed")
+}
+
+// TestSweepAuthority_Fence_SamplePauseRace pins §4.4(b): a SweepAuthority
+// callback that parks INSIDE the sample (holding authMu) while a
+// grace-expired reaper reaches its fence must block the reaper until the
+// sample returns false and records; the fence must then see the
+// mismatch and discard.
+//
+// Per review finding P1-2 (codex-r1-postimpl.md), the original version
+// launched the reaper and immediately released the parked sample without
+// ever proving the reaper had reached AND BLOCKED — a broken
+// implementation that schedules the reaper only after generation
+// recording (i.e. one that races the fence in the WRONG order) could
+// still have passed. A bounded non-completion check — the same
+// goroutine-blocked idiom TestSweep_SingleFlight uses
+// (orphan_reap_test.go) — now proves that. Note this proves blocking on
+// authMu generally, not specifically inside maybeReapOrphan's own
+// Lock(): resolveLiveSet's vouch snapshot (earlier in the SAME pass)
+// ALSO takes authMu, so with the sample parked for the whole callback,
+// the pass is provably stuck on authMu well before it could ever reach
+// the reap fence — an equally valid proof of "reached and blocked",
+// since both acquisitions are the identical sweepMu->authMu ordering
+// the review's lock-ordering claim is about. (A hook placed
+// specifically at the reap fence's own Lock() call was tried and
+// rejected: it is UNREACHABLE in this exact interleaving, since
+// resolveLiveSet's own authMu use blocks first — attempting to wait for
+// it deadlocks.)
+func TestSweepAuthority_Fence_SamplePauseRace(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive()
+	h.setAuthorized(true)
+
+	h.pass(t) // seeds the clock at the current generation
+	genAtSeed := h.gen()
+	h.advance(orphanTestGrace + time.Second) // grace elapsed
+
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	h.setAuthFn(func() bool {
+		close(parked)
+		<-release
+
+		return false
+	})
+
+	sampleDone := make(chan struct{})
+	go func() {
+		h.coord.sampleAuthority()
+		close(sampleDone)
+	}()
+	<-parked // the sample now holds authMu, parked inside the callback
+
+	reapDone := make(chan struct{})
+	go func() {
+		h.pass(t) // must block on authMu until the sample releases
+		close(reapDone)
+	}()
+
+	// Prove the reap pass actually BLOCKS on authMu instead of racing
+	// through: the sample is still holding it, so the pass must not
+	// complete within a bounded window.
+	select {
+	case <-reapDone:
+		t.Fatal("the reap pass completed before the parked sample released authMu — it was not reached and blocked")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release) // the sample returns false, records, releases authMu
+	<-sampleDone
+	<-reapDone
+
+	require.Greater(t, h.gen(), genAtSeed, "the parked sample must have recorded")
+	require.True(t, h.claimExists(t, "p-gone"), "the fenced reap must discard, not reap, on the mismatch")
+	_, ok := h.clockOf("p-gone")
+	require.False(t, ok)
+}
+
+// parkingDeleteStore blocks its Delete call until released, then
+// delegates to the wrapped store's Delete (a definitive outcome).
+type parkingDeleteStore struct {
+	ClaimStore
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *parkingDeleteStore) Delete(ctx context.Context, pid string, rev uint64) error {
+	close(s.entered)
+	<-s.release
+
+	return s.ClaimStore.Delete(ctx, pid, rev)
+}
+
+// TestSweepAuthority_Fence_InverseOrdering pins §4.4(c): the fence's
+// generation comparison passes and the delete is in flight when a false
+// sample arrives — the sample blocks on authMu until the delete returns;
+// the claim is gone; the sample records AFTERWARD (allowed by I3's
+// linearization point).
+//
+// Per review finding P1-2, the original version released the delete
+// immediately after starting the sample, without ever asserting the
+// sample actually remained blocked while the delete was in flight — an
+// unfenced sample could have completed during the delete and still
+// satisfied the final assertions. A bounded non-completion check (the
+// established goroutine-blocked idiom in this package — see
+// TestSweep_SingleFlight, orphan_reap_test.go) now proves that.
+func TestSweepAuthority_Fence_InverseOrdering(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive()
+	h.setAuthorized(true)
+
+	h.pass(t) // seeds the clock at the current generation
+	genAtSeed := h.gen()
+	h.advance(orphanTestGrace + time.Second)
+
+	parking := &parkingDeleteStore{ClaimStore: h.store, entered: make(chan struct{}), release: make(chan struct{})}
+	h.swapStore(parking)
+
+	reapDone := make(chan struct{})
+	go func() {
+		h.pass(t) // reaches the fence (gen matches), Delete parks
+		close(reapDone)
+	}()
+	<-parking.entered // Delete is in flight, authMu held
+
+	h.setAuthorized(false)
+	sampleDone := make(chan struct{})
+	go func() {
+		h.coord.sampleAuthority() // must block on authMu until Delete returns
+		close(sampleDone)
+	}()
+
+	// The sample must remain blocked WHILE the delete is still in
+	// flight, not race ahead of it.
+	select {
+	case <-sampleDone:
+		t.Fatal("sampleAuthority returned before the in-flight delete released authMu")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(parking.release) // Delete returns nil: definitive apply
+	<-reapDone
+	<-sampleDone
+
+	require.False(t, h.claimExists(t, "p-gone"), "the definitive delete must apply")
+	require.Greater(t, h.gen(), genAtSeed, "the false sample records AFTER the delete's linearization point")
+}
+
+// TestSweepAuthority_Fence_VouchToSeedBarrier_FullPass pins §4.4(d) for
+// the full-pass body: a false sample recorded in the gap between the
+// vouch snapshot and the first claim decision produces a clock whose gen
+// is already stale — the fence must discard it.
+func TestSweepAuthority_Fence_VouchToSeedBarrier_FullPass(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive() // absent: this pass will seed a fresh clock
+	h.setAuthorized(true)
+
+	hookEntered := make(chan struct{})
+	hookRelease := make(chan struct{})
+	h.coord.testHookAfterVouchSnapshot = func() {
+		close(hookEntered)
+		<-hookRelease
+	}
+
+	passDone := make(chan struct{})
+	go func() {
+		h.pass(t) // full pass (nothing cached yet)
+		close(passDone)
+	}()
+	<-hookEntered // vouch snapshot taken; parked before the first claim decision
+
+	genAtSnapshot := h.gen()
+	h.setAuthorized(false)
+	require.False(t, h.coord.sampleAuthority()) // records a false sample IN THE GAP
+	require.Greater(t, h.gen(), genAtSnapshot)
+
+	close(hookRelease)
+	<-passDone
+	h.coord.testHookAfterVouchSnapshot = nil
+
+	clock, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	require.Equal(t, genAtSnapshot, clock.gen, "the clock carries the STALE pre-race generation")
+	require.NotEqual(t, h.gen(), clock.gen)
+
+	// The fence must discard it at reap time.
+	h.setAuthorized(true)
+	h.advance(orphanTestGrace + time.Second)
+	h.pass(t)
+	require.True(t, h.claimExists(t, "p-gone"), "a stale-generation clock must discard, not reap")
+	_, ok = h.clockOf("p-gone")
+	require.False(t, ok)
+}
+
+// TestSweepAuthority_Fence_VouchToSeedBarrier_CachedPass pins §4.4(d) for
+// the cached-pass body — the identical race, but the pass being raced is
+// a gated (cached) pass, proven by zero additional ListKeys calls across
+// it.
+func TestSweepAuthority_Fence_VouchToSeedBarrier_CachedPass(t *testing.T) {
+	t.Parallel()
+
+	base := newMemStore()
+	store := &probeMemStore{memStore: base, pos: natsutil.KVStreamPos{Created: time.Unix(1000, 0), LastSeq: 1}}
+
+	var (
+		mu         sync.Mutex
+		now        = time.Now().UTC()
+		live       = map[string]struct{}{}
+		vouch      = true
+		authorized atomic.Bool
+	)
+	authorized.Store(true)
+
+	coord, ok := New(Config{
+		Store: store,
+		Now: func() time.Time {
+			mu.Lock()
+			defer mu.Unlock()
+
+			return now
+		},
+		LivePartitions: func(context.Context) (map[string]struct{}, bool) {
+			mu.Lock()
+			defer mu.Unlock()
+			out := make(map[string]struct{}, len(live))
+			for k := range live {
+				out[k] = struct{}{}
+			}
+
+			return out, vouch
+		},
+		SweepAuthority: authorized.Load,
+		OrphanGrace:    orphanTestGrace,
+		SweepInterval:  -1,
+		MaxRetries:     1,
+		BaseBackoff:    time.Millisecond,
+		MaxBackoff:     2 * time.Millisecond,
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	coord.sweepConfirmGap = time.Nanosecond
+
+	c1 := NewInitialClaim("p-live", "worker-1", now, time.Minute)
+	_, err := store.PutIfEpoch(context.Background(), "p-live", 0, c1)
+	require.NoError(t, err)
+	c2 := NewInitialClaim("p-gone", "worker-1", now, time.Minute)
+	_, err = store.PutIfEpoch(context.Background(), "p-gone", 0, c2)
+	require.NoError(t, err)
+
+	mu.Lock()
+	live = map[string]struct{}{"p-live": {}, "p-gone": {}}
+	mu.Unlock()
+
+	require.True(t, coord.maybeSweepClaims(context.Background(), sweepOriginTicker)) // full pass: latches both
+	require.EqualValues(t, 1, store.listCalls.Load())
+
+	// p-gone drops out of the live set: no bucket write, so the position
+	// is unchanged and the gate stays cached for the next pass.
+	mu.Lock()
+	live = map[string]struct{}{"p-live": {}}
+	mu.Unlock()
+
+	hookEntered := make(chan struct{})
+	hookRelease := make(chan struct{})
+	coord.testHookAfterVouchSnapshot = func() {
+		close(hookEntered)
+		<-hookRelease
+	}
+
+	passDone := make(chan struct{})
+	go func() {
+		admitted := coord.maybeSweepClaims(context.Background(), sweepOriginTicker) // cached pass
+		require.True(t, admitted)
+		close(passDone)
+	}()
+	<-hookEntered
+
+	coord.authMu.Lock()
+	genAtSnapshot := coord.unvouchedGen
+	coord.authMu.Unlock()
+
+	authorized.Store(false)
+	require.False(t, coord.sampleAuthority()) // records a false sample IN THE GAP
+
+	close(hookRelease)
+	<-passDone
+	coord.testHookAfterVouchSnapshot = nil
+	require.EqualValues(t, 1, store.listCalls.Load(), "the raced pass must have been CACHED, not full")
+
+	clock, ok := coord.orphanAbsentSince["p-gone"]
+	require.True(t, ok)
+	require.Equal(t, genAtSnapshot, clock.gen)
+
+	coord.authMu.Lock()
+	currentGen := coord.unvouchedGen
+	coord.authMu.Unlock()
+	require.NotEqual(t, currentGen, clock.gen)
+
+	// The fence must discard it at reap time.
+	authorized.Store(true)
+	mu.Lock()
+	now = now.Add(orphanTestGrace + time.Second)
+	mu.Unlock()
+	require.True(t, coord.maybeSweepClaims(context.Background(), sweepOriginTicker))
+
+	_, rev, err := store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "a stale-generation clock must discard, not reap")
+	_, ok = coord.orphanAbsentSince["p-gone"]
+	require.False(t, ok)
+}
+
+// TestSweepAuthority_Fence_MismatchDiscard pins §4.4(e) in isolation: on
+// a fence mismatch the clock is REMOVED (not left in place, not
+// re-seeded) — asserted as three separate facts: absent immediately
+// after, absent until a later freshly vouched pass, and that later pass
+// seeds from ITS OWN snapshot (never a re-seed from pass-start now).
+func TestSweepAuthority_Fence_MismatchDiscard(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive()
+
+	h.pass(t) // seed at the current generation
+	h.advance(orphanTestGrace + time.Second)
+
+	h.setAuthorized(false)
+	require.False(t, h.coord.sampleAuthority()) // bump the generation past the seed
+
+	h.setAuthorized(true)
+	h.pass(t) // fence mismatch: discard
+	_, ok := h.clockOf("p-gone")
+	require.False(t, ok, "removed immediately")
+
+	h.pass(t) // still absent, no time advanced: seeds fresh at the CURRENT generation
+	clock, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+	require.Equal(t, h.gen(), clock.gen)
+	require.True(t, h.claimExists(t, "p-gone"), "the fresh seed must not itself reap")
+}
+
+// TestSweepAuthority_Fence_InPassUnvouchedClearsClocks pins §4.4(f): an
+// unvouched ADMITTED pass clears every absence clock — resolveLiveSet's
+// existing contract, unweakened by the fence (cross-referenced from
+// TestOrphanReap_UnvouchedGapResetsExistingClock and
+// TestSweepAuthority_I1_UnvouchedPassClearsClocksAndAdvancesGeneration,
+// which additionally pins the generation bump).
+func TestSweepAuthority_Fence_InPassUnvouchedClearsClocks(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive()
+
+	h.pass(t)
+	_, ok := h.clockOf("p-gone")
+	require.True(t, ok)
+
+	h.setVouch(false)
+	h.pass(t)
+	_, ok = h.clockOf("p-gone")
+	require.False(t, ok, "an unvouched admitted pass must clear every absence clock")
+}
+
+// TestSweepAuthority_Fence_LockOrdering pins §4.4(g): the reap path
+// acquires sweepMu -> authMu only; sampleAuthority never touches
+// sweepMu. Heavy concurrent contention between full sweep passes (which
+// enter authMu from inside sweepMu) and bare sampleAuthority calls
+// (authMu alone) must never deadlock or race — run under -race.
+//
+// Per review finding P1-2, the original version never advanced the fake
+// clock after seeding, so the 1ms grace never elapsed: every pass hit
+// the initial-seed branch (return before the fence) or the
+// already-seeded, still-under-grace branch, and the ONLY authMu
+// acquisition actually exercised under contention was
+// resolveLiveSet's own separate snapshot — never the REAP fence
+// (sweepMu -> authMu inside maybeReapOrphan's delete branch) the test
+// claims to pin. A dedicated goroutine now continuously reseeds fresh
+// claims and advances the clock past grace, so pass goroutines
+// repeatedly reach and cross the reap fence itself throughout the
+// contention window; a final assertion confirms at least one claim was
+// actually reaped, proving the fence path — not just the vouch-snapshot
+// path — was genuinely exercised.
+func TestSweepAuthority_Fence_LockOrdering(t *testing.T) {
+	t.Parallel()
+
+	h := newFenceHarness(t, time.Millisecond) // tiny grace: passes actually reach the fence
+	for i := range 20 {
+		h.seed(stableClaim(fmt.Sprintf("p-%d", i), h.now))
+	}
+	h.setLive() // all absent
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Continuously reseed fresh claims and advance the clock past grace
+	// so pass goroutines keep reaching the REAP fence's authMu.Lock()
+	// throughout the run, not just once at the very start.
+	wg.Go(func() {
+		n := 20
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				h.seed(stableClaim(fmt.Sprintf("p-%d", n), h.now))
+				n++
+				h.advance(2 * time.Millisecond)
+			}
+		}
+	})
+
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					h.pass(t)
+				}
+			}
+		})
+	}
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					h.coord.sampleAuthority()
+				}
+			}
+		})
+	}
+
+	time.Sleep(50 * time.Millisecond) // bounded contention window (not a state-wait)
+	close(done)
+	wg.Wait()
+
+	reaped := false
+	for i := range 20 {
+		if !h.claimExists(t, fmt.Sprintf("p-%d", i)) {
+			reaped = true
+
+			break
+		}
+	}
+	require.True(t, reaped,
+		"the reap fence must have actually been reached and applied at least once during the contention window")
+}
+
+// scheduledAmbiguousDeleteStore makes exactly one armed Delete call
+// return an ambiguous (non-definitive) DeadlineExceeded WITHOUT EVER
+// touching the underlying store — modeling a client-side timeout on an
+// already-sent request whose eventual server-side application (if any)
+// is entirely test-orchestrated, out-of-band, strictly AFTER this
+// Delete call has already returned to its caller (see
+// TestSweepAuthority_Fence_AmbiguousDeleteOutcome's "late deletion
+// eventually applies" subtest). Per review finding P1-2, an earlier
+// version applied a "late" deletion SYNCHRONOUSLY inside this call,
+// before returning the ambiguous error — but maybeReapOrphan holds
+// authMu for the whole Delete call, so nothing (in particular, no false
+// sample) could ever interleave in that window; there was no gap for
+// the interleaving §4.4(h) actually describes to occur in.
+type scheduledAmbiguousDeleteStore struct {
+	ClaimStore
+	mu    sync.Mutex
+	armed bool
+}
+
+func (s *scheduledAmbiguousDeleteStore) arm() {
+	s.mu.Lock()
+	s.armed = true
+	s.mu.Unlock()
+}
+
+func (s *scheduledAmbiguousDeleteStore) Delete(ctx context.Context, pid string, rev uint64) error {
+	s.mu.Lock()
+	armed := s.armed
+	s.armed = false
+	s.mu.Unlock()
+	if !armed {
+		return s.ClaimStore.Delete(ctx, pid, rev)
+	}
+
+	return context.DeadlineExceeded
+}
+
+// TestSweepAuthority_Fence_AmbiguousDeleteOutcome pins §4.4(h): the
+// store's conditioned delete returns an ambiguous error while the
+// deletion request may still apply after the fence releases. Assert (i)
+// the generation self-poisons, (ii) a late-applying deletion is
+// tolerated (no double-decision), and (iii) a never-applying deletion
+// still requires a full fresh grace before any reap.
+func TestSweepAuthority_Fence_AmbiguousDeleteOutcome(t *testing.T) {
+	t.Parallel()
+
+	t.Run("late deletion eventually applies", func(t *testing.T) {
+		t.Parallel()
+
+		h := newFenceHarness(t, orphanTestGrace)
+		h.seed(stableClaim("p-gone", h.now))
+		h.setLive()
+		h.pass(t) // seed at the current generation
+		genAtSeed := h.gen()
+
+		store := &scheduledAmbiguousDeleteStore{ClaimStore: h.store}
+		h.swapStore(store)
+		store.arm()
+
+		h.advance(orphanTestGrace + time.Second)
+		h.pass(t) // ambiguous outcome: generation self-poisons; Delete has NOT applied
+
+		require.Greater(t, h.gen(), genAtSeed, "(i) the generation must self-poison on the ambiguous outcome")
+		require.True(t, h.claimExists(t, "p-gone"), "the sweep must return with the claim still present — nothing has applied yet")
+		genAfterAmbiguous := h.gen()
+
+		// The test records a false sample IN THE GAP: after the sweep has
+		// returned (authMu is free again) and BEFORE the "late" deletion
+		// is applied — the exact interleaving §4.4(h) describes.
+		h.setAuthorized(false)
+		require.False(t, h.coord.sampleAuthority())
+		require.Greater(t, h.gen(), genAfterAmbiguous, "the false sample must record its own generation bump")
+
+		// THEN the test applies the deletion out-of-band, exactly as a
+		// server that eventually honors the earlier ambiguous request
+		// would — bypassing the coordinator entirely.
+		_, rev, err := h.store.Get(context.Background(), "p-gone")
+		require.NoError(t, err)
+		require.NoError(t, h.store.Delete(context.Background(), "p-gone", rev))
+
+		require.False(t, h.claimExists(t, "p-gone"),
+			"(ii) the late deletion applying is tolerated: the key is simply gone")
+
+		// The next pass handles the vanished key through the existing
+		// paths — no double-decision, no error.
+		h.setAuthorized(true)
+		h.pass(t)
+	})
+
+	t.Run("scheduled deletion never applies", func(t *testing.T) {
+		t.Parallel()
+
+		h := newFenceHarness(t, orphanTestGrace)
+		h.seed(stableClaim("p-gone", h.now))
+		h.setLive()
+		h.pass(t)
+		genAtSeed := h.gen()
+
+		store := &scheduledAmbiguousDeleteStore{ClaimStore: h.store}
+		h.swapStore(store)
+		store.arm() // ambiguous outcome; this subtest never applies the deletion
+
+		h.advance(orphanTestGrace + time.Second)
+		h.pass(t) // ambiguous outcome: generation self-poisons, claim retained
+
+		require.Greater(t, h.gen(), genAtSeed)
+		require.True(t, h.claimExists(t, "p-gone"))
+
+		// (iii) the claim requires a FULL fresh grace from the next
+		// vouched seed before any reap: the stale clock discards first...
+		h.swapStore(h.store)
+		h.pass(t)
+		require.True(t, h.claimExists(t, "p-gone"), "the stale clock must discard, not reap")
+		_, ok := h.clockOf("p-gone")
+		require.False(t, ok)
+
+		// ...then a fresh seed, then a full grace.
+		h.pass(t)
+		h.advance(orphanTestGrace - time.Second)
+		h.pass(t)
+		require.True(t, h.claimExists(t, "p-gone"), "must not reap before the fresh grace fully elapses")
+
+		h.advance(2 * time.Second)
+		h.pass(t)
+		require.False(t, h.claimExists(t, "p-gone"))
+	})
+}
+
+// --- §4.5: backstopDue latch ---
+
+// TestSweepAuthority_BackstopDueLatch pins §4.5: an Apply-origin sweep
+// landing just before the due tick absorbs it via the shared interval
+// throttle (admitted=false observed via SweepObserver); the latch keeps
+// the tick "due" and the NEXT tick admits — bounding either-origin
+// admitted cadence to (backstopEvery+1) x SweepInterval.
+func TestSweepAuthority_BackstopDueLatch(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{phaseSeed: 0}) // backstopEvery=10
+	h.setAuthorized(false)
+
+	for range 9 {
+		h.pushTick() // ticks 1..9: off-cycle skips
+	}
+
+	// An Apply-origin sweep lands right before the due tick and consumes
+	// the shared interval throttle.
+	require.NoError(t, h.coord.Apply(context.Background(), "worker-1", types.Assignment{}, types.Assignment{}))
+	applyEv := h.recvEvent(t)
+	require.Equal(t, sweepOriginApply, applyEv.origin)
+	require.True(t, applyEv.authorized, "Apply-origin authorized is the constant true marker")
+	require.True(t, applyEv.admitted)
+
+	// The due tick (10) fires close behind (< one interval later): its
+	// OWN throttle check absorbs it — admitted=false — but the backstop
+	// latch keeps it due.
+	h.pushTickAdvance(h.interval - time.Second)
+	tickEv := h.recvTickEvent(t)
+	require.Equal(t, sweepOriginTicker, tickEv.origin)
+	require.False(t, tickEv.authorized)
+	require.False(t, tickEv.admitted, "the due tick's own pass must be absorbed by the shared interval throttle")
+
+	// The latch forces the VERY NEXT tick (11, off-cycle by schedule) to
+	// retry, and this time the throttle has cleared.
+	h.pushTick()
+	retryEv := h.recvTickEvent(t)
+	require.Equal(t, sweepOriginTicker, retryEv.origin)
+	require.False(t, retryEv.authorized)
+	require.True(t, retryEv.admitted, "the backstopDue latch must force a retry on the very next tick")
+}
+
+// TestSweepAuthority_ContinuousApplyBoundsEitherOriginCadence pins the
+// §4.5 continuous-Apply case the review (P1-3) flagged as missing:
+// TestSweepAuthority_BackstopDueLatch above pins a SINGLE Apply/ticker
+// collision; this test drives sustained Apply-origin sweeps, round after
+// round, across several backstop cycles — repeatedly swallowing the
+// ticker's own due-tick attempts — and asserts that the either-origin
+// admitted cadence (whichever origin actually lands: Apply's own
+// frequent admissions, or the ticker's eventual latched retry) never
+// exceeds the (backstopEvery+1) x SweepInterval bound between any two
+// successive admitted passes, using the fake clock and the full
+// SweepObserver history (never a real wait).
+func TestSweepAuthority_ContinuousApplyBoundsEitherOriginCadence(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{phaseSeed: 0}) // backstopEvery=10
+	h.setAuthorized(false)
+	bound := time.Duration(backstopEveryFor(h.interval)+1) * h.interval
+
+	lastAdmitAt := h.nowVal()
+	checkGap := func(at time.Time) {
+		gap := at.Sub(lastAdmitAt)
+		require.LessOrEqual(t, gap, bound,
+			"either-origin admitted cadence exceeded the (backstopEvery+1) x interval bound: gap=%s bound=%s", gap, bound)
+		lastAdmitAt = at
+	}
+
+	const rounds = 30 // three full backstop cycles' worth of ticks
+	for range rounds {
+		// A sustained Apply-origin sweep lands every round, well inside
+		// one interval of the previous admission — modeling continuous
+		// Apply traffic that keeps consuming the shared throttle ahead
+		// of the ticker.
+		h.advance(h.interval / 2)
+		require.NoError(t, h.coord.Apply(context.Background(), "worker-1", types.Assignment{}, types.Assignment{}))
+		applyEv := h.recvEvent(t)
+		require.Equal(t, sweepOriginApply, applyEv.origin)
+		if applyEv.admitted {
+			checkGap(h.nowVal())
+		}
+
+		// The ticker tick for this round, landing shortly after Apply.
+		h.pushTickAdvance(h.interval / 2)
+		if ev, ok := h.maybeRecvTickEvent(t); ok && ev.admitted {
+			checkGap(h.nowVal())
+		}
+	}
+}
+
+// --- §4.6: admitted-pass fault matrix ---
+//
+// Per review finding P1-3, every row below asserts all four spec
+// obligations: (a) the faulted pass is counted as admitted via
+// SweepObserver; (b) backstopDue actually clears; (c) the next attempt
+// occurs at the documented next backstop tick; (d) recovery converges
+// once the fault lifts.
+//
+// Rows 1-4 (probe/ListKeys/per-key-Get/reconcile-CAS faults) touch
+// NOTHING the generation fence guards — sampleAuthority and the fence
+// are entirely orthogonal to them — so they run under a SUSTAINED
+// authority=false backstop cadence via the shared runFaultMatrix*
+// helpers below, where (b)/(c) are directly observable exactly as
+// phrased.
+//
+// Rows 5-6 (reap-Delete definitive non-application: revision-CAS loss,
+// ErrKeyNotFound) and the new fast ambiguous-outcome row run under a
+// CONTINUOUSLY AUTHORIZED (leader) ticker instead: sampleAuthority
+// bumps unvouchedGen on EVERY unauthorized sample, unconditionally, for
+// EVERY real tick — including off-cycle skips, which call it before the
+// skip check. Under a sustained backstop (authority=false) worker, this
+// means the fault-tick's OWN sample already bumps the generation past
+// whatever an earlier admitted pass seeded, so the fence would discard
+// the clock before ever reaching Delete — that is the fence protocol
+// working exactly as intended (a worker that has been unauthorized at
+// any point since seeding a clock must never trust it; that is the
+// whole point of §4.4's fence, exercised directly by the dedicated
+// Fence_* tests). It is not a gap in these rows: it makes the delete
+// arms UNREACHABLE under backstop cadence by construction, so a leader
+// ticker pass is the only way to exercise them at all. There is no
+// "backstopDue"/"next backstop tick" concept under full leader cadence
+// (every tick admits), so (b)/(c) there become "the fault does not
+// disrupt full ticker cadence" and "the immediately following tick
+// already reflects the fault's resolution" — which is what these rows
+// assert instead.
+
+// runFaultMatrixFirstAdmit sets authority=false and drives h to the
+// FIRST backstop tick (tick backstopEveryFor(h.interval), phase 0 —
+// every row below uses the default phaseSeed=0), returning that
+// admitted pass's event. The caller arms its fault BEFORE calling this
+// so the fault is active for the pass it returns.
+func runFaultMatrixFirstAdmit(t *testing.T, h *authHarness) sweepAuthEvent {
+	t.Helper()
+	h.setAuthorized(false)
+	backstopEvery := backstopEveryFor(h.interval)
+
+	return h.runSkipThenAdmit(t, backstopEvery-1)
+}
+
+// assertBackstopDueClears pins obligation (b): the tick immediately
+// after an admitted (even faulted) pass must NOT itself admit —
+// proving backstopDue actually cleared rather than staying latched.
+func assertBackstopDueClears(t *testing.T, h *authHarness) {
+	t.Helper()
+	h.pushTick()
+	select {
+	case unexpected := <-h.events:
+		t.Fatalf("backstopDue must clear after an admitted pass — got an unexpected event: %+v", unexpected)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// runFaultMatrixNextBackstop pins obligation (c): drives h to the NEXT
+// documented backstop tick — one full backstopEvery cycle after the
+// tick assertBackstopDueClears already consumed — returning that pass's
+// event.
+func runFaultMatrixNextBackstop(t *testing.T, h *authHarness) sweepAuthEvent {
+	t.Helper()
+	backstopEvery := backstopEveryFor(h.interval)
+
+	return h.runSkipThenAdmit(t, backstopEvery-2)
+}
+
+func TestSweepAuthority_FaultMatrix_ProbeFailureFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	base := newMemStore()
+	store := &probeMemStore{memStore: base, pos: natsutil.KVStreamPos{Created: time.Unix(1000, 0), LastSeq: 1}}
+	h := newAuthHarness(t, authHarnessOpts{store: store, baseStore: base})
+	c := NewInitialClaim("p1", "worker-1", h.nowVal(), time.Minute)
+	_, err := store.PutIfEpoch(context.Background(), "p1", 0, c)
+	require.NoError(t, err)
+
+	store.mu.Lock()
+	store.probeErr = context.DeadlineExceeded
+	store.mu.Unlock()
+
+	ev := runFaultMatrixFirstAdmit(t, h)
+	require.True(t, ev.admitted, "(a) a probe failure must still count as admitted (throttle consumed)")
+	require.EqualValues(t, 1, store.listCalls.Load(), "a probe failure must fail open to a full pass")
+
+	assertBackstopDueClears(t, h)
+
+	store.mu.Lock()
+	store.probeErr = nil
+	store.mu.Unlock()
+
+	ev = runFaultMatrixNextBackstop(t, h)
+	require.True(t, ev.admitted, "(c) the next attempt must land at the documented next backstop tick")
+	require.EqualValues(t, 2, store.listCalls.Load(), "(d) recovery converges: the gate resumes normal operation once the fault lifts")
+}
+
+type listFailStore struct {
+	ClaimStore
+	mu   sync.Mutex
+	fail bool
+}
+
+func (s *listFailStore) ListKeys(ctx context.Context) ([]string, error) {
+	s.mu.Lock()
+	fail := s.fail
+	s.mu.Unlock()
+	if fail {
+		return nil, errors.New("listkeys: injected failure")
+	}
+
+	return s.ClaimStore.ListKeys(ctx)
+}
+
+func TestSweepAuthority_FaultMatrix_ListKeysFailure(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{})
+	// A stuck, expired prepare: the reconcile arm heals it once a pass
+	// can actually see it (ListKeys succeeds) — this is what "(d)
+	// recovery converges" observes for this row; a ListKeys failure
+	// itself leaves no other trace to check.
+	stuck := Claim{
+		PartitionID: "p1", Owner: "w2", PendingOwner: "w1",
+		State: ClaimStatePrepare, Epoch: 3, LastUpdated: h.nowVal(), TTLSeconds: 1,
+	}
+	h.seed(stuck)
+	failing := &listFailStore{ClaimStore: h.store, fail: true}
+	h.coord.cfg.Store = failing
+
+	ev := runFaultMatrixFirstAdmit(t, h)
+	require.True(t, ev.admitted, "(a) a ListKeys failure must still count as admitted (the pass returns without healing)")
+	got, rev, err := h.store.Get(context.Background(), "p1")
+	require.NoError(t, err)
+	require.NotZero(t, rev)
+	require.Equal(t, ClaimStatePrepare, got.State, "a ListKeys failure must leave the claim untouched — the pass never saw it")
+
+	assertBackstopDueClears(t, h)
+
+	failing.mu.Lock()
+	failing.fail = false
+	failing.mu.Unlock()
+
+	ev = runFaultMatrixNextBackstop(t, h)
+	require.True(t, ev.admitted, "(c) the next attempt must land at the documented next backstop tick")
+	got, rev, err = h.store.Get(context.Background(), "p1")
+	require.NoError(t, err)
+	require.NotZero(t, rev)
+	require.Equal(t, ClaimStateStable, got.State, "(d) recovery converges: the reconcile arm heals once ListKeys works again")
+}
+
+func TestSweepAuthority_FaultMatrix_PerKeyGetFailureStillClearsInSetClocks(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{grace: orphanTestGrace})
+	h.seed(stableClaim("p-flap", h.nowVal()))
+	failing := &getFailArmedStore{ClaimStore: h.store, target: "p-flap"}
+	h.coord.cfg.Store = failing
+
+	// Seed p-flap's absence clock via an Apply-origin sweep BEFORE any
+	// ticks: Apply-origin passes never sample SweepAuthority, so they
+	// cannot pre-poison the generation the fault-tick fence will later
+	// check (irrelevant here — this row never reaps — but keeping the
+	// seed off the ticker avoids the row depending on which tick number
+	// first admits).
+	h.setLive() // absent
+	require.NoError(t, h.coord.Apply(context.Background(), "worker-1", types.Assignment{}, types.Assignment{}))
+	seedEv := h.recvEvent(t)
+	require.True(t, seedEv.admitted)
+
+	h.setLive("p-flap") // reappears in the vouched set
+	failing.arm()       // this pass's Get for p-flap fails (self-disarming)
+
+	ev := runFaultMatrixFirstAdmit(t, h)
+	require.True(t, ev.admitted, "(a) a per-key Get failure must still count as admitted")
+
+	// B3: the pass-level clear (independent of the per-key read outcome)
+	// must still have cleared p-flap's absence clock.
+	_, ok := h.coord.orphanAbsentSince["p-flap"]
+	require.False(t, ok, "an in-set pid's clock must clear even when its own Get fails (B3)")
+
+	assertBackstopDueClears(t, h)
+
+	// getFailArmedStore self-disarms after firing once — no explicit
+	// disarm needed; (d) recovery converges trivially: steady state is
+	// maintained (p-flap stays live and clock-free) at the next
+	// documented backstop tick.
+	ev = runFaultMatrixNextBackstop(t, h)
+	require.True(t, ev.admitted, "(c) the next attempt must land at the documented next backstop tick")
+	_, ok = h.coord.orphanAbsentSince["p-flap"]
+	require.False(t, ok, "(d) recovery converges: no absence clock lingers for a live pid")
+	_, rev, err := h.store.Get(context.Background(), "p-flap")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "p-flap's claim must have survived untouched")
+}
+
+type casFailStore struct {
+	ClaimStore
+}
+
+func (s *casFailStore) PutIfEpoch(context.Context, string, int64, Claim) (uint64, error) {
+	return 0, errors.New("cas: injected conflict")
+}
+
+func TestSweepAuthority_FaultMatrix_ReconcileCASExhaustion(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{})
+	// A stuck, expired prepare: sweepReconcile targets it for a reset, but
+	// every CAS attempt fails (contention), exhausting MaxRetries.
+	stuck := Claim{
+		PartitionID: "p1", Owner: "w2", PendingOwner: "w1",
+		State: ClaimStatePrepare, Epoch: 3, LastUpdated: h.nowVal(), TTLSeconds: 1,
+	}
+	h.seed(stuck)
+	h.coord.cfg.MaxRetries = 1
+	failing := &casFailStore{ClaimStore: h.store}
+	h.coord.cfg.Store = failing
+
+	h.advance(2 * time.Second) // past the 1s TTL, before any tick is pushed
+	ev := runFaultMatrixFirstAdmit(t, h)
+	require.True(t, ev.admitted, "(a) CAS exhaustion inside the reconcile arm must still count as admitted")
+
+	got, rev, err := h.store.Get(context.Background(), "p1")
+	require.NoError(t, err)
+	require.NotZero(t, rev)
+	require.Equal(t, ClaimStatePrepare, got.State, "the claim must be unchanged after CAS exhaustion")
+
+	assertBackstopDueClears(t, h)
+
+	h.coord.cfg.Store = h.store // (d) lift the fault
+
+	ev = runFaultMatrixNextBackstop(t, h)
+	require.True(t, ev.admitted, "(c) the next attempt must land at the documented next backstop tick")
+	got, rev, err = h.store.Get(context.Background(), "p1")
+	require.NoError(t, err)
+	require.NotZero(t, rev)
+	require.Equal(t, ClaimStateStable, got.State, "(d) recovery converges: the reconcile CAS succeeds once the fault lifts")
+}
+
+// definitiveConflictStore always returns jetstream.ErrKeyExists from
+// Delete — the definitive "the server answered: revision moved" outcome.
+type definitiveConflictStore struct {
+	ClaimStore
+}
+
+func (s *definitiveConflictStore) Delete(context.Context, string, uint64) error {
+	return jetstream.ErrKeyExists
+}
+
+// TestSweepAuthority_FaultMatrix_ReapRevisionCASLoss drives the
+// reap-Delete revision-CAS-loss row via a continuously-authorized
+// (leader) ticker pass — see the §4.6 section doc for why the
+// generation fence makes this row unreachable under backstop cadence.
+func TestSweepAuthority_FaultMatrix_ReapRevisionCASLoss(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{grace: orphanTestGrace})
+	h.seed(stableClaim("p-gone", h.nowVal()))
+	h.setLive() // absent
+	h.setAuthorized(true)
+
+	h.pushTick() // seeds the clock at the current generation
+	seedEv := h.recvTickEvent(t)
+	require.True(t, seedEv.admitted)
+	genAtSeed := h.gen()
+
+	h.coord.cfg.Store = &definitiveConflictStore{ClaimStore: h.store}
+
+	h.pushTickAdvance(orphanTestGrace + time.Second)
+	ev := h.recvTickEvent(t)
+	require.True(t, ev.admitted, "(a) a revision-CAS loss must still count as admitted")
+
+	_, rev, err := h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "a revision-CAS loss must keep the claim")
+	clock, ok := h.coord.orphanAbsentSince["p-gone"]
+	require.True(t, ok, "a revision-CAS loss must keep the clock")
+	require.Equal(t, genAtSeed, clock.gen)
+	require.Equal(t, genAtSeed, h.gen(), "a DEFINITIVE non-application must NOT self-poison the generation")
+
+	// (b') full leader cadence is unaffected: the very next tick also
+	// admits (there is no backstopDue latch under a continuously
+	// authorized leader).
+	h.coord.cfg.Store = h.store // (d) lift the fault
+
+	ev = h.pushTickThenRecv(t)
+	require.True(t, ev.admitted, "(b')/(c') the immediately following tick admits and converges")
+	_, rev, err = h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.Zero(t, rev, "(d) recovery converges: the claim is reaped once the fault lifts")
+}
+
+// definitiveKeyGoneStore always returns jetstream.ErrKeyNotFound from
+// Delete — the OTHER definitive "the server answered" outcome pinned by
+// §2.2a alongside ErrKeyExists: the key is already gone. This row was
+// entirely missing before (review finding P1-3): keep claim + clock, NO
+// self-poison — same DEFINITIVE non-application treatment as a
+// revision-CAS loss.
+type definitiveKeyGoneStore struct {
+	ClaimStore
+}
+
+func (s *definitiveKeyGoneStore) Delete(context.Context, string, uint64) error {
+	return jetstream.ErrKeyNotFound
+}
+
+func TestSweepAuthority_FaultMatrix_ReapKeyNotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{grace: orphanTestGrace})
+	h.seed(stableClaim("p-gone", h.nowVal()))
+	h.setLive()
+	h.setAuthorized(true)
+
+	h.pushTick()
+	seedEv := h.recvTickEvent(t)
+	require.True(t, seedEv.admitted)
+	genAtSeed := h.gen()
+
+	h.coord.cfg.Store = &definitiveKeyGoneStore{ClaimStore: h.store}
+
+	h.pushTickAdvance(orphanTestGrace + time.Second)
+	ev := h.recvTickEvent(t)
+	require.True(t, ev.admitted, "(a) an ErrKeyNotFound outcome must still count as admitted")
+
+	_, rev, err := h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "an ErrKeyNotFound outcome must keep the claim")
+	clock, ok := h.coord.orphanAbsentSince["p-gone"]
+	require.True(t, ok, "an ErrKeyNotFound outcome must keep the clock")
+	require.Equal(t, genAtSeed, clock.gen)
+	require.Equal(t, genAtSeed, h.gen(), "a DEFINITIVE non-application must NOT self-poison the generation")
+
+	h.coord.cfg.Store = h.store // (d) lift the fault
+
+	ev = h.pushTickThenRecv(t)
+	require.True(t, ev.admitted, "(b')/(c') the immediately following tick admits and converges")
+	_, rev, err = h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.Zero(t, rev, "(d) recovery converges: the claim is reaped once the fault lifts")
+}
+
+// TestSweepAuthority_FaultMatrix_ReapAmbiguousOutcome drives the
+// reap-Delete ambiguous-outcome row via a continuously-authorized
+// (leader) ticker pass with a FAST (non-blocking) ambiguous store,
+// proving SweepObserver reports it correctly (admitted=true,
+// origin=ticker) — the slower TestSweepAuthority_FaultMatrix_
+// ReapAmbiguousTimeoutBoundsAuthMu below additionally proves the real
+// reapDeleteTimeout bound and the concurrent-sampleAuthority-blocking
+// behavior, which this row does not repeat.
+func TestSweepAuthority_FaultMatrix_ReapAmbiguousOutcome(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{grace: orphanTestGrace})
+	h.seed(stableClaim("p-gone", h.nowVal()))
+	h.setLive()
+	h.setAuthorized(true)
+
+	h.pushTick()
+	seedEv := h.recvTickEvent(t)
+	require.True(t, seedEv.admitted)
+	genAtSeed := h.gen()
+
+	store := &scheduledAmbiguousDeleteStore{ClaimStore: h.store}
+	h.coord.cfg.Store = store
+	store.arm()
+
+	h.pushTickAdvance(orphanTestGrace + time.Second)
+	ev := h.recvTickEvent(t)
+	require.True(t, ev.admitted, "(a) an ambiguous delete outcome must still count as admitted")
+
+	_, rev, err := h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "an ambiguous outcome must keep the claim")
+	require.Greater(t, h.gen(), genAtSeed, "an ambiguous outcome must self-poison the generation")
+
+	h.coord.cfg.Store = h.store // (d) lift the fault
+
+	// (b')/(c') full leader cadence is unaffected, but (d) full
+	// recovery convergence for an AMBIGUOUS (self-poisoned) outcome is a
+	// longer chain than the definitive rows above: the stale clock must
+	// first discard at its next fence check, then a later pass reseeds
+	// fresh, then a full fresh grace completes the reap.
+	ev = h.pushTickThenRecv(t)
+	require.True(t, ev.admitted)
+	_, rev, err = h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.NotZero(t, rev, "the stale (self-poisoned) clock must discard, not reap")
+
+	ev = h.pushTickThenRecv(t) // reseed
+	require.True(t, ev.admitted)
+
+	ev = h.pushTickThenRecvAdvance(t, orphanTestGrace+time.Second)
+	require.True(t, ev.admitted)
+	_, rev, err = h.store.Get(context.Background(), "p-gone")
+	require.NoError(t, err)
+	require.Zero(t, rev, "(d) recovery converges: the claim reaps once a full fresh grace elapses from the fresh seed")
+}
+
+// blockingUntilCtxDoneStore blocks Delete until ctx is done, then returns
+// ctx.Err() — models a genuinely stalled store honoring only the
+// caller's context, exercising the REAL reapDeleteTimeout bound (not a
+// hand-parked double).
+type blockingUntilCtxDoneStore struct {
+	ClaimStore
+	entered chan struct{}
+}
+
+func (s *blockingUntilCtxDoneStore) Delete(ctx context.Context, pid string, rev uint64) error {
+	if s.entered != nil {
+		close(s.entered)
+	}
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+// TestSweepAuthority_FaultMatrix_ReapAmbiguousTimeoutBoundsAuthMu pins
+// the reap-Delete-ambiguous-outcome fault-matrix row against the REAL
+// reapDeleteTimeout (not a hand-parked double): a stalled store's Delete
+// call is bounded by the internal context.WithTimeout, so authMu is
+// eventually released; a sampleAuthority call that blocks on authMu for
+// the duration proceeds once the timeout expires, and its record is not
+// lost (both the delete's self-poison AND the sample's own false-record
+// land). Slow (~reapDeleteTimeout) by construction — it waits out a real
+// bounded timeout to prove the bound, not a mock of it.
+func TestSweepAuthority_FaultMatrix_ReapAmbiguousTimeoutBoundsAuthMu(t *testing.T) {
+	h := newFenceHarness(t, orphanTestGrace)
+	h.seed(stableClaim("p-gone", h.now))
+	h.setLive()
+	h.pass(t)
+	genAtSeed := h.gen()
+	h.advance(orphanTestGrace + time.Second)
+
+	entered := make(chan struct{})
+	h.swapStore(&blockingUntilCtxDoneStore{ClaimStore: h.store, entered: entered})
+
+	reapDone := make(chan struct{})
+	go func() {
+		h.pass(t)
+		close(reapDone)
+	}()
+	<-entered // Delete is in flight, authMu held, bounded by reapDeleteTimeout
+
+	h.setAuthorized(false)
+	sampleDone := make(chan struct{})
+	start := time.Now()
+	go func() {
+		h.coord.sampleAuthority()
+		close(sampleDone)
+	}()
+
+	<-reapDone
+	<-sampleDone
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 10*time.Second,
+		"sampleAuthority must proceed once the bounded delete times out, not block forever")
+	require.True(t, h.claimExists(t, "p-gone"), "an ambiguous (timed-out) delete must keep the claim")
+	require.Equal(t, genAtSeed+2, h.gen(),
+		"both the ambiguous delete's self-poison AND the blocked sample's own false-record must land — neither lost")
+}
+
+// --- §4.7: split-brain R1-neutrality ---
+
+// TestSweepAuthority_SplitBrain_R1Neutrality pins §4.7: two coordinators
+// share one store, both authority=true, with DIVERGENT vouched live
+// sets. The pin is R1-neutrality — the gating mechanism changes nothing
+// about which reaps fire relative to a full-cadence (nil-authority)
+// baseline under the identical interleaving. The divergent-view deletion
+// itself is the PRE-EXISTING leader-vouched reaper contract, out of R1's
+// scope; this test only pins that R1 adds no new decision.
+func TestSweepAuthority_SplitBrain_R1Neutrality(t *testing.T) {
+	t.Parallel()
+
+	run := func(nilAuthority bool) bool {
+		store := newMemStore()
+		now := time.Now().UTC()
+		store.data["p-shared"] = stableClaim("p-shared", now)
+		store.rev["p-shared"] = 1
+
+		newCoord := func() *twoPhaseCoordinator {
+			cfg := Config{
+				Store:         store,
+				Now:           func() time.Time { return now },
+				OrphanGrace:   time.Second,
+				SweepInterval: -1,
+				MaxRetries:    1,
+				BaseBackoff:   time.Millisecond,
+				MaxBackoff:    2 * time.Millisecond,
+			}
+			if !nilAuthority {
+				cfg.SweepAuthority = func() bool { return true }
+			}
+			c, ok := New(cfg, true).(*twoPhaseCoordinator)
+			require.True(t, ok)
+
+			return c
+		}
+
+		coordA := newCoord() // A's view: the partition is live
+		coordA.cfg.LivePartitions = func(context.Context) (map[string]struct{}, bool) {
+			return map[string]struct{}{"p-shared": {}}, true
+		}
+		coordB := newCoord() // B's divergent view: the partition is absent
+		coordB.cfg.LivePartitions = func(context.Context) (map[string]struct{}, bool) {
+			return map[string]struct{}{}, true
+		}
+
+		// Identical interleaving regardless of nilAuthority: A's pass is a
+		// no-op (its view has the partition live); B seeds its own
+		// (process-local) absence clock; once B's grace elapses, B reaps.
+		require.True(t, coordA.maybeSweepClaims(context.Background(), sweepOriginTicker))
+		require.True(t, coordB.maybeSweepClaims(context.Background(), sweepOriginTicker))
+		now = now.Add(2 * time.Second)
+		require.True(t, coordB.maybeSweepClaims(context.Background(), sweepOriginTicker))
+
+		_, rev, err := store.Get(context.Background(), "p-shared")
+		require.NoError(t, err)
+
+		return rev == 0 // reaped?
+	}
+
+	gatedReaped := run(false)
+	baselineReaped := run(true)
+
+	require.Equal(t, baselineReaped, gatedReaped,
+		"SweepAuthority=true must not change which reaps fire vs nil authority")
+}
+
+// --- §4.8: negative space + boundary table ---
+
+// TestSweepAuthority_BackstopEveryBoundaryTable pins §4.8's floor-division
+// boundary table, plus the §2.3 default example.
+func TestSweepAuthority_BackstopEveryBoundaryTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		interval time.Duration
+		want     int
+	}{
+		{100 * time.Second, 3},
+		{149 * time.Second, 2},
+		{150 * time.Second, 2},
+		{151 * time.Second, 1},
+		{300 * time.Second, 1},
+		{3600 * time.Second, 1},
+		{30 * time.Second, 10}, // the §2.3 default example
+	}
+	for _, tc := range cases {
+		t.Run(tc.interval.String(), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, backstopEveryFor(tc.interval))
+		})
+	}
+}
+
+// TestSweepAuthority_ApplyOriginUnaffectedByAuthority pins §4.8: Apply
+// origin cadence and admission are unaffected by authority=false.
+func TestSweepAuthority_ApplyOriginUnaffectedByAuthority(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthHarness(t, authHarnessOpts{})
+	h.setAuthorized(false) // even a non-authorized worker's Apply sweeps run
+
+	require.NoError(t, h.coord.Apply(context.Background(), "worker-1", types.Assignment{}, types.Assignment{}))
+	ev := h.recvEvent(t)
+	require.Equal(t, sweepOriginApply, ev.origin)
+	require.True(t, ev.authorized, "Apply-origin authorized is a constant true marker, independent of real authority")
+	require.True(t, ev.admitted)
+}
+
+// TestSweepAuthority_TickerDisableOnlyOnNegativeInterval pins §4.8: only
+// a NEGATIVE internal SweepInterval disables the ticker; zero normalizes
+// to the 30s default and starts it.
+func TestSweepAuthority_TickerDisableOnlyOnNegativeInterval(t *testing.T) {
+	t.Parallel()
+
+	t.Run("negative disables the ticker", func(t *testing.T) {
+		t.Parallel()
+		coord, ok := New(Config{Store: newMemStore(), SweepInterval: -1}, true).(*twoPhaseCoordinator)
+		require.True(t, ok)
+		coord.Start(context.Background())
+		require.False(t, coord.started.Load(), "a negative interval must never start the ticker goroutine")
+	})
+
+	t.Run("zero normalizes to the 30s default, ticker starts", func(t *testing.T) {
+		t.Parallel()
+		coord, ok := New(Config{Store: newMemStore(), SweepInterval: 0}, true).(*twoPhaseCoordinator)
+		require.True(t, ok)
+		require.Equal(t, 30*time.Second, coord.cfg.SweepInterval)
+		coord.Start(context.Background())
+		require.True(t, coord.started.Load())
+	})
+}
+
+// --- §4.9: closed SweepTicks channel ---
+
+// TestSweepAuthority_ClosedTicksChannelExitsWithoutSpinning pins §4.9:
+// the two-value receive on SweepTicks means a CLOSED injected channel
+// terminates the ticker goroutine cleanly instead of hot-looping on zero
+// values. A single-value-receive regression would call SweepAuthority
+// continuously; a bounded window with a counting SweepAuthority
+// distinguishes the two — the fixed behavior stays at exactly 0 calls; a
+// spin would rack up an enormous count within the same window.
+func TestSweepAuthority_ClosedTicksChannelExitsWithoutSpinning(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	ticks := make(chan time.Time)
+	close(ticks)
+
+	coord, ok := New(Config{
+		Store:         newMemStore(),
+		SweepInterval: time.Second,
+		SweepTicks:    ticks,
+		SweepAuthority: func() bool {
+			calls.Add(1)
+
+			return true
+		},
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+
+	coord.Start(context.Background())
+	<-time.After(20 * time.Millisecond)
+	require.Zero(t, calls.Load(),
+		"a closed SweepTicks channel must exit the goroutine without ever sampling authority")
+}

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -278,8 +278,57 @@ func (t *twoPhaseCoordinator) Start(ctx context.Context) {
 	}()
 }
 
+// transitionVersionAdjacent reports whether next is the immediate version
+// successor of previous (previous.Version+1 == next.Version). Adjacency
+// detects VERSION GAPS ONLY — it is necessary for trusting the prepare
+// diff, but it is NOT an authoritative or claim-level continuity proof:
+// equal-Version authority divergence and stale cross-worker claim mutation
+// (the deferred fence project's shapes) are invisible to it. No future
+// walk restriction may treat adjacency==true as authorization on its own.
+//
+// Any gap (a coalesced or missed intermediate version — the routine case,
+// since debounce coalescing, warm restart, and the apply/fetch stashes are
+// designed gap sources, not rare ones), equality (same-Version redelivery
+// with possibly different content — the alias-vs-commit shape), or
+// regression is treated as UNPROVEN and fails open.
+//
+// The equality/regression arms are defense in depth, not a claimed
+// production-reachable path: production dispatch drops same-or-stale
+// Version deliveries before they ever reach Apply (manager_assignment.go
+// alias and commit handlers, ~lines 1070-1085), so in practice only the gap
+// shape is exercised. See Apply's doc comment for what this check does and
+// does not repair.
+func transitionVersionAdjacent(previous, next types.Assignment) bool {
+	return previous.Version+1 == next.Version
+}
+
 // Apply performs the multi-phase handoff application for the worker's new assignment.
 // Steps: prepare -> (optional delay) -> apply consumer -> commit -> (optional delay) -> stabilize.
+//
+// Fail-open on unproven continuity (PARTIAL repair). previous is not
+// necessarily next's direct predecessor — production callers diff against
+// the worker's last COMMITTED assignment, which a coalesced retry/stash can
+// leave more than one version behind next. When
+// transitionVersionAdjacent(previous, next) is false, Apply treats previous
+// as empty for the prepare phase only (commit and stabilize already walk
+// all of next unconditionally and are untouched): prepare then re-evaluates
+// every partition in next, so a foreign stable claim is re-recorded as
+// PendingOwner and a missing claim is recreated via NewInitialClaim, both
+// carried to stable by the unchanged commit/stabilize phases.
+//
+// Scope: this heals missed-version (gap) discontinuities only — including
+// both of the round-1 counterexamples (A regains a partition coalesced
+// through an intermediate owner; a reaped claim is recreated after a missed
+// removal/re-add). It is NOT an end-to-end continuity proof. Two shapes
+// stay open, tracked as findings, not covered here: (a) equal-Version
+// authority changes (an alias and a commit can expose different content at
+// the same Version; a publisher's CAS-loss recovery can also emit two
+// different assignments at the same Version) never reach a full Apply,
+// because production dispatch drops <=-Version deliveries before Apply is
+// even called; (b) claims carry no assignment Version/commit identity, so a
+// stale cross-worker retry can still mutate a claim behind an adjacent,
+// locally-continuous transition. Both require the deferred claim-level
+// commit-identity fence project.
 func (t *twoPhaseCoordinator) Apply(ctx context.Context, workerID string, previous, next types.Assignment) error {
 	// Opportunistic sweep of expired/non-stable claims; skip metrics as requested.
 	// Runs before any early returns to maximize cleanup. Apply-origin sweeps
@@ -292,8 +341,25 @@ func (t *twoPhaseCoordinator) Apply(ctx context.Context, workerID string, previo
 
 	inst := newInstrumenter(t.cfg.Metrics)
 
+	// Prepare diffs against previous only when continuity is proven; on any
+	// gap/equality/regression, previous is treated as empty so prepare
+	// walks all of next (see the fail-open doc above). Commit and stabilize
+	// are unconditionally full-next walks already and are untouched.
+	preparePrevious := previous
+	if !transitionVersionAdjacent(previous, next) {
+		preparePrevious = types.Assignment{}
+		if t.cfg.Logger != nil {
+			t.cfg.Logger.Debug("handoff_discontinuous_apply",
+				"worker_id", workerID,
+				"previous_version", previous.Version,
+				"next_version", next.Version,
+				"partitions", len(next.Partitions),
+			)
+		}
+	}
+
 	// Phase: prepare - write/update claims for partitions being added.
-	if err := inst.phase("prepare", func() error { return t.preparePhase(ctx, workerID, previous, next) }); err != nil {
+	if err := inst.phase("prepare", func() error { return t.preparePhase(ctx, workerID, preparePrevious, next) }); err != nil {
 		inst.finish(err)
 		return err
 	}

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -676,7 +676,18 @@ func (t *twoPhaseCoordinator) sweepConfirmWait(ctx context.Context) bool {
 // absence clock: time spent unvouched is time this worker could not
 // verify continuous absence, so it must not count toward OrphanGrace —
 // otherwise a clock started before a long follower stint would reap
-// instantly on the first vouched pass after it. Runs under sweepMu.
+// instantly on the first vouched pass after it.
+//
+// liveOK=true clears the absence clock for every pid PRESENT in this
+// pass's live set, pass-level and independent of any later per-claim
+// read outcome. Without this, a claim that reappears in a vouched live
+// set on a pass whose per-key Get then fails would skip sweepClaim
+// entirely (see sweepPass), leaving maybeReapOrphan's own in-set clear
+// unreached; a later pass could then reap using the ORIGINAL absence
+// timestamp instead of requiring a fresh grace measured from the
+// SECOND disappearance. maybeReapOrphan's in-set clear stays as
+// defense in depth for the common case. Runs under sweepMu, called by
+// both the full-pass and cached-pass bodies.
 func (t *twoPhaseCoordinator) resolveLiveSet(ctx context.Context) (map[string]struct{}, bool) {
 	if t.cfg.OrphanGrace <= 0 || t.cfg.LivePartitions == nil {
 		return nil, false
@@ -684,6 +695,12 @@ func (t *twoPhaseCoordinator) resolveLiveSet(ctx context.Context) (map[string]st
 	live, liveOK := t.cfg.LivePartitions(ctx)
 	if !liveOK {
 		clear(t.orphanAbsentSince)
+	} else {
+		for pid := range t.orphanAbsentSince {
+			if _, ok := live[pid]; ok {
+				delete(t.orphanAbsentSince, pid)
+			}
+		}
 	}
 
 	return live, liveOK

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -12,8 +12,26 @@ import (
 	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go/jetstream"
 	"golang.org/x/sync/errgroup"
 )
+
+// followerBackstopTarget caps the GATING-INDUCED slowdown for a
+// non-authority worker: its ticker cadence is never gated below
+// max(SweepInterval, ~followerBackstopTarget). It is NOT an absolute
+// healing-latency bound — SweepInterval has no upper bound, and a large
+// configured interval slows leaders and followers alike exactly as it
+// does today; the gate adds at most this factor on top.
+const followerBackstopTarget = 5 * time.Minute
+
+// reapDeleteTimeout bounds the reap arm's conditioned KV delete. The
+// ticker sweep otherwise runs on the manager-lifetime context, so
+// without this bound a degraded store could hold authMu (and therefore
+// block authority sampling) for an unbounded request timeout. With it,
+// the worst case is: a tick fires during a stalled delete, blocks in
+// sampleAuthority for at most this long, then proceeds — samples are
+// delayed, never lost.
+const reapDeleteTimeout = 5 * time.Second
 
 // twoPhaseCoordinator implements a prepare/commit protocol using KV-backed claims.
 // It supports optional observability delays (for tests/demos) and opportunistic
@@ -34,14 +52,60 @@ type twoPhaseCoordinator struct {
 	lastSweep time.Time
 	started   atomic.Bool
 
-	// orphanAbsentSince records, per claim key, when the sweep first observed
-	// the partition absent from a vouched LivePartitions set. Entries clear
-	// when the partition reappears, when the claim is reaped, when the claim
-	// key stops being listed, or wholesale on an unvouched pass. Guarded by
-	// sweepMu (single-flight sweep = single writer). In-memory only: a
-	// restart or leadership change restarts the grace clock, which is the
-	// conservative direction.
-	orphanAbsentSince map[string]time.Time
+	// authMu serializes three critical sections that together implement
+	// the sweep-authority generation fence: (1) sampleAuthority's
+	// sample+record of SweepAuthority, (2) resolveLiveSet's vouch
+	// snapshot {vouchNow, passGen}, taken (or the generation bumped)
+	// every time LivePartitions is resolved, and (3) maybeReapOrphan's
+	// final generation check plus its conditioned Delete. Lock ordering
+	// is sweepMu -> authMu for every sweep-path acquisition;
+	// sampleAuthority (the ticker's per-tick sample) takes authMu alone.
+	// Never the reverse — and SweepAuthority itself must never call back
+	// into the coordinator (that would be exactly the reverse-order
+	// cycle).
+	authMu sync.Mutex
+	// unvouchedGen is a GENERATION, not a timestamp, guarded by authMu.
+	// It advances once per: (a) a recorded false SweepAuthority sample;
+	// (b) an unvouched vouch attempt (resolveLiveSet's liveOK=false);
+	// (c) an ambiguous reap-delete outcome (self-poison) — this third
+	// cause advances the generation even under nil SweepAuthority, so
+	// nil authority does not make the reap arm's discard path
+	// permanently unreachable: a retained clock whose delete outcome is
+	// unknown must re-earn a fresh vouched grace regardless of whether
+	// SweepAuthority is configured.
+	unvouchedGen uint64
+	// backstopDue latches a due backstop tick whose pass was NOT
+	// admitted (TryLock lost to a concurrent sweep, or the in-pass
+	// interval throttle absorbed it because an Apply-origin sweep ran
+	// recently): every subsequent tick retries until one ticker pass is
+	// admitted. Touched only by the ticker goroutine (Start's single
+	// background loop) — no lock needed.
+	backstopDue bool
+	// testHookAfterVouchSnapshot, when non-nil, is invoked immediately
+	// after resolveLiveSet's vouch snapshot and before the first claim
+	// decision — in BOTH the full-pass and cached-pass bodies. TEST-ONLY:
+	// always nil in production. Lets a test park a pass between the
+	// vouch snapshot and its first reap decision to deterministically
+	// race a false sample against it.
+	testHookAfterVouchSnapshot func()
+
+	// orphanAbsentSince records, per claim key, the vouch snapshot in
+	// effect when the sweep first observed the partition absent from a
+	// vouched LivePartitions set: since = the pass's vouchNow (not
+	// pass-start now — strictly conservative, never seeds earlier than
+	// today's behavior) and gen = the pass's unvouchedGen snapshot,
+	// fencing the eventual reap decision against any false-authority
+	// sample or ambiguous delete outcome recorded after the clock was
+	// seeded. Entries clear when the partition reappears, when the claim
+	// is reaped, when the claim key stops being listed, wholesale on an
+	// unvouched pass, or on a fence mismatch at reap time (discard —
+	// never re-seeded from a stale timestamp within the same pass; only
+	// a later freshly vouched pass seeds a replacement). Guarded by
+	// sweepMu (single-flight sweep = single writer) for map access; the
+	// `gen` comparison additionally reads authMu-guarded unvouchedGen.
+	// In-memory only: a restart or leadership change restarts the grace
+	// clock, which is the conservative direction.
+	orphanAbsentSince map[string]orphanClock
 
 	// Sweep scan-gate state, all guarded by sweepMu like every other
 	// sweep field. sweepCache holds the (claim, revision) view of the
@@ -100,10 +164,67 @@ type cachedClaim struct {
 	rev   uint64
 }
 
+// orphanClock is one absence-clock entry: the vouch snapshot the clock
+// was seeded from (see orphanAbsentSince).
+type orphanClock struct {
+	since time.Time
+	gen   uint64
+}
+
+// vouchSnapshot is the {vouchNow, passGen} pair resolveLiveSet takes,
+// under authMu, when LivePartitions vouches for the live set (liveOK ==
+// true). Every absence clock seeded during the pass carries this
+// snapshot, so a reap decision can later fence itself against any
+// unvouched observation recorded after the vouch.
+type vouchSnapshot struct {
+	now time.Time
+	gen uint64
+}
+
+// backstopEveryFor derives the follower backstop's tick period from the
+// (already-normalized, guaranteed positive) sweep interval: FLOOR
+// division, floored at 1 (a no-op — the follower keeps the configured
+// full cadence — once the interval alone already exceeds
+// followerBackstopTarget). Extracted as a pure function so the boundary
+// table (§4.8) is directly unit-testable.
+func backstopEveryFor(interval time.Duration) int {
+	return max(1, int(followerBackstopTarget/interval))
+}
+
+// sampleAuthority is the ONLY path by which a ticker fire observes
+// SweepAuthority. Sample and record are one authMu critical section, so
+// a false sample can never exist "observed but not yet recorded" while a
+// concurrent reap fences its decision against unvouchedGen. A nil
+// SweepAuthority short-circuits to authorized == true without touching
+// the generation — nil-authority ticker cadence, scan-gate behavior, and
+// the reconcile arms stay byte-for-byte today's.
+func (t *twoPhaseCoordinator) sampleAuthority() bool {
+	t.authMu.Lock()
+	defer t.authMu.Unlock()
+	authorized := t.cfg.SweepAuthority == nil || t.cfg.SweepAuthority()
+	if !authorized {
+		t.unvouchedGen++
+	}
+
+	return authorized
+}
+
 // Start launches a background goroutine that sweeps stale claims at SweepInterval.
 //
 // This ensures stale/expired claims are cleaned up even in idle systems where
-// Apply is rarely called. The goroutine exits when ctx is cancelled.
+// Apply is rarely called. The goroutine exits when ctx is cancelled (or, in
+// tests, when an injected SweepTicks channel is closed).
+//
+// Every tick samples sweep authority (sampleAuthority). An authorized
+// (leader) worker sweeps at the full configured cadence, byte-for-byte
+// today's behavior. A non-authorized worker only attempts a pass on
+// backstop ticks — every backstopEvery-th tick, phase-staggered by
+// SweepPhaseSeed across the fleet — unless a previous due tick's pass was
+// not admitted (backstopDue latch), in which case every subsequent tick
+// retries until one pass is admitted. This bounds ticker-driven healing
+// on non-authority workers to roughly (backstopEvery+1) x SweepInterval
+// even when no worker holds authority, while a healthy leader keeps
+// today's full cadence.
 //
 // Start is idempotent: calling it more than once has no effect.
 func (t *twoPhaseCoordinator) Start(ctx context.Context) {
@@ -113,15 +234,45 @@ func (t *twoPhaseCoordinator) Start(ctx context.Context) {
 	if !t.started.CompareAndSwap(false, true) {
 		return // already started
 	}
+
+	// backstopEveryFor always returns >= 1 (max(1, ...)), so this
+	// narrowing to uint64 never wraps; computed once here so the
+	// modulo check inside the goroutine needs no repeated conversion.
+	backstopEvery := uint64(backstopEveryFor(t.cfg.SweepInterval)) //nolint:gosec // G115: backstopEveryFor >= 1 always
+	phase := t.cfg.SweepPhaseSeed % backstopEvery
+
 	go func() {
-		ticker := time.NewTicker(t.cfg.SweepInterval)
-		defer ticker.Stop()
+		tickSrc := t.cfg.SweepTicks
+		if tickSrc == nil {
+			ticker := time.NewTicker(t.cfg.SweepInterval)
+			defer ticker.Stop()
+			tickSrc = ticker.C
+		}
+
+		var tick uint64 // coordinator-lifetime monotonic; never reset on authority flaps
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				t.maybeSweepClaims(ctx, sweepOriginTicker)
+			case _, ok := <-tickSrc:
+				if !ok {
+					return // closed injected channel: clean test teardown
+				}
+				tick++
+				authorized := t.sampleAuthority()
+				if !authorized {
+					if (tick+phase)%backstopEvery != 0 && !t.backstopDue {
+						continue // follower off-cycle: no probe, no KV I/O
+					}
+					t.backstopDue = true
+				}
+				admitted := t.maybeSweepClaims(ctx, sweepOriginTicker)
+				if admitted {
+					t.backstopDue = false
+				}
+				if t.cfg.SweepObserver != nil {
+					t.cfg.SweepObserver(sweepOriginTicker, authorized, admitted)
+				}
 			}
 		}
 	}()
@@ -131,8 +282,13 @@ func (t *twoPhaseCoordinator) Start(ctx context.Context) {
 // Steps: prepare -> (optional delay) -> apply consumer -> commit -> (optional delay) -> stabilize.
 func (t *twoPhaseCoordinator) Apply(ctx context.Context, workerID string, previous, next types.Assignment) error {
 	// Opportunistic sweep of expired/non-stable claims; skip metrics as requested.
-	// Runs before any early returns to maximize cleanup.
-	t.maybeSweepClaims(ctx, sweepOriginApply)
+	// Runs before any early returns to maximize cleanup. Apply-origin sweeps
+	// are never gated by sweep authority (untouched, every worker): the
+	// authorized value reported to the observer is a constant true marker.
+	admitted := t.maybeSweepClaims(ctx, sweepOriginApply)
+	if t.cfg.SweepObserver != nil {
+		t.cfg.SweepObserver(sweepOriginApply, true, admitted)
+	}
 
 	inst := newInstrumenter(t.cfg.Metrics)
 
@@ -550,18 +706,26 @@ func (t *twoPhaseCoordinator) stabilizePhase(ctx context.Context, workerID strin
 // work keeps firing at today's cadence on an idle bucket. Apply-origin
 // passes never use the gate (no probe, no confirm wait, no gate-state
 // mutation): the manager's apply pipeline is byte-for-byte unchanged.
-func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweepOrigin) {
+//
+// Returns admitted: false on the Store == nil, TryLock-miss, and
+// interval-throttle returns; true from the moment the interval throttle
+// is consumed (lastSweep advanced) — even if the body then aborts on
+// probe failure (fail-open full pass runs, per today's contract) or on
+// context cancellation mid-probe (only reachable at shutdown). This
+// "admitted = throttle consumed" definition matches the throttle
+// semantics that already gate the next pass.
+func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweepOrigin) (admitted bool) {
 	if t.cfg.Store == nil {
-		return
+		return false
 	}
 	if !t.sweepMu.TryLock() {
-		return // another sweep is mid-body; this opportunistic pass skips
+		return false // another sweep is mid-body; this opportunistic pass skips
 	}
 	defer t.sweepMu.Unlock()
 
 	now := t.cfg.Now()
 	if t.cfg.SweepInterval > 0 && !t.lastSweep.IsZero() && now.Sub(t.lastSweep) < t.cfg.SweepInterval {
-		return
+		return false
 	}
 	t.lastSweep = now
 
@@ -573,7 +737,7 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 	if origin != sweepOriginTicker || t.prober == nil {
 		t.sweepPass(ctx, now, nil)
 
-		return
+		return true
 	}
 
 	pos, ok, reason := t.sweepProbe(ctx)
@@ -587,13 +751,13 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 			// blocks. ctx cancellation aborts the pass with gate state
 			// untouched.
 			if !t.sweepConfirmWait(ctx) {
-				return
+				return true
 			}
 			pos2, ok2, reason2 := t.sweepProbe(ctx)
 			if ok2 && pos2.Same(t.sweepCachePos) {
 				t.sweepCachedPass(ctx, now)
 
-				return
+				return true
 			}
 			pos, ok = pos2, ok2
 			reason = reason2
@@ -621,6 +785,8 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 		)
 	}
 	t.sweepSkipsSinceFull = 0
+
+	return true
 }
 
 // sweepProbe takes one stream-position probe under the fail-open and
@@ -686,24 +852,45 @@ func (t *twoPhaseCoordinator) sweepConfirmWait(ctx context.Context) bool {
 // unreached; a later pass could then reap using the ORIGINAL absence
 // timestamp instead of requiring a fresh grace measured from the
 // SECOND disappearance. maybeReapOrphan's in-set clear stays as
-// defense in depth for the common case. Runs under sweepMu, called by
-// both the full-pass and cached-pass bodies.
-func (t *twoPhaseCoordinator) resolveLiveSet(ctx context.Context) (map[string]struct{}, bool) {
+// defense in depth for the common case.
+//
+// liveOK=true additionally takes — under authMu, as one atomic snapshot
+// alongside the clock clear above — {vouchNow: cfg.Now(), passGen:
+// unvouchedGen} and returns it as vouch. Every clock seeded during this
+// pass carries this snapshot: since = vouchNow (strictly conservative vs
+// pass-start now — never seeds earlier than today's behavior), and gen
+// fences the eventual reap decision against any unvouched observation
+// recorded after this instant. liveOK=false additionally increments
+// unvouchedGen under authMu (self-poison: an unvouched pass invalidates
+// every clock, matching its wholesale clear above).
+//
+// Runs under sweepMu, called by both the full-pass and cached-pass
+// bodies.
+func (t *twoPhaseCoordinator) resolveLiveSet(ctx context.Context) (live map[string]struct{}, liveOK bool, vouch vouchSnapshot) {
 	if t.cfg.OrphanGrace <= 0 || t.cfg.LivePartitions == nil {
-		return nil, false
+		return nil, false, vouchSnapshot{}
 	}
-	live, liveOK := t.cfg.LivePartitions(ctx)
+	live, liveOK = t.cfg.LivePartitions(ctx)
 	if !liveOK {
 		clear(t.orphanAbsentSince)
-	} else {
-		for pid := range t.orphanAbsentSince {
-			if _, ok := live[pid]; ok {
-				delete(t.orphanAbsentSince, pid)
-			}
+		t.authMu.Lock()
+		t.unvouchedGen++
+		t.authMu.Unlock()
+
+		return live, false, vouchSnapshot{}
+	}
+
+	for pid := range t.orphanAbsentSince {
+		if _, ok := live[pid]; ok {
+			delete(t.orphanAbsentSince, pid)
 		}
 	}
 
-	return live, liveOK
+	t.authMu.Lock()
+	vouch = vouchSnapshot{now: t.cfg.Now(), gen: t.unvouchedGen}
+	t.authMu.Unlock()
+
+	return live, true, vouch
 }
 
 // sweepClaim runs the per-claim sweep decision arms shared by full and
@@ -718,6 +905,7 @@ func (t *twoPhaseCoordinator) sweepClaim(
 	live map[string]struct{},
 	liveOK bool,
 	now time.Time,
+	vouch vouchSnapshot,
 ) {
 	// Cheap pre-filter: skip a CAS write attempt when this claim needs
 	// no reconcile (the common case for already-stable claims).
@@ -736,7 +924,7 @@ func (t *twoPhaseCoordinator) sweepClaim(
 	}
 
 	if liveOK {
-		t.maybeReapOrphan(ctx, pid, cur, rev, live, now)
+		t.maybeReapOrphan(ctx, pid, cur, rev, live, now, vouch)
 	}
 }
 
@@ -775,7 +963,10 @@ func (t *twoPhaseCoordinator) sweepPass(ctx context.Context, now time.Time, latc
 		t.cfg.Metrics.SetClaimStoreSize(len(keys))
 	}
 
-	live, liveOK := t.resolveLiveSet(ctx)
+	live, liveOK, vouch := t.resolveLiveSet(ctx)
+	if t.testHookAfterVouchSnapshot != nil {
+		t.testHookAfterVouchSnapshot()
+	}
 
 	var cache map[string]cachedClaim
 	if latch != nil {
@@ -796,7 +987,7 @@ func (t *twoPhaseCoordinator) sweepPass(ctx context.Context, now time.Time, latc
 		if cache != nil {
 			cache[pid] = cachedClaim{claim: cur, rev: rev}
 		}
-		t.sweepClaim(ctx, pid, cur, rev, live, liveOK, now)
+		t.sweepClaim(ctx, pid, cur, rev, live, liveOK, now, vouch)
 	}
 
 	if liveOK {
@@ -846,10 +1037,13 @@ func (t *twoPhaseCoordinator) sweepCachedPass(ctx context.Context, now time.Time
 		t.cfg.Metrics.SetClaimStoreSize(len(t.sweepCache))
 	}
 
-	live, liveOK := t.resolveLiveSet(ctx)
+	live, liveOK, vouch := t.resolveLiveSet(ctx)
+	if t.testHookAfterVouchSnapshot != nil {
+		t.testHookAfterVouchSnapshot()
+	}
 
 	for pid, cc := range t.sweepCache {
-		t.sweepClaim(ctx, pid, cc.claim, cc.rev, live, liveOK, now)
+		t.sweepClaim(ctx, pid, cc.claim, cc.rev, live, liveOK, now, vouch)
 	}
 
 	// The cached key set IS the current bucket key set (the gate proved
@@ -871,11 +1065,32 @@ func (t *twoPhaseCoordinator) sweepCachedPass(ctx context.Context, now time.Time
 //   - in the set → clear any absence clock, keep;
 //   - not stable, or a pending owner recorded → keep (in-flight handoffs are
 //     the existing sweep arms' job, never the reaper's);
-//   - first vouched absence → start the clock, keep;
-//   - absent for >= OrphanGrace → compare-and-delete at the revision this
-//     pass read. A lost CAS means the claim transitioned concurrently (e.g.
-//     the partition was re-added and prepared) — the reaper yields and the
-//     next pass re-evaluates from a fresh read.
+//   - first vouched absence → start the clock (seeded from vouch, not
+//     pass-start now), keep;
+//   - absent for >= OrphanGrace → the fenced decide-and-delete below.
+//
+// Fenced decide-and-delete: once grace has elapsed, the clock's gen is
+// compared against the current unvouchedGen under authMu. A mismatch
+// means an unvouched observation (false sample, unvouched vouch attempt,
+// or an earlier ambiguous delete) was recorded after this clock's vouch:
+// the window is invalid, so the clock is DISCARDED (deleted, not
+// re-seeded from any stale timestamp) and the pass returns without
+// reaping — only a later freshly vouched pass may seed a replacement
+// from its own snapshot. On a generation match, the conditioned delete
+// runs with a bounded reapDeleteTimeout (the ticker sweep otherwise runs
+// on the manager-lifetime context) while still holding authMu, and its
+// outcome is classified:
+//
+//   - nil: DEFINITIVE application — clear the clock;
+//   - jetstream.ErrKeyExists / ErrKeyNotFound: DEFINITIVE non-application
+//     — the server answered (revision moved / key already gone); keep
+//     the claim and clock, exactly as today's expected-loser skip;
+//   - anything else: AMBIGUOUS — the delete request was already sent and
+//     a context expiry only stops the client-side wait; the server may
+//     still apply it later. Keep the claim and clock AND self-poison the
+//     generation (unvouchedGen++) so every clock seeded before this
+//     instant discards at its next fence — conservative whether or not
+//     the delete eventually applies.
 func (t *twoPhaseCoordinator) maybeReapOrphan(
 	ctx context.Context,
 	pid string,
@@ -883,9 +1098,11 @@ func (t *twoPhaseCoordinator) maybeReapOrphan(
 	rev uint64,
 	live map[string]struct{},
 	now time.Time,
+	vouch vouchSnapshot,
 ) {
 	// Runs under sweepMu (single-flight sweep) — the sole writer of
-	// orphanAbsentSince, so no further locking is needed here.
+	// orphanAbsentSince, so no further locking is needed here except for
+	// the authMu-guarded generation fence below.
 	if _, ok := live[pid]; ok {
 		delete(t.orphanAbsentSince, pid)
 
@@ -895,33 +1112,61 @@ func (t *twoPhaseCoordinator) maybeReapOrphan(
 	if cur.State != ClaimStateStable || cur.PendingOwner != "" {
 		return
 	}
-	since, seen := t.orphanAbsentSince[pid]
+	clock, seen := t.orphanAbsentSince[pid]
 	if !seen {
-		t.orphanAbsentSince[pid] = now
+		t.orphanAbsentSince[pid] = orphanClock{since: vouch.now, gen: vouch.gen}
 
 		return
 	}
-	if now.Sub(since) < t.cfg.OrphanGrace {
+	if now.Sub(clock.since) < t.cfg.OrphanGrace {
 		return
 	}
 
-	if err := t.cfg.Store.Delete(ctx, pid, rev); err != nil {
-		// Revision conflict or transient KV failure: keep the claim and the
-		// clock; a genuine orphan is re-attempted next pass, a re-added
-		// partition clears via the in-set branch above.
+	t.authMu.Lock()
+	if clock.gen != t.unvouchedGen {
+		delete(t.orphanAbsentSince, pid)
+		t.authMu.Unlock()
 		if t.cfg.Logger != nil {
-			t.cfg.Logger.Debug("orphan claim reap skipped",
-				"partition_id", pid, "error", err)
+			t.cfg.Logger.Debug("orphan claim reap discarded: stale generation",
+				"partition_id", pid)
 		}
 
 		return
 	}
-	delete(t.orphanAbsentSince, pid)
+
+	delCtx, cancel := context.WithTimeout(ctx, reapDeleteTimeout)
+	delErr := t.cfg.Store.Delete(delCtx, pid, rev)
+	cancel()
+
+	switch {
+	case delErr == nil:
+		delete(t.orphanAbsentSince, pid)
+	case errors.Is(delErr, jetstream.ErrKeyExists), errors.Is(delErr, jetstream.ErrKeyNotFound):
+		// Definitive non-application: revision conflict or the key is
+		// already gone. Keep the claim and the clock; a genuine orphan is
+		// re-attempted next pass, a re-added partition clears via the
+		// in-set branch above. No self-poison — the outcome is certain.
+	default:
+		// Ambiguous outcome: self-poison so no local bookkeeping can
+		// extend a grace window across it.
+		t.unvouchedGen++
+	}
+	t.authMu.Unlock()
+
+	if delErr != nil {
+		if t.cfg.Logger != nil {
+			t.cfg.Logger.Debug("orphan claim reap skipped",
+				"partition_id", pid, "error", delErr)
+		}
+
+		return
+	}
+
 	if t.cfg.Logger != nil {
 		t.cfg.Logger.Info("reaped orphan claim",
 			"partition_id", pid,
 			"owner", cur.Owner,
-			"absent_for", now.Sub(since).String(),
+			"absent_for", now.Sub(clock.since).String(),
 		)
 	}
 }

--- a/internal/assignment/handoff/twophase_continuity_test.go
+++ b/internal/assignment/handoff/twophase_continuity_test.go
@@ -1,0 +1,441 @@
+package handoff
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// --- B4: missed-version continuity fail-open ---
+//
+// previous is always sourced from the worker's own last COMMITTED
+// assignment in production (manager_assignment.go's
+// committedAssignmentOrEmpty), and retry/stash coalescing can advance
+// `next` past more than one version relative to it. Both reproducers below
+// (from tmp/diff-restricted-walks-design.md §2.1, round-1 P0) model that
+// gap directly at the coordinator level: previous stays pinned at V1 while
+// next jumps to V3, even though an intermediate V2 was actually observed
+// and committed by (or against) another worker's claim in the same shared
+// store.
+
+// TestB4_Sequence1_AtoBtoA_AcrossCoalescedVersion reproduces round-1's
+// first counterexample: A holds p at V1, B takes stable ownership at V2,
+// then V3 hands p back to A — but A's local `previous` is still V1 (V2 was
+// coalesced/missed by A, e.g. because A's own V2 removal attempt returned
+// ErrRemovalPending and was superseded by V3 before it could retry). The
+// V1->V3 diff excludes p (present in both), so a diff-restricted prepare
+// never runs for it. Today's unconditional full commit/stabilize walk does
+// not heal this either: NextCommit only promotes a non-empty PendingOwner,
+// so commit produces state=commit, Owner=B, and A's stabilize skips
+// because the claim's owner is still B.
+func TestB4_Sequence1_AtoBtoA_AcrossCoalescedVersion(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+	coord := New(Config{
+		Store:           store,
+		ConsumerUpdater: nopUpdater{},
+		Now:             time.Now,
+		TTL:             time.Minute,
+		SweepInterval:   time.Hour, // keep the opportunistic sweep out of this reproducer
+		MaxRetries:      3,
+		BaseBackoff:     time.Millisecond,
+		MaxBackoff:      2 * time.Millisecond,
+	}, true)
+
+	p := types.Partition{Keys: []string{"p"}}
+	ctx := t.Context()
+
+	// 1. A commits V1 containing p.
+	v1 := types.Assignment{Version: 1, Partitions: []types.Partition{p}}
+	require.NoError(t, coord.Apply(ctx, "A", types.Assignment{}, v1))
+
+	// 2. B completes V2 -> stable claim Owner=B. B's own `previous` is not
+	// what this reproducer pins; only the resulting claim shape is.
+	v2 := types.Assignment{Version: 2, Partitions: []types.Partition{p}}
+	require.NoError(t, coord.Apply(ctx, "B", types.Assignment{}, v2))
+
+	setup, _, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.Equal(t, "B", setup.Owner, "setup: B must be stable owner before A's V3")
+	require.Equal(t, ClaimStateStable, setup.State)
+
+	// 3. A applies V3 with previous=V1 — a Version gap (A missed/coalesced
+	// past V2), exactly the shape production's committedAssignment-based
+	// diffing produces when a retry or stash coalesces to a newer target.
+	v3 := types.Assignment{Version: 3, Partitions: []types.Partition{p}}
+	require.NoError(t, coord.Apply(ctx, "A", v1, v3))
+
+	got, _, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.Equal(t, ClaimStateStable, got.State,
+		"p must converge to stable after A's V3 re-acquire across the coalesced V2")
+	require.Equal(t, "A", got.Owner,
+		"p must end owned by A: the V1->V3 diff excludes p, so only a fail-open full "+
+			"prepare walk records A as PendingOwner for the untouched commit/stabilize "+
+			"phases to promote")
+}
+
+// TestB4_Sequence2_ReapAndReAdd_AcrossMissedRemoval reproduces round-1's
+// second counterexample: A holds p at V1; the claim is then deleted out of
+// band (models the sweep reaper firing after A missed an intermediate
+// removal version), and V3 re-adds p to A with `previous` still V1 (the
+// removal/re-add pair was coalesced past). The V1->V3 diff again excludes p
+// (present in both), so no prepare recreates the missing claim; today's
+// commit/stabilize walk also no-ops on a nil claim.
+func TestB4_Sequence2_ReapAndReAdd_AcrossMissedRemoval(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+	coord := New(Config{
+		Store:           store,
+		ConsumerUpdater: nopUpdater{},
+		Now:             time.Now,
+		TTL:             time.Minute,
+		SweepInterval:   time.Hour,
+		MaxRetries:      3,
+		BaseBackoff:     time.Millisecond,
+		MaxBackoff:      2 * time.Millisecond,
+	}, true)
+
+	p := types.Partition{Keys: []string{"p"}}
+	ctx := t.Context()
+
+	// A commits V1 with p.
+	v1 := types.Assignment{Version: 1, Partitions: []types.Partition{p}}
+	require.NoError(t, coord.Apply(ctx, "A", types.Assignment{}, v1))
+
+	setup, setupRev, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.NotZero(t, setupRev, "setup: claim must exist after V1")
+	require.Equal(t, "A", setup.Owner)
+
+	// The source removes p in a version A misses; the leader's sweep reaps
+	// the now-orphaned stable claim. Modeled directly as an out-of-band
+	// delete rather than driven through the sweep's TTL/grace machinery,
+	// which is not what this reproducer is pinning.
+	require.NoError(t, store.Delete(ctx, p.SubjectKey(), setupRev))
+	_, revAfterDelete, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.Zero(t, revAfterDelete, "setup: claim must be gone before A's V3")
+
+	// A applies V3 re-adding p, with previous=V1 — the removal was
+	// coalesced past, exactly as production's committedAssignment-based
+	// diffing would produce.
+	v3 := types.Assignment{Version: 3, Partitions: []types.Partition{p}}
+	require.NoError(t, coord.Apply(ctx, "A", v1, v3))
+
+	got, rev, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.NotZero(t, rev,
+		"p's claim must be recreated: the V1->V3 diff excludes p, so only a fail-open "+
+			"full prepare walk's NewInitialClaim recreates the missing claim")
+	require.Equal(t, ClaimStateStable, got.State)
+	require.Equal(t, "A", got.Owner)
+}
+
+// --- transitionVersionAdjacent: pure-function table test ---
+
+func TestTransitionVersionAdjacent_Table(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		previous types.Assignment
+		next     types.Assignment
+		want     bool
+	}{
+		{
+			name:     "consecutive is continuous",
+			previous: types.Assignment{Version: 5},
+			next:     types.Assignment{Version: 6},
+			want:     true,
+		},
+		{
+			name:     "zero-value start is continuous",
+			previous: types.Assignment{},
+			next:     types.Assignment{Version: 1},
+			want:     true,
+		},
+		{
+			name:     "gap (coalesced version) fails open",
+			previous: types.Assignment{Version: 1},
+			next:     types.Assignment{Version: 3},
+			want:     false,
+		},
+		{
+			name:     "equality (same-version redelivery) fails open",
+			previous: types.Assignment{Version: 4},
+			next:     types.Assignment{Version: 4},
+			want:     false,
+		},
+		{
+			name:     "regression fails open",
+			previous: types.Assignment{Version: 7},
+			next:     types.Assignment{Version: 6},
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, transitionVersionAdjacent(tc.previous, tc.next))
+		})
+	}
+}
+
+// getCountingStore wraps a *memStore and counts ClaimStore.Get calls per
+// partition ID, so a test can distinguish "touched by prepare" (3 Gets:
+// prepare+commit+stabilize) from "touched only by commit/stabilize" (2
+// Gets) without the opportunistic Apply-origin sweep's own ListKeys+Get
+// traffic conflating the count (see the row-warmup helper below).
+type getCountingStore struct {
+	inner *memStore
+
+	mu   sync.Mutex
+	gets map[string]int
+}
+
+var _ ClaimStore = (*getCountingStore)(nil)
+
+func newGetCountingStore(inner *memStore) *getCountingStore {
+	return &getCountingStore{inner: inner, gets: make(map[string]int)}
+}
+
+func (s *getCountingStore) Get(ctx context.Context, pid string) (Claim, uint64, error) {
+	s.mu.Lock()
+	s.gets[pid]++
+	s.mu.Unlock()
+
+	return s.inner.Get(ctx, pid)
+}
+
+func (s *getCountingStore) PutIfEpoch(ctx context.Context, pid string, expectedEpoch int64, next Claim) (uint64, error) {
+	return s.inner.PutIfEpoch(ctx, pid, expectedEpoch, next)
+}
+
+func (s *getCountingStore) ListKeys(ctx context.Context) ([]string, error) {
+	return s.inner.ListKeys(ctx)
+}
+
+func (s *getCountingStore) Delete(ctx context.Context, pid string, revision uint64) error {
+	return s.inner.Delete(ctx, pid, revision)
+}
+
+func (s *getCountingStore) count(pid string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.gets[pid]
+}
+
+func (s *getCountingStore) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gets = make(map[string]int)
+}
+
+// newContinuityTestCoordinator builds a *twoPhaseCoordinator over a fixed
+// clock and an hour-long SweepInterval, then consumes the first-call
+// opportunistic sweep with a throwaway empty Apply while the store is still
+// empty (so it costs zero Gets). Because the clock never advances, every
+// subsequent Apply's sweep throttle sees now-lastSweep==0 < SweepInterval
+// and is skipped — isolating the returned getCountingStore's counts to
+// prepare/commit/stabilize phase reads only, matching round-1/round-2's
+// "suppress or separately account for the initial sweep" resolution.
+func newContinuityTestCoordinator(t *testing.T) (*twoPhaseCoordinator, *getCountingStore) {
+	t.Helper()
+
+	fixed := time.Now()
+	counting := newGetCountingStore(newMemStore())
+	cfg := Config{
+		Store:           counting,
+		ConsumerUpdater: nopUpdater{},
+		Now:             func() time.Time { return fixed },
+		TTL:             time.Minute,
+		SweepInterval:   time.Hour,
+		MaxRetries:      3,
+		BaseBackoff:     time.Millisecond,
+		MaxBackoff:      2 * time.Millisecond,
+	}
+	c := New(cfg, true)
+	tp, ok := c.(*twoPhaseCoordinator)
+	require.True(t, ok, "expected a *twoPhaseCoordinator")
+
+	require.NoError(t, tp.Apply(t.Context(), "warmup", types.Assignment{}, types.Assignment{}))
+	counting.reset()
+
+	return tp, counting
+}
+
+// TestTransitionVersionAdjacent_PrepareWalkSet pins the Apply-level consequence
+// of transitionVersionAdjacent: a continuous Apply's prepare only touches gained
+// keys (an already-stable, self-owned key sees no prepare Get — 2 total,
+// commit+stabilize only), while a discontinuous Apply's prepare walks every
+// key in next, including ones already present (byte-identical) in
+// previous — 3 Gets for every key, gained or not.
+func TestTransitionVersionAdjacent_PrepareWalkSet(t *testing.T) {
+	t.Parallel()
+
+	unchanged := types.Partition{Keys: []string{"unchanged"}}
+	gained := types.Partition{Keys: []string{"gained"}}
+
+	t.Run("continuous trusts the diff", func(t *testing.T) {
+		t.Parallel()
+
+		tp, counting := newContinuityTestCoordinator(t)
+		ctx := t.Context()
+
+		// Seed "unchanged" as already stable, owned by A.
+		seed := NewInitialClaim(unchanged.SubjectKey(), "A", time.Now(), time.Minute)
+		counting.inner.data[unchanged.SubjectKey()] = seed
+		counting.inner.rev[unchanged.SubjectKey()] = 1
+
+		previous := types.Assignment{Version: 1, Partitions: []types.Partition{unchanged}}
+		next := types.Assignment{Version: 2, Partitions: []types.Partition{unchanged, gained}}
+		require.True(t, transitionVersionAdjacent(previous, next), "test precondition: must be continuous")
+
+		require.NoError(t, tp.Apply(ctx, "A", previous, next))
+
+		require.Equal(t, 2, counting.count(unchanged.SubjectKey()),
+			"unchanged key must be touched only by commit+stabilize, not prepare")
+		require.Equal(t, 3, counting.count(gained.SubjectKey()),
+			"gained key must be touched by prepare+commit+stabilize")
+	})
+
+	t.Run("gap fails open to a full walk", func(t *testing.T) {
+		t.Parallel()
+
+		tp, counting := newContinuityTestCoordinator(t)
+		ctx := t.Context()
+
+		seed := NewInitialClaim(unchanged.SubjectKey(), "A", time.Now(), time.Minute)
+		counting.inner.data[unchanged.SubjectKey()] = seed
+		counting.inner.rev[unchanged.SubjectKey()] = 1
+
+		// previous carries "unchanged" byte-identically, but the Version
+		// gap (1 -> 3) means the diff cannot be trusted.
+		previous := types.Assignment{Version: 1, Partitions: []types.Partition{unchanged}}
+		next := types.Assignment{Version: 3, Partitions: []types.Partition{unchanged, gained}}
+		require.False(t, transitionVersionAdjacent(previous, next), "test precondition: must be discontinuous")
+
+		require.NoError(t, tp.Apply(ctx, "A", previous, next))
+
+		require.Equal(t, 3, counting.count(unchanged.SubjectKey()),
+			"discontinuous Apply must full-walk prepare even for a key present in previous")
+		require.Equal(t, 3, counting.count(gained.SubjectKey()),
+			"gained key must still be touched by prepare+commit+stabilize")
+	})
+}
+
+// TestTransitionVersionAdjacent_DebounceGapPin prices in the routine-cost case
+// the design note calls out: a debounce-coalesced delivery whose content is
+// completely unchanged (no gained/lost keys, next.Version jumps by more
+// than one) still runs the full prepare walk — every key touched, every
+// prepare write a no-op — rather than the zero-prepare-Get diffed path a
+// continuous Apply would take.
+func TestTransitionVersionAdjacent_DebounceGapPin(t *testing.T) {
+	t.Parallel()
+
+	tp, counting := newContinuityTestCoordinator(t)
+	ctx := t.Context()
+
+	p1 := types.Partition{Keys: []string{"p1"}}
+	p2 := types.Partition{Keys: []string{"p2"}}
+	for _, p := range []types.Partition{p1, p2} {
+		seed := NewInitialClaim(p.SubjectKey(), "A", time.Now(), time.Minute)
+		counting.inner.data[p.SubjectKey()] = seed
+		counting.inner.rev[p.SubjectKey()] = 1
+	}
+
+	// Debounce coalesced V2..V4 away: content unchanged, Version jumps 1->4.
+	previous := types.Assignment{Version: 1, Partitions: []types.Partition{p1, p2}}
+	next := types.Assignment{Version: 4, Partitions: []types.Partition{p1, p2}}
+	require.False(t, transitionVersionAdjacent(previous, next), "test precondition: debounce gap must be discontinuous")
+
+	require.NoError(t, tp.Apply(ctx, "A", previous, next))
+
+	for _, p := range []types.Partition{p1, p2} {
+		require.Equal(t, 3, counting.count(p.SubjectKey()),
+			"debounce-gap Apply must full-walk prepare for every key even though content is unchanged")
+
+		got, _, err := counting.Get(ctx, p.SubjectKey())
+		require.NoError(t, err)
+		require.Equal(t, ClaimStateStable, got.State, "no-op prepare must leave the claim clean stable")
+		require.Equal(t, "A", got.Owner)
+	}
+}
+
+// --- known-open hazard: stale cross-worker retry mutates a claim ---
+
+// TestStaleCrossWorkerRetry_StealsClaim pins a KNOWN-OPEN hazard (round-2
+// P0-2, tmp/diff-restricted-walks_v2_review.md, "Adjacent worker
+// assignments do not fence late claim mutations"): claims carry no
+// assignment Version/commit identity, so an OLDER apply from a DIFFERENT
+// worker is admitted by the coordinator regardless of
+// transitionVersionAdjacent. The check cannot see this shape because it is
+// evaluated per-worker: B's own transition (empty -> V1) is locally
+// adjacent, even though a fresher global commit (A's V2) already moved the
+// partition elsewhere before B's stale retry landed.
+//
+// Sequence:
+//  1. A applies V2 for partition p (previous empty) -> stable, Owner=A.
+//  2. B applies V1 (previous empty) containing p -- a STALE assignment from
+//     BEFORE A's ownership (models a retry of an earlier failed/delayed
+//     apply that B is only now completing).
+//
+// documented current behavior (round-2 P0-2); claims carry no commit
+// identity to fence this; deferred to the fence project. When the fence
+// lands this test must flip.
+func TestStaleCrossWorkerRetry_StealsClaim(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+	coord := New(Config{
+		Store:           store,
+		ConsumerUpdater: nopUpdater{},
+		Now:             time.Now,
+		TTL:             time.Minute,
+		SweepInterval:   time.Hour, // keep the opportunistic sweep out of this reproducer
+		MaxRetries:      3,
+		BaseBackoff:     time.Millisecond,
+		MaxBackoff:      2 * time.Millisecond,
+	}, true)
+
+	p := types.Partition{Keys: []string{"p"}}
+	ctx := t.Context()
+
+	// 1. A applies V2 for p; previous empty (A's first apply).
+	v2 := types.Assignment{Version: 2, Partitions: []types.Partition{p}}
+	require.NoError(t, coord.Apply(ctx, "A", types.Assignment{}, v2))
+
+	setup, _, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.Equal(t, "A", setup.Owner, "setup: A must be stable owner before B's stale V1 retry")
+	require.Equal(t, ClaimStateStable, setup.State)
+
+	// 2. B applies V1 -- a STALE assignment from before A's ownership. B's
+	// own previous is empty (B never locally stored anything before this
+	// retry), so the coordinator sees a locally well-formed, adjacent
+	// transition and has no way to know a fresher global commit (A's V2)
+	// already moved p elsewhere.
+	v1 := types.Assignment{Version: 1, Partitions: []types.Partition{p}}
+	applyErr := coord.Apply(ctx, "B", types.Assignment{}, v1)
+
+	// 3. Assert current behavior: B's Apply succeeds and the claim ends
+	// stable Owner=B -- the stale retry STOLE the claim from A.
+	require.NoError(t, applyErr, "documented current behavior: the coordinator has no "+
+		"cross-worker commit-identity fence, so a stale apply is not rejected")
+
+	got, _, err := store.Get(ctx, p.SubjectKey())
+	require.NoError(t, err)
+	require.Equal(t, ClaimStateStable, got.State)
+	require.Equal(t, "B", got.Owner,
+		"documented current behavior (round-2 P0-2); claims carry no commit identity to "+
+			"fence this; deferred to the fence project. When the fence lands this test must flip.")
+}

--- a/internal/assignment/worker_monitor.go
+++ b/internal/assignment/worker_monitor.go
@@ -351,9 +351,24 @@ func (m *WorkerMonitor) GetActiveWorkers(ctx context.Context) ([]string, error) 
 // Workers whose payload fails to decode are silently omitted — a malformed
 // heartbeat is logged at debug level but does not fail the entire scan.
 //
+// Every per-key Get is bounded by the same pass deadline (opCtx) that
+// guards the Keys() scan — mirroring GetHeartbeatsFor's per-iteration
+// opCtx.Err() guard — so a single wedged Get cannot hang the whole pass
+// past that deadline. Once the deadline has expired anywhere in the pass,
+// the pass aborts and returns the partial map collected so far alongside a
+// wrapped error. That includes an empty Keys() scan: nats.go surfaces a
+// context that closes before any entry is yielded as its no-keys error, so
+// an empty result is accepted as an authoritative empty worker set only
+// while the pass deadline is still live — an expired empty scan aborts
+// with the wrapped error instead.
+//
 // Returns:
-//   - map[string]types.Heartbeat: Decoded heartbeats, keyed by worker ID
-//   - error: Non-nil only on KV access failure that prevents listing keys
+//   - map[string]types.Heartbeat: Decoded heartbeats collected before any
+//     abort, keyed by worker ID
+//   - error: Non-nil on KV access failure that prevents listing keys, or
+//     when the pass deadline expires at any point in the pass — including
+//     an empty Keys() scan whose deadline had already expired (partial map
+//     still returned on mid-scan aborts)
 func (m *WorkerMonitor) GetHeartbeats(ctx context.Context) (map[string]types.Heartbeat, error) {
 	opCtx, cancel := m.boundedOpCtx(ctx)
 	defer cancel()
@@ -361,6 +376,13 @@ func (m *WorkerMonitor) GetHeartbeats(ctx context.Context) (map[string]types.Hea
 	keys, err := m.heartbeatKV.Keys(opCtx)
 	if err != nil {
 		if types.IsNoKeysFoundError(err) {
+			// nats.go Keys() returns its no-keys error when the context
+			// closes before yielding entries, so an EXPIRED empty scan must
+			// not masquerade as an authoritative empty worker set.
+			if cerr := opCtx.Err(); cerr != nil {
+				return nil, fmt.Errorf("heartbeat fetch aborted: %w", cerr)
+			}
+
 			return map[string]types.Heartbeat{}, nil
 		}
 
@@ -369,13 +391,16 @@ func (m *WorkerMonitor) GetHeartbeats(ctx context.Context) (map[string]types.Hea
 
 	out := make(map[string]types.Heartbeat, len(keys))
 	for _, key := range keys {
+		if err := opCtx.Err(); err != nil {
+			return out, fmt.Errorf("heartbeat fetch aborted: %w", err)
+		}
 		// Use the same prefix-strip rule as GetActiveWorkers.
 		if len(key) <= len(m.hbPrefix)+1 || key[:len(m.hbPrefix)] != m.hbPrefix {
 			continue
 		}
 		workerID := key[len(m.hbPrefix)+1:]
 
-		entry, gerr := m.heartbeatKV.Get(ctx, key)
+		entry, gerr := m.heartbeatKV.Get(opCtx, key)
 		if gerr != nil {
 			m.logger.Debug("heartbeat get failed during scan", "key", key, "error", gerr)
 			continue
@@ -386,6 +411,10 @@ func (m *WorkerMonitor) GetHeartbeats(ctx context.Context) (map[string]types.Hea
 			continue
 		}
 		out[workerID] = hb
+	}
+
+	if err := opCtx.Err(); err != nil {
+		return out, fmt.Errorf("heartbeat fetch aborted: %w", err)
 	}
 
 	return out, nil

--- a/internal/assignment/worker_monitor_test.go
+++ b/internal/assignment/worker_monitor_test.go
@@ -288,6 +288,140 @@ func TestWorkerMonitor_GetHeartbeatsFor(t *testing.T) {
 	require.Len(t, errs, 2)
 }
 
+// TestWorkerMonitor_GetHeartbeats_PerKeyGetBoundedByPassDeadline is the bug
+// reproducer: GetHeartbeats' per-key Get must be bounded by the pass
+// deadline (opCtx) — the same bound that already guards the Keys() scan —
+// not by the raw, longer-lived caller ctx (1s here vs opCtx's ~100ms).
+//
+// The primary assertion is order-robust and free of wall-clock arithmetic:
+// the ctx deadline the fake observed on its Get call must be STRICTLY
+// earlier than the outer ctx's own deadline. Pre-fix code passed the raw
+// caller ctx through to Get, so the observed deadline would EQUAL the
+// outer one — the strict inequality is exactly the bug signal, with no
+// scheduler sensitivity. A single key whose Get blocks until the pass
+// deadline expires is a whole-pass abort: GetHeartbeats must return a
+// wrapped context.DeadlineExceeded rather than silently swallowing the
+// trailing-key timeout.
+func TestWorkerMonitor_GetHeartbeats_PerKeyGetBoundedByPassDeadline(t *testing.T) {
+	t.Parallel()
+
+	kv := &fakeKV{keys: []string{"worker.w1"}, getBlocking: true}
+	fakeTTL := 200 * time.Millisecond // opCtx deadline = hbTTL/2 = 100ms
+	monitor := NewWorkerMonitor(kv, "worker", fakeTTL, nil, logging.NewNop())
+
+	// Outer ctx deadline (1s) is deliberately far above the pass deadline
+	// (~100ms) so a Get bound to the wrong context is distinguishable.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	outerDeadline, ok := ctx.Deadline()
+	require.True(t, ok, "outer ctx must carry a deadline for the comparison below")
+
+	_, err := monitor.GetHeartbeats(ctx)
+
+	require.Error(t, err,
+		"a trailing per-key timeout must abort the whole pass, not be swallowed")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	deadlines := kv.GetDeadlines()
+	require.Len(t, deadlines, 1, "exactly one Get call for the single key")
+	require.False(t, deadlines[0].IsZero(), "the ctx passed to Get must carry a deadline")
+
+	// Order-robust primary signal: the pass-bounded opCtx deadline is
+	// strictly earlier than the outer ctx's. A Get handed the raw caller
+	// ctx would observe a deadline EQUAL to outerDeadline.
+	require.True(t, deadlines[0].Before(outerDeadline),
+		"Get's ctx deadline (%v) must be strictly earlier than the outer ctx deadline (%v): "+
+			"the per-key Get must be bounded by the pass deadline (hbTTL/2), not the caller's ctx",
+		deadlines[0], outerDeadline)
+}
+
+// TestWorkerMonitor_GetHeartbeats_AbortsOnExpiredPassDeadline proves the
+// whole-pass-abort contract end to end, including partial-result
+// preservation: key1's Get resolves immediately with a valid, decodable
+// heartbeat; key2's Get blocks until the pass deadline (opCtx) expires;
+// key3 is present in the key list but must never be attempted, since the
+// next iteration's top-of-loop opCtx.Err() guard must short-circuit first.
+// Asserts: the returned map contains exactly key1's decoded heartbeat, the
+// error is non-nil and wraps context.DeadlineExceeded, and key3's Get was
+// never called.
+func TestWorkerMonitor_GetHeartbeats_AbortsOnExpiredPassDeadline(t *testing.T) {
+	t.Parallel()
+
+	key1HB := types.Heartbeat{WorkerID: "key1", SchemaVersion: 1, Timestamp: time.Now().UTC()}
+	key1Bytes, err := jsonMarshal(key1HB)
+	require.NoError(t, err)
+
+	kv := &fakeKV{
+		keys: []string{"worker.key1", "worker.key2", "worker.key3"},
+		getScript: map[string]func(ctx context.Context) (jetstream.KeyValueEntry, error){
+			//nolint:unparam // signature must match getScript's shared func type
+			"worker.key1": func(_ context.Context) (jetstream.KeyValueEntry, error) {
+				return &fakeKVEntry{key: "worker.key1", op: jetstream.KeyValuePut, value: key1Bytes}, nil
+			},
+			//nolint:unparam // signature must match getScript's shared func type
+			"worker.key2": func(ctx context.Context) (jetstream.KeyValueEntry, error) {
+				return nil, blockUntilDone(ctx)
+			},
+			"worker.key3": func(context.Context) (jetstream.KeyValueEntry, error) {
+				// Must never be reached: the top-of-loop opCtx.Err() guard
+				// must abort the pass before key3's iteration calls Get.
+				return nil, errors.New("worker.key3 Get must never be attempted")
+			},
+		},
+	}
+	fakeTTL := 200 * time.Millisecond // opCtx deadline = hbTTL/2 = 100ms
+	monitor := NewWorkerMonitor(kv, "worker", fakeTTL, nil, logging.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	hbs, err := monitor.GetHeartbeats(ctx)
+
+	require.Error(t, err, "an expired pass deadline mid-scan must abort with a non-nil error")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	require.Len(t, hbs, 1, "key1's successful Get before the abort must be preserved")
+	gotKey1, ok := hbs["key1"]
+	require.True(t, ok, "key1's decoded heartbeat must be present in the partial result")
+	require.Equal(t, key1HB.WorkerID, gotKey1.WorkerID)
+	require.Equal(t, key1HB.SchemaVersion, gotKey1.SchemaVersion)
+
+	calls := kv.GetCalls()
+	require.Equal(t, []string{"worker.key1", "worker.key2"}, calls,
+		"key3's Get must never be attempted after the pass deadline expired")
+}
+
+// TestWorkerMonitor_GetHeartbeats_ExpiredEmptyScanAborts pins the
+// ErrNoKeysFound arm of the whole-pass-abort contract: nats.go Keys()
+// surfaces a context that closes before yielding any entry as its no-keys
+// error, so a Keys call that consumed the entire pass deadline and then
+// reported "no keys found" must NOT be accepted as an authoritative empty
+// worker set — GetHeartbeats must return the wrapped
+// context.DeadlineExceeded abort error instead of empty-success.
+func TestWorkerMonitor_GetHeartbeats_ExpiredEmptyScanAborts(t *testing.T) {
+	t.Parallel()
+
+	kv := &fakeKV{keysScript: func(ctx context.Context) ([]string, error) {
+		// Reproduce nats.go's exact surface: consume the pass deadline,
+		// then report no-keys rather than the ctx error.
+		<-ctx.Done()
+
+		return nil, jetstream.ErrNoKeysFound
+	}}
+	fakeTTL := 200 * time.Millisecond // opCtx deadline = hbTTL/2 = 100ms
+	monitor := NewWorkerMonitor(kv, "worker", fakeTTL, nil, logging.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	hbs, err := monitor.GetHeartbeats(ctx)
+
+	require.Error(t, err,
+		"an empty scan whose pass deadline already expired must abort, not return empty-success")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Empty(t, hbs)
+}
+
 func TestWorkerMonitor_GetActiveWorkers_EmptyPrefix(t *testing.T) {
 	t.Parallel()
 	_, nc := partitest.StartEmbeddedNATS(t)
@@ -519,11 +653,41 @@ type fakeKV struct {
 	currentWatcher *fakeKeyWatcher
 	// keysBlocking, when true, causes Keys to block until ctx.Done().
 	keysBlocking bool
+	// keysScript, when non-nil, fully replaces Keys' behavior (consulted
+	// before keysBlocking). Lets tests reproduce nats.go's exact expired-
+	// scan surface: a Keys call that consumes the pass deadline and then
+	// returns the no-keys error rather than the ctx error (see
+	// TestWorkerMonitor_GetHeartbeats_ExpiredEmptyScanAborts).
+	keysScript func(ctx context.Context) ([]string, error)
 	// keys is the server-side truth returned by Keys when keysBlocking is
 	// false. The zero value (nil) preserves the pre-existing behavior of
 	// every test that does not call SetKeys: Keys returns (nil, nil), which
 	// GetActiveWorkers treats as an empty worker set.
 	keys []string
+	// getBlocking, when true, causes Get to block until the ctx it is
+	// called with is Done(), then return that ctx's error — proving which
+	// context a per-key Get is actually bounded by. Tests that use it give
+	// the OUTER ctx a real but generous deadline, well above the pass
+	// deadline (hbTTL/2), so a Get bound to the wrong context shows up as
+	// elapsed time or an outer-deadline error rather than a test hang (see
+	// TestWorkerMonitor_GetHeartbeats_PerKeyGetBoundedByPassDeadline and
+	// TestWorkerMonitor_GetHeartbeats_AbortsOnExpiredPassDeadline).
+	getBlocking bool
+	// getScript, when non-nil, is consulted before the getBlocking branch:
+	// a per-key function controlling exactly what that key's Get call does
+	// (block, return a scripted entry, return an error, etc). Keys absent
+	// from the map fall through to the getBlocking/default behavior. Lets
+	// tests script one key to resolve immediately and another to block
+	// until its context expires, deterministically proving both the
+	// partial-result and abort halves of the whole-pass-abort contract.
+	getScript map[string]func(ctx context.Context) (jetstream.KeyValueEntry, error)
+	// getDeadlines records, per Get call, whether the passed ctx carried a
+	// deadline and what it was — proving which context (pass-bounded opCtx
+	// vs the raw outer ctx) a per-key Get actually received.
+	getDeadlines []time.Time
+	// getCalls records every key a Get call was made for, in order — used
+	// to prove a key was never attempted after an earlier abort.
+	getCalls []string
 }
 
 // SetKeys configures the key list returned by a subsequent (non-blocking)
@@ -564,10 +728,20 @@ func (f *fakeKV) Watch(_ context.Context, _ string, _ ...jetstream.WatchOpt) (je
 	return w, nil
 }
 
+// blockUntilDone blocks until ctx is done and returns its error — shared by
+// fakeKV's *Blocking branches to prove which context bounds a given call.
+func blockUntilDone(ctx context.Context) error {
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
 func (f *fakeKV) Keys(ctx context.Context, _ ...jetstream.WatchOpt) ([]string, error) {
+	if f.keysScript != nil {
+		return f.keysScript(ctx)
+	}
 	if f.keysBlocking {
-		<-ctx.Done()
-		return nil, ctx.Err()
+		return nil, blockUntilDone(ctx)
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -588,8 +762,45 @@ func (f *fakeKV) Update(_ context.Context, _ string, _ []byte, _ uint64) (uint64
 }
 func (f *fakeKV) Delete(_ context.Context, _ string, _ ...jetstream.KVDeleteOpt) error { return nil }
 func (f *fakeKV) Purge(_ context.Context, _ string, _ ...jetstream.KVDeleteOpt) error  { return nil }
-func (f *fakeKV) Get(_ context.Context, _ string) (jetstream.KeyValueEntry, error) {
+func (f *fakeKV) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	f.mu.Lock()
+	f.getCalls = append(f.getCalls, key)
+	if deadline, ok := ctx.Deadline(); ok {
+		f.getDeadlines = append(f.getDeadlines, deadline)
+	} else {
+		f.getDeadlines = append(f.getDeadlines, time.Time{})
+	}
+	script := f.getScript
+	f.mu.Unlock()
+
+	if script != nil {
+		if fn, ok := script[key]; ok {
+			return fn(ctx)
+		}
+	}
+
+	if f.getBlocking {
+		return nil, blockUntilDone(ctx)
+	}
+
 	return nil, jetstream.ErrKeyNotFound
+}
+
+// GetCalls returns a snapshot of the keys Get was called for, in order.
+func (f *fakeKV) GetCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]string(nil), f.getCalls...)
+}
+
+// GetDeadlines returns a snapshot of the per-call ctx deadlines observed by
+// Get. A zero time.Time means that call's ctx carried no deadline.
+func (f *fakeKV) GetDeadlines() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]time.Time(nil), f.getDeadlines...)
 }
 func (f *fakeKV) GetRevision(_ context.Context, _ string, _ uint64) (jetstream.KeyValueEntry, error) {
 	return nil, jetstream.ErrKeyNotFound

--- a/internal/durable/broadcast_config.go
+++ b/internal/durable/broadcast_config.go
@@ -93,6 +93,16 @@ type BroadcastConsumerConfig struct {
 	// Default: 5s.
 	FetchTimeout time.Duration `default:"5s" validate:"gt=0"`
 
+	// PullHeartbeatCap optionally bounds the derived nats.go PullHeartbeat
+	// value. The heartbeat is normally FetchTimeout/2, clamped to nats.go's
+	// PullHeartbeat validity range [500ms, 30s]; when PullHeartbeatCap > 0
+	// the derived heartbeat is further capped to this value. This bounds
+	// missed-heartbeat (ErrNoHeartbeat) detection latency independent of how
+	// high FetchTimeout is raised to reduce idle pull-request churn. 0
+	// (default) disables the cap. See consumer.WithPullHeartbeatCap for the
+	// validated public entry point ([500ms, 30s] when nonzero).
+	PullHeartbeatCap time.Duration `validate:"gte=0"`
+
 	// MaxWaiting caps outstanding pull requests for the durable consumer.
 	// Default: 2.
 	MaxWaiting int `default:"2" validate:"gt=0"`
@@ -197,5 +207,5 @@ func (c *BroadcastConsumerConfig) Validate() error {
 		return fmt.Errorf("wildcard filter is invalid: %w", err)
 	}
 
-	return nil
+	return validatePullHeartbeatCap(c.PullHeartbeatCap)
 }

--- a/internal/durable/broadcast_consumer.go
+++ b/internal/durable/broadcast_consumer.go
@@ -124,7 +124,7 @@ func NewBroadcastConsumer(js jetstream.JetStream, cfg BroadcastConsumerConfig, f
 		handler:          handler,
 		consumerID:       consumerID,
 		consumerIDSource: consumerIDSource,
-		iterFactory:      defaultIterFactory,
+		iterFactory:      makeDefaultIterFactory(cfg.PullHeartbeatCap),
 		loopDone:         make(chan struct{}),
 		rng:              newRetryRNG(cfg.Retry.Seed),
 		recovery: recovery.NewController(recovery.ControllerConfig{

--- a/internal/durable/config.go
+++ b/internal/durable/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arloliu/fuda"
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/internal/recovery"
 	"github.com/arloliu/parti/v2/types"
@@ -247,6 +248,18 @@ type WorkerConsumerConfig struct {
 	// Default: DefaultFetchTimeout (5s).
 	FetchTimeout time.Duration `default:"5s" validate:"gt=0"`
 
+	// PullHeartbeatCap optionally bounds the derived nats.go PullHeartbeat
+	// value. The heartbeat is normally FetchTimeout/2, clamped to nats.go's
+	// PullHeartbeat validity range [500ms, 30s]; when PullHeartbeatCap > 0
+	// the derived heartbeat is further capped to this value. This bounds
+	// missed-heartbeat (ErrNoHeartbeat) detection latency — which fires at
+	// roughly 2x the heartbeat and is how a deleted durable consumer is
+	// detected (see defaultIterFactory) — independent of how high
+	// FetchTimeout is raised to reduce idle pull-request churn. 0 (default)
+	// disables the cap. See consumer.WithPullHeartbeatCap for the validated
+	// public entry point ([500ms, 30s] when nonzero).
+	PullHeartbeatCap time.Duration `validate:"gte=0"`
+
 	// MaxWaiting caps outstanding pull requests for each per-subject durable.
 	// Default: DefaultMaxWaiting (2).
 	MaxWaiting int `default:"2" validate:"gt=0"`
@@ -393,6 +406,31 @@ func validateStreamMissingHookStrategy(hookConfigured bool, strategy RecoveryStr
 	}
 }
 
+// validatePullHeartbeatCap enforces nats.go's PullHeartbeat validity range
+// [500ms, 30s] (jetstream_options.go configureConsume/configureMessages,
+// nats.go v1.52.0) on a nonzero PullHeartbeatCap. Zero is always accepted:
+// it means "no cap", not "zero heartbeat".
+//
+// This closes the internal door around package consumer's identically-named
+// validatePullHeartbeatCap: WorkerConsumerConfig and BroadcastConsumerConfig
+// can be constructed directly (bypassing the public consumer.* option
+// surface), and without this check a PullHeartbeatCap outside the range
+// passed the struct-tag `gte=0` floor, reached natsutil.DerivePullHeartbeat,
+// and produced a value nats.go rejects at iterator creation — the
+// restart/warn loop the cap knob exists to fix.
+func validatePullHeartbeatCap(heartbeatCap time.Duration) error {
+	if heartbeatCap == 0 {
+		return nil
+	}
+	if heartbeatCap < natsutil.MinPullHeartbeat || heartbeatCap > natsutil.MaxPullHeartbeat {
+		return fmt.Errorf(
+			"durable: PullHeartbeatCap must be 0 (disabled) or within [500ms, 30s] (nats.go PullHeartbeat range), got %v",
+			heartbeatCap)
+	}
+
+	return nil
+}
+
 // DefaultWorkerConsumerConfig returns a WorkerConsumerConfig with sensible defaults.
 // Note: Required fields (StreamName, ConsumerPrefix, SubjectTemplate) must still be set by the user.
 func DefaultWorkerConsumerConfig() WorkerConsumerConfig {
@@ -474,6 +512,9 @@ func (c *WorkerConsumerConfig) Validate() error {
 	}
 	if err := validateSubjectTemplate(c.SubjectTemplate, true); err != nil {
 		return fmt.Errorf("subject template is invalid: %w", err)
+	}
+	if err := validatePullHeartbeatCap(c.PullHeartbeatCap); err != nil {
+		return err
 	}
 
 	return validateStreamMissingHookStrategy(c.StreamMissingHook != nil, c.RecoveryStrategy)

--- a/internal/durable/pull_heartbeat_test.go
+++ b/internal/durable/pull_heartbeat_test.go
@@ -1,0 +1,140 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	partitesting "github.com/arloliu/parti/v2/partitest"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkerConsumer_IteratorFactoryInjection_TakesPrecedenceOverPullHeartbeatCap
+// pins that a caller-supplied IteratorFactory still wins over the
+// PullHeartbeatCap-derived default — the cap only affects the default
+// derivation path, never an injected override.
+func TestWorkerConsumer_IteratorFactoryInjection_TakesPrecedenceOverPullHeartbeatCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel: injected factory called")
+	injected := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		return nil, sentinel
+	}
+
+	cfg := WorkerConsumerConfig{
+		StreamName:       "S",
+		ConsumerPrefix:   "wc",
+		SubjectTemplate:  "s.{{.PartitionID}}",
+		PullHeartbeatCap: 2 * time.Second,
+		IteratorFactory:  injected,
+	}
+
+	wc, err := NewWorkerConsumer(js, cfg, func(context.Context, jetstream.Msg) error { return nil })
+	require.NoError(t, err)
+
+	_, err = wc.iterFactory(nil, 1, 30*time.Second)
+	require.ErrorIs(t, err, sentinel, "custom IteratorFactory must take precedence over the PullHeartbeatCap-derived default")
+}
+
+// TestBroadcastConsumer_IteratorFactoryInjection_TakesPrecedenceOverPullHeartbeatCap
+// is the BroadcastConsumer equivalent of the WorkerConsumer precedence pin
+// above: both share the same makeDefaultIterFactory/derivePullHeartbeat
+// derivation, and both must respect the same injection-seam precedence.
+func TestBroadcastConsumer_IteratorFactoryInjection_TakesPrecedenceOverPullHeartbeatCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel: injected factory called")
+	injected := func(_ jetstream.Consumer, _ int, _ time.Duration) (jetstream.MessagesContext, error) {
+		return nil, sentinel
+	}
+
+	cfg := BroadcastConsumerConfig{
+		StreamName:       "S",
+		ConsumerPrefix:   "bc",
+		WildcardFilter:   "s.>",
+		PullHeartbeatCap: 2 * time.Second,
+		IteratorFactory:  injected,
+	}
+
+	bc, err := NewBroadcastConsumer(js, cfg, func(context.Context, jetstream.Msg) error { return nil })
+	require.NoError(t, err)
+
+	_, err = bc.iterFactory(nil, 1, 30*time.Second)
+	require.ErrorIs(t, err, sentinel, "custom IteratorFactory must take precedence over the PullHeartbeatCap-derived default")
+}
+
+// TestWorkerConsumerConfig_Validate_PullHeartbeatCapNegative pins that the
+// struct-tag floor (`validate:"gte=0"`) rejects a negative PullHeartbeatCap
+// at this layer, before validatePullHeartbeatCap's range check ever runs.
+func TestWorkerConsumerConfig_Validate_PullHeartbeatCapNegative(t *testing.T) {
+	cfg := WorkerConsumerConfig{
+		StreamName:       "TEST",
+		ConsumerPrefix:   "wc",
+		SubjectTemplate:  "events.{{.PartitionID}}",
+		PullHeartbeatCap: -time.Second,
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+}
+
+// TestWorkerConsumerConfig_Validate_PullHeartbeatCapBounds pins that this
+// internal config door enforces the same [500ms, 30s] nats.go PullHeartbeat
+// range as the public consumer package: a config built directly through
+// internal/durable (bypassing consumer.WithPullHeartbeatCap) must not be
+// able to smuggle in a cap that natsutil.DerivePullHeartbeat would turn into
+// a value nats.go rejects at iterator creation.
+func TestWorkerConsumerConfig_Validate_PullHeartbeatCapBounds(t *testing.T) {
+	validate := func(heartbeatCap time.Duration) error {
+		cfg := WorkerConsumerConfig{
+			StreamName:       "TEST",
+			ConsumerPrefix:   "wc",
+			SubjectTemplate:  "events.{{.PartitionID}}",
+			PullHeartbeatCap: heartbeatCap,
+		}
+
+		return cfg.Validate()
+	}
+
+	require.NoError(t, validate(0), "0 (disabled) must pass")
+	require.Error(t, validate(499*time.Millisecond), "PullHeartbeatCap below the 500ms nats.go PullHeartbeat floor must fail validation")
+	require.NoError(t, validate(500*time.Millisecond), "PullHeartbeatCap == 500ms is the boundary and must pass")
+	require.NoError(t, validate(30*time.Second), "PullHeartbeatCap == 30s is the boundary and must pass")
+	require.Error(t, validate(30*time.Second+time.Nanosecond), "PullHeartbeatCap above the 30s nats.go PullHeartbeat ceiling must fail validation")
+}
+
+// TestBroadcastConsumerConfig_Validate_PullHeartbeatCapBounds is the
+// BroadcastConsumerConfig equivalent of the WorkerConsumerConfig bounds test
+// above: both share the durable package's validatePullHeartbeatCap helper.
+func TestBroadcastConsumerConfig_Validate_PullHeartbeatCapBounds(t *testing.T) {
+	validate := func(heartbeatCap time.Duration) error {
+		cfg := BroadcastConsumerConfig{
+			StreamName:       "TEST",
+			ConsumerPrefix:   "bc",
+			WildcardFilter:   "events.>",
+			PullHeartbeatCap: heartbeatCap,
+		}
+
+		return cfg.Validate()
+	}
+
+	require.NoError(t, validate(0), "0 (disabled) must pass")
+	require.Error(t, validate(499*time.Millisecond), "PullHeartbeatCap below the 500ms nats.go PullHeartbeat floor must fail validation")
+	require.NoError(t, validate(500*time.Millisecond), "PullHeartbeatCap == 500ms is the boundary and must pass")
+	require.NoError(t, validate(30*time.Second), "PullHeartbeatCap == 30s is the boundary and must pass")
+	require.Error(t, validate(30*time.Second+time.Nanosecond), "PullHeartbeatCap above the 30s nats.go PullHeartbeat ceiling must fail validation")
+}

--- a/internal/durable/worker_consumer.go
+++ b/internal/durable/worker_consumer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/arloliu/parti/v2/internal/dynamicbuild"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/ratelimit"
 	"github.com/arloliu/parti/v2/jsutil"
 	"github.com/arloliu/parti/v2/kvutil"
@@ -124,7 +125,7 @@ func NewWorkerConsumer(js jetstream.JetStream, cfg WorkerConsumerConfig, fn func
 		logger:          cfg.Logger,
 		handler:         handler,
 		subjects:        make(map[string]*partitionConsumer, 64),
-		iterFactory:     defaultIterFactory,
+		iterFactory:     makeDefaultIterFactory(cfg.PullHeartbeatCap),
 		subjectTemplate: tmpl,
 		partitionPrefix: prefix,
 		partitionSuffix: suffix,
@@ -762,14 +763,23 @@ func (wc *WorkerConsumer) shouldSuppressPull(partitionID string) (bool, string) 
 	return false, ""
 }
 
-// defaultIterFactory provides the default messages iterator factory.
-// PullHeartbeat is set to expiry/2 (min 100ms) so that ErrNoHeartbeat
-// fires reliably when the consumer is deleted — enabling Path B detection.
-func defaultIterFactory(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
-	heartbeat := max(expiry/2, 100*time.Millisecond)
-	return cons.Messages(
-		jetstream.PullMaxMessages(batch),
-		jetstream.PullExpiry(expiry),
-		jetstream.PullHeartbeat(heartbeat),
-	)
+// makeDefaultIterFactory returns the default messages iterator factory, with
+// PullHeartbeat derived by natsutil.DerivePullHeartbeat from the expiry
+// passed at call time and heartbeatCap fixed at construction time.
+func makeDefaultIterFactory(heartbeatCap time.Duration) func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
+	return func(cons jetstream.Consumer, batch int, expiry time.Duration) (jetstream.MessagesContext, error) {
+		heartbeat := natsutil.DerivePullHeartbeat(expiry, heartbeatCap)
+
+		return cons.Messages(
+			jetstream.PullMaxMessages(batch),
+			jetstream.PullExpiry(expiry),
+			jetstream.PullHeartbeat(heartbeat),
+		)
+	}
 }
+
+// defaultIterFactory is the uncapped default iterator factory (equivalent to
+// makeDefaultIterFactory(0)), kept as a package-level value for call sites
+// that construct a WorkerConsumer or BroadcastConsumer literal directly
+// without a PullHeartbeatCap.
+var defaultIterFactory = makeDefaultIterFactory(0)

--- a/internal/ipartition/config.go
+++ b/internal/ipartition/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arloliu/parti/v2/internal/durable"
 	"github.com/arloliu/parti/v2/internal/logging"
 	"github.com/arloliu/parti/v2/internal/metrics"
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/partutil"
 	"github.com/arloliu/parti/v2/partition"
 	"github.com/arloliu/parti/v2/types"
@@ -41,6 +42,16 @@ type ConsumerConfig struct {
 
 	// FetchTimeout is the maximum time to wait for messages in each pull.
 	FetchTimeout time.Duration `default:"5s"`
+
+	// PullHeartbeatCap optionally bounds the derived nats.go PullHeartbeat
+	// value. The heartbeat is normally FetchTimeout/2, clamped to nats.go's
+	// PullHeartbeat validity range [500ms, 30s]; when PullHeartbeatCap > 0
+	// the derived heartbeat is further capped to this value. This bounds
+	// missed-heartbeat (ErrNoHeartbeat) detection latency independent of how
+	// high FetchTimeout is raised to reduce idle pull-request churn. 0
+	// (default) disables the cap. See consumer.WithPullHeartbeatCap for the
+	// validated public entry point ([500ms, 30s] when nonzero).
+	PullHeartbeatCap time.Duration
 
 	// MaxWaiting is the maximum number of outstanding pull requests allowed.
 	// Default: 2.
@@ -158,6 +169,9 @@ func (cfg *ConsumerConfig) Validate() error {
 	if cfg.AckPolicy == jetstream.AckNonePolicy {
 		cfg.AckPolicy = jetstream.AckExplicitPolicy
 	}
+	if err := validatePullHeartbeatCap(cfg.PullHeartbeatCap); err != nil {
+		return err
+	}
 
 	// Validate DispatchByKey requires {{key}} in SubjectPattern
 	if cfg.DispatchByKey != nil && *cfg.DispatchByKey {
@@ -178,6 +192,26 @@ func (cfg *ConsumerConfig) Validate() error {
 	}
 	if cfg.Metrics == nil {
 		cfg.Metrics = metrics.NewNop()
+	}
+
+	return nil
+}
+
+// validatePullHeartbeatCap enforces nats.go's PullHeartbeat validity range
+// [500ms, 30s] (jetstream_options.go configureConsume/configureMessages,
+// nats.go v1.52.0) on a nonzero PullHeartbeatCap. Zero is always accepted:
+// it means "no cap", not "zero heartbeat". Mirrors the identically-named
+// helpers in packages durable and consumer; duplicated rather than shared
+// because those helpers are unexported and ipartition constructs its
+// ConsumerConfig independently of both.
+func validatePullHeartbeatCap(heartbeatCap time.Duration) error {
+	if heartbeatCap == 0 {
+		return nil
+	}
+	if heartbeatCap < natsutil.MinPullHeartbeat || heartbeatCap > natsutil.MaxPullHeartbeat {
+		return fmt.Errorf(
+			"ipartition: PullHeartbeatCap must be 0 (disabled) or within [500ms, 30s] (nats.go PullHeartbeat range), got %v",
+			heartbeatCap)
 	}
 
 	return nil

--- a/internal/ipartition/consumer.go
+++ b/internal/ipartition/consumer.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/natsutil"
 	"github.com/arloliu/parti/v2/internal/partutil"
 	"github.com/arloliu/parti/v2/internal/recovery"
 	"github.com/arloliu/parti/v2/jsutil"
@@ -300,7 +301,7 @@ func (c *JSConsumer) run(ctx context.Context) {
 			return
 		}
 
-		heartbeat := max(c.config.FetchTimeout/2, 100*time.Millisecond)
+		heartbeat := natsutil.DerivePullHeartbeat(c.config.FetchTimeout, c.config.PullHeartbeatCap)
 
 		iter, err := cons.Messages(
 			jetstream.PullMaxMessages(c.config.BatchSize),

--- a/internal/ipartition/pull_heartbeat_test.go
+++ b/internal/ipartition/pull_heartbeat_test.go
@@ -1,0 +1,95 @@
+package ipartition
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	partitesting "github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/partition"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestJSConsumer_FetchTimeoutAbove60s_ReceivesMessages proves the run() pull
+// loop's derivePullHeartbeat wiring end-to-end: before the 30s ceiling was
+// added, a FetchTimeout above 60s derived a heartbeat above nats.go's 30s
+// PullHeartbeat maximum, iterator creation failed on every attempt inside
+// run()'s loop, and no message was ever delivered.
+func TestJSConsumer_FetchTimeoutAbove60s_ReceivesMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipping in short mode")
+	}
+
+	ctx := t.Context()
+	_, nc := partitesting.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	_, err = js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "hb90",
+		Subjects: []string{"hb90.*"},
+	})
+	require.NoError(t, err)
+
+	_, err = js.Publish(ctx, "hb90.0", []byte("test"))
+	require.NoError(t, err)
+
+	processed := make(chan struct{}, 1)
+	consumer, err := NewJSConsumer(js, ConsumerConfig{
+		PartitionConfig: partition.PartitionConfig{
+			NumPartitions:  2,
+			SubjectPattern: "hb90.{{partition}}",
+		},
+		StreamName:   "hb90",
+		ConsumerName: "hb90-consumer-0",
+		Partition:    0,
+		FetchTimeout: 90 * time.Second,
+	}, messageHandlerFunc(func(_ context.Context, _ jetstream.Msg) error {
+		processed <- struct{}{}
+
+		return nil
+	}))
+	require.NoError(t, err)
+
+	require.NoError(t, consumer.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = consumer.Stop(stopCtx)
+	})
+
+	select {
+	case <-processed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for message processing; iterator creation likely rejected by nats.go (heartbeat above 30s ceiling)")
+	}
+}
+
+// TestConsumerConfig_Validate_PullHeartbeatCapBounds pins that ConsumerConfig
+// enforces the same [500ms, 30s] nats.go PullHeartbeat range as the durable
+// and consumer packages: a config built directly through internal/ipartition
+// must not be able to smuggle in a cap that natsutil.DerivePullHeartbeat
+// would turn into a value nats.go rejects at iterator creation.
+func TestConsumerConfig_Validate_PullHeartbeatCapBounds(t *testing.T) {
+	validate := func(heartbeatCap time.Duration) error {
+		cfg := ConsumerConfig{
+			PartitionConfig: partition.PartitionConfig{
+				NumPartitions:  2,
+				SubjectPattern: "events.{{partition}}",
+			},
+			StreamName:       "EVENTS",
+			ConsumerName:     "consumer-0",
+			Partition:        0,
+			PullHeartbeatCap: heartbeatCap,
+		}
+
+		return cfg.Validate()
+	}
+
+	require.NoError(t, validate(0), "0 (disabled) must pass")
+	require.Error(t, validate(499*time.Millisecond), "PullHeartbeatCap below the 500ms nats.go PullHeartbeat floor must fail validation")
+	require.NoError(t, validate(500*time.Millisecond), "PullHeartbeatCap == 500ms is the boundary and must pass")
+	require.NoError(t, validate(30*time.Second), "PullHeartbeatCap == 30s is the boundary and must pass")
+	require.Error(t, validate(30*time.Second+time.Nanosecond), "PullHeartbeatCap above the 30s nats.go PullHeartbeat ceiling must fail validation")
+}

--- a/internal/natsutil/pullheartbeat.go
+++ b/internal/natsutil/pullheartbeat.go
@@ -1,0 +1,52 @@
+package natsutil
+
+import "time"
+
+// MinPullHeartbeat and MaxPullHeartbeat are nats.go v1.52.0's validity bounds
+// for an explicit jetstream.PullHeartbeat option: configureConsume and
+// configureMessages both reject a value outside [500ms, 30s] with
+// ErrInvalidOption (jetstream_options.go), and pull.go separately rejects a
+// heartbeat greater than half the expiry ("must be less than 50% of expiry").
+const (
+	MinPullHeartbeat = 500 * time.Millisecond
+	MaxPullHeartbeat = 30 * time.Second
+)
+
+// DerivePullHeartbeat computes the PullHeartbeat value for a pull expiry
+// (FetchTimeout), optionally bounded further by heartbeatCap.
+//
+// heartbeat = expiry/2, clamped to nats.go's PullHeartbeat validity range
+// [MinPullHeartbeat, MaxPullHeartbeat], then capped by heartbeatCap when
+// heartbeatCap > 0.
+//
+// The 500ms floor arm is unreachable only through the validated public
+// consumer config paths: every FetchTimeout entry point there enforces a 1s
+// floor upstream of this call (consumer.validateFetchTimeoutFloor), so
+// expiry/2 >= 500ms always for those callers. It is reachable through
+// internal callers that bypass that gate — internal/durable accepts any
+// positive FetchTimeout, and internal/ipartition only defaults values <= 0 —
+// so a positive sub-second FetchTimeout can drive expiry/2 below 500ms and
+// hit the floor. When it does, the floored heartbeat can then exceed
+// expiry/2, which nats.go separately rejects ("must be less than 50% of
+// expiry") at iterator-creation setup; this function has no way to enforce
+// the 1s precondition itself. The floor exists so this function never
+// returns a value outside nats.go's own [500ms, 30s] PullHeartbeat range —
+// it does not guarantee the value satisfies the expiry/2 relation.
+//
+// Without an upper bound, raising FetchTimeout above 60s (to cut idle
+// MSG.NEXT pull-request churn) derived a heartbeat above nats.go's 30s
+// ceiling, which nats.go rejected outright — iterator creation failed on
+// every attempt and the pull loop spun in a restart/warn cycle forever with
+// no terminal signal. The 30s clamp fixes that unconditionally; heartbeatCap
+// lets a caller pull the ceiling down further to bound missed-heartbeat
+// (ErrNoHeartbeat) detection latency, which fires at roughly 2x the
+// heartbeat and is how a deleted durable consumer is detected.
+func DerivePullHeartbeat(expiry, heartbeatCap time.Duration) time.Duration {
+	heartbeat := max(expiry/2, MinPullHeartbeat)
+	heartbeat = min(heartbeat, MaxPullHeartbeat)
+	if heartbeatCap > 0 {
+		heartbeat = min(heartbeat, heartbeatCap)
+	}
+
+	return heartbeat
+}

--- a/internal/natsutil/pullheartbeat_test.go
+++ b/internal/natsutil/pullheartbeat_test.go
@@ -1,0 +1,73 @@
+package natsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDerivePullHeartbeat_Table pins the derivation formula across the full
+// expiry x cap matrix: expiry in {1s, 5s, 30s, 60s, 61s, 90s} x cap in
+// {0, 500ms, 2s, 5s, 30s}. The expiry=30s/cap=0 case (want=15s) is the
+// documented pre-knob default heartbeat that WithPullHeartbeatCap leaves
+// unchanged when unset.
+//
+// Expected values are hardcoded (not recomputed via the production formula)
+// so this test can't pass by mirroring a bug in derivePullHeartbeat itself.
+func TestDerivePullHeartbeat_Table(t *testing.T) {
+	tests := []struct {
+		expiry       time.Duration
+		heartbeatCap time.Duration
+		want         time.Duration
+	}{
+		{time.Second, 0, 500 * time.Millisecond},
+		{time.Second, 500 * time.Millisecond, 500 * time.Millisecond},
+		{time.Second, 2 * time.Second, 500 * time.Millisecond},
+		{time.Second, 5 * time.Second, 500 * time.Millisecond},
+		{time.Second, 30 * time.Second, 500 * time.Millisecond},
+
+		{5 * time.Second, 0, 2500 * time.Millisecond},
+		{5 * time.Second, 500 * time.Millisecond, 500 * time.Millisecond},
+		{5 * time.Second, 2 * time.Second, 2 * time.Second},
+		{5 * time.Second, 5 * time.Second, 2500 * time.Millisecond},
+		{5 * time.Second, 30 * time.Second, 2500 * time.Millisecond},
+
+		{30 * time.Second, 0, 15 * time.Second},
+		{30 * time.Second, 500 * time.Millisecond, 500 * time.Millisecond},
+		{30 * time.Second, 2 * time.Second, 2 * time.Second},
+		{30 * time.Second, 5 * time.Second, 5 * time.Second},
+		{30 * time.Second, 30 * time.Second, 15 * time.Second},
+
+		{60 * time.Second, 0, 30 * time.Second},
+		{60 * time.Second, 500 * time.Millisecond, 500 * time.Millisecond},
+		{60 * time.Second, 2 * time.Second, 2 * time.Second},
+		{60 * time.Second, 5 * time.Second, 5 * time.Second},
+		{60 * time.Second, 30 * time.Second, 30 * time.Second},
+
+		{61 * time.Second, 0, 30 * time.Second},
+		{61 * time.Second, 500 * time.Millisecond, 500 * time.Millisecond},
+		{61 * time.Second, 2 * time.Second, 2 * time.Second},
+		{61 * time.Second, 5 * time.Second, 5 * time.Second},
+		{61 * time.Second, 30 * time.Second, 30 * time.Second},
+
+		{90 * time.Second, 0, 30 * time.Second},
+		{90 * time.Second, 500 * time.Millisecond, 500 * time.Millisecond},
+		{90 * time.Second, 2 * time.Second, 2 * time.Second},
+		{90 * time.Second, 5 * time.Second, 5 * time.Second},
+		{90 * time.Second, 30 * time.Second, 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expiry.String()+"/cap="+tt.heartbeatCap.String(), func(t *testing.T) {
+			got := DerivePullHeartbeat(tt.expiry, tt.heartbeatCap)
+			require.Equal(t, tt.want, got)
+			require.GreaterOrEqual(t, got, MinPullHeartbeat, "result must respect nats.go's PullHeartbeat floor")
+			require.LessOrEqual(t, got, MaxPullHeartbeat, "result must respect nats.go's PullHeartbeat ceiling")
+			if tt.expiry >= time.Second {
+				require.LessOrEqual(t, got, tt.expiry/2,
+					"result must never exceed expiry/2 for an in-range FetchTimeout (nats.go rejects Heartbeat > 50%% of Expires)")
+			}
+		})
+	}
+}

--- a/manager.go
+++ b/manager.go
@@ -450,6 +450,18 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 		cfg.LabelSpillGrace = *options.labelSpillGrace // may be 0 ⇒ immediate spill
 	}
 
+	// WithBucketEpochProbeInterval overrides Config.BucketEpochProbeInterval
+	// (already defaulted by SetDefaults above). The guard mirrors the config
+	// field's gt=0 validation, which the option path bypasses because Option
+	// cannot return an error.
+	if options.bucketEpochProbeIntervalSet {
+		if options.bucketEpochProbeInterval <= 0 {
+			return nil, fmt.Errorf("WithBucketEpochProbeInterval: %w: must be > 0, got %s",
+				types.ErrInvalidConfig, options.bucketEpochProbeInterval)
+		}
+		cfg.BucketEpochProbeInterval = options.bucketEpochProbeInterval
+	}
+
 	metricsCollector := options.metrics
 	if metricsCollector == nil {
 		metricsCollector = metrics.NewNop()

--- a/manager.go
+++ b/manager.go
@@ -195,6 +195,35 @@ type Manager struct {
 	stashedApplyRetry atomic.Pointer[Assignment]
 	applyRetryActive  atomic.Bool
 
+	// stashedFetchRetry holds the most recent commit whose payload
+	// fetch/verification failed (buildAssignmentFromCommit ok=false), pending
+	// the scheduleCommitFetchRetry coalescing path. Independent of
+	// stashedApplyRetry: a fetch-stage failure has only the commit — no
+	// Assignment has been built yet — so it cannot reuse the Assignment-typed
+	// apply-retry stash. Once a retry attempt fetches the payload
+	// successfully it hands off to the normal apply pipeline, which owns
+	// stashedApplyRetry from that point if Apply itself then fails.
+	stashedFetchRetry atomic.Pointer[types.AssignmentCommit]
+	fetchRetryActive  atomic.Bool
+
+	// highestAcceptedTarget is the highest (Version, LeaderRevision) target
+	// ever ADMITTED by a delivery gate this session: the commit-path
+	// version/LR/dual-read gate in handleCommitValueOnce (raised BEFORE
+	// buildAssignmentFromCommit, so a payload-fetch failure still raises it)
+	// and the alias-path version gate in handleAssignmentEntry. It is
+	// independent of stashedApplyRetry/stashedFetchRetry: those two retry
+	// loops each hold their own in-flight target, and neither alone reflects
+	// what the other admitted. applyAssignmentWithPrevCore's pre-existing
+	// stale gate only drops a candidate behind CurrentAssignment (the last
+	// STORED snapshot); this fence additionally drops a candidate strictly
+	// behind the highest target ever admitted, closing the interleaving
+	// where a slow fetch-retry or apply-retry replays a target that a
+	// sibling retry loop's already-admitted target has since superseded.
+	// raiseAcceptedTarget (max-CAS) is the sole writer; nil means no
+	// delivery gate has admitted a target yet this session, so the fence
+	// check at the apply gate is skipped.
+	highestAcceptedTarget atomic.Pointer[acceptedTarget]
+
 	// committedAssignment holds the last assignment this worker successfully
 	// applied+acked (a successful handoffCoordinator.Apply through
 	// applyAssignmentWithPrevCore). Two roles: (1) the prev source for every

--- a/manager.go
+++ b/manager.go
@@ -354,6 +354,19 @@ type Manager struct {
 	// NOT set this field. Same concurrency contract as
 	// testHookHandleAssignment: set before spawning runCommitWatchSession.
 	testHookHandleCommitValue func(commit *types.AssignmentCommit)
+
+	// testHookRetryLoopEmptyObserved, when non-nil, is invoked synchronously
+	// by activateApplyRetryLoop/activateFetchRetryLoop immediately after a
+	// retry loop observes an empty stash and commits to exiting — at both
+	// exit sites (the pre-attempt pending==nil return and the post-apply
+	// drain-check return) in both loops — BEFORE the deferred ownership-
+	// handoff re-check runs. Lets a test deterministically land a producer's
+	// stash+activate-CAS inside the exit window the ownership-handoff
+	// re-check exists to close. Set ONLY by same-package tests before the
+	// relevant goroutine starts; production MUST leave this nil. See
+	// TestFetchRetry_LostWakeup_StashedDuringExitWindowIsRecovered and
+	// TestApplyRetry_LostWakeup_StashedDuringExitWindowIsRecovered.
+	testHookRetryLoopEmptyObserved func()
 }
 
 // assignmentCalculator defines the interface for partition assignment calculation.

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -1897,7 +1897,9 @@ func (m *Manager) invokeAssignmentChangedHooks(_ /* workerID */ string, oldAssig
 // scheduleApplyRetry stages a failed assignment for a bounded
 // exponential-backoff retry. Multiple failures coalesce to the
 // highest-Version target via stashedApplyRetry. Only one retry goroutine
-// is active at a time; subsequent calls update the stash and return.
+// is active at a time; subsequent calls update the stash and activate
+// (a no-op CAS) so the running loop's ownership-handoff re-check (see
+// activateApplyRetryLoop) is what actually picks the new target up.
 //
 // The retry initial backoff is 1s, doubling up to 30s with ±20% jitter.
 // On retry success the goroutine self-terminates.
@@ -1918,13 +1920,45 @@ func (m *Manager) scheduleApplyRetry(newAssignment Assignment) {
 		}
 	}
 
-	// Only one retry loop at a time.
+	m.activateApplyRetryLoop()
+}
+
+// activateApplyRetryLoop CASes applyRetryActive false->true and, on success,
+// spawns the retry loop goroutine. A losing caller returns immediately,
+// trusting the already-running loop (or its ownership-handoff re-check
+// below) to observe its stash.
+//
+// Lost-wakeup fix: the loop's empty-stash observation and the deferred flag
+// clear below are NOT atomic. A producer can stash a value AND lose this
+// function's activation CAS (the flag is still true) in the window between
+// the loop's last empty-stash check and the flag actually clearing —
+// stranding that value with no loop running to pick it up, unboundedly
+// (reconcile cannot re-deliver a same-Version/higher-LeaderRevision target
+// past the version gate). The deferred ownership-handoff re-check closes
+// this: after clearing the flag it re-checks the stash and re-activates if
+// a racing producer lost. The re-activation CAS is idempotent against a
+// producer that instead won the race itself, so at most one loop ends up
+// running.
+//
+// The ctx guard is mandatory. Without it, a non-empty stash at shutdown
+// (m.ctx.Done()) makes the exiting loop and its respawn ping-pong forever:
+// each respawned loop immediately hits its own ctx.Done() select case and
+// re-triggers the same handoff. With the guard, shutdown strands the stash
+// instead — acceptable, since shutdown is terminal and nothing will ever
+// drain it anyway; without the guard, the race behavior above is otherwise
+// unchanged.
+func (m *Manager) activateApplyRetryLoop() {
 	if !m.applyRetryActive.CompareAndSwap(false, true) {
 		return
 	}
 
 	m.wg.Go(func() {
-		defer m.applyRetryActive.Store(false)
+		defer func() {
+			m.applyRetryActive.Store(false)
+			if m.ctx.Err() == nil && m.stashedApplyRetry.Load() != nil {
+				m.activateApplyRetryLoop()
+			}
+		}()
 		backoff := time.Second
 		const maxBackoff = 30 * time.Second
 		for {
@@ -1939,6 +1973,10 @@ func (m *Manager) scheduleApplyRetry(newAssignment Assignment) {
 
 			pending := m.stashedApplyRetry.Swap(nil)
 			if pending == nil {
+				if hook := m.testHookRetryLoopEmptyObserved; hook != nil {
+					hook()
+				}
+
 				return
 			}
 			prev := m.CurrentAssignment()
@@ -1955,6 +1993,10 @@ func (m *Manager) scheduleApplyRetry(newAssignment Assignment) {
 			}
 			// Success — drain any newer stash that arrived during the apply.
 			if again := m.stashedApplyRetry.Load(); again == nil {
+				if hook := m.testHookRetryLoopEmptyObserved; hook != nil {
+					hook()
+				}
+
 				return
 			}
 			backoff = time.Second // reset for the next attempt
@@ -1991,7 +2033,21 @@ func (m *Manager) scheduleApplyRetry(newAssignment Assignment) {
 func (m *Manager) scheduleCommitFetchRetry(commit *types.AssignmentCommit) {
 	m.stashFetchRetryCandidate(commit)
 
-	// Only one fetch-retry loop at a time.
+	m.activateFetchRetryLoop()
+}
+
+// activateFetchRetryLoop CASes fetchRetryActive false->true and, on success,
+// spawns the retry loop goroutine. A losing caller returns immediately,
+// trusting the already-running loop (or its ownership-handoff re-check
+// below) to observe its stash.
+//
+// Shares scheduleApplyRetry/activateApplyRetryLoop's lost-wakeup fix and
+// rationale verbatim (see activateApplyRetryLoop's Godoc): the deferred
+// cleanup re-checks stashedFetchRetry after clearing fetchRetryActive and
+// re-activates if a racing producer's scheduleCommitFetchRetry lost the
+// activation CAS in the exit window, guarded by m.ctx.Err() == nil to avoid
+// a shutdown-time respawn ping-pong.
+func (m *Manager) activateFetchRetryLoop() {
 	if !m.fetchRetryActive.CompareAndSwap(false, true) {
 		return
 	}
@@ -1999,7 +2055,12 @@ func (m *Manager) scheduleCommitFetchRetry(commit *types.AssignmentCommit) {
 	workerID := m.WorkerID()
 
 	m.wg.Go(func() {
-		defer m.fetchRetryActive.Store(false)
+		defer func() {
+			m.fetchRetryActive.Store(false)
+			if m.ctx.Err() == nil && m.stashedFetchRetry.Load() != nil {
+				m.activateFetchRetryLoop()
+			}
+		}()
 		backoff := time.Second
 		const maxBackoff = 30 * time.Second
 		for {
@@ -2013,6 +2074,10 @@ func (m *Manager) scheduleCommitFetchRetry(commit *types.AssignmentCommit) {
 
 			pending := m.stashedFetchRetry.Swap(nil)
 			if pending == nil {
+				if hook := m.testHookRetryLoopEmptyObserved; hook != nil {
+					hook()
+				}
+
 				return
 			}
 
@@ -2082,6 +2147,10 @@ func (m *Manager) scheduleCommitFetchRetry(commit *types.AssignmentCommit) {
 			// this attempt was running (mirrors scheduleApplyRetry's
 			// success-drain).
 			if again := m.stashedFetchRetry.Load(); again == nil {
+				if hook := m.testHookRetryLoopEmptyObserved; hook != nil {
+					hook()
+				}
+
 				return
 			}
 			backoff = time.Second

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -667,6 +667,14 @@ func (m *Manager) handleAssignmentEntry(workerID string, entry jetstream.KeyValu
 		return
 	}
 
+	// Admission point for the accepted-target fence: this alias's version
+	// gate has passed (the equivalent admission the commit path raises at,
+	// before its own build/apply). Raise even though the dual-read authority
+	// check below may still reject this alias in favor of the commit path —
+	// raiseAcceptedTarget only ever moves the fence forward, so a rejected
+	// alias can at most be a harmless no-op against an already-fresher fence.
+	m.raiseAcceptedTarget(newAssignment.Version, newAssignment.LeaderRevision)
+
 	// Record this as the most-recent legacy alias observation so the
 	// dual-read selector on the commit path can consult it.
 	aliasCopy := newAssignment
@@ -1050,7 +1058,7 @@ func (m *Manager) observeFleetSizeN(version int64, leaderRev uint64, n int) {
 //	(a) commit.Version <= cur.Version          → no-op, LSR = max(LSR, commit.LR)
 //	(b) commit.LR < LSR                        → drop, LSR unchanged, RecordStaleLeaderRejected
 //	(c) worker in Workers, payload checks pass → applyAssignment, LSR = max(LSR, commit.LR)
-//	(c) payload check fails                    → drop, LSR + pending unchanged, stage-specific metric
+//	(c) payload check fails                    → scheduleCommitFetchRetry, LSR unchanged, stage-specific metric
 //	(d) worker NOT in Workers                  → applyAssignment(empty), LSR = max(LSR, commit.LR)
 //	(e) pendingApplyInFlight                   → stash highest-version target, return
 func (m *Manager) handleCommitValue(commit *types.AssignmentCommit) {
@@ -1121,12 +1129,40 @@ func (m *Manager) handleCommitValueOnce(commit *types.AssignmentCommit) *types.A
 		}
 	}
 
+	// Admission point for the accepted-target fence: this commit has passed
+	// every gate above (version, stale-leader fence, dual-read authority,
+	// case (e) coalesce) and is about to be built/applied. Raise BEFORE
+	// buildAssignmentFromCommit so a payload-fetch failure still raises the
+	// fence — the fetch-retry loop this failure schedules must never let an
+	// older sibling target apply ahead of it once this one recovers.
+	m.raiseAcceptedTarget(commit.Version, commit.LeaderRevision)
+
 	newAssignment, ok := m.buildAssignmentFromCommit(commit, workerID)
 	if !ok {
-		// Payload verification failure: case (c) drop; lastSeen and stash
-		// unchanged. Clear pending-flag explicitly (no defer here so the
-		// drain check below sees a consistent flag state) and return.
+		// Payload fetch/verification failure: case (c) drop from the
+		// immediate pipeline. lastSeen unchanged. Clear pending-flag
+		// explicitly (no defer here so the drain check below sees a
+		// consistent flag state).
 		m.pendingApplyInFlight.Store(false)
+
+		// A newer commit may have arrived (and case (e)-stashed into
+		// stashedCommit) while this fetch was in flight. If so it
+		// supersedes the commit that just failed to fetch — hand it back to
+		// the outer drain loop for a fresh attempt instead of retrying the
+		// now-superseded commit.
+		if pending := m.stashedCommit.Swap(nil); pending != nil && commitSupersedesForStash(pending, commit) {
+			return pending
+		}
+
+		// This assignment-bearing commit must not be silently dropped —
+		// the watcher contract (§3.6/§4.4) guarantees delivery of every
+		// assignment-changing commit, and reconcile only ever re-delivers
+		// the CURRENT singleton commit, so a superseded version can never
+		// be recovered later on its own. Route the failure into the same
+		// bounded-backoff retry machinery an Apply failure uses, re-fetching
+		// the payload on each attempt.
+		m.scheduleCommitFetchRetry(commit)
+
 		return nil
 	}
 
@@ -1187,8 +1223,8 @@ func commitSupersedesAppliedForDrain(pending *types.AssignmentCommit, applied As
 
 // buildAssignmentFromCommit constructs the Assignment this worker must
 // apply for the given commit. Returns ok=false on payload-verification
-// failure (case (c) drop) — caller leaves lastSeen unchanged so the next
-// tick retries.
+// failure (case (c)) — the caller routes this into scheduleCommitFetchRetry
+// (leaving lastSeen unchanged) rather than dropping it.
 //
 // Case (c) ok: worker in Workers AND payload checks pass → return a fully
 // populated Assignment.
@@ -1327,6 +1363,47 @@ func isApplyResultStale(candidate, cur Assignment) bool {
 		return candidate.Version < cur.Version
 	}
 	return candidate.LeaderRevision < cur.LeaderRevision
+}
+
+// acceptedTarget is the (Version, LeaderRevision) coordinate of the highest
+// commit/alias target ever admitted by a delivery gate this session. See
+// Manager.highestAcceptedTarget's Godoc for the shared accepted-target fence
+// this feeds.
+type acceptedTarget struct {
+	Version        int64
+	LeaderRevision uint64
+}
+
+// raiseAcceptedTarget max-CASes m.highestAcceptedTarget to (v, lr) when it is
+// strictly (Version, LeaderRevision)-newer than the current fence. It reuses
+// isApplyResultStale itself (wrapping the bare coordinates into Assignment
+// values) rather than a separately-maintained comparison, so the fence and
+// the apply-gate check it feeds can never drift out of lex-order agreement —
+// including isApplyResultStale's V=0 handling, which matters for the
+// core-entry belt-and-braces call from applyAssignmentWithPrevCore (the
+// startup bootstrap path applies an explicit Assignment{}).
+//
+// A losing CAS retries against the winner's value; a candidate that is not
+// strictly newer than the current fence (older, equal, or racing against a
+// concurrent winner) is a no-op.
+func (m *Manager) raiseAcceptedTarget(v int64, lr uint64) {
+	target := Assignment{Version: v, LeaderRevision: lr}
+	for {
+		cur := m.highestAcceptedTarget.Load()
+		if cur != nil {
+			curAsCandidate := Assignment{Version: cur.Version, LeaderRevision: cur.LeaderRevision}
+			// cur is the fence's current value; it is only worth replacing
+			// when it is itself stale relative to the new target, i.e. the
+			// new target is strictly newer.
+			if !isApplyResultStale(curAsCandidate, target) {
+				return
+			}
+		}
+		next := &acceptedTarget{Version: v, LeaderRevision: lr}
+		if m.highestAcceptedTarget.CompareAndSwap(cur, next) {
+			return
+		}
+	}
 }
 
 // assignmentSupersedesForStash reports whether candidate should replace cur in
@@ -1594,6 +1671,41 @@ func (m *Manager) applyAssignmentWithPrevCore(oldAssignment, newAssignment Assig
 		return nil
 	}
 
+	// Accepted-target fence. The stale gate above only compares against
+	// CurrentAssignment (the last STORED snapshot); it does not see a
+	// sibling retry loop's already-admitted target. Two independent retry
+	// stashes (fetch-retry, apply-retry) can each hold a candidate that
+	// passes the stale gate against the stored snapshot yet is behind the
+	// highest (V, LR) target any delivery gate has admitted this session —
+	// e.g. V5's fetch recovers and replays after V6 was admitted (and
+	// itself apply-failed into the apply-retry stash): V5 > stored V4 so
+	// the stale gate alone would let it through. Drop here instead, BEFORE
+	// any coordinator-side effect. Candidate EQUAL to the fence passes (the
+	// legitimate retry of the newest admitted target).
+	if fence := m.highestAcceptedTarget.Load(); fence != nil {
+		fenceAssignment := Assignment{Version: fence.Version, LeaderRevision: fence.LeaderRevision}
+		if isApplyResultStale(newAssignment, fenceAssignment) {
+			m.applyStoreMu.Unlock()
+			m.metrics.RecordStaleSnapshotStoreDropped()
+			m.logger.Info("apply dropped by accepted-target fence",
+				"worker_id", workerID,
+				"candidate_version", newAssignment.Version,
+				"candidate_leader_revision", newAssignment.LeaderRevision,
+				"fence_version", fence.Version,
+				"fence_leader_revision", fence.LeaderRevision,
+			)
+
+			return nil
+		}
+	}
+
+	// Belt-and-braces: keep the fence monotone for core-entry callers that
+	// bypass the two delivery-handler admission points (handleCommitValueOnce,
+	// handleAssignmentEntry) — e.g. the initial-bootstrap path. Harmless here:
+	// the candidate has already cleared both gates above, so raising the
+	// fence to its own coordinates cannot retroactively drop it.
+	m.raiseAcceptedTarget(newAssignment.Version, newAssignment.LeaderRevision)
+
 	// Prev source = the last assignment this worker successfully applied+acked
 	// (committedAssignment), NOT the passed-in oldAssignment / CurrentAssignment().
 	// The snapshot can be advanced past a failed apply by the recovery refresh's
@@ -1848,6 +1960,151 @@ func (m *Manager) scheduleApplyRetry(newAssignment Assignment) {
 			backoff = time.Second // reset for the next attempt
 		}
 	})
+}
+
+// scheduleCommitFetchRetry stages a commit whose payload fetch/verification
+// failed (buildAssignmentFromCommit ok=false) for the same bounded
+// exponential-backoff retry scheduleApplyRetry uses for a failed Apply — the
+// identical 1s->30s ±20% jitter envelope, the same "one goroutine at a time"
+// interlock, and the same unbounded-until-success-or-shutdown behavior (no
+// new escalation policy). This closes the silent-elision gap where a
+// payload-fetch failure previously just cleared pendingApplyInFlight and
+// returned: an assignment-bearing commit is now never dropped without either
+// a later commit explicitly superseding it (below) or this retry loop
+// running until m.ctx is done.
+//
+// Multiple fetch failures coalesce to the highest-identity target via
+// commitSupersedesForStash — the SAME ordering the in-flight case (e) stash
+// (stashedCommit) and the commit-vs-commit comparisons already use, so a
+// newer commit arriving while a fetch retry is pending always wins.
+//
+// On a successful fetch this hands off to applyAssignmentWithPrevSkipJitter,
+// which owns the Apply stage from there: on Apply failure it calls
+// scheduleApplyRetry itself with the now-built Assignment, transferring
+// ownership to the Apply-retry loop; on success it stores directly. If a
+// fresher commit already applied through the normal (non-retry) path while
+// this loop was waiting, the isApplyResultStale gate inside
+// applyAssignmentWithPrevCore silently no-ops the now-stale attempt — the
+// same tolerance scheduleApplyRetry's own late-retry case already relies on
+// — so no double-apply or regression is possible even without explicit
+// cross-goroutine cancellation.
+func (m *Manager) scheduleCommitFetchRetry(commit *types.AssignmentCommit) {
+	m.stashFetchRetryCandidate(commit)
+
+	// Only one fetch-retry loop at a time.
+	if !m.fetchRetryActive.CompareAndSwap(false, true) {
+		return
+	}
+
+	workerID := m.WorkerID()
+
+	m.wg.Go(func() {
+		defer m.fetchRetryActive.Store(false)
+		backoff := time.Second
+		const maxBackoff = 30 * time.Second
+		for {
+			//nolint:gosec // jitter does not require crypto-secure random
+			jitter := time.Duration(float64(backoff) * 0.2 * (2*rand.Float64() - 1))
+			select {
+			case <-m.ctx.Done():
+				return
+			case <-time.After(backoff + jitter):
+			}
+
+			pending := m.stashedFetchRetry.Swap(nil)
+			if pending == nil {
+				return
+			}
+
+			// Fast path: skip the refetch entirely when a delivery gate has
+			// already admitted a strictly newer target than this stashed
+			// commit — the apply-time accepted-target fence would drop it
+			// anyway, so paying for a fetch (and possibly a successful one,
+			// for a payload nobody will ever apply) is pure waste.
+			if fence := m.highestAcceptedTarget.Load(); fence != nil {
+				pendingTarget := Assignment{Version: pending.Version, LeaderRevision: pending.LeaderRevision}
+				fenceTarget := Assignment{Version: fence.Version, LeaderRevision: fence.LeaderRevision}
+				if isApplyResultStale(pendingTarget, fenceTarget) {
+					// Same semantic family as the core apply-time fence drop:
+					// reuse RecordStaleSnapshotStoreDropped so this drop is
+					// observable identically regardless of which of the two
+					// gates catches it (a pre-existing caller may already be
+					// asserting on this metric for a target that happens to
+					// be caught here instead of at the core gate).
+					m.metrics.RecordStaleSnapshotStoreDropped()
+					m.logger.Debug("fetch-retry target dropped by accepted-target fence; skipping refetch",
+						"worker_id", workerID,
+						"candidate_version", pending.Version,
+						"candidate_leader_revision", pending.LeaderRevision,
+						"fence_version", fence.Version,
+						"fence_leader_revision", fence.LeaderRevision,
+					)
+
+					if again := m.stashedFetchRetry.Load(); again == nil {
+						return
+					}
+					backoff = time.Second
+
+					continue
+				}
+			}
+
+			newAssignment, ok := m.buildAssignmentFromCommit(pending, workerID)
+			if !ok {
+				// Still unfetchable: re-stash (coalescing against anything
+				// that arrived meanwhile) and keep going with a grown
+				// backoff. Recursing through scheduleCommitFetchRetry's own
+				// stash CAS mirrors how scheduleApplyRetry's core failure
+				// path re-stashes itself; the activate-CAS below it is a
+				// harmless no-op since this goroutine is already active.
+				m.stashFetchRetryCandidate(pending)
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+
+				continue
+			}
+
+			// Payload fetched: hand off to the normal apply pipeline (see
+			// Godoc above for how Apply-stage failure/success are owned
+			// from here). The returned error is already logged and
+			// retry-scheduled inside applyAssignmentWithPrevCore/
+			// rejectIfStaleIncarnation — nothing further to do with it here,
+			// matching handleCommitValueOnce's own `_ = m.applyAssignment(...)`
+			// discard convention for the same reason.
+			prev := m.CurrentAssignment()
+			_ = m.applyAssignmentWithPrevSkipJitter(prev, newAssignment)
+
+			// Drain any newer fetch-retry target that coalesced in while
+			// this attempt was running (mirrors scheduleApplyRetry's
+			// success-drain).
+			if again := m.stashedFetchRetry.Load(); again == nil {
+				return
+			}
+			backoff = time.Second
+		}
+	})
+}
+
+// stashFetchRetryCandidate coalesces commit into stashedFetchRetry using the
+// same commitSupersedesForStash ordering the in-flight case (e) stash
+// (stashedCommit) uses: keep the existing stash unless commit is strictly
+// newer in (Version, LeaderRevision) or differs at equal coordinates on
+// BatchDigest/source-revision.
+func (m *Manager) stashFetchRetryCandidate(commit *types.AssignmentCommit) {
+	for {
+		cur := m.stashedFetchRetry.Load()
+		if cur != nil && !commitSupersedesForStash(commit, cur) {
+			return
+		}
+		candidate := *commit
+		if m.stashedFetchRetry.CompareAndSwap(cur, &candidate) {
+			return
+		}
+	}
 }
 
 func (m *Manager) recordAssignmentMetrics(oldAssignment, newAssignment Assignment) {

--- a/manager_bucketepochprobeinterval_test.go
+++ b/manager_bucketepochprobeinterval_test.go
@@ -1,0 +1,95 @@
+package parti
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveBucketEpochProbeInterval pins the small helper monitorBucketEpochs
+// delegates its ticker interval to: a positive configured value passes
+// through unchanged, and a non-positive one (unset Config in tests, or a
+// value that somehow slipped past cfg.Validate's gt=0 rule) falls back to
+// 10s.
+func TestResolveBucketEpochProbeInterval(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{"positive value passes through", 30 * time.Second, 30 * time.Second},
+		{"zero falls back to 10s", 0, 10 * time.Second},
+		{"negative falls back to 10s", -5 * time.Second, 10 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, resolveBucketEpochProbeInterval(tc.configured))
+		})
+	}
+}
+
+// newUnconnectedManagerDeps returns constructor dependencies sufficient for
+// exercising NewManager's option/validation path without a live NATS
+// connection — an unconnected jetstream.JetStream is enough for the
+// constructor to run (the same pattern manager_test.go's option tests use
+// inline).
+func newUnconnectedManagerDeps() (jetstream.JetStream, *mockSource, *mockStrategy) {
+	conn := &nats.Conn{}
+	js, _ := jetstream.New(conn)
+
+	return js, &mockSource{}, &mockStrategy{}
+}
+
+// TestManager_BucketEpochProbeInterval_Option verifies WithBucketEpochProbeInterval
+// overrides Config.BucketEpochProbeInterval on the Manager's resolved config,
+// and that omitting the option leaves the config-default value (applied by
+// SetDefaults inside NewManager) in place. No live NATS connection is
+// needed — mirrors TestManager_WorkerLabels_WithOptionOverride's helper
+// pattern (an unconnected jetstream.JetStream is sufficient for the
+// constructor path).
+func TestManager_BucketEpochProbeInterval_Option(t *testing.T) {
+	t.Parallel()
+
+	js, src, assignStrat := newUnconnectedManagerDeps()
+
+	t.Run("no option keeps the config default", func(t *testing.T) {
+		t.Parallel()
+		cfg := DefaultConfig()
+		mgr, err := NewManager(&cfg, js, src, assignStrat)
+		require.NoError(t, err)
+		require.Equal(t, 10*time.Second, mgr.cfg.BucketEpochProbeInterval)
+	})
+
+	t.Run("option overrides the config value", func(t *testing.T) {
+		t.Parallel()
+		cfg := DefaultConfig()
+		mgr, err := NewManager(&cfg, js, src, assignStrat, WithBucketEpochProbeInterval(45*time.Second))
+		require.NoError(t, err)
+		require.Equal(t, 45*time.Second, mgr.cfg.BucketEpochProbeInterval)
+	})
+}
+
+// TestManager_BucketEpochProbeInterval_InvalidRejected verifies the option's
+// guard mirrors Config.BucketEpochProbeInterval's gt=0 validation (matching
+// OperationTimeout's own rule), rejecting zero and negative durations with a
+// wrapped ErrInvalidConfig naming the option.
+func TestManager_BucketEpochProbeInterval_InvalidRejected(t *testing.T) {
+	t.Parallel()
+
+	js, src, assignStrat := newUnconnectedManagerDeps()
+
+	for _, d := range []time.Duration{0, -time.Second} {
+		cfg := DefaultConfig()
+		_, err := NewManager(&cfg, js, src, assignStrat, WithBucketEpochProbeInterval(d))
+		require.Error(t, err)
+		require.ErrorIs(t, err, types.ErrInvalidConfig, "must wrap ErrInvalidConfig")
+		require.Contains(t, err.Error(), "WithBucketEpochProbeInterval", "message must name the option")
+	}
+}

--- a/manager_degraded.go
+++ b/manager_degraded.go
@@ -612,8 +612,9 @@ func (m *Manager) attemptRecoveryFromDegraded() {
 // is outstanding (terminal Degraded => restart/rotation, docs/OPERATIONS.md).
 //
 // This is a LIVE re-probe (not a latch) so there is no pre-arm window: the
-// epoch-fence monitor ticks every OperationTimeout (10s) while recovery ticks
-// every 1s, so a latch could arm after a faster recovery had already exited.
+// epoch-fence monitor ticks every BucketEpochProbeInterval (10s default)
+// while recovery ticks every 1s, so a latch could arm after a faster
+// recovery had already exited.
 //
 // Probe errors are NOT actionable and are skipped (mirroring checkBucketEpochs'
 // continue-on-error): only a successful read with a DIFFERENT Created is a

--- a/manager_election_test.go
+++ b/manager_election_test.go
@@ -518,7 +518,7 @@ func makeBucket(t *testing.T, js jetstream.JetStream, name string) jetstream.Key
 // backing stream and assert checkBucketEpochs trips degraded mode
 // with the expected reason. The test drives checkBucketEpochs
 // directly so the assertion is deterministic (no polling on the
-// production OperationTimeout tick).
+// production BucketEpochProbeInterval tick).
 func TestManager_F1_BucketRecreate_TripsDegraded(t *testing.T) {
 	t.Parallel()
 	_, nc := partitest.StartEmbeddedNATS(t)

--- a/manager_fetch_retry_test.go
+++ b/manager_fetch_retry_test.go
@@ -1,0 +1,705 @@
+package parti
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/assignment/handoff"
+	"github.com/arloliu/parti/v2/internal/hooks"
+	"github.com/arloliu/parti/v2/internal/logging"
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Reproducer: assignment-bearing commit silently dropped when its payload
+// fetch fails.
+// ============================================================================
+//
+// THE DEFECT (found by external review, codex-u2-r5-report.md §1.9)
+//
+// buildAssignmentFromCommit's payload fetch/verify failure (ok=false) used to
+// be handled by handleCommitValueOnce as a bare drop: pendingApplyInFlight
+// was cleared and the function returned, with no scheduleApplyRetry call and
+// no degraded transition. scheduleApplyRetry was only reachable after a
+// SUCCESSFUL fetch whose handoffCoordinator.Apply then failed. Reconcile only
+// ever re-delivers the CURRENT singleton commit (runCommitWatchSession's
+// onReconcile re-GETs the same key), so once a newer commit lands, a
+// superseded intermediate version's payload can never be recovered — a
+// transient KV blip or a payload that was garbage-collected while still
+// needed silently elides that version forever.
+//
+// THE FIX
+//
+// buildAssignmentFromCommit ok=false now routes through
+// scheduleCommitFetchRetry, a sibling of scheduleApplyRetry with the
+// identical bounded-backoff envelope, coalescing, and unbounded-until-
+// success-or-shutdown behavior (manager_assignment.go).
+
+// newFetchRetryTestManager builds a Manager fixture wired with a real
+// embedded-NATS KV bucket (so FetchAndVerifyCommitPayload's Get can
+// genuinely fail or succeed) and an always-succeeding handoff coordinator,
+// mirroring newRetryDigestManager's shape (manager_apply_retry_test.go) but
+// also returning the recordingMetrics handle this file's tests need.
+func newFetchRetryTestManager(t *testing.T) (*Manager, *failNCoordinator, *recordingMetrics) {
+	t.Helper()
+	fc := &failNCoordinator{}
+	m, rm := newFetchRetryTestManagerWithCoordinator(t, fc)
+
+	return m, fc, rm
+}
+
+// newFetchRetryTestManagerWithCoordinator is newFetchRetryTestManager's
+// construction shared with an injectable coordinator, for tests that need
+// finer Apply-timing control than failNCoordinator's simple fail-then-succeed
+// count offers (e.g. the accepted-target fence interleaving tests, which must
+// deterministically hold one retry loop's success open while asserting on
+// the other).
+func newFetchRetryTestManagerWithCoordinator(t *testing.T, coord handoff.Coordinator) (*Manager, *recordingMetrics) {
+	t.Helper()
+	_, nc := partitest.StartEmbeddedNATS(t)
+	akv := partitest.CreateJetStreamKV(t, nc, "fetch-retry-asgn")
+
+	rm := newRecordingMetrics()
+	nopHooks := hooks.NewNop()
+	m := &Manager{
+		cfg:                TestConfig(),
+		hooks:              &nopHooks,
+		metrics:            rm,
+		logger:             logging.NewNop(),
+		heartbeat:          &recordingHeartbeat{},
+		handoffCoordinator: coord,
+		assignmentKV:       akv,
+	}
+	m.workerID.Store("worker-test")
+	m.assignment.Store(Assignment{})
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	m.ctx = ctx
+	m.cancel = cancel
+
+	return m, rm
+}
+
+// fenceRaceCoordinator gives the accepted-target-fence interleaving test
+// (T1) deterministic control over when a specific version's Apply call may
+// succeed. Without this, whether V6's apply-retry stores V6 before or after
+// V5's fetch-retry attempts its own apply is a race between two independent
+// 1s+jitter backoff timers — the confirmed defect only reproduces on ONE of
+// the two possible orderings (V5 attempting apply while V6 has NOT yet
+// stored), so a timer race would make the test flaky in both directions.
+//
+// Every call to heldVersion fails until release() is called, after which
+// every call (past-failed retries included) succeeds; every other version's
+// call always succeeds. Deliberately non-blocking: applyAssignmentWithPrevCore
+// holds applyStoreMu across the ENTIRE Apply call, so a coordinator that
+// blocked INSIDE Apply would hold that mutex hostage and deadlock the other
+// version's retry attempt against it (every apply path — commit, alias,
+// fetch-retry, apply-retry — serializes on the same mutex). Fast, repeated
+// failure achieves the same "cannot store yet" guarantee without ever
+// holding the lock across a wait. Every call is recorded in arrival order
+// for post-hoc assertions.
+type fenceRaceCoordinator struct {
+	heldVersion int64
+	released    atomic.Bool
+
+	mu    sync.Mutex
+	calls []digestEntry
+}
+
+func newFenceRaceCoordinator(heldVersion int64) *fenceRaceCoordinator {
+	return &fenceRaceCoordinator{heldVersion: heldVersion}
+}
+
+func (c *fenceRaceCoordinator) Start(_ context.Context) {}
+
+func (c *fenceRaceCoordinator) Apply(_ context.Context, _ string, _, next types.Assignment) error {
+	if next.Version == c.heldVersion && !c.released.Load() {
+		c.record(next, false)
+
+		return errors.New("synthetic apply failure (held by test)")
+	}
+
+	c.record(next, true)
+
+	return nil
+}
+
+func (c *fenceRaceCoordinator) record(next types.Assignment, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, digestEntry{
+		version: next.Version,
+		lr:      next.LeaderRevision,
+		digest:  types.PartitionSetDigest(next.Partitions),
+		ok:      ok,
+	})
+}
+
+func (c *fenceRaceCoordinator) log() []digestEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]digestEntry, len(c.calls))
+	copy(out, c.calls)
+
+	return out
+}
+
+// release lets heldVersion's Apply calls succeed from this point on. Safe to
+// call multiple times (idempotent atomic.Bool store).
+func (c *fenceRaceCoordinator) release() {
+	c.released.Store(true)
+}
+
+// computeCommitPayloadRef computes the content-addressed ref publishCommitPayload
+// (manager_apply_retry_test.go) would write for parts, WITHOUT publishing it —
+// lets a test build a commit that references a not-yet-existing payload key so
+// the first fetch attempt genuinely fails.
+func computeCommitPayloadRef(t *testing.T, parts []types.Partition) types.AssignmentPayloadRef {
+	t.Helper()
+	payload := types.AssignmentPayload{
+		SchemaVersion: types.AssignmentSchemaVersion,
+		Partitions:    parts,
+	}
+	canonical, err := json.Marshal(payload)
+	require.NoError(t, err)
+	hash := sha256.Sum256(canonical)
+	hashHex := hex.EncodeToString(hash[:])
+
+	return types.AssignmentPayloadRef{
+		Key:         "assignment._payload." + hashHex,
+		PayloadHash: hashHex,
+		SetDigest:   types.PartitionSetDigest(parts),
+	}
+}
+
+// TestFetchRetry_PayloadFetchFailure_RetriesAndApplies is the primary
+// reproducer. It fails on the pre-fix parent (require.Eventually times out:
+// nothing ever retries a fetch failure) and passes post-fix (the retry loop
+// eventually observes the payload once it is published and applies it).
+func TestFetchRetry_PayloadFetchFailure_RetriesAndApplies(t *testing.T) {
+	t.Parallel()
+	m, fc, rm := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	parts := []types.Partition{{Keys: []string{"alpha"}}}
+	ref := computeCommitPayloadRef(t, parts) // NOT published yet — fetch must fail.
+
+	commit := &types.AssignmentCommit{
+		Version:        5,
+		LeaderRevision: 10,
+		Workers:        []string{wid},
+		Payloads:       map[string]types.AssignmentPayloadRef{wid: ref},
+	}
+
+	m.handleCommitValue(commit)
+
+	// Immediately after: the fetch failed, so nothing applied yet and the
+	// commit must not have been silently forgotten (this alone is already
+	// true pre-fix, since case (c) drop leaves state untouched).
+	require.Equal(t, int64(0), fc.applyCount.Load(), "fetch failure must not call Apply")
+	require.Nil(t, m.committedAssignment.Load(), "must not be committed before the payload is fetchable")
+	require.GreaterOrEqual(t, rm.payloadFetchError.Load(), int64(1), "fetch failure must be recorded")
+
+	// The retry loop's active flag is set synchronously (CompareAndSwap)
+	// before scheduleCommitFetchRetry returns, i.e. before handleCommitValue
+	// above returned — no sleep needed to "give it a moment to arm".
+	require.True(t, m.fetchRetryActive.Load(), "fetch-retry loop must be active synchronously after the failed fetch")
+
+	// Simulate the transient KV blip resolving: publish the payload the
+	// commit already references. This genuinely exercises "recover after
+	// failure" (the loop's first attempt already failed above), not
+	// "succeed on the very first attempt".
+	publishCommitPayload(t, m.assignmentKV, parts)
+
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 5
+	}, 6*time.Second, 50*time.Millisecond,
+		"an assignment-bearing commit must not be silently dropped on payload-fetch failure: "+
+			"the fetch-retry loop must eventually apply it once the payload becomes fetchable")
+
+	committed := m.committedAssignment.Load()
+	require.Equal(t, types.PartitionSetDigest(parts), types.PartitionSetDigest(committed.Partitions))
+	require.Equal(t, int64(1), fc.applyCount.Load(), "exactly one Apply — the retry's successful attempt")
+}
+
+// TestFetchRetry_CoalescesToHighestVersion pins the fetch-retry stash's
+// coalescing contract: when a second commit also fails to fetch its payload
+// while the first is still pending retry, the stash must hold the newer
+// (higher-identity) commit, not the older one — mirroring
+// scheduleApplyRetry's assignmentSupersedesForStash coalescing
+// (TestApplyRetry_SameVersionDifferentDigest_CommitLost) but for the
+// commit-typed fetch-retry stash and commitSupersedesForStash.
+func TestFetchRetry_CoalescesToHighestVersion(t *testing.T) {
+	t.Parallel()
+	m, fc, _ := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	partsV5 := []types.Partition{{Keys: []string{"alpha"}}}
+	partsV6 := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+	refV5 := computeCommitPayloadRef(t, partsV5) // never published in this test
+	refV6 := computeCommitPayloadRef(t, partsV6) // never published in this test
+
+	commitV5 := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV5},
+	}
+	commitV6 := &types.AssignmentCommit{
+		Version: 6, LeaderRevision: 20, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV6},
+	}
+
+	m.handleCommitValue(commitV5)
+	stashed := m.stashedFetchRetry.Load()
+	require.NotNil(t, stashed, "V5's fetch failure must schedule a fetch retry")
+	require.Equal(t, int64(5), stashed.Version)
+	require.True(t, m.fetchRetryActive.Load(), "retry goroutine must be active")
+
+	// V6 arrives (fresh path — its own fetch also fails) before the pending
+	// retry's backoff fires (initial backoff is ~1s).
+	m.handleCommitValue(commitV6)
+	stashedAfterV6 := m.stashedFetchRetry.Load()
+	require.NotNil(t, stashedAfterV6)
+	require.Equal(t, int64(6), stashedAfterV6.Version,
+		"the fetch-retry stash must coalesce to the higher-version commit V6, not keep the superseded V5")
+
+	require.Equal(t, int64(0), fc.applyCount.Load(), "neither commit ever fetched its payload, so Apply must never run")
+}
+
+// TestFetchRetry_Supersession_NewerAppliesDirectly_LateFetchDropped covers
+// the brief's supersession case: a newer commit applies via the normal
+// (non-retry) path while an older commit's fetch retry is still pending. When
+// the older retry eventually DOES manage to fetch its payload, the apply-time
+// (V, LR) stale gate must silently drop it — no double-apply, no regression,
+// no elision (the newer version is what's live; the older one is subsumed by
+// it, not "lost").
+func TestFetchRetry_Supersession_NewerAppliesDirectly_LateFetchDropped(t *testing.T) {
+	t.Parallel()
+	m, fc, rm := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	partsV5 := []types.Partition{{Keys: []string{"alpha"}}}
+	partsV6 := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+	refV5 := computeCommitPayloadRef(t, partsV5) // published LATE, after V6 already applied
+	refV6 := computeCommitPayloadRef(t, partsV6)
+
+	commitV5 := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV5},
+	}
+	m.handleCommitValue(commitV5)
+	require.NotNil(t, m.stashedFetchRetry.Load(), "V5 fetch failure must be stashed for retry")
+
+	// V6's payload is available immediately, so it applies directly through
+	// the normal (non-retry) path.
+	publishCommitPayload(t, m.assignmentKV, partsV6)
+	commitV6 := &types.AssignmentCommit{
+		Version: 6, LeaderRevision: 20, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV6},
+	}
+	m.handleCommitValue(commitV6)
+
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 6
+	}, 2*time.Second, 20*time.Millisecond, "V6 must apply directly")
+
+	// Now let V5's payload become fetchable too (the "blip resolves" case),
+	// but it is now stale relative to the already-applied V6.
+	publishCommitPayload(t, m.assignmentKV, partsV5)
+
+	// Wait past the fetch-retry's backoff window for it to have fetched V5
+	// and attempted (and been gate-dropped for) its apply.
+	require.Eventually(t, func() bool {
+		return rm.staleSnapshotStoreDropped.Load() >= 1
+	}, 6*time.Second, 50*time.Millisecond,
+		"the late-fetched, now-stale V5 must be dropped by the (V, LR) stale gate")
+
+	committed := m.committedAssignment.Load()
+	require.NotNil(t, committed)
+	require.Equal(t, int64(6), committed.Version, "committed assignment must remain V6 — no regression to the stale V5")
+	require.Equal(t, types.PartitionSetDigest(partsV6), types.PartitionSetDigest(committed.Partitions))
+	require.Equal(t, int64(1), fc.applyCount.Load(),
+		"Apply must have run exactly once (for V6) — V5's late apply attempt must be gate-dropped before Apply, not double-applied")
+}
+
+// TestFetchRetry_ExhaustionMirrorsApplyRetry_NoEscalation pins the "no new
+// escalation policy" requirement: a commit whose payload is permanently
+// unfetchable (never published) is retried forever with the same bounded
+// backoff an Apply failure gets — never escalated to a degraded transition
+// or any other new policy, and never silently given up on either. This
+// mirrors the pre-existing scheduleApplyRetry exhaustion behavior (an
+// Apply failure's retry loop also has no max-attempts cutoff — it retries
+// until success or shutdown).
+func TestFetchRetry_ExhaustionMirrorsApplyRetry_NoEscalation(t *testing.T) {
+	t.Parallel()
+	m, fc, rm := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	parts := []types.Partition{{Keys: []string{"alpha"}}}
+	ref := computeCommitPayloadRef(t, parts) // never published — permanently unfetchable in this test
+
+	commit := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: ref},
+	}
+	m.handleCommitValue(commit)
+
+	require.True(t, m.fetchRetryActive.Load(), "retry goroutine must be active immediately after the first failure")
+
+	// Wait long enough for at least two retry attempts (backoff starts at
+	// ~1s) without ever publishing the payload.
+	require.Eventually(t, func() bool {
+		return rm.payloadFetchError.Load() >= 3
+	}, 8*time.Second, 50*time.Millisecond,
+		"a permanently unfetchable payload must keep retrying (no give-up) exactly like an Apply failure would")
+
+	// No escalation: never applied, never a new/different policy fired.
+	require.Equal(t, int64(0), fc.applyCount.Load(), "Apply must never run for a payload that never became fetchable")
+	require.Nil(t, m.committedAssignment.Load())
+	require.True(t, m.fetchRetryActive.Load(), "the retry loop must still be running, not have given up")
+
+	// Sanity: the manager's high-level state was never pushed anywhere by
+	// this path (no enterDegraded wiring exists here, so State stays at its
+	// zero value) — confirms no new escalation/degraded transition was
+	// introduced by the fix.
+	require.Equal(t, StateInit, m.State())
+}
+
+// TestCommitSupersedesForStash pins ALL branches of the commit-typed
+// coalescing comparator (manager_assignment.go) that
+// TestFetchRetry_CoalescesToHighestVersion only exercises the simplest
+// (strictly-newer-Version) case of. Mirrors
+// TestAssignmentSupersedesForStash (manager_apply_retry_test.go), the
+// Assignment-typed sibling comparator over the same (Version,
+// LeaderRevision, identity) ordering.
+func TestCommitSupersedesForStash(t *testing.T) {
+	base := func() *types.AssignmentCommit {
+		return &types.AssignmentCommit{Version: 7, LeaderRevision: 10, BatchDigest: 100}
+	}
+
+	tests := []struct {
+		name      string
+		cur       *types.AssignmentCommit
+		candidate *types.AssignmentCommit
+		want      bool // candidate supersedes cur (replace)
+	}{
+		{
+			name:      "strictly newer version replaces",
+			cur:       base(),
+			candidate: &types.AssignmentCommit{Version: 8, LeaderRevision: 1, BatchDigest: 1},
+			want:      true,
+		},
+		{
+			name:      "strictly older version is dropped",
+			cur:       base(),
+			candidate: &types.AssignmentCommit{Version: 6, LeaderRevision: 99, BatchDigest: 1},
+			want:      false,
+		},
+		{
+			name:      "same version higher leader revision replaces",
+			cur:       base(),
+			candidate: &types.AssignmentCommit{Version: 7, LeaderRevision: 20, BatchDigest: 100},
+			want:      true,
+		},
+		{
+			name:      "same version lower leader revision is dropped",
+			cur:       &types.AssignmentCommit{Version: 7, LeaderRevision: 20, BatchDigest: 100},
+			candidate: &types.AssignmentCommit{Version: 7, LeaderRevision: 10, BatchDigest: 1},
+			want:      false,
+		},
+		{
+			name:      "equal (V,LR) different BatchDigest replaces",
+			cur:       base(),
+			candidate: &types.AssignmentCommit{Version: 7, LeaderRevision: 10, BatchDigest: 200},
+			want:      true,
+		},
+		{
+			name: "equal (V,LR) same BatchDigest but candidate adds known source revision replaces",
+			cur:  base(),
+			candidate: &types.AssignmentCommit{
+				Version: 7, LeaderRevision: 10, BatchDigest: 100,
+				SourceRevisionKnown: true, SourceRevision: 5,
+			},
+			want: true,
+		},
+		{
+			name: "equal (V,LR) same BatchDigest different known source revision value replaces",
+			cur: &types.AssignmentCommit{
+				Version: 7, LeaderRevision: 10, BatchDigest: 100,
+				SourceRevisionKnown: true, SourceRevision: 5,
+			},
+			candidate: &types.AssignmentCommit{
+				Version: 7, LeaderRevision: 10, BatchDigest: 100,
+				SourceRevisionKnown: true, SourceRevision: 6,
+			},
+			want: true,
+		},
+		{
+			name:      "identical duplicate keeps cur",
+			cur:       base(),
+			candidate: base(),
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := commitSupersedesForStash(tc.candidate, tc.cur)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ============================================================================
+// Reproducer: shared accepted-target fence across the fetch-retry and
+// apply-retry loops.
+// ============================================================================
+//
+// THE DEFECT (found by the final cross-model review)
+//
+// The fetch-retry stash (stashedFetchRetry) and the apply-retry stash
+// (stashedApplyRetry) are independent, and applyAssignmentWithPrevCore's
+// stale gate compares a candidate ONLY against CurrentAssignment (the last
+// successfully STORED snapshot) — it has no visibility into what the OTHER
+// retry loop has already admitted. Two symmetric interleavings let a STALE
+// admitted target reach the coordinator:
+//
+//   - V5's payload fetch fails (fetch-retry stash) while V6 is admitted,
+//     builds, and its Apply fails (apply-retry stash). V5's fetch then
+//     recovers: the stale gate alone sees current=V4 (nothing stored yet),
+//     V5 > V4, so V5 would apply — even though V6 is the fresher admitted
+//     target.
+//   - The reverse: V5 Apply-fails into the apply-retry stash; V6 arrives but
+//     its fetch fails into the fetch-retry stash; V5's apply-retry fires
+//     before V6's fetch recovers and would apply V5 over the fresher V6.
+//
+// THE FIX
+//
+// Manager.highestAcceptedTarget tracks the highest (Version, LeaderRevision)
+// target ever ADMITTED by a delivery gate this session (handleCommitValueOnce
+// and handleAssignmentEntry, raised via raiseAcceptedTarget BEFORE the
+// payload fetch so a fetch failure still raises it). applyAssignmentWithPrevCore
+// checks a candidate against this fence immediately after the existing
+// CurrentAssignment stale gate, in the same applyStoreMu critical section,
+// and drops anything strictly behind it before any coordinator-side effect.
+
+// TestAcceptedTargetFence_LateFetchRecoveryDroppedByNewerApplyFailure is T1:
+// interleaving (a). V5's fetch fails first; V6 is then admitted, builds, and
+// its Apply fails. V5's fetch later recovers and its retry fires — the fence
+// (raised to V6's coordinates at V6's admission, before V6's Apply ever ran)
+// must drop it before the coordinator ever sees it. V6's own apply-retry
+// then succeeds, converging the worker on V6.
+func TestAcceptedTargetFence_LateFetchRecoveryDroppedByNewerApplyFailure(t *testing.T) {
+	t.Parallel()
+	// V6 (heldVersion) fails every Apply call until release() is called, so
+	// V6 cannot store ahead of this test's control no matter how many times
+	// its own apply-retry loop fires in the background — see
+	// fenceRaceCoordinator's Godoc for why a plain failNCoordinator (or a
+	// coordinator that BLOCKS inside Apply) would make this interleaving a
+	// flaky race, or deadlock on applyStoreMu.
+	coord := newFenceRaceCoordinator(6)
+	m, _ := newFetchRetryTestManagerWithCoordinator(t, coord)
+	wid := m.WorkerID()
+
+	partsV5 := []types.Partition{{Keys: []string{"alpha"}}}
+	partsV6 := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+	refV5 := computeCommitPayloadRef(t, partsV5) // NOT published yet — V5's fetch must fail.
+
+	commitV5 := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV5},
+	}
+	m.handleCommitValue(commitV5)
+	require.NotNil(t, m.stashedFetchRetry.Load(), "V5's fetch failure must schedule a fetch retry")
+	require.True(t, m.fetchRetryActive.Load())
+
+	// V6's payload IS published, so it builds successfully; its Apply is the
+	// coordinator's first call to V6, which fails (fenceRaceCoordinator's
+	// heldVersion=6 fails every call until release()).
+	refV6 := publishCommitPayload(t, m.assignmentKV, partsV6)
+	commitV6 := &types.AssignmentCommit{
+		Version: 6, LeaderRevision: 20, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV6},
+	}
+	m.handleCommitValue(commitV6)
+	require.NotNil(t, m.stashedApplyRetry.Load(), "V6's Apply failure must schedule an apply retry")
+	require.True(t, m.applyRetryActive.Load())
+
+	// The fence must already be at V6's coordinates: V6's admission (in
+	// handleCommitValueOnce, before its build/Apply) raised it past V5's.
+	fence := m.highestAcceptedTarget.Load()
+	require.NotNil(t, fence)
+	require.Equal(t, int64(6), fence.Version)
+	require.Equal(t, uint64(20), fence.LeaderRevision)
+
+	// V5's payload becomes fetchable — simulating the transient blip
+	// resolving. Its fetch-retry loop will pick this up on its next
+	// backoff tick.
+	publishCommitPayload(t, m.assignmentKV, partsV5)
+
+	// Wait for V5's fetch-retry episode to conclude — either it applied
+	// (the pre-fix defect) or was dropped by the fence (post-fix) — signaled
+	// by the fetch-retry loop exiting. V6 is guaranteed to still be
+	// un-stored here (every one of its background apply-retry attempts
+	// keeps failing until release() below), so CurrentAssignment stays at
+	// the zero-value V0 snapshot for this entire window: exactly the
+	// interleaving the confirmed defect needs (V5's retry sees a snapshot
+	// that has NOT yet advanced past it).
+	require.Eventually(t, func() bool {
+		return !m.fetchRetryActive.Load()
+	}, 15*time.Second, 50*time.Millisecond,
+		"V5's fetch-retry attempt must conclude (apply or fence-drop) while V6 is still unreleased")
+
+	// The core assertion: the coordinator must never receive V5 — at this
+	// point V6 is STILL unreleased, so the only way a V5 entry could appear
+	// is the pre-fix defect: the old stale gate alone, comparing against
+	// the still-empty snapshot, lets V5 through.
+	for _, e := range coord.log() {
+		require.NotEqual(t, int64(5), e.version, "V5 must never reach the coordinator's Apply")
+	}
+	require.Nil(t, m.committedAssignment.Load(), "V5 must not have been stored either, while V6 is still unreleased")
+
+	// Release V6 and let its next apply-retry attempt succeed.
+	coord.release()
+
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 6
+	}, 15*time.Second, 50*time.Millisecond,
+		"V6's apply-retry must succeed once released and converge the worker on V6")
+
+	committed := m.committedAssignment.Load()
+	require.Equal(t, types.PartitionSetDigest(partsV6), types.PartitionSetDigest(committed.Partitions))
+
+	// Explicit fence-equality check (T3's second half): V6's apply-retry
+	// succeeded while the fence was AT V6's own coordinates — candidate ==
+	// fence must pass, not just candidate < fence being dropped.
+	finalFence := m.highestAcceptedTarget.Load()
+	require.NotNil(t, finalFence)
+	require.Equal(t, int64(6), finalFence.Version)
+	require.Equal(t, uint64(20), finalFence.LeaderRevision)
+}
+
+// TestAcceptedTargetFence_ApplyRetryDroppedByNewerFetchAdmission is T2:
+// interleaving (b), the reverse of T1. V5 is admitted and its Apply fails
+// first; V6 is then admitted (raising the fence past V5) but its fetch
+// fails. When V5's apply-retry fires, the fence must drop it before the
+// coordinator ever sees it — even though V6 itself has not yet built or
+// applied anything. V6's fetch later recovers and applies normally.
+func TestAcceptedTargetFence_ApplyRetryDroppedByNewerFetchAdmission(t *testing.T) {
+	t.Parallel()
+	m, fc, rm := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+	fc.failUntil = 1 // V5's initial Apply attempt fails; all later calls succeed.
+
+	partsV5 := []types.Partition{{Keys: []string{"alpha"}}}
+	partsV6 := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+	refV5 := publishCommitPayload(t, m.assignmentKV, partsV5) // fetchable immediately
+	refV6 := computeCommitPayloadRef(t, partsV6)              // NOT published yet — V6's fetch must fail.
+
+	commitV5 := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV5},
+	}
+	m.handleCommitValue(commitV5)
+	require.NotNil(t, m.stashedApplyRetry.Load(), "V5's Apply failure must schedule an apply retry")
+	require.True(t, m.applyRetryActive.Load())
+	require.Equal(t, int64(1), fc.applyCount.Load(), "setup: exactly one Apply call so far (V5's failed attempt)")
+
+	commitV6 := &types.AssignmentCommit{
+		Version: 6, LeaderRevision: 20, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refV6},
+	}
+	m.handleCommitValue(commitV6)
+	require.NotNil(t, m.stashedFetchRetry.Load(), "V6's fetch failure must schedule a fetch retry")
+	require.True(t, m.fetchRetryActive.Load())
+
+	// The fence must already be at V6's coordinates, raised at V6's
+	// admission BEFORE its (failed) payload fetch.
+	fence := m.highestAcceptedTarget.Load()
+	require.NotNil(t, fence)
+	require.Equal(t, int64(6), fence.Version)
+	require.Equal(t, uint64(20), fence.LeaderRevision)
+
+	// Drive V5's apply-retry: wait for it to fire and be dropped by the
+	// fence (recorded via the shared stale-drop metric).
+	require.Eventually(t, func() bool {
+		return rm.staleSnapshotStoreDropped.Load() >= 1
+	}, 15*time.Second, 50*time.Millisecond,
+		"V5's apply-retry must fire and be dropped by the accepted-target fence")
+
+	require.Equal(t, int64(1), fc.applyCount.Load(),
+		"the coordinator must never receive V5's retry — the fence drops it before Apply")
+
+	// Now let V6's fetch recover and apply.
+	publishCommitPayload(t, m.assignmentKV, partsV6)
+
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 6
+	}, 15*time.Second, 50*time.Millisecond,
+		"V6's fetch-retry must eventually fetch its payload and apply")
+
+	committed := m.committedAssignment.Load()
+	require.Equal(t, types.PartitionSetDigest(partsV6), types.PartitionSetDigest(committed.Partitions))
+
+	require.Equal(t, int64(2), fc.applyCount.Load(),
+		"exactly two Apply calls total: V5's failed attempt and V6's successful one — "+
+			"V5's dropped retry never called Apply")
+	for _, e := range fc.log() {
+		if e.version == 5 {
+			require.False(t, e.ok, "the only V5 log entry must be its initial failed attempt")
+		}
+	}
+}
+
+// TestAcceptedTargetFence_EqualToFencePasses is T3's first half: a lone
+// commit whose fetch fails and later recovers, with no sibling commit ever
+// admitted, must still apply normally — the fence sits AT the candidate's
+// own coordinates (raised by the candidate's own admission), and candidate
+// == fence must pass, not be treated as stale. Guards against an
+// off-by-one/strict-vs-inclusive regression in the fence comparison.
+func TestAcceptedTargetFence_EqualToFencePasses(t *testing.T) {
+	t.Parallel()
+	m, fc, _ := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	parts := []types.Partition{{Keys: []string{"alpha"}}}
+	ref := computeCommitPayloadRef(t, parts) // not published yet — fetch must fail first.
+
+	commit := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: ref},
+	}
+	m.handleCommitValue(commit)
+	require.NotNil(t, m.stashedFetchRetry.Load())
+
+	// The fence is raised at admission, before the fetch even runs, to
+	// exactly this commit's own coordinates.
+	fence := m.highestAcceptedTarget.Load()
+	require.NotNil(t, fence)
+	require.Equal(t, int64(5), fence.Version)
+	require.Equal(t, uint64(10), fence.LeaderRevision)
+
+	publishCommitPayload(t, m.assignmentKV, parts)
+
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 5
+	}, 6*time.Second, 50*time.Millisecond,
+		"a lone commit's recovered fetch-retry must apply normally when the fence equals its own coordinates")
+
+	committed := m.committedAssignment.Load()
+	require.Equal(t, types.PartitionSetDigest(parts), types.PartitionSetDigest(committed.Partitions))
+	require.Equal(t, int64(1), fc.applyCount.Load())
+}

--- a/manager_fetch_retry_test.go
+++ b/manager_fetch_retry_test.go
@@ -460,6 +460,64 @@ func TestCommitSupersedesForStash(t *testing.T) {
 	}
 }
 
+// TestCommitHandler_EqualVersionDifferentContent_DoesNotReachApply pins a
+// KNOWN-OPEN hazard that internal/assignment/handoff's version-adjacency
+// fail-open cannot see: the commit handler's case (a) no-op
+// (`commit.Version <= cur.Version` in handleCommitValueOnce) fires on
+// Version alone, with no check on content, before Apply is ever called.
+// A second commit at the SAME Version as the last applied one, carrying
+// DIFFERENT partition content, is silently dropped by that comparison —
+// so the coordinator's own equal-Version fail-open
+// (transitionVersionAdjacent's equality arm,
+// internal/assignment/handoff/twophase.go) is production-unreachable
+// through this path.
+//
+// This is documented current behavior; the equal-Version authority-
+// divergence hazard (an alias and a commit can expose different content at
+// the same Version; a publisher's CAS-loss recovery can also emit two
+// different assignments at the same Version) is deferred to the
+// claim-level commit-identity fence project — see
+// tmp/diff-restricted-walks_v2_review.md, "Equal-Version authority changes
+// never reach the proposed fail-open".
+func TestCommitHandler_EqualVersionDifferentContent_DoesNotReachApply(t *testing.T) {
+	t.Parallel()
+	m, fc, _ := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	// First commit at V5 with content X: applies normally through the
+	// commit-watcher entry point.
+	partsX := []types.Partition{{Keys: []string{"alpha"}}}
+	refX := publishCommitPayload(t, m.assignmentKV, partsX)
+	commitX := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refX},
+	}
+	m.handleCommitValue(commitX)
+
+	require.Equal(t, int64(1), fc.applyCount.Load(), "setup: the first commit must apply")
+	require.Equal(t, int64(5), m.CurrentAssignment().Version, "setup: worker must be at V5")
+	require.Equal(t, types.PartitionSetDigest(partsX), types.PartitionSetDigest(m.CurrentAssignment().Partitions),
+		"setup: applied content must be X")
+
+	// Second commit at the SAME Version 5 with DIFFERENT content Y,
+	// delivered through the same entry point the watcher path uses.
+	partsY := []types.Partition{{Keys: []string{"beta"}}}
+	refY := publishCommitPayload(t, m.assignmentKV, partsY)
+	commitY := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 11, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refY},
+	}
+	m.handleCommitValue(commitY)
+
+	require.Equal(t, int64(1), fc.applyCount.Load(),
+		"documented current behavior: an equal-Version delivery is dropped by the "+
+			"commit.Version <= cur.Version no-op case before it ever reaches Apply, "+
+			"regardless of differing content")
+	require.Equal(t, int64(5), m.CurrentAssignment().Version)
+	require.Equal(t, types.PartitionSetDigest(partsX), types.PartitionSetDigest(m.CurrentAssignment().Partitions),
+		"the applied assignment content must be unchanged by the dropped equal-Version delivery")
+}
+
 // ============================================================================
 // Reproducer: shared accepted-target fence across the fetch-retry and
 // apply-retry loops.

--- a/manager_handoff_test.go
+++ b/manager_handoff_test.go
@@ -478,3 +478,72 @@ func TestLivePartitionSet(t *testing.T) {
 		require.Nil(t, set)
 	})
 }
+
+// TestManagerHandoff_HealthyLeaderHealsStaleClaimWithinSweepInterval pins
+// design §4.11's manager-level healthy-leader companion to the
+// handoff-package §4.10 no-leader proof
+// (TestSweepAuthorityLive_NoLeaderHealingWithinI2Bound): with a real,
+// single-worker Manager — which becomes leader synchronously by the time
+// Start returns, a lone worker always winning election — a stale claim
+// (an expired-TTL prepare, planted directly into the handoff bucket,
+// bypassing the manager/coordinator entirely) heals to stable within
+// ~SweepInterval via the ticker sweep's full (leader, unauthorized-gating
+// never applies) cadence, exactly today's pre-gating behavior. This is
+// the regression pin the leader-gated backstop cadence must not weaken.
+func TestManagerHandoff_HealthyLeaderHealsStaleClaimWithinSweepInterval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	js, err := jetstream.New(nc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const bucket = "healthy-leader-heals-stale-claim"
+
+	cfg := twoPhaseHandoffConfig(bucket)
+	// Short, explicit sweep interval: twoPhaseHandoffConfig leaves
+	// Handoff.SweepInterval at zero, which coordinator.New coerces to the
+	// 30s production default (see TestHandoffConflictStress's identical
+	// note) — too slow for a "heals within ~SweepInterval" test bound.
+	cfg.Handoff.SweepInterval = 1 * time.Second
+
+	mgr, err := NewManager(&cfg, js, source.NewStatic([]Partition{{Keys: []string{"p-0"}}}), strategy.NewConsistentHash())
+	require.NoError(t, err)
+	require.NoError(t, mgr.Start(ctx))
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	require.True(t, mgr.IsLeader(), "a lone worker must become leader synchronously on Start")
+
+	kv, err := js.KeyValue(ctx, bucket)
+	require.NoError(t, err)
+	store := handoff.NewNATSClaimStore(kv, "claims/")
+
+	// A stuck, TTL-expired prepare for a partition the manager's own
+	// source never lists — nothing but the coordinator's reconcile arm
+	// (independent of LivePartitions/leadership) can ever touch it.
+	stuck := handoff.Claim{
+		PartitionID:  "p-stuck",
+		Owner:        "worker-A",
+		PendingOwner: "worker-B",
+		State:        handoff.ClaimStatePrepare,
+		Epoch:        1,
+		LastUpdated:  time.Now().UTC().Add(-time.Hour),
+		TTLSeconds:   1, // long since expired relative to LastUpdated
+	}
+	_, err = store.PutIfEpoch(ctx, "p-stuck", 0, stuck)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		got, rev, gerr := store.Get(ctx, "p-stuck")
+		if gerr != nil || rev == 0 {
+			return false
+		}
+
+		return got.State == handoff.ClaimStateStable && got.PendingOwner == ""
+	}, 3*cfg.Handoff.SweepInterval, 50*time.Millisecond,
+		"a stale claim must heal to stable within ~SweepInterval when a healthy leader exists")
+}

--- a/manager_retry_lostwakeup_test.go
+++ b/manager_retry_lostwakeup_test.go
@@ -1,0 +1,149 @@
+package parti
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Reproducer: retry-loop exit races a concurrent producer's activation CAS,
+// stranding the producer's stashed target forever.
+// ============================================================================
+//
+// THE DEFECT (found by external review, codex-b2-postimpl.md P1)
+//
+// Both scheduleApplyRetry's loop and scheduleCommitFetchRetry's loop observe
+// an empty stash and commit to returning while their active flag
+// (applyRetryActive / fetchRetryActive) is STILL true — the flag only clears
+// in the deferred cleanup that runs after the goroutine body returns. A
+// producer that stashes a value and loses the activation CAS inside that
+// window (the flag has not cleared yet) leaves its value stranded: the
+// exiting loop never sees it, and no new loop is spawned to pick it up.
+// Unbounded: reconcile cannot re-deliver a same-Version/higher-LeaderRevision
+// commit past the version gate (manager_assignment.go case (a)), so a
+// stranded commit or assignment can be lost until a genuinely newer one
+// happens to arrive.
+//
+// THE FIX
+//
+// activateApplyRetryLoop/activateFetchRetryLoop's deferred cleanup clears the
+// active flag and then RE-CHECKS the stash; if a producer raced the window
+// and lost, the stash is non-empty and the re-check re-activates a loop for
+// it (idempotent against a producer that instead wins the CAS itself).
+//
+// THE HOOK
+//
+// testHookRetryLoopEmptyObserved fires synchronously, on the retry loop's own
+// goroutine, at the exact point (immediately after the empty-stash
+// observation, before the deferred flag clear) where a racing producer's
+// stash+CAS would lose. Calling the schedule function from inside the hook
+// deterministically reproduces the race without any real concurrency: at
+// that point the active flag is still true, so the hook's own activation CAS
+// fails exactly as a genuinely concurrent producer's would.
+
+// TestFetchRetry_LostWakeup_StashedDuringExitWindowIsRecovered reproduces the
+// fetch-retry loop's lost-wakeup window at its post-apply empty-stash exit.
+// Pre-fix: B is stashed and stranded forever (test times out). Post-fix: the
+// ownership-handoff re-check respawns a loop and B eventually applies.
+func TestFetchRetry_LostWakeup_StashedDuringExitWindowIsRecovered(t *testing.T) {
+	t.Parallel()
+	m, _, _ := newFetchRetryTestManager(t)
+	wid := m.WorkerID()
+
+	partsA := []types.Partition{{Keys: []string{"alpha"}}}
+	partsB := []types.Partition{{Keys: []string{"beta"}}, {Keys: []string{"gamma"}}}
+	refA := computeCommitPayloadRef(t, partsA) // not published yet: A's first fetch must fail
+	refB := computeCommitPayloadRef(t, partsB)
+
+	commitA := &types.AssignmentCommit{
+		Version: 5, LeaderRevision: 10, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refA},
+	}
+	commitB := &types.AssignmentCommit{
+		Version: 6, LeaderRevision: 20, Workers: []string{wid},
+		Payloads: map[string]types.AssignmentPayloadRef{wid: refB},
+	}
+
+	var fired atomic.Bool
+	m.testHookRetryLoopEmptyObserved = func() {
+		// Fire exactly once, at the fetch loop's post-apply empty-stash exit
+		// after A has successfully applied. Simulates commit B's handler
+		// stashing B and losing the activation CAS in the window between
+		// this loop's empty-stash observation and its deferred flag clear.
+		if !fired.CompareAndSwap(false, true) {
+			return
+		}
+		m.scheduleCommitFetchRetry(commitB)
+	}
+
+	m.handleCommitValue(commitA)
+	require.True(t, m.fetchRetryActive.Load(), "A's fetch failure must activate the retry loop synchronously")
+
+	// B's payload is published up front so its eventual (respawned) fetch
+	// succeeds; only A's payload needs to be initially unfetchable to drive
+	// the loop through one failed+retried attempt.
+	publishCommitPayload(t, m.assignmentKV, partsB)
+	// A's payload becomes fetchable before the retry loop's first backoff
+	// fires (~1s+/-20% jitter), so the retry succeeds and reaches the
+	// post-apply empty-stash exit where the hook is armed.
+	publishCommitPayload(t, m.assignmentKV, partsA)
+
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 5
+	}, 6*time.Second, 50*time.Millisecond, "A must apply via the retry loop")
+
+	require.True(t, fired.Load(), "the hook must have fired at the post-apply empty-stash exit")
+
+	// WITHOUT the fix, B is stashed but stranded: fetchRetryActive cleared to
+	// false with no loop re-checking the stash, so this never becomes true.
+	require.Eventually(t, func() bool {
+		c := m.committedAssignment.Load()
+		return c != nil && c.Version == 6
+	}, 8*time.Second, 50*time.Millisecond,
+		"B must not be stranded: the ownership-handoff re-check must respawn the retry loop and apply it")
+}
+
+// TestApplyRetry_LostWakeup_StashedDuringExitWindowIsRecovered mirrors the
+// fetch-retry reproducer for scheduleApplyRetry's identical lost-wakeup
+// window at its post-apply empty-stash exit.
+func TestApplyRetry_LostWakeup_StashedDuringExitWindowIsRecovered(t *testing.T) {
+	t.Parallel()
+	fc := &failNCoordinator{failUntil: 1} // only A's first Apply attempt fails
+	m := newRetryDigestManager(t, fc)
+
+	a := Assignment{Version: 5, LeaderRevision: 10, Partitions: []types.Partition{{Keys: []string{"alpha"}}}}
+	b := Assignment{Version: 10, LeaderRevision: 20, Partitions: []types.Partition{{Keys: []string{"beta"}}}}
+
+	var fired atomic.Bool
+	m.testHookRetryLoopEmptyObserved = func() {
+		// Fire exactly once, at the apply loop's post-apply empty-stash exit
+		// after A has successfully applied. Simulates a concurrent producer
+		// stashing B and losing the activation CAS in the same window.
+		if !fired.CompareAndSwap(false, true) {
+			return
+		}
+		m.scheduleApplyRetry(b)
+	}
+
+	err := m.applyAssignment(a)
+	require.Error(t, err, "A's first apply must fail and arm the retry loop")
+	require.True(t, m.applyRetryActive.Load(), "A's apply failure must activate the retry loop synchronously")
+
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 5
+	}, 6*time.Second, 50*time.Millisecond, "A must apply via the retry loop")
+
+	require.True(t, fired.Load(), "the hook must have fired at the post-apply empty-stash exit")
+
+	// WITHOUT the fix, B is stashed but stranded: applyRetryActive cleared to
+	// false with no loop re-checking the stash, so this never becomes true.
+	require.Eventually(t, func() bool {
+		return m.CurrentAssignment().Version == 10
+	}, 8*time.Second, 50*time.Millisecond,
+		"B must not be stranded: the ownership-handoff re-check must respawn the retry loop and apply it")
+}

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -3,6 +3,7 @@ package parti
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"time"
 
 	"github.com/arloliu/parti/v2/internal/assignment/handoff"
@@ -240,6 +241,16 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 		// See livePartitionSet and orphanClaimGrace (manager_handoff.go).
 		LivePartitions: m.livePartitionSet,
 		OrphanGrace:    orphanClaimGrace,
+		// Leader-gated ticker claim sweep: SweepAuthority reads the same
+		// atomic leadership flag livePartitionSet gates on, non-blocking
+		// and without taking any manager lock (same shape as the
+		// leader-aware LivePartitions supplier and the
+		// source.WithLeadershipProbe precedent). SweepPhaseSeed staggers
+		// non-leader backstop ticks across the fleet by the worker's
+		// claimed stable ID, already available at this point in Start
+		// (Step 1, before this Step 1.6 handoff setup).
+		SweepAuthority: func() bool { return m.isLeader.Load() },
+		SweepPhaseSeed: fnv1a64(m.WorkerID()),
 	}, true)
 
 	// Hygiene + resumable detection
@@ -253,6 +264,16 @@ func (m *Manager) setupHandoff(startupCtx context.Context, js jetstream.JetStrea
 	}
 
 	return nil
+}
+
+// fnv1a64 hashes s with 64-bit FNV-1a, used to derive the handoff
+// coordinator's SweepPhaseSeed from the worker's claimed stable ID so
+// non-leader ticker backstops stagger across the fleet instead of
+// thundering together on the same tick.
+func fnv1a64(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s)) // hash.Hash64.Write never returns an error
+	return h.Sum64()
 }
 
 // ensureKVBucket creates or opens a KV bucket with the specified TTL and storage type.

--- a/manager_setup.go
+++ b/manager_setup.go
@@ -673,18 +673,38 @@ func (m *Manager) captureBucketEpoch(ctx context.Context, bucket string, kv jets
 	m.bucketEpochs[bucket] = bucketEpoch{kv: probeKV, created: created}
 }
 
+// resolveBucketEpochProbeInterval returns the effective bucket-epoch fence
+// ticker interval for a configured Config.BucketEpochProbeInterval value,
+// defensively falling back to 10s for a non-positive input (e.g. a
+// directly-constructed Config in tests, or an operator misconfiguration
+// that somehow slipped past cfg.Validate's gt=0 rule).
+//
+// Split out as a small pure function — rather than inlined in
+// monitorBucketEpochs — so the interval-selection logic (and its
+// decoupling from OperationTimeout) is directly unit-testable without
+// driving the ticker loop itself.
+func resolveBucketEpochProbeInterval(configured time.Duration) time.Duration {
+	if configured > 0 {
+		return configured
+	}
+
+	return 10 * time.Second
+}
+
 // monitorBucketEpochs polls each Parti-owned bucket's stream-Created
 // timestamp on a periodic ticker. A mismatch against the cached value
 // means the bucket was wiped and recreated under us; we enter degraded
 // mode with reason "bucket-recreated:<bucket>" so the readiness probe
 // can rotate the pod and start re-provisions the missing buckets.
 //
-// The poll interval is OperationTimeout (defaults to 10s; the same knob
-// that bounds the ensure-bucket calls at Start). A stream-info read that
-// itself fails is not degraded-mode worthy — the connection monitor,
-// source-hook, and generic kvErrorCount paths handle connectivity
-// errors. The epoch fence is solely concerned with the wipe-and-recreate
-// case where the operation succeeds but returns a different Created.
+// The poll interval is Config.BucketEpochProbeInterval (defaults to 10s;
+// see that field's doc for the cadence-vs-deadline split from
+// OperationTimeout, which still bounds each probe). A
+// stream-info read that itself fails is not degraded-mode worthy — the
+// connection monitor, source-hook, and generic kvErrorCount paths handle
+// connectivity errors. The epoch fence is solely concerned with the
+// wipe-and-recreate case where the operation succeeds but returns a
+// different Created.
 //
 // Exits when m.ctx is cancelled. Started by Start after the five Parti-
 // owned buckets have been captured.
@@ -692,10 +712,7 @@ func (m *Manager) monitorBucketEpochs(ctx context.Context) {
 	if len(m.bucketEpochs) == 0 {
 		return
 	}
-	interval := m.cfg.OperationTimeout
-	if interval <= 0 {
-		interval = 10 * time.Second
-	}
+	interval := resolveBucketEpochProbeInterval(m.cfg.BucketEpochProbeInterval)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/options.go
+++ b/options.go
@@ -30,6 +30,18 @@ type managerOptions struct {
 	// field cannot express. Validated in NewManager, because Option cannot
 	// return an error.
 	labelSpillGrace *time.Duration
+
+	// bucketEpochProbeInterval carries the value supplied via
+	// WithBucketEpochProbeInterval; bucketEpochProbeIntervalSet distinguishes
+	// "option provided" from "unset" so the option can override
+	// Config.BucketEpochProbeInterval (already defaulted by SetDefaults).
+	// Unlike labelSpillGrace, 0 has no distinct meaning for this field
+	// (validated gt=0, matching OperationTimeout), so a bool flag is
+	// sufficient — no pointer indirection is needed to preserve an
+	// "explicit 0" case. Validated in NewManager, because Option cannot
+	// return an error.
+	bucketEpochProbeInterval    time.Duration
+	bucketEpochProbeIntervalSet bool
 }
 
 // WithElectionAgent sets a custom election agent.
@@ -160,6 +172,27 @@ func WithWorkerLabels(labels ...string) Option {
 func WithLabelSpillGrace(d time.Duration) Option {
 	return func(o *managerOptions) {
 		o.labelSpillGrace = &d
+	}
+}
+
+// WithBucketEpochProbeInterval sets how often the bucket-epoch fence probes
+// each Parti-owned KV bucket for a wipe-and-recreate event, overriding
+// Config.BucketEpochProbeInterval — see that field's doc for the full
+// cadence-vs-deadline rationale (OperationTimeout still bounds each
+// individual probe).
+//
+// A non-positive duration causes NewManager to return an error wrapping
+// types.ErrInvalidConfig, matching the config field's gt=0 rule.
+//
+// Parameters:
+//   - d: Probe interval (> 0)
+//
+// Returns:
+//   - Option: Functional option for NewManager
+func WithBucketEpochProbeInterval(d time.Duration) Option {
+	return func(o *managerOptions) {
+		o.bucketEpochProbeInterval = d
+		o.bucketEpochProbeIntervalSet = true
 	}
 }
 

--- a/test/integration/failure/np2_epoch_fence_return_to_stable_test.go
+++ b/test/integration/failure/np2_epoch_fence_return_to_stable_test.go
@@ -29,8 +29,8 @@ import (
 // Root cause this probe pins (do NOT fix here, just prove):
 //   - checkBucketEpochs (manager_setup.go:684-690) compares the live stream
 //     Created against the cached ep.created but NEVER re-captures ep.created
-//     after firing. So every subsequent epoch tick (OperationTimeout cadence)
-//     re-enters Degraded with reason "bucket-recreated:<heartbeat>".
+//     after firing. So every subsequent epoch tick (BucketEpochProbeInterval
+//     cadence) re-enters Degraded with reason "bucket-recreated:<heartbeat>".
 //   - attemptRecoveryFromDegraded (manager_degraded.go:376-416) runs on the
 //     connection monitor (1s) once the connection has been up for ExitThreshold.
 //     It refreshes assignment from the STILL-INTACT assignment bucket, the
@@ -52,8 +52,9 @@ func TestNP2EpochFence_NonAssignmentRecreate_DegradedDoesNotFlap(t *testing.T) {
 
 	t.Parallel()
 
-	// ~5 epoch ticks (OperationTimeout=1s) plus headroom for the recovery loop
-	// to fight back. The whole probe fits comfortably under this bound.
+	// ~5 epoch ticks (BucketEpochProbeInterval=1s) plus headroom for the
+	// recovery loop to fight back. The whole probe fits comfortably under
+	// this bound.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -65,9 +66,13 @@ func TestNP2EpochFence_NonAssignmentRecreate_DegradedDoesNotFlap(t *testing.T) {
 
 	cfg := testutil.IntegrationTestConfig()
 	// Fast epoch tick so the fence fires several times within the observation
-	// window; OperationTimeout is the monitorBucketEpochs cadence. The
-	// non-strict OperationTimeout <= ElectionTimeout/3 boundary holds
-	// (ElectionTimeout=3s).
+	// window; BucketEpochProbeInterval is the monitorBucketEpochs cadence
+	// (decoupled from OperationTimeout, which continues to bound only each
+	// individual probe's deadline). OperationTimeout is kept at the same
+	// value too, so the non-strict OperationTimeout <= ElectionTimeout/3
+	// boundary still holds (ElectionTimeout=3s) and no unrelated startup
+	// warning fires.
+	cfg.BucketEpochProbeInterval = 1 * time.Second
 	cfg.OperationTimeout = 1 * time.Second
 	// Recover quickly so the flap is observable within the window: the recovery
 	// loop attempts exitDegraded after ExitThreshold of healthy connection.
@@ -168,8 +173,9 @@ func TestNP2EpochFence_NonAssignmentRecreate_DegradedDoesNotFlap(t *testing.T) {
 		6*time.Second, 100*time.Millisecond,
 		"epoch fence never fired for the recreated heartbeat bucket — the probe is vacuous")
 
-	// Observe the full window (>= 5 epoch ticks at OperationTimeout=1s) so the
-	// recovery loop has ample opportunity to fight the fence back to Stable.
+	// Observe the full window (>= 5 epoch ticks at BucketEpochProbeInterval=1s)
+	// so the recovery loop has ample opportunity to fight the fence back to
+	// Stable.
 	time.Sleep(10 * time.Second)
 
 	// Snapshot the final counts as evidence before asserting.

--- a/test/integration/manager/manager_epoch_monitor_concurrency_test.go
+++ b/test/integration/manager/manager_epoch_monitor_concurrency_test.go
@@ -31,9 +31,10 @@ import (
 // This test reproduces the race condition the fix prevents:
 //
 //   - Start a real 3-worker cluster with embedded NATS
-//   - Set OperationTimeout=50ms so the epoch monitor runs at high
-//     frequency (default is 10s; the per-spec docs explicitly call out
-//     OperationTimeout as the ticker cadence)
+//   - Set BucketEpochProbeInterval=50ms so the epoch monitor runs at high
+//     frequency (default is 10s). BucketEpochProbeInterval — not
+//     OperationTimeout — is the epoch-fence ticker cadence; OperationTimeout
+//     only bounds the deadline of each individual probe.
 //   - Drive ~5 seconds of normal cluster activity (heartbeats every
 //     500ms, leader election renewals, assignment publishes)
 //   - Assert no race-detector trigger via t.Failed() after Stop
@@ -61,12 +62,12 @@ func TestEpochMonitor_NoRaceUnderConcurrentKVTraffic(t *testing.T) {
 	nc, cleanup := testutil.StartEmbeddedNATS(t)
 	defer cleanup()
 
-	// Aggressive OperationTimeout drives the epoch monitor at ~50ms
+	// Aggressive BucketEpochProbeInterval drives the epoch monitor at ~50ms
 	// cadence (vs default 10s). The point is to maximise the number of
 	// kv.Status calls per second so the race window is exercised many
 	// times during the test's runtime.
 	cfg := testutil.IntegrationTestConfig()
-	cfg.OperationTimeout = 50 * time.Millisecond
+	cfg.BucketEpochProbeInterval = 50 * time.Millisecond
 
 	partitions := testutil.CreateTestPartitions(10)
 	src := source.NewStatic(partitions)

--- a/test/integration/manager/np1_live_recreate_returns_stable_test.go
+++ b/test/integration/manager/np1_live_recreate_returns_stable_test.go
@@ -150,9 +150,9 @@ func TestNP1_LiveBucketRecreate_MustNotReturnToStable(t *testing.T) {
 	require.NoError(t, err)
 
 	// Window long enough that a heal-then-redegrade flap can manifest if it
-	// exists: a couple of recovery ticks, an epoch-fence poll (OperationTimeout),
-	// and an election cycle. Size the outer context to comfortably contain
-	// startup + all four phases.
+	// exists: a couple of recovery ticks, an epoch-fence poll
+	// (BucketEpochProbeInterval), and an election cycle. Size the outer
+	// context to comfortably contain startup + all four phases.
 	ctx, cancel := context.WithTimeout(t.Context(), 120*time.Second)
 	defer cancel()
 
@@ -214,9 +214,9 @@ func TestNP1_LiveBucketRecreate_MustNotReturnToStable(t *testing.T) {
 	t.Logf("phase 3: operator recreated 4 empty buckets at %s", recreatedAt.Format(time.RFC3339Nano))
 
 	// Phase 4: observe a window long enough for a heal-then-redegrade flap to
-	// manifest if it exists — >= 3*OperationTimeout (epoch-fence ticks) plus a
-	// couple of recovery ticks and an election cycle.
-	observeWindow := 3*cfg.OperationTimeout +
+	// manifest if it exists — >= 3*BucketEpochProbeInterval (epoch-fence
+	// ticks) plus a couple of recovery ticks and an election cycle.
+	observeWindow := 3*cfg.BucketEpochProbeInterval +
 		2*cfg.DegradedBehavior.RecoveryGracePeriod +
 		cfg.ElectionTimeout
 	if observeWindow < 35*time.Second {

--- a/test/perf-measurement/cmd/harness/handofflog.go
+++ b/test/perf-measurement/cmd/harness/handofflog.go
@@ -1,0 +1,85 @@
+// handoffLogger is rig-only measurement plumbing for the post-hardening
+// validation session (Session V brief). The harness normally builds every
+// parti.Manager without a logger — parti defaults to a Nop logger (see
+// manager.go's logger resolution) — so the coordinator's Debug-level
+// "handoff_discontinuous_apply" event (internal/assignment/handoff/
+// twophase.go, fields: worker_id, previous_version, next_version,
+// partitions) is invisible by default. --handoff-log wires one shared
+// handoffLogger into every worker's Manager options so that single event
+// becomes observable without perturbing worker log volume otherwise.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// handoffDiscontinuousApplyMsg is the exact Debug msg string emitted by
+// the two-phase handoff coordinator when Apply fails open to a full
+// prepare walk (see internal/assignment/handoff/twophase.go).
+const handoffDiscontinuousApplyMsg = "handoff_discontinuous_apply"
+
+// handoffLogger implements types.Logger. It forwards ONLY Debug calls
+// whose msg equals handoffDiscontinuousApplyMsg to an append-only file
+// (one line per event: RFC3339 timestamp, then the key=value pairs).
+// Every other Debug call, and every Info/Warn/Error/Fatal call, is a
+// no-op — worker log volume stays at zero so sharing one instance across
+// every worker (including churn-re-added ones) never perturbs the
+// measurement. Safe for concurrent use.
+type handoffLogger struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+var _ types.Logger = (*handoffLogger)(nil)
+
+// newHandoffLogger opens (creating if needed) an append-only file at
+// path for handoffLogger to write into.
+func newHandoffLogger(path string) (*handoffLogger, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open handoff log %q: %w", path, err)
+	}
+
+	return &handoffLogger{f: f}, nil
+}
+
+// Close closes the underlying file.
+func (h *handoffLogger) Close() error {
+	return h.f.Close()
+}
+
+// Debug forwards only handoff_discontinuous_apply events to the capture
+// file; every other message is dropped.
+func (h *handoffLogger) Debug(msg string, keysAndValues ...any) {
+	if msg != handoffDiscontinuousApplyMsg {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString(time.Now().UTC().Format(time.RFC3339Nano))
+	b.WriteByte(' ')
+	b.WriteString(msg)
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		fmt.Fprintf(&b, " %v=%v", keysAndValues[i], keysAndValues[i+1])
+	}
+	b.WriteByte('\n')
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, _ = h.f.WriteString(b.String())
+}
+
+// Info, Warn, Error, and Fatal are no-ops: capture is scoped to exactly
+// one Debug event (see package doc above), and none of them is ever
+// called by parti's runtime code paths for Fatal, so dropping it here is
+// safe (nothing in the library relies on Fatal calling os.Exit).
+func (h *handoffLogger) Info(string, ...any)  {}
+func (h *handoffLogger) Warn(string, ...any)  {}
+func (h *handoffLogger) Error(string, ...any) {}
+func (h *handoffLogger) Fatal(string, ...any) {}

--- a/test/perf-measurement/cmd/harness/harness.go
+++ b/test/perf-measurement/cmd/harness/harness.go
@@ -121,6 +121,19 @@ type Options struct {
 	// phase (post-kill and post-re-add), for the cluster to report
 	// Stable before logging that phase as failed and moving on.
 	ChurnConvergeTimeout time.Duration
+
+	// --- rig-only handoff-discontinuity capture (see handofflog.go) ---
+
+	// HandoffLogPath is the file path to capture parti's
+	// handoff_discontinuous_apply Debug events; "" disables capture
+	// entirely (default; zero overhead — no logger is wired into any
+	// worker's Manager options).
+	HandoffLogPath string
+	// HandoffLog is the constructed capture logger, built once in Run
+	// from HandoffLogPath and shared across every worker (including
+	// churn-re-added ones so no wave's events are missed). nil when
+	// HandoffLogPath is "".
+	HandoffLog types.Logger
 }
 
 // PartitionSourceBucket is the JetStream-KV bucket the harness creates
@@ -533,6 +546,9 @@ func StartWorker(
 	}
 
 	opts := []parti.Option{parti.WithHooks(hooks)}
+	if o.HandoffLog != nil {
+		opts = append(opts, parti.WithLogger(o.HandoffLog))
+	}
 
 	// Wire the consumer. Dynamic registers as the WorkerConsumerUpdater
 	// so the manager applies assignment changes to it; Queue runs
@@ -790,6 +806,7 @@ type ManifestOptions struct {
 	ChurnWaves            int     `yaml:"churnWaves"`
 	ChurnPlateau          string  `yaml:"churnPlateau"`
 	ChurnConvergeTimeout  string  `yaml:"churnConvergeTimeout"`
+	HandoffLogPath        string  `yaml:"handoffLogPath"`
 }
 
 // ManifestStream records the storage class confirmed by
@@ -847,6 +864,7 @@ func buildManifestOptions(o Options) ManifestOptions {
 		ChurnWaves:            o.ChurnWaves,
 		ChurnPlateau:          o.ChurnPlateau.String(),
 		ChurnConvergeTimeout:  o.ChurnConvergeTimeout.String(),
+		HandoffLogPath:        o.HandoffLogPath,
 	}
 }
 

--- a/test/perf-measurement/cmd/harness/main.go
+++ b/test/perf-measurement/cmd/harness/main.go
@@ -101,6 +101,8 @@ func parseFlags(args []string) (Options, error) {
 		churnWaves           = fs.Int("churn-waves", 3, "rig-only E4 churn schedule: number of kill->converge->re-add repetitions")
 		churnPlateau         = fs.Duration("churn-plateau", 90*time.Second, "rig-only E4 churn schedule: idle wait after capture-window start before wave 1's kill")
 		churnConvergeTimeout = fs.Duration("churn-converge-timeout", 120*time.Second, "rig-only E4 churn schedule: per-phase budget for the cluster to reach Stable after a kill or a re-add; a wave that exceeds this is logged as wave_failed and the schedule continues to the next wave")
+
+		handoffLog = fs.String("handoff-log", "", "rig-only: file path to capture parti's handoff_discontinuous_apply Debug events (one line per event: RFC3339 timestamp + key=value fields — worker_id, previous_version, next_version, partitions); empty disables capture (default; zero overhead, no logger wired into any worker)")
 	)
 
 	if err := fs.Parse(args); err != nil {
@@ -164,6 +166,8 @@ func parseFlags(args []string) (Options, error) {
 		ChurnWaves:           *churnWaves,
 		ChurnPlateau:         *churnPlateau,
 		ChurnConvergeTimeout: *churnConvergeTimeout,
+
+		HandoffLogPath: *handoffLog,
 	}, nil
 }
 
@@ -232,6 +236,22 @@ func Run(ctx context.Context, o Options, errLog io.Writer) error {
 			return fmt.Errorf("start ready listener: %w", rerr)
 		}
 		defer shutdownReadyListener(readySrv)
+	}
+
+	// Step 0c: rig-only handoff-discontinuity capture (see
+	// handofflog.go). Disabled by default (empty path). When set, one
+	// shared handoffLogger instance is built here and stashed on o (a
+	// plain value from here on, same mutation pattern as
+	// o.StartupBudget above) so every StartWorker call below — including
+	// the churn schedule's re-add calls, which thread the same o through
+	// — wires it into that worker's Manager via parti.WithLogger.
+	if o.HandoffLogPath != "" {
+		hlog, herr := newHandoffLogger(o.HandoffLogPath)
+		if herr != nil {
+			return fmt.Errorf("open handoff log: %w", herr)
+		}
+		defer func() { _ = hlog.Close() }()
+		o.HandoffLog = hlog
 	}
 
 	// Step 1: setup NATS + wrapper. The setup wrapper is intentionally

--- a/test/perf-measurement/internal/calibrate/calibrate.go
+++ b/test/perf-measurement/internal/calibrate/calibrate.go
@@ -95,15 +95,41 @@ func (p *PullConsumer) Stop() {
 	}
 }
 
+// minPullHeartbeat and maxPullHeartbeat mirror nats.go's PullHeartbeat
+// validity range [500ms, 30s] (jetstream_options.go configureConsume /
+// configureMessages, nats.go v1.52.0 — the same bounds the parent module
+// tracks as internal/natsutil.MinPullHeartbeat/MaxPullHeartbeat). This rig
+// is a separate Go module and deliberately does not import the parent
+// module's internal packages, so the constants are mirrored locally rather
+// than imported.
+const (
+	minPullHeartbeat = 500 * time.Millisecond
+	maxPullHeartbeat = 30 * time.Second
+)
+
+// boundedPullHeartbeat derives a PullHeartbeat from a pull expiry using the
+// same expiry/2-clamped-to-[500ms,30s] formula as the production
+// derivation, internal/natsutil.DerivePullHeartbeat — that function is the
+// source of truth; this is a local mirror of its formula only (this rig has
+// no PullHeartbeatCap knob, so there is no further-capping arm to mirror).
+// Without the 30s clamp, a FetchTimeout above 60s derives a heartbeat above
+// nats.go's ceiling, which nats.go rejects at iterator creation.
+func boundedPullHeartbeat(expiry time.Duration) time.Duration {
+	heartbeat := max(expiry/2, minPullHeartbeat)
+
+	return min(heartbeat, maxPullHeartbeat)
+}
+
 // CreatePullConsumers creates n durable pull consumers on the given stream,
 // each named `<prefix>-<NNNN>` (1-based, zero-padded), and starts a no-op
 // drain goroutine per consumer using `consumer.Messages()` with the given
 // fetch expiry. The drain goroutines discard messages — this is the M4.1
 // idle scenario where no messages flow.
 //
-// Heartbeat is set to expiry/2 (min 100ms), matching the parti durable
-// consumer convention so pull-iterator state-tracking behaves like
-// production.
+// Heartbeat is derived via boundedPullHeartbeat (expiry/2, clamped to
+// [500ms, 30s]), mirroring the clamped production derivation in
+// internal/natsutil.DerivePullHeartbeat so pull-iterator state-tracking
+// behaves like production.
 func CreatePullConsumers(ctx context.Context, stream jetstream.Stream, prefix string, n int, fetchTimeout time.Duration) ([]*PullConsumer, error) {
 	out := make([]*PullConsumer, 0, n)
 	for i := 1; i <= n; i++ {
@@ -126,7 +152,7 @@ func CreatePullConsumers(ctx context.Context, stream jetstream.Stream, prefix st
 		done := make(chan struct{})
 		pc := &PullConsumer{Name: name, Consumer: cons, cancel: cancel, done: done}
 
-		heartbeat := max(fetchTimeout/2, 100*time.Millisecond)
+		heartbeat := boundedPullHeartbeat(fetchTimeout)
 		it, err := cons.Messages(
 			jetstream.PullMaxMessages(1),
 			jetstream.PullExpiry(fetchTimeout),

--- a/test/perf-measurement/scripts/run-v.sh
+++ b/test/perf-measurement/scripts/run-v.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# run-v.sh — Session V (post-hardening validation) single-cell driver.
+#
+# Mirrors run-e4.sh's readiness-gated capture assembly (reset -> harness
+# background start -> wait_for_ready -> cgroup-io/iostat/jsz(+detail)/
+# node-exporter captures -> synchronous harness wait -> verify -> aggregate)
+# WITHOUT the E5 pprof choreography (no --pprof-addr, no profile subshell —
+# profiles are not needed this session). Adds --handoff-log passthrough
+# (the discontinuity-event capture flag) and makes the churn schedule
+# optional so the same driver runs both the V1 churn cell and the V2
+# idle-long cell.
+#
+# One-off measurement-session script (Session V brief), not part of the
+# reusable run-matrix.sh cell loop.
+#
+# All rig runs are synchronous, blocking, foreground calls — this script
+# does not background itself and does not return until the harness process
+# (and the capture/aggregate tail) has completed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RIG_DIR="$(dirname "$SCRIPT_DIR")"
+
+HARNESS_BIN="${RIG_DIR}/cmd/harness/harness"
+if [[ -x "${RIG_DIR}/cmd/aggregate/aggregate" ]]; then
+    AGGREGATE_BIN="${RIG_DIR}/cmd/aggregate/aggregate"
+else
+    AGGREGATE_BIN="aggregate"
+fi
+
+CONTAINERS_R3="perf-nats-1,perf-nats-2,perf-nats-3"
+NATS_MONITOR_R3="localhost:8222,localhost:8223,localhost:8224"
+
+READY_ADDR="127.0.0.1:6061"
+READY_TIMEOUT_SECS=1800
+
+SEED=42   # campaign-canonical seed, recorded in run-meta.yaml (no shuffle here)
+
+CELL="" N="" WORKERS="" WARMUP_SECS=300 CAPTURE_SECS=600
+CHURN_IDX="-1" CHURN_WAVES=3 CHURN_PLATEAU="90s" CHURN_CONVERGE_TIMEOUT="180s"
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cell) CELL="$2"; shift 2 ;;
+        --n) N="$2"; shift 2 ;;
+        --workers) WORKERS="$2"; shift 2 ;;
+        --churn-worker-idx) CHURN_IDX="$2"; shift 2 ;;
+        --churn-waves) CHURN_WAVES="$2"; shift 2 ;;
+        --churn-plateau) CHURN_PLATEAU="$2"; shift 2 ;;
+        --churn-converge-timeout) CHURN_CONVERGE_TIMEOUT="$2"; shift 2 ;;
+        --warmup-secs) WARMUP_SECS="$2"; shift 2 ;;
+        --capture-secs) CAPTURE_SECS="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        *) echo "run-v.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+for req in CELL N WORKERS OUTPUT_DIR; do
+    if [[ -z "${!req}" ]]; then
+        echo "run-v.sh: --${req,,} is required" >&2
+        exit 1
+    fi
+done
+
+RUN_DIR="${RIG_DIR}/${OUTPUT_DIR}"
+mkdir -p "$RUN_DIR"
+
+echo "=== V cell ${CELL}  N=${N} workers=${WORKERS} churn_idx=${CHURN_IDX} warmup=${WARMUP_SECS}s capture=${CAPTURE_SECS}s ==="
+echo "  run dir: ${RUN_DIR}"
+
+# Pre-run sidecar (seed + cell metadata recorded before anything starts,
+# matching run-matrix.sh's run-meta.yaml traceability convention).
+{
+    echo "seed: ${SEED}"
+    echo "cell: ${CELL}"
+    echo "n: ${N}"
+    echo "workers: ${WORKERS}"
+    echo "replicas: 3"
+    echo "warmup_secs: ${WARMUP_SECS}"
+    echo "capture_secs: ${CAPTURE_SECS}"
+    echo "churn_worker_idx: ${CHURN_IDX}"
+    echo "handoff_log: handoff-discontinuity.log"
+    echo "session: v-post-hardening"
+} > "${RUN_DIR}/run-meta.yaml"
+
+# shellcheck source=_capture_lib.sh
+source "${SCRIPT_DIR}/_capture_lib.sh"
+CAPTURE_PIDS=() CAPTURE_NAMES=() CAPTURE_RCS=()
+trap 'echo "run-v.sh: signal received — stopping captures and exiting" >&2; stop_captures; exit 130' INT TERM
+
+echo "  resetting rig (replicas=3)..."
+PERF_RIG_NATS_REPLICAS=3 make -C "$RIG_DIR" reset
+
+HARNESS_LOG="${RUN_DIR}/harness.log"
+echo "  starting harness; waiting for readiness (timeout ${READY_TIMEOUT_SECS}s)..."
+
+HARNESS_ARGS=(
+    --n="$N" --workers="$WORKERS" --replicas=3
+    --two-phase=true --consumer-mode=dynamic --consumer-memory-storage
+    --warmup="${WARMUP_SECS}s" --capture-window="${CAPTURE_SECS}s"
+    --rpc-dump-interval=1s
+    --output-dir="$RUN_DIR"
+    --ready-addr="$READY_ADDR"
+    --handoff-log="${RUN_DIR}/handoff-discontinuity.log"
+)
+if [[ "$CHURN_IDX" -ge 0 ]]; then
+    HARNESS_ARGS+=(
+        --churn-worker-idx="$CHURN_IDX" --churn-waves="$CHURN_WAVES"
+        --churn-plateau="$CHURN_PLATEAU" --churn-converge-timeout="$CHURN_CONVERGE_TIMEOUT"
+    )
+fi
+
+PERF_RIG_RUN_INDEX="v-post-hardening-${CELL}" \
+PERF_RIG_NATS_IMAGE="${PERF_RIG_NATS_IMAGE:-nats:2.12.6}" \
+    "$HARNESS_BIN" "${HARNESS_ARGS[@]}" > "$HARNESS_LOG" 2>&1 &
+HARNESS_PID=$!
+
+if ! wait_for_ready "$READY_ADDR" "$READY_TIMEOUT_SECS" "$HARNESS_PID"; then
+    echo "  readiness gate FAILED — see ${HARNESS_LOG}" >&2
+    kill "$HARNESS_PID" 2>/dev/null || true
+    wait "$HARNESS_PID" 2>/dev/null || true
+    echo "readiness gate failed" > "${RUN_DIR}/failed.txt"
+    exit 1
+fi
+echo "  cluster ready — starting captures..."
+
+CAPTURE_TOTAL=$(( WARMUP_SECS + CAPTURE_SECS + 60 )) # +60s slack over the harness's own window
+bash "${SCRIPT_DIR}/capture-cgroup-io.sh" --output "${RUN_DIR}/cgroup_io.raw" --duration "$CAPTURE_TOTAL" --containers "$CONTAINERS_R3" &
+CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("cgroup-io")
+bash "${SCRIPT_DIR}/capture-iostat.sh" --output "${RUN_DIR}/iostat.raw" --duration "$CAPTURE_TOTAL" &
+CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("iostat")
+bash "${SCRIPT_DIR}/capture-jsz.sh" --output "${RUN_DIR}/jsz.raw" --duration "$CAPTURE_TOTAL" --nats-nodes "$NATS_MONITOR_R3" --jsz-detail &
+CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("jsz")
+if curl -sf --max-time 2 http://localhost:9100/metrics >/dev/null 2>&1; then
+    bash "${SCRIPT_DIR}/capture-node-exporter.sh" --output "${RUN_DIR}/node_exporter.prom" --duration "$CAPTURE_TOTAL" &
+    CAPTURE_PIDS+=($!); CAPTURE_NAMES+=("node-exporter")
+else
+    printf '# node_exporter unavailable at run start; stub for aggregator presence check\n' > "${RUN_DIR}/node_exporter.prom"
+fi
+echo "  captures started (PIDs: ${CAPTURE_PIDS[*]})"
+
+echo "  waiting for harness (pid ${HARNESS_PID}) to complete — this is a synchronous, blocking, foreground wait..."
+HARNESS_RC=0
+wait "$HARNESS_PID" || HARNESS_RC=$?
+echo "  harness exited rc=${HARNESS_RC}"
+
+echo "  stopping captures..."
+stop_captures
+
+if ! verify_captures "$RUN_DIR"; then
+    echo "  run FAILED (capture verify) — see ${RUN_DIR}/capture-failed.txt" >&2
+    exit 1
+fi
+
+if [[ "$HARNESS_RC" -ne 0 ]]; then
+    printf 'harness exit code %d\n' "$HARNESS_RC" > "${RUN_DIR}/failed.txt"
+    echo "  run FAILED (harness_rc=${HARNESS_RC})" >&2
+    exit 1
+fi
+
+echo "  aggregating..."
+if ! "$AGGREGATE_BIN" --run-dir "$RUN_DIR"; then
+    echo "  aggregate FAILED" >&2
+    echo "aggregate exited non-zero" > "${RUN_DIR}/aggregate-failed.txt"
+    exit 1
+fi
+
+echo "  run OK: ${RUN_DIR}"

--- a/test/simulation/cmd/simulation/bucket_chaos.go
+++ b/test/simulation/cmd/simulation/bucket_chaos.go
@@ -119,9 +119,11 @@ func isProbeBucketUnavailable(err error) bool {
 //
 // Invariant INV1 (plan lines 336-344): after delete on parti-stableid,
 // every running worker emits a WorkerDegradedReport with Reason matching
-// "bucket-unavailable:" OR "bucket-recreated:parti-stableid" within
-// 3 × OperationTimeout. No worker should reach Shutdown via
-// claimLostShutdown in this window.
+// "bucket-unavailable:" OR "bucket-recreated:parti-stableid". The
+// bucket-recreated arm rides the epoch fence, whose cadence is
+// BucketEpochProbeInterval (not OperationTimeout); the oracle window
+// registered below is 2 × WorkerIDTTL, wide enough for either arm. No
+// worker should reach Shutdown via claimLostShutdown in this window.
 func handleBucketDelete(ctx context.Context, bucket string) {
 	js, err := freshJS()
 	if err != nil {
@@ -196,12 +198,12 @@ func handleBucketDelete(ctx context.Context, bucket string) {
 // handleBucketRecreate deletes a bucket then immediately re-creates it via
 // kvutil.EnsureKVBucket. This is the "epoch fence" trigger: the backing
 // stream's Created timestamp will be fresh, and monitorBucketEpochs (one
-// tick = OperationTimeout) will compare it to the cached value and call
-// enterDegraded("bucket-recreated:<bucket>").
+// tick = BucketEpochProbeInterval) will compare it to the cached value and
+// call enterDegraded("bucket-recreated:<bucket>").
 //
 // Invariant INV3 (plan lines 354-359): after recreate of parti-assignment,
 // at least one worker enters degraded with Reason exactly
-// "bucket-recreated:parti-assignment" within 2 × OperationTimeout.
+// "bucket-recreated:parti-assignment" within 2 × BucketEpochProbeInterval.
 func handleBucketRecreate(ctx context.Context, bucket string) {
 	js, err := freshJS()
 	if err != nil {
@@ -221,8 +223,8 @@ func handleBucketRecreate(ctx context.Context, bucket string) {
 	if aioCoord != nil {
 		if o := aioCoord.DegradedReasonOracle(); o != nil {
 			pc := parti.DefaultConfig()
-			// Plan INV3 specified 2 × OperationTimeout (=20s), which is
-			// the epoch-fence ticker cadence. That suffices to OBSERVE
+			// Plan INV3 specified 2 × BucketEpochProbeInterval (=20s),
+			// which is the epoch-fence ticker cadence. That suffices to OBSERVE
 			// a single transition, but if the scenario fires multiple
 			// chaos events the OnDegraded hook only re-fires on
 			// transitions out-of and back-into degraded. To keep this

--- a/types/assignment_commit.go
+++ b/types/assignment_commit.go
@@ -71,8 +71,9 @@ type AssignmentPayloadRef struct {
 	// Diagnostic / audit only. Never used for content identity.
 	SetDigest uint64 `json:"set_digest"`
 
-	// Revision is the KV revision of the payload key at the time of Create or
-	// Get. Diagnostic only.
+	// Revision is the KV revision of the payload key as written by this
+	// publish: the Create for a fresh payload, or the successful adoption
+	// CAS-touch (Update) when the payload already existed. Diagnostic only.
 	Revision uint64 `json:"revision"`
 }
 


### PR DESCRIPTION
The load-overhead hardening release train: a measurement campaign (4 rig sessions + a post-hardening validation session, W≤100/P≤10,000/R=3) drove one load refactor, two tuning knobs, and — via the campaign's review discipline — six pre-existing correctness fixes. Fourteen scope-pure commits; every commit individually reviewed (per-commit external review rounds), plus a consolidated whole-branch review (orchestrator + cross-model) whose one P1 finding is fixed in-train.

## Correctness fixes (all pre-existing, none introduced by this branch)
- **Heartbeat scan pass deadline** — per-key reads can no longer stall a scan pass indefinitely on a degraded KV.
- **Payload GC vs adoption race** — adoption CAS-touches the payload; GC deletes are revision-conditioned; whichever lands first wins deterministically.
- **Payload-fetch failures retried** — a commit whose payload fetch failed was silently dropped, stranding the worker on a stale assignment until the next unrelated commit.
- **Lost wakeup in both retry loops** — a retry stashed in the loop-exit window was stranded forever; both loops now re-check after deactivating (ctx-guarded).
- **Shared accepted-target fence** — without it, a slow fetch/apply retry could apply a superseded assignment (removal-guard bypass + worst-case cross-worker claim steal). Both delivery gates now raise a monotonic highest-accepted (Version, LeaderRevision) fence checked before any coordinator work. *(Found by the consolidated whole-branch review — invisible to per-commit reviews.)*
- **Missed-version continuity fail-open** — non-adjacent version transitions now trigger a full prepare walk, healing the A→B→A permanent-gating and reaped-claim-never-recreated shapes. Explicitly a partial repair: equal-Version divergence and cross-worker claim staleness are documented-open (test-pinned) and deferred to a claim-level commit-identity fence project.
- **FetchTimeout > 60s no longer bricks pull loops** — the derived pull heartbeat is clamped to nats.go's [500ms, 30s] validity range at all four derivation sites.
- **Fresh orphan grace** — a reappearing-then-disappearing claim owner gets a full fresh grace window before reaping.

## Load refactor + knobs (measurement-gated)
- **Leader-gated claim sweeps** with phase-staggered follower backstops and generation/revision-fenced orphan reaping. Validated post-hardening: idle claim-read floor **21× lower**, churn read-storm de-synchronized (peak 3.4–4.5× lower, no recurrence), probe-traffic model confirmed to 0.2%.
- **`WithPullHeartbeatCap`** + **`WithBucketEpochProbeInterval`** — measured at P=10k: FetchTimeout 5s→30s saves ~0.77 idle / ~1.13 loaded CPU cores with P99 improved; the cap keeps deleted-consumer detection fast. New SCALING.md guidance section.

## Validation
- `make pre-pr` (lint + unit + integration, -race) green over the final stack.
- **30/30 simulation scenarios** green over the final stack (re-run after every post-review fold).
- Post-hardening rig validation session: 3 healthy runs; all R1 model obligations closed; B4 fail-open's extra-cost path measured at **zero** occurrences under rig coalescing pressure.
- Every fix landed verify-first (RED reproducer confirmed on the parent before the fix).

Deferred findings (fence project, residual backstop re-latch volume, measurement anomalies) are documented in the program's findings package and will be filed as issues after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3evmLZovmtfQK4Zb5B7WF