### PR TITLE
v2.10.1: LabelState pull accessor + per-origin claim-sweep pass counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.10.1] - 2026-07-17
+
+A small additive follow-up clearing two deferred observability items. No
+assignment or routing behavior changes; no API is removed or changed
+incompatibly.
+
+### Added
+
+- **`Manager.LabelState()` + `parti.LabelState`** — pull-style label
+  observability for deployments without a `MetricsCollector`: the leader
+  retains its last published per-label pool sizes and parked partition
+  counts, and the accessor returns a copied snapshot ("are any `vip`
+  partitions parked right now?" from a health endpoint, zero collector
+  code). Leader-only lifecycle mirroring the push gauges: populated
+  strictly post-publish, cleared on leadership loss/stop. See "Label
+  observability without a metrics pipeline" in `docs/LABELS.md`.
+- **`types.HandoffSweepMetricsRecorder`** — optional capability interface a
+  `HandoffMetricsRecorder` may additionally implement to receive
+  `IncClaimSweepPass(origin, outcome, reason)` for every admitted claim
+  sweep that runs a pass body (origin `apply|ticker`, outcome `full|cached`,
+  and the closed
+  full-pass reason set incl. `mismatch`/`forced`). The bundled
+  `PrometheusRecorder` exports it as
+  `claim_sweep_passes_total{origin,outcome,reason}`. This is the
+  measurement precondition for the post-churn re-latch investigation
+  (issue #75): full-pass origins no longer need to be inferred from timing
+  signatures. Existing recorder implementations are unaffected;
+  `types.NopHandoffMetricsRecorder` gains a no-op `IncClaimSweepPass`.
+
 ## [v2.10.0] - 2026-07-17
 
 A hardening and load-overhead release driven by a measurement campaign against

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -225,6 +225,44 @@ if mgr.IsLeader() {
 
 ---
 
+#### LabelState
+
+Returns the leader-computed label-mode snapshot (per-label pool sizes and
+parked partition counts) from this node's last successfully published
+rebalance, pull-style — no `MetricsCollector` required.
+
+```go
+type LabelState struct {
+    PoolSizes map[string]int // label → live workers eligible for it
+    Parked    map[string]int // label → partitions currently parked
+}
+
+func (m *Manager) LabelState() LabelState
+```
+
+**Returns**:
+- `LabelState`: The snapshot; the zero value (nil maps) on non-leaders,
+  leaders that have not yet published, and stopped managers. Use
+  `IsLeader()` to disambiguate "not the leader" from "leader with nothing
+  labeled". Keys are exactly the labeled pools of the published decision;
+  a label with zero parked partitions is present with an explicit `0`.
+
+**Thread Safety**: Safe for concurrent use. The returned maps are fresh
+copies owned by the caller. The snapshot is point-in-time: a leadership
+transition strictly concurrent with the call may race it, but once
+`IsLeader()` reports false the accessor returns the zero value.
+
+**Example**:
+```go
+if n := mgr.LabelState().Parked["vip"]; n > 0 {
+    log.Printf("%d vip partitions are parked", n)
+}
+```
+
+See [Label observability without a metrics pipeline](LABELS.md#label-observability-without-a-metrics-pipeline).
+
+---
+
 #### CurrentAssignment
 
 Returns the current partition assignment.

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -741,11 +741,32 @@ Grep for these log lines when diagnosing a labeled deployment:
 
 ### Label observability without a metrics pipeline
 
-You don't need a Prometheus (or other) `MetricsCollector` to see label state. A
-small in-memory collector that embeds `types.NopMetrics` and overrides only the
-`LabelMetrics` methods gives you a live snapshot to read from your own health
-endpoint. `NopMetrics` supplies no-ops for every other `MetricsCollector`
-method, so this is all the code:
+You don't need a Prometheus (or other) `MetricsCollector` to see label state.
+
+**The zero-code option: `Manager.LabelState()`.** The manager retains the
+leader's last published per-label pool sizes and parked counts and serves
+them pull-style — no collector wiring at all:
+
+```go
+// In your health handler (on any pod; only the leader returns data):
+st := mgr.LabelState()
+if n := st.Parked["vip"]; n > 0 {
+    // vip partitions are parked right now — surface it.
+}
+```
+
+`LabelState()` is leader-only: non-leaders, a leader that hasn't published
+yet, and stopped managers return the zero value (nil maps) — check
+`mgr.IsLeader()` to tell "not the leader" apart from "leader with nothing
+labeled". Keys are exactly the labeled pools of the last published decision
+(a label with zero parked partitions is present with an explicit `0`), and
+the returned maps are copies the caller owns.
+
+**The collector option.** If you also want the label *counters* (spills,
+fallbacks) or push-style export, a small in-memory collector that embeds
+`types.NopMetrics` and overrides only the `LabelMetrics` methods gives you a
+live snapshot to read from your own health endpoint. `NopMetrics` supplies
+no-ops for every other `MetricsCollector` method, so this is all the code:
 
 ```go
 // labelSnapshot exposes parked counts / pool sizes / spill totals over your
@@ -787,11 +808,12 @@ snap := newLabelSnapshot()
 mgr, err := parti.NewManager(cfg, js, src, strategy, parti.WithMetrics(snap))
 ```
 
-**Leader-only caveat.** These gauges are computed by the leader's calculator, so
-a per-pod collector shows data **only on the pod that is currently leader**;
-every follower's snapshot stays empty, and a leader that steps down zeroes the
-gauges it was reporting. Point operators at the leader's endpoint (or aggregate
-across pods and read whichever is non-empty) — "are any `vip` partitions parked
+**Leader-only caveat.** Both options read the leader's calculator, so a
+per-pod collector (or a per-pod `LabelState()` call) shows data **only on the
+pod that is currently leader**; every follower's snapshot stays empty, and a
+leader that steps down zeroes the gauges it was reporting (and clears its
+`LabelState`). Point operators at the leader's endpoint (or aggregate across
+pods and read whichever is non-empty) — "are any `vip` partitions parked
 right now?" is only answerable on the leader.
 
 ## Gotchas

--- a/internal/assignment/calculator.go
+++ b/internal/assignment/calculator.go
@@ -216,6 +216,23 @@ type Calculator struct {
 	// (called from rebalance under rebalanceMu) and zeroLabelGaugesOnStop
 	// (takes rebalanceMu itself) — no separate mutex needed.
 	prevMetricLabels map[string]bool
+
+	// labelReadModel is the retained pull-side counterpart of the
+	// recordLabelMetrics push pass: the per-label pool sizes and parked
+	// counts from the last successfully published rebalance, kept for
+	// Manager.LabelState. Written only post-publish (retainLabelReadModel)
+	// and cleared in Stop — leader-scoped, like the label gauges. nil until
+	// the first publish.
+	labelReadModel atomic.Pointer[LabelReadModel]
+}
+
+// LabelReadModel is the retained label snapshot behind Manager.LabelState:
+// per-label live pool sizes and parked partition counts from the last
+// successfully published rebalance. Keys carry exact parity with the
+// recordLabelMetrics gauge pass (topo.SortedLabels — labeled pools only).
+type LabelReadModel struct {
+	PoolSizes map[string]int
+	Parked    map[string]int
 }
 
 // cachedWorkerList bundles worker data with its timestamp for atomic operations.
@@ -574,6 +591,10 @@ func (c *Calculator) Stop(ctx context.Context) error {
 	// after the joins above so no rebalance can record concurrently or
 	// after the zeroing pass.
 	c.zeroLabelGaugesOnStop()
+
+	// Same leader-scoped lifecycle for the pull-side snapshot: a deposed or
+	// stopping leader must not keep serving stale label state.
+	c.labelReadModel.Store(nil)
 
 	return nil
 }
@@ -1882,6 +1903,43 @@ func (c *Calculator) recordLabelMetrics(res labelPipelineResult) {
 	}
 }
 
+// retainLabelReadModel stores the pull-side label snapshot for
+// Manager.LabelState from the pipeline result a rebalance just published.
+// Derivation matches recordLabelMetrics exactly (pool sizes from topo.Pools,
+// parked counts from res.parked by label, keys = topo.SortedLabels), but it
+// runs UNCONDITIONALLY — the pull accessor must work precisely when no
+// LabelMetrics collector is wired. Callers must only invoke this after a
+// successful publish, alongside recordLabelMetrics.
+func (c *Calculator) retainLabelReadModel(res labelPipelineResult) {
+	topo := res.topo
+	model := &LabelReadModel{
+		PoolSizes: make(map[string]int, len(topo.SortedLabels)),
+		Parked:    make(map[string]int, len(topo.SortedLabels)),
+	}
+	parkedCountByLabel := make(map[string]int, len(topo.SortedLabels))
+	for _, p := range res.parked {
+		parkedCountByLabel[p.Label]++
+	}
+	for _, l := range topo.SortedLabels {
+		model.PoolSizes[l] = len(topo.Pools[l])
+		model.Parked[l] = parkedCountByLabel[l]
+	}
+	c.labelReadModel.Store(model)
+}
+
+// LabelSnapshot returns copies of the retained label read model, or ok=false
+// when no rebalance has published since this calculator started. Lock-free;
+// safe concurrently with Stop (the caller may observe either the snapshot or
+// the cleared state, never a partial one).
+func (c *Calculator) LabelSnapshot() (pools, parked map[string]int, ok bool) {
+	model := c.labelReadModel.Load()
+	if model == nil {
+		return nil, nil, false
+	}
+
+	return maps.Clone(model.PoolSizes), maps.Clone(model.Parked), true
+}
+
 // zeroLabelGaugesOnStop closes out the leader-scoped gauge lifecycle (spec
 // §13): a deposed/stopping leader zeroes every per-label gauge it last
 // recorded so its own metrics export doesn't freeze at stale non-zero
@@ -2461,6 +2519,7 @@ func (c *Calculator) rebalance(ctx context.Context, lifecycle string) error {
 	// broad-failure/error aborts earlier in this function return before
 	// reaching here, so a rebalance that didn't publish records nothing.
 	c.recordLabelMetrics(pipeline)
+	c.retainLabelReadModel(pipeline)
 
 	// Arm/disarm the label re-check timer for any parked grace (Task 9
 	// provides the body; the stub is a no-op).

--- a/internal/assignment/calculator_label_readmodel_test.go
+++ b/internal/assignment/calculator_label_readmodel_test.go
@@ -1,0 +1,130 @@
+package assignment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/partitest"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCalculator_LabelSnapshot_RetainedAfterPublish pins the pull-side
+// (Manager.LabelState) retention contract across the publish lifecycle:
+//
+// Phase A: before any publish the snapshot is absent; the first published
+// rebalance retains pool sizes and parked counts with exact key parity to
+// the gauge pass (labeled pools only, explicit zeros).
+// Phase B: a deferred (unpublished) rebalance — the first observation of a
+// newly-empty pool — must NOT touch the retained snapshot.
+// Phase C: the confirming rebalance publishes with the gold partitions
+// parked and the snapshot updates, including a zero-size pool key.
+//
+// The calculator here is wired with the DEFAULT no-op-collector path
+// (newLabelCalc): retention must work precisely when no LabelMetrics
+// collector is configured — that deployment is the accessor's whole purpose.
+func TestCalculator_LabelSnapshot_RetainedAfterPublish(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-readmodel-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-readmodel-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+	putLabeledHeartbeat(t, ctx, hbKV, "w1", nil)
+
+	vipPart := types.Partition{Keys: []string{"v"}, Label: "vip"}
+	plainPart := types.Partition{Keys: []string{"p"}}
+	src := &mutableSource{partitions: []types.Partition{vipPart, plainPart}}
+
+	// Long grace: a confirmed-empty pool PARKS its partitions instead of
+	// spilling, which is the state the accessor exists to expose.
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV, grace: time.Hour})
+
+	// Phase A: nothing published yet → no snapshot.
+	_, _, ok := calc.LabelSnapshot()
+	require.False(t, ok, "a calculator that never published must have no label snapshot")
+
+	require.NoError(t, calc.rebalance(ctx, "test"))
+	require.NotNil(t, readCalcCommit(t, ctx, asgnKV))
+
+	pools, parked, ok := calc.LabelSnapshot()
+	require.True(t, ok)
+	require.Equal(t, map[string]int{"vip": 1}, pools,
+		"key parity with the gauge pass: labeled pools only — the unlabeled general pool is never a key")
+	require.Equal(t, map[string]int{"vip": 0}, parked,
+		"a label with nothing parked is present with an explicit 0")
+
+	// Phase B: add gold partitions with NO gold-labeled worker. The first
+	// empty-pool observation defers (nothing published) — the retained
+	// snapshot must be byte-identical to phase A, with no gold key.
+	goldA := types.Partition{Keys: []string{"g1"}, Label: "gold"}
+	goldB := types.Partition{Keys: []string{"g2"}, Label: "gold"}
+	src.set([]types.Partition{vipPart, plainPart, goldA, goldB})
+
+	require.NoError(t, calc.handleRebalance(ctx, "test"))
+	pools, parked, ok = calc.LabelSnapshot()
+	require.True(t, ok)
+	require.Equal(t, map[string]int{"vip": 1}, pools, "a deferred (unpublished) rebalance must not touch the snapshot")
+	require.Equal(t, map[string]int{"vip": 0}, parked, "a deferred (unpublished) rebalance must not touch the snapshot")
+
+	// Phase C: the confirming rebalance publishes with both gold partitions
+	// parked (grace window still open) and the snapshot updates.
+	require.NoError(t, calc.handleRebalance(ctx, "test"))
+	commit := readCalcCommit(t, ctx, asgnKV)
+	require.NotNil(t, commit)
+	require.Equal(t, 2, commit.ParkedCount, "both gold partitions must be parked, not spilled, inside the grace window")
+
+	pools, parked, ok = calc.LabelSnapshot()
+	require.True(t, ok)
+	require.Equal(t, map[string]int{"vip": 1, "gold": 0}, pools, "an empty pool is a key with an explicit 0 size")
+	require.Equal(t, map[string]int{"vip": 0, "gold": 2}, parked)
+
+	// Copy semantics: mutating the returned maps must not affect what the
+	// next call observes.
+	pools["vip"] = 99
+	delete(parked, "gold")
+	pools2, parked2, ok := calc.LabelSnapshot()
+	require.True(t, ok)
+	require.Equal(t, map[string]int{"vip": 1, "gold": 0}, pools2, "returned maps are copies; caller mutation must not leak back")
+	require.Equal(t, map[string]int{"vip": 0, "gold": 2}, parked2, "returned maps are copies; caller mutation must not leak back")
+}
+
+// TestCalculator_LabelSnapshot_StopClears pins the leader-scoped lifecycle:
+// the snapshot lives only while THIS worker is the calculating leader, so
+// Stop must clear it — a deposed leader must not keep serving stale label
+// state through Manager.LabelState. Start-driven so Stop exercises the real
+// teardown ordering (mirrors TestCalculator_LabelMetrics_StopZeroesGauges).
+func TestCalculator_LabelSnapshot_StopClears(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "lbl-rmstop-asgn-"+t.Name())
+	hbKV := partitest.CreateJetStreamKV(t, nc, "lbl-rmstop-hb-"+t.Name())
+
+	putLabeledHeartbeat(t, ctx, hbKV, "w0", []string{"vip"})
+
+	src := &mutableSource{partitions: []types.Partition{{Keys: []string{"v"}, Label: "vip"}}}
+	calc := newLabelCalc(t, labelCalcConfig{source: src, heartbeatKV: hbKV, assignmentKV: asgnKV})
+
+	require.NoError(t, calc.Start(ctx))
+	stopped := false
+	defer func() {
+		if !stopped {
+			_ = calc.Stop(ctx)
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		_, _, ok := calc.LabelSnapshot()
+		return ok
+	}, 5*time.Second, 25*time.Millisecond, "the initial rebalance must retain a label snapshot")
+
+	require.NoError(t, calc.Stop(ctx))
+	stopped = true
+
+	_, _, ok := calc.LabelSnapshot()
+	require.False(t, ok, "Stop must clear the retained snapshot: a deposed leader serves no label state")
+}

--- a/internal/assignment/handoff/coordinator.go
+++ b/internal/assignment/handoff/coordinator.go
@@ -240,6 +240,8 @@ func New(cfg Config, enableTwoPhase bool) Coordinator {
 		// Optional store capability: probing the backing stream position
 		// lets ticker sweeps skip provably-no-op ListKeys+Get storms.
 		coord.prober, _ = cfg.Store.(bucketPosProber)
+		// Optional recorder capability: per-origin sweep pass counters.
+		coord.sweepMetrics, _ = cfg.Metrics.(types.HandoffSweepMetricsRecorder)
 
 		return coord
 	}

--- a/internal/assignment/handoff/metrics_prometheus.go
+++ b/internal/assignment/handoff/metrics_prometheus.go
@@ -28,6 +28,7 @@ import (
 //   - claim_stale_handoff_reset_total
 //   - claim_write_throttled_total
 //   - claim_write_throttle_wait_seconds
+//   - claim_sweep_passes_total{origin,outcome,reason}
 //
 // These cover end-to-end outcomes, latency, and basic KV conflict/health.
 type PrometheusRecorder struct {
@@ -45,6 +46,7 @@ type PrometheusRecorder struct {
 	claimStaleHandoffReset prometheus.Counter
 	claimWriteThrottled    prometheus.Counter
 	claimWriteThrottleWait prometheus.Histogram
+	claimSweepPasses       *prometheus.CounterVec
 }
 
 // NewPrometheusRecorder creates a new recorder.
@@ -117,6 +119,12 @@ func (p *PrometheusRecorder) ensure() {
 			Help:      "Duration in seconds that claim-write attempts waited due to rate limiting.",
 			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5},
 		})
+		p.claimSweepPasses = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: p.namespace,
+			Subsystem: "handoff",
+			Name:      "claim_sweep_passes_total",
+			Help:      "Admitted claim-sweep passes by origin (apply|ticker), outcome (full|cached), and full-pass reason.",
+		}, []string{"origin", "outcome", "reason"})
 
 		p.reg.MustRegister(
 			p.handoffTotal,
@@ -128,6 +136,7 @@ func (p *PrometheusRecorder) ensure() {
 			p.claimStaleHandoffReset,
 			p.claimWriteThrottled,
 			p.claimWriteThrottleWait,
+			p.claimSweepPasses,
 		)
 	})
 }
@@ -181,4 +190,12 @@ func (p *PrometheusRecorder) IncClaimWriteThrottled() {
 func (p *PrometheusRecorder) ObserveClaimWriteThrottleWait(seconds float64) {
 	p.ensure()
 	p.claimWriteThrottleWait.Observe(seconds)
+}
+
+// IncClaimSweepPass counts one admitted claim-sweep pass. It satisfies the
+// optional types.HandoffSweepMetricsRecorder capability the coordinator
+// type-asserts for; label sets are the closed ones documented there.
+func (p *PrometheusRecorder) IncClaimSweepPass(origin, outcome, reason string) {
+	p.ensure()
+	p.claimSweepPasses.WithLabelValues(origin, outcome, reason).Inc()
 }

--- a/internal/assignment/handoff/sweep_metrics_test.go
+++ b/internal/assignment/handoff/sweep_metrics_test.go
@@ -1,0 +1,273 @@
+package handoff
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arloliu/parti/v2/internal/natsutil"
+	"github.com/arloliu/parti/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+// sweepPassEvent captures one IncClaimSweepPass call.
+type sweepPassEvent struct {
+	origin  string
+	outcome string
+	reason  string
+}
+
+// recordingSweepMetrics implements the full HandoffMetricsRecorder surface
+// via the embedded no-op plus the optional HandoffSweepMetricsRecorder
+// capability, recording every sweep-pass event in order.
+type recordingSweepMetrics struct {
+	types.NopHandoffMetricsRecorder
+
+	mu     sync.Mutex
+	events []sweepPassEvent
+}
+
+func (r *recordingSweepMetrics) IncClaimSweepPass(origin, outcome, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, sweepPassEvent{origin: origin, outcome: outcome, reason: reason})
+}
+
+func (r *recordingSweepMetrics) snapshot() []sweepPassEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.events)
+}
+
+// bareHandoffMetrics implements HandoffMetricsRecorder WITHOUT the optional
+// sweep capability — deliberately not embedding the no-op, which now carries
+// IncClaimSweepPass and would satisfy the capability by accident.
+type bareHandoffMetrics struct{}
+
+func (bareHandoffMetrics) IncHandoffTotal(string)                     {}
+func (bareHandoffMetrics) ObserveHandoffDuration(time.Duration)       {}
+func (bareHandoffMetrics) ObservePhaseDuration(string, time.Duration) {}
+func (bareHandoffMetrics) IncCASConflicts()                           {}
+func (bareHandoffMetrics) SetClaimStoreSize(int)                      {}
+func (bareHandoffMetrics) IncClaimStoreStale()                        {}
+func (bareHandoffMetrics) IncClaimStaleHandoffReset()                 {}
+
+// TestSweepPassCounter_OriginsAndReasons drives the sweep pipeline through
+// every counter emission point and pins the exact (origin, outcome, reason)
+// sequence: apply-origin ungated full pass, ticker unlatched-then-latching
+// full pass, a confirmed cached pass, a position-mismatch full pass, the
+// max-skips forced full pass, and a probe-error fail-open full pass. The
+// sequence is EXACT (require.Equal on the whole slice), so any stray
+// emission fails the test. The remaining reasons and the emits-nothing
+// exclusions are pinned by TestSweepPassCounter_RemainingReasons and
+// TestSweepPassCounter_NonAdmittedEmitsNothing.
+func TestSweepPassCounter_OriginsAndReasons(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	h := newSweepGateHarness(t, time.Hour)
+	rec := &recordingSweepMetrics{}
+	h.coord.sweepMetrics = rec
+	h.seedStable(t, "p1")
+
+	// 1. Apply-origin passes bypass the gate entirely: full, "ungated".
+	h.advance(time.Second)
+	h.coord.maybeSweepClaims(ctx, sweepOriginApply)
+
+	// 2. First ticker pass has no cache to skip against: full, "unlatched"
+	// (and it latches the clean position).
+	h.tick(ctx)
+
+	// 3. Quiet bucket, double-probe confirms: cached pass.
+	h.tick(ctx)
+
+	// 4. An external write advances the position: full, "mismatch".
+	h.store.advancePos()
+	h.tick(ctx)
+
+	// 5. One cached pass, then the forced backstop at sweepMaxSkips=1.
+	h.coord.sweepMaxSkips = 1
+	h.tick(ctx) // cached (skips -> 1)
+	h.tick(ctx) // forced full
+
+	// 6. Probe failure fails open: full, "probe_error".
+	h.store.probeErr = errors.New("probe boom")
+	h.tick(ctx)
+
+	require.Equal(t, []sweepPassEvent{
+		{origin: "apply", outcome: "full", reason: "ungated"},
+		{origin: "ticker", outcome: "full", reason: "unlatched"},
+		{origin: "ticker", outcome: "cached", reason: ""},
+		{origin: "ticker", outcome: "full", reason: "mismatch"},
+		{origin: "ticker", outcome: "cached", reason: ""},
+		{origin: "ticker", outcome: "full", reason: "forced"},
+		{origin: "ticker", outcome: "full", reason: "probe_error"},
+	}, rec.snapshot())
+}
+
+// TestSweepPassCounter_WiredThroughNew pins the construction-time seam: a
+// Config.Metrics recorder that implements the optional capability is
+// type-asserted and receives events without any other wiring.
+func TestSweepPassCounter_WiredThroughNew(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	rec := &recordingSweepMetrics{}
+	coord, ok := New(Config{
+		Store:         newProbeMemStore(),
+		TTL:           time.Minute,
+		SweepInterval: -1,
+		Metrics:       rec,
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+
+	coord.maybeSweepClaims(ctx, sweepOriginApply)
+	require.Equal(t, []sweepPassEvent{
+		{origin: "apply", outcome: "full", reason: "ungated"},
+	}, rec.snapshot())
+}
+
+// TestSweepPassCounter_RecorderWithoutCapability pins the optionality
+// contract: a recorder implementing only the base HandoffMetricsRecorder
+// leaves the coordinator's capability handle nil, and the sweep pipeline —
+// gated and ungated arms alike — runs unchanged without panicking.
+func TestSweepPassCounter_RecorderWithoutCapability(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	coord, ok := New(Config{
+		Store:         newProbeMemStore(),
+		TTL:           time.Minute,
+		SweepInterval: -1,
+		Metrics:       bareHandoffMetrics{},
+	}, true).(*twoPhaseCoordinator)
+	require.True(t, ok)
+	require.Nil(t, coord.sweepMetrics, "a base-only recorder must not satisfy the sweep capability")
+
+	coord.sweepConfirmGap = time.Millisecond
+	coord.maybeSweepClaims(ctx, sweepOriginApply)  // ungated arm
+	coord.maybeSweepClaims(ctx, sweepOriginTicker) // full-pass arm (unlatched)
+	coord.maybeSweepClaims(ctx, sweepOriginTicker) // cached arm
+}
+
+// TestSweepPassCounter_RemainingReasons closes the documented full-pass
+// reason set: "unsafe_config" (a probed position failing the scan-gate
+// config guard) and "no_probe_handle" (a store advertising the probe
+// capability without a live handle — which also permanently ungates the
+// coordinator, so the NEXT pass is "ungated").
+func TestSweepPassCounter_RemainingReasons(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("unsafe_config", func(t *testing.T) {
+		t.Parallel()
+		h := newSweepGateHarness(t, time.Hour)
+		rec := &recordingSweepMetrics{}
+		h.coord.sweepMetrics = rec
+
+		// MaxAge on the claim bucket breaks the gate's cache-coherence
+		// assumption (entries can vanish without a position change).
+		h.store.setPos(func(p *natsutil.KVStreamPos) { p.MaxAge = time.Hour })
+		h.tick(ctx)
+		require.Equal(t, []sweepPassEvent{
+			{origin: "ticker", outcome: "full", reason: "unsafe_config"},
+		}, rec.snapshot())
+	})
+
+	t.Run("no_probe_handle", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingSweepMetrics{}
+		coord, ok := New(Config{
+			Store:         &noHandleStore{memStore: newMemStore()},
+			TTL:           time.Minute,
+			SweepInterval: -1,
+			Metrics:       rec,
+		}, true).(*twoPhaseCoordinator)
+		require.True(t, ok)
+
+		coord.maybeSweepClaims(ctx, sweepOriginTicker) // drops the prober for good
+		coord.maybeSweepClaims(ctx, sweepOriginTicker) // now permanently ungated
+		require.Equal(t, []sweepPassEvent{
+			{origin: "ticker", outcome: "full", reason: "no_probe_handle"},
+			{origin: "ticker", outcome: "full", reason: "ungated"},
+		}, rec.snapshot())
+	})
+}
+
+// TestSweepPassCounter_NonAdmittedEmitsNothing pins the emits-nothing
+// exclusions: the counter counts passes that RUN a body, so the store-nil
+// return, a single-flight TryLock miss, the interval throttle, and the
+// confirm-wait abort (admitted, but no body ran) must all record zero
+// events.
+func TestSweepPassCounter_NonAdmittedEmitsNothing(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("store nil", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingSweepMetrics{}
+		coord, ok := New(Config{SweepInterval: -1, Metrics: rec}, true).(*twoPhaseCoordinator)
+		require.True(t, ok)
+
+		require.False(t, coord.maybeSweepClaims(ctx, sweepOriginApply))
+		require.Empty(t, rec.snapshot())
+	})
+
+	t.Run("trylock miss", func(t *testing.T) {
+		t.Parallel()
+		h := newSweepGateHarness(t, time.Hour)
+		rec := &recordingSweepMetrics{}
+		h.coord.sweepMetrics = rec
+
+		// Hold the single-flight lock directly: an opportunistic pass
+		// arriving while another sweep is mid-body skips, uncounted.
+		h.coord.sweepMu.Lock()
+		require.False(t, h.coord.maybeSweepClaims(ctx, sweepOriginApply))
+		h.coord.sweepMu.Unlock()
+		require.Empty(t, rec.snapshot())
+	})
+
+	t.Run("interval throttle", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingSweepMetrics{}
+		fixed := time.Now().UTC()
+		coord, ok := New(Config{
+			Store:         newProbeMemStore(),
+			TTL:           time.Minute,
+			SweepInterval: time.Hour,
+			Now:           func() time.Time { return fixed },
+			Metrics:       rec,
+		}, true).(*twoPhaseCoordinator)
+		require.True(t, ok)
+
+		require.True(t, coord.maybeSweepClaims(ctx, sweepOriginApply))
+		require.False(t, coord.maybeSweepClaims(ctx, sweepOriginApply), "second pass within the interval is throttled")
+		require.Equal(t, []sweepPassEvent{
+			{origin: "apply", outcome: "full", reason: "ungated"},
+		}, rec.snapshot(), "the throttled attempt must not emit")
+	})
+
+	t.Run("confirm-wait abort", func(t *testing.T) {
+		t.Parallel()
+		h := newSweepGateHarness(t, time.Hour)
+		rec := &recordingSweepMetrics{}
+		h.coord.sweepMetrics = rec
+
+		// Latch a clean cache first (full "unlatched" pass), then drive a
+		// ticker pass with a cancelled context: probe 1 confirms the cached
+		// position, and the confirm wait aborts on ctx.Done — admitted,
+		// but neither pass body runs, so nothing is emitted for it.
+		h.tick(ctx)
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+		h.advance(time.Second)
+		require.True(t, h.coord.maybeSweepClaims(cancelled, sweepOriginTicker))
+		require.Equal(t, []sweepPassEvent{
+			{origin: "ticker", outcome: "full", reason: "unlatched"},
+		}, rec.snapshot(), "the aborted confirm-wait pass must not emit")
+	})
+}

--- a/internal/assignment/handoff/twophase.go
+++ b/internal/assignment/handoff/twophase.go
@@ -130,6 +130,11 @@ type twoPhaseCoordinator struct {
 	// prober is cfg.Store's optional position-probe capability,
 	// type-asserted once by New; nil disables the gate.
 	prober bucketPosProber
+
+	// sweepMetrics is cfg.Metrics' optional claim-sweep observability
+	// capability, type-asserted once by New; nil means the recorder does
+	// not implement it and sweep passes go uncounted.
+	sweepMetrics types.HandoffSweepMetricsRecorder
 }
 
 // sweepOrigin tags who initiated a sweep pass. The scan gate is
@@ -142,6 +147,16 @@ const (
 	sweepOriginApply sweepOrigin = iota
 	sweepOriginTicker
 )
+
+// String returns the metrics label for the origin ("apply" | "ticker") —
+// the closed set documented on types.HandoffSweepMetricsRecorder.
+func (o sweepOrigin) String() string {
+	if o == sweepOriginApply {
+		return "apply"
+	}
+
+	return "ticker"
+}
 
 // bucketPosProber is an optional capability of a ClaimStore: reporting
 // the backing stream's position without creating a consumer. The sweep
@@ -802,6 +817,7 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 	// stale cache can never satisfy the next ticker probe).
 	if origin != sweepOriginTicker || t.prober == nil {
 		t.sweepPass(ctx, now, nil)
+		t.recordSweepPass(origin, "full", "ungated")
 
 		return true
 	}
@@ -822,6 +838,7 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 			pos2, ok2, reason2 := t.sweepProbe(ctx)
 			if ok2 && pos2.Same(t.sweepCachePos) {
 				t.sweepCachedPass(ctx, now)
+				t.recordSweepPass(origin, "cached", "")
 
 				return true
 			}
@@ -844,6 +861,9 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 		latch = &pos
 	}
 	t.sweepPass(ctx, now, latch)
+	// reason is always non-empty here: every path into this full-pass
+	// fallthrough set one (forced/mismatch/unlatched/probe failures).
+	t.recordSweepPass(origin, "full", reason)
 	if t.cfg.Logger != nil {
 		t.cfg.Logger.Debug("handoff sweep full pass",
 			"cached_passes_since_last_full", t.sweepSkipsSinceFull,
@@ -853,6 +873,14 @@ func (t *twoPhaseCoordinator) maybeSweepClaims(ctx context.Context, origin sweep
 	t.sweepSkipsSinceFull = 0
 
 	return true
+}
+
+// recordSweepPass emits one claim-sweep pass to the optional metrics
+// capability; a no-op when the configured recorder doesn't implement it.
+func (t *twoPhaseCoordinator) recordSweepPass(origin sweepOrigin, outcome, reason string) {
+	if t.sweepMetrics != nil {
+		t.sweepMetrics.IncClaimSweepPass(origin.String(), outcome, reason)
+	}
 }
 
 // sweepProbe takes one stream-position probe under the fail-open and

--- a/manager.go
+++ b/manager.go
@@ -1050,6 +1050,64 @@ func (m *Manager) WorkerLabels() []string {
 	return slices.Clone(m.workerLabels)
 }
 
+// LabelState is a point-in-time, leader-computed snapshot of label-mode
+// observability state, exposed pull-style so deployments without a
+// MetricsCollector get baseline label visibility ("are any VIP partitions
+// parked right now?") from a health endpoint or log line. It complements,
+// and does not replace, the push [types.LabelMetrics] interface.
+type LabelState struct {
+	// PoolSizes maps each label present in the last published rebalance to
+	// the number of live workers eligible for it.
+	PoolSizes map[string]int
+
+	// Parked maps each such label to the number of partitions currently
+	// parked (intentionally left unassigned) for it.
+	Parked map[string]int
+}
+
+// LabelState returns the label snapshot from this node's last successfully
+// published rebalance. Leader-only: non-leaders, leaders that have not yet
+// published a rebalance, and stopped Managers return the zero value (nil
+// maps). Use [Manager.IsLeader] to disambiguate "not the leader" from
+// "leader with nothing labeled". The returned maps are fresh copies; the
+// caller owns them and may retain or mutate them freely.
+//
+// The snapshot is point-in-time: a leadership transition strictly concurrent
+// with the call may race it, but once the transition is observable
+// (IsLeader() reports false — the election loop flips the flag before any
+// calculator teardown begins), the accessor returns the zero value.
+//
+// Key-set parity with the push gauges: keys are exactly the labeled pools of
+// the published decision (the unlabeled general pool is never a key), and a
+// label with zero parked partitions is present with an explicit 0.
+//
+// Returns:
+//   - LabelState: The snapshot, or the zero value when this node has none.
+func (m *Manager) LabelState() LabelState {
+	// Leadership gate first: on deposition the election loop clears the
+	// flag BEFORE stopCalculator/calculator.Stop tear the snapshot down,
+	// so trusting the calculator handle alone would serve a deposed
+	// leader's stale state for the whole teardown window.
+	if !m.IsLeader() {
+		return LabelState{}
+	}
+
+	m.mu.RLock()
+	calc := m.calculator
+	m.mu.RUnlock()
+
+	c, ok := calc.(*assignment.Calculator)
+	if !ok {
+		return LabelState{}
+	}
+	pools, parked, ok := c.LabelSnapshot()
+	if !ok {
+		return LabelState{}
+	}
+
+	return LabelState{PoolSizes: pools, Parked: parked}
+}
+
 // CurrentAssignment returns the current partition assignment for this worker.
 //
 // The returned Assignment shares its Partitions backing array with the

--- a/manager_test.go
+++ b/manager_test.go
@@ -2,11 +2,13 @@ package parti
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/arloliu/parti/v2/internal/assignment"
 	"github.com/arloliu/parti/v2/partitest"
 	"github.com/arloliu/parti/v2/source"
 	"github.com/arloliu/parti/v2/strategy"
@@ -168,6 +170,110 @@ func TestManager_WorkerLabels_WithOptionOverride(t *testing.T) {
 	got := mgr.WorkerLabels()
 	want := []string{"vip-a", "vip-b"} // normalizeWorkerLabels sorts the option's labels
 	require.Equal(t, want, got)
+}
+
+// TestManager_LabelState_NoCalculator verifies LabelState's zero-value
+// contract on every path that has no running calculator: a never-started
+// Manager (calculator not yet installed) and a Manager holding the Nop
+// placeholder (follower / post-stop state). Both must return the zero value
+// — nil maps, no error, no panic — since LabelState is leader-only.
+func TestManager_LabelState_NoCalculator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("never started", func(t *testing.T) {
+		t.Parallel()
+		cfg := DefaultConfig()
+		conn := &nats.Conn{}
+		js, _ := jetstream.New(conn)
+		mgr, err := NewManager(&cfg, js, &mockSource{}, &mockStrategy{})
+		require.NoError(t, err)
+
+		st := mgr.LabelState()
+		require.Nil(t, st.PoolSizes)
+		require.Nil(t, st.Parked)
+	})
+
+	t.Run("nop calculator", func(t *testing.T) {
+		t.Parallel()
+		// Leadership set so the test reaches past the IsLeader gate and
+		// pins the calculator-handle fallback (follower/post-stop state).
+		m := &Manager{calculator: assignment.NewNopCalculator()}
+		m.isLeader.Store(true)
+
+		st := m.LabelState()
+		require.Nil(t, st.PoolSizes)
+		require.Nil(t, st.Parked)
+	})
+}
+
+// TestManager_LabelState_LeadershipGate pins the leader-only contract against
+// the deposed-leader teardown window: the election loop clears the leadership
+// flag BEFORE stopCalculator/calculator.Stop tear the snapshot down, so for
+// that whole window the installed calculator still holds live label state. A
+// non-leader Manager must return the zero value anyway — the accessor gates
+// on IsLeader() rather than trusting the calculator handle's lifecycle.
+func TestManager_LabelState_LeadershipGate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	_, nc := partitest.StartEmbeddedNATS(t)
+	asgnKV := partitest.CreateJetStreamKV(t, nc, "mgr-labelstate-asgn")
+	hbKV := partitest.CreateJetStreamKV(t, nc, "mgr-labelstate-hb")
+
+	// One vip-labeled worker heartbeat + one vip partition: the published
+	// rebalance retains a non-empty label snapshot in the calculator.
+	hb := types.Heartbeat{
+		WorkerID:      "w0",
+		SchemaVersion: 1,
+		Capabilities:  types.CapAckV1,
+		Labels:        []string{"vip"},
+		Timestamp:     time.Now().UTC(),
+	}
+	hbData, err := json.Marshal(hb)
+	require.NoError(t, err)
+	_, err = hbKV.Put(ctx, "worker-hb.w0", hbData)
+	require.NoError(t, err)
+
+	calc, err := assignment.NewCalculator(&assignment.Config{
+		AssignmentKV:         asgnKV,
+		HeartbeatKV:          hbKV,
+		AssignmentPrefix:     "assignment",
+		Source:               source.NewStatic([]types.Partition{{Keys: []string{"v"}, Label: "vip"}}),
+		Strategy:             &mockStrategy{},
+		HeartbeatPrefix:      "worker-hb",
+		HeartbeatTTL:         30 * time.Second,
+		EmergencyGracePeriod: 1 * time.Second,
+		ColdStartWindow:      10 * time.Millisecond,
+		PlannedScaleWindow:   10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NoError(t, calc.Start(ctx))
+	t.Cleanup(func() { _ = calc.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		_, _, ok := calc.LabelSnapshot()
+		return ok
+	}, 5*time.Second, 25*time.Millisecond, "the initial rebalance must retain a label snapshot")
+
+	// The deposed-leader window: a real calculator with live state installed,
+	// leadership flag false. The accessor must serve the zero value.
+	m := &Manager{calculator: calc}
+	st := m.LabelState()
+	require.Nil(t, st.PoolSizes, "a non-leader must get the zero value even while the calculator still holds a snapshot")
+	require.Nil(t, st.Parked, "a non-leader must get the zero value even while the calculator still holds a snapshot")
+
+	// The same Manager as leader serves the snapshot.
+	m.isLeader.Store(true)
+	st = m.LabelState()
+	require.Equal(t, map[string]int{"vip": 1}, st.PoolSizes)
+	require.Equal(t, map[string]int{"vip": 0}, st.Parked)
+
+	// Deposed again: the flag flips first (manager_election clears it before
+	// any calculator teardown), and the accessor immediately returns zero.
+	m.isLeader.Store(false)
+	st = m.LabelState()
+	require.Nil(t, st.PoolSizes)
+	require.Nil(t, st.Parked)
 }
 
 // TestManager_SetCapability_AtomicBitmask verifies that SetCapability correctly

--- a/options.go
+++ b/options.go
@@ -203,6 +203,11 @@ func WithBucketEpochProbeInterval(d time.Duration) Option {
 // sweeper behavior. In production, leave unset to use the default no-op or a
 // future global wiring.
 //
+// A recorder that additionally implements the optional
+// [HandoffSweepMetricsRecorder] capability also receives per-origin
+// claim-sweep pass counts; the coordinator type-asserts for it, so a
+// recorder without the capability loses nothing else.
+//
 // Parameters:
 //   - mr: HandoffMetricsRecorder implementation
 //

--- a/test/integration/assignment/label_orphan_stale_test.go
+++ b/test/integration/assignment/label_orphan_stale_test.go
@@ -438,6 +438,23 @@ func TestGhostLabel_ParksThenSpills_NeverOrphans(t *testing.T) {
 		parkCommit.ParkedDigest, "parked digest must be the ghost partition")
 	require.True(t, checkCoverage(ctx, assignKV, parkCommit, withGhost).ok, "coverage during park")
 
+	// Pull-side parity (Manager.LabelState): the single worker is the leader,
+	// so its retained snapshot must agree with the published park commit —
+	// the ghost pool has no eligible workers and exactly one parked partition,
+	// and the unlabeled plain partitions are not keys. Eventually, not a
+	// one-shot read: the commit becomes externally observable inside the
+	// publish call, a few lines before the calculator retains the snapshot,
+	// so a read racing that gap would flake.
+	require.Eventually(t, func() bool {
+		st := plainWorker.LabelState()
+		// len==1 pins "ghost" as the ONLY key (unlabeled partitions are
+		// never keys), and the indexed reads pin the explicit-zero pool
+		// size and the single parked partition.
+		return len(st.PoolSizes) == 1 && st.PoolSizes["ghost"] == 0 &&
+			len(st.Parked) == 1 && st.Parked["ghost"] == 1
+	}, 10*time.Second, 100*time.Millisecond,
+		"LabelState must converge to the published park decision: ghost pool empty, one parked, labeled keys only")
+
 	// PHASE SPILL: after grace, with NO source/worker event, the re-check timer
 	// spills the ghost onto the fallback ladder (the unlabeled worker).
 	// ParkedCount==0 and the ghost is now in a payload.

--- a/types.go
+++ b/types.go
@@ -32,8 +32,12 @@ type (
 	AssignmentMetrics        = types.AssignmentMetrics
 	WorkerConsumerMetrics    = types.WorkerConsumerMetrics
 	HandoffMetricsRecorder   = types.HandoffMetricsRecorder
-	Logger                   = types.Logger
-	Hooks                    = types.Hooks
+	// HandoffSweepMetricsRecorder is the optional claim-sweep observability
+	// capability a HandoffMetricsRecorder may additionally implement; see
+	// [types.HandoffSweepMetricsRecorder] for the label contract.
+	HandoffSweepMetricsRecorder = types.HandoffSweepMetricsRecorder
+	Logger                      = types.Logger
+	Hooks                       = types.Hooks
 	// StreamMissingHook is the operator-supplied escalation invoked when
 	// the dynamic partition consumer's recovery flow detects the
 	// underlying JetStream stream is absent. See

--- a/types/handoff_metrics.go
+++ b/types/handoff_metrics.go
@@ -50,7 +50,40 @@ type HandoffMetricsRecorder interface {
 	IncClaimStaleHandoffReset()
 }
 
-// NopHandoffMetricsRecorder is a no-op implementation of [HandoffMetricsRecorder].
+// HandoffSweepMetricsRecorder is an optional capability a
+// [HandoffMetricsRecorder] implementation may additionally satisfy to
+// receive claim-sweep pass observability. The handoff coordinator
+// type-asserts its configured recorder for this interface once at
+// construction; a recorder without it loses nothing else.
+//
+// [NopHandoffMetricsRecorder] implements it, so recorders embedding the
+// no-op satisfy the capability automatically (as no-ops).
+type HandoffSweepMetricsRecorder interface {
+	// IncClaimSweepPass counts one admitted claim-sweep pass. Non-admitted
+	// attempts (single-flight lock misses, interval throttling) and the
+	// shutdown-only confirm-wait abort emit nothing.
+	//
+	// All three label sets are closed and low-cardinality:
+	//   - origin: "apply" (opportunistic, from an assignment Apply) or
+	//     "ticker" (the periodic sweep loop).
+	//   - outcome: "full" (ListKeys + per-key reads) or "cached" (the
+	//     scan-gated pass over the cached claim view; ticker-only).
+	//   - reason: why a full pass ran; "" for cached passes. One of:
+	//     "ungated" (apply-origin, or the store has no position probe),
+	//     "unlatched" (no valid cache to skip against), "mismatch" (the
+	//     bucket position moved since the cache was latched), "forced"
+	//     (max consecutive cached passes reached — the backstop),
+	//     "probe_error", "unsafe_config", "no_probe_handle".
+	//
+	// Parameters:
+	//   - origin: Who initiated the pass.
+	//   - outcome: Whether the pass ran full or against the cached view.
+	//   - reason: Full-pass cause, "" for cached passes.
+	IncClaimSweepPass(origin, outcome, reason string)
+}
+
+// NopHandoffMetricsRecorder is a no-op implementation of [HandoffMetricsRecorder]
+// (and of the optional [HandoffSweepMetricsRecorder] capability).
 type NopHandoffMetricsRecorder struct{}
 
 func (NopHandoffMetricsRecorder) IncHandoffTotal(string)                     {}
@@ -60,3 +93,4 @@ func (NopHandoffMetricsRecorder) IncCASConflicts()                           {}
 func (NopHandoffMetricsRecorder) SetClaimStoreSize(int)                      {}
 func (NopHandoffMetricsRecorder) IncClaimStoreStale()                        {}
 func (NopHandoffMetricsRecorder) IncClaimStaleHandoffReset()                 {}
+func (NopHandoffMetricsRecorder) IncClaimSweepPass(string, string, string)   {}


### PR DESCRIPTION
## Summary

Small additive follow-up batch clearing two deferred observability items; cut as v2.10.1.

- **`Manager.LabelState()` pull accessor** (deferred from the v2.9.1 label follow-ups): deployments without a `MetricsCollector` previously ran label mode blind. The leader's calculator now retains its last published per-label pool sizes and parked partition counts, and the accessor serves a copied snapshot — "are any `vip` partitions parked right now?" from a health endpoint with zero collector code. Leader-only lifecycle mirroring the push gauges: populated strictly post-publish (deferred/failed rebalances leave it untouched), cleared on leadership loss/stop, key-set parity with the gauge pass.
- **Per-origin claim-sweep pass counters** (measurement precondition for #75): new optional capability `types.HandoffSweepMetricsRecorder` — type-asserted from the configured recorder, so existing implementations are untouched — receives `IncClaimSweepPass(origin, outcome, reason)` for every admitted sweep pass, with the coordinator's existing closed reason set (`ungated`/`unlatched`/`mismatch`/`forced`/`probe_error`/`unsafe_config`/`no_probe_handle`). `PrometheusRecorder` exports `claim_sweep_passes_total{origin,outcome,reason}`. Post-churn re-latch volume and leader hold-rate no longer need to be inferred from timing signatures.

No behavior changes; both items are additive. `NopHandoffMetricsRecorder` gains a no-op `IncClaimSweepPass`, so embedders auto-satisfy the capability.

## Test plan

- New unit tests: retention lifecycle (post-publish only, deferred-rebalance non-touch, Stop-clear, copy semantics, key-set parity incl. explicit zeros); exact-sequence sweep counter emissions across all origins/outcomes/reasons; capability optionality (base-only recorder → nil handle, pipeline unchanged).
- Integration: `TestGhostLabel_ParksThenSpills_NeverOrphans` gains a LabelState↔commit parity assertion at the park phase.
- `make pre-pr` green (lint + unit -race + integration -race); cross-model review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3evmLZovmtfQK4Zb5B7WF
