### PR TITLE
fix(assignment): publisher CAS-loss coherent reseed + equal-version divergence counter (v2.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.10.2] - 2026-07-17
+
+A small correctness + observability release closing the standalone slice of
+the deferred claim-level commit-identity fence project (issue #74). No
+routing or dispatch behavior changes; no API is removed or changed
+incompatibly.
+
+### Fixed
+
+- **Publisher CAS-loss recovery could reuse an external winner's Version** —
+  after losing the commit CAS to another leader's in-flight write, the
+  recovery path refreshed only the commit KV revision, not the live Version,
+  so the recovering leader's next publish could CAS-succeed at the SAME
+  Version the winner had already published — silently overwriting it
+  (workers drop equal-version deliveries at dispatch, so the overwrite was
+  invisible fleet-wide). The recovery now reseeds the publisher's whole
+  commit view coherently (revision, Version, cached commit, observation
+  instant — all four or none) from the live winner, so the next publish is
+  strictly beyond both observed Versions (`max(local, winner)+1`) and can
+  never reuse one. If the winner entry is unreadable or malformed,
+  the publisher fails closed: publishes abort before any payload/alias/CAS
+  write (existing `ErrCommitCASFailed` class; new
+  `IncrementBatchAborted("commit_reseed_pending")` reason) until the live
+  commit becomes readable. Ordinary clean leader takeovers were always safe;
+  this closes the CAS-loss counterexample.
+
+### Added
+
+- **`types.AssignmentDivergenceMetricsRecorder`** — optional capability
+  interface a `MetricsCollector` may additionally implement to receive
+  `IncEqualVersionDivergence(source)` (source `commit|alias`): an authority
+  delivery arrived at the worker's current assignment version carrying
+  DIFFERENT content for that worker. Dispatch drops equal-version deliveries
+  before payload fetch, so this counter is the observable precondition of
+  the deferred equal-version divergence hazard family — zero in healthy
+  operation (redeliveries carry identical content); sustained nonzero means
+  concurrent writers published different content at the same version and is
+  the trigger to revisit the fence design. `types.NopMetrics` gains a no-op
+  implementation, so collectors embedding it auto-satisfy; existing
+  collectors are unaffected.
+- **`docs/design/claim-commit-identity-fence.md`** — the converged
+  claim-level commit-identity fence design (7 external review rounds),
+  recorded as Proposed and deferred-by-decision, with the deferral rationale
+  and re-activation triggers in the preamble.
+
 ## [v2.10.1] - 2026-07-17
 
 A small additive follow-up clearing two deferred observability items. No

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -700,6 +700,18 @@ type MetricsCollector interface {
 }
 ```
 
+**Optional capability — equal-version divergence** (`v2.10.2+`): a collector
+that additionally implements `AssignmentDivergenceMetricsRecorder` receives
+`IncEqualVersionDivergence(source)` whenever an authority delivery (commit or
+legacy alias, `source` label accordingly) arrives at the worker's current
+assignment version with different content for that worker. Dispatch drops
+equal-version deliveries before payload fetch, so this counter is the only
+visibility into such divergence; healthy redeliveries never increment it, and
+a sustained nonzero rate means concurrent writers published different content
+at the same version (see `docs/design/claim-commit-identity-fence.md`). The
+manager type-asserts once at construction; `types.NopMetrics` implements the
+capability, so collectors embedding it auto-satisfy.
+
 **New Degraded Mode Metrics**:
 
 #### RecordDegradedDuration

--- a/docs/design/claim-commit-identity-fence.md
+++ b/docs/design/claim-commit-identity-fence.md
@@ -1,0 +1,745 @@
+# Claim-level commit-identity fence — design v7 (FINAL)
+
+**Status**: Proposed — deferred by decision on 2026-07-17
+**Origin**: Issue #74 (claim-level commit-identity fence: close equal-Version
+divergence and cross-worker claim staleness), spun out of the v2.10.0
+load-overhead hardening review rounds
+**Review provenance**: 7 external cross-model review rounds — 5 architectural
+(P0 trajectory 4→3→2→1→0, round 5: "architecturally converged"), one final
+precision pass (0 P0), one closure verification (all findings folded)
+**Deferral rationale**: The hazard preconditions were measured at ZERO across
+the production-shaped load campaign (~300 discontinuity events, all benign
+first-Apply shapes); the most reachable interleaving of the family was closed
+by v2.10.0's accepted-target fence; and the two standalone slices shipped in
+v2.10.2 (the publisher CAS-loss coherent reseed closing the F2 emission path,
+and the `IncEqualVersionDivergence` precondition counter). The remaining
+F1/F3/F4 shapes require narrow multi-failure interleavings and are pinned as
+documented-open behavior by tests (e.g.
+`TestStaleCrossWorkerRetry_StealsClaim`, which MUST FLIP when this design
+lands).
+**Re-activation triggers**: (a) the equal-version divergence counter goes
+nonzero in production; (b) a scale roadmap that needs the R2 diff-restricted
+walks (the ~2P→~2T read reduction) this design gates; (c) infrastructure
+prone to split-brain leadership (aggressive lease timeouts, unstable NATS
+connectivity)
+**Artifact note**: `tmp/...` paths cited below are design-time working
+artifacts (drafts v1-v6 and the full review ledger) retained outside the
+repository; the design is self-contained without them. Code anchors were
+verified against main @ c690f3e (v2.10.1).
+
+
+> **Historical note (2026-07-17):** the rollout language in this section and
+> throughout the body — "Closes issue #74", "Targets v2.11.0", "Next gate …
+> implementation", the commit train in §10 — reflects the design's state at
+> convergence. The project is **deferred** (see the Status preamble above);
+> the F2 publisher-reseed slice and the divergence precondition counter
+> shipped separately in v2.10.2, so issue #74 is NOT closed by anything here.
+> Read the body as the settled *design*, not a committed rollout plan.
+
+Would close issue #74 (F1-F4) if implemented; gates the deferred R2 walks
+(`tmp/diff-restricted-walks-design.md` §3). Targeted v2.11.0. Supersedes v6
+per `tmp/fence-project-design_final_precision_review.md` (0 P0 / 4 P1
+precision items / 2 P2, all folded as [FP-Pn]; "no further architectural
+round is indicated"). Architectural lineage: rounds 1-5
+(`_r1.._r5_review.md`), P0 trajectory 4→3→2→1→0. Anchors re-verified
+against main @ c690f3e (v2.10.1); nats.go citations are MODULE-CACHED
+paths (`$GOMODCACHE/github.com/nats-io/nats.go@v1.52.0/...`), not
+vendored. Closure verification completed; deferred before implementation.
+
+---
+
+## 0. Problem in one paragraph
+
+parti's staleness protection is Version-scalar end to end; Version is not a
+unique identity (F1 alias/commit divergence, F2 CAS-loss reuse), and claims
+carry no assignment identity, so stale or reset-raced walks mutate them
+(F3, F4). Remediation: a semantic authority coordinate carried losslessly
+through the manager, and claim-store transitions fenced on it with
+phase-specific, IDEMPOTENT rules.
+
+## 1. The authority coordinate
+
+```
+Authority = (BucketEpoch†, Version, LeaderRevision, SourceKind, EntryRev)
+```
+
+- `BucketEpoch` — assignment bucket stream `Created` identity
+  (kvutil/bucket.go:122-151), equality-only (†never ordered).
+- `Version`, `LeaderRevision` — today's semantic pair.
+- `SourceKind` — commit(1) > alias(0) at equal (V, LR): matches the
+  dual-read selector (manager_select_authority.go:53-65; round 2 confirmed
+  commit and legacy alias are the ONLY two sources; cold-empty bootstrap is
+  absence, not a third).
+- `EntryRev` — delivering entry's KV revision; orders only within the same
+  (V, LR, SourceKind) class (re-publications, e.g. F2's overwrite).
+
+### 1.1 Comparison relations [zero-epoch semantics per R2-P1-2]
+
+The comparator returns one of FOUR results — newer / equal / older /
+**unproven** — and epoch participation is explicit:
+
+- **Manager-local ordering** (dispatch gates, stashes, fence): all
+  deliveries observed by one Manager come from ITS assignment bucket, so
+  the manager compares only (V, LR, SourceKind, EntryRev). A failed epoch
+  capture does NOT disable manager-side semantic ordering (else F1 would
+  reopen locally). BucketEpoch is carried for stamping, not for
+  manager-local comparison.
+- **Claim-side proof** (fence checks against a stored stamp): requires a
+  VALID epoch on both sides. stamp.epoch zero/absent → stamp UNPROVEN;
+  walk.epoch zero (capture failed) → walk cannot PROVE, §6.5; epochs
+  valid and different → UNPROVEN (foreign); epochs valid and equal → full
+  lex ordering on the remaining four.
+- Exact equality of all five = duplicate/idempotent retry — admissible
+  everywhere equality is admissible today (isApplyResultStale model,
+  manager_assignment.go:1344-1366).
+
+## 2. Delivery envelope and manager reform
+
+### 2.1 The envelope
+
+As v2: `authorityEnvelope{kind, bucketEpoch, entryRev, payload}` plumbed
+through every holder that today discards revisions — watcher debounce
+(manager_assignment.go:751-838, :929-943), reconcile (:903-913), startup
+Gets (:352-362, manager.go:785-838), `stashedCommit`, apply-retry stash,
+fetch-retry stash, drain (:1213-1221), current/committed snapshots,
+degraded recovery comparison (:1522-1530, manager_degraded.go:504-520),
+fleet-size observation (:1029-1039), accepted-target fence.
+
+### 2.2 Two-stage admission [rewritten per R2-P0-3]
+
+Admission splits into two distinct decisions:
+
+1. **Authority admission** — the envelope comparator + dual-read
+   selection, decided BEFORE payload construction (the commit handler
+   has every input at manager_assignment.go:1082-1129 ONCE COMMIT 1's
+   envelope plumbing lands — today `decodeCommitEntry` discards the
+   entry revision, :929-943 [FP-P2 wording]).
+   - Authority-REJECTED deliveries (e.g. the post-commit compat alias
+     losing to its equal-(V,LR) commit) NEVER raise the accepted-target
+     fence. The alias handler's raise moves after ITS authority
+     admission.
+   - Authority-ADMITTED deliveries raise the fence AT ADMISSION — before
+     payload fetch — preserving the v2.10.0 rule that a fetch failure
+     still fences out older sibling retries (:1132-1164). This is the
+     explicit reconciliation of "rejected never raises" with "raise
+     pre-fetch": the subject of each clause is a different decision.
+   - A successfully STASHED commit is authority-admitted: it raises
+     immediately at stash time (the current branch returns before the
+     raise, :1118-1129 — changed).
+2. **Materialization/applicability** — payload fetch, decode, digest,
+   label-incarnation validation (:1224-1269, :1533-1578). Failures here
+   never un-raise: an authoritative-but-unfetchable commit keeps its
+   fence (fetch-retry converges to it); a terminal incarnation rejection
+   keeps it too (convergence waits for the next label-correct commit,
+   matching :1533-1538's existing terminal disposition).
+
+Startup follows the same split: once the commit is authority-admitted over
+the equal-authority alias, startup RETAINS the commit envelope and retries
+its materialization; it must NOT fall back to applying the lower-ranked
+alias (today's fallback at manager.go:785-838 — changed).
+
+Dispatch reform proper (closes F1): both handlers admit iff strictly newer
+by §1.1 manager-local ordering; equal-(V,LR) commit-after-alias admits via
+SourceKind; admitted equal-Version deliveries full-apply (adjacency
+already fails open on equality, twophase.go:304-318 post-v2.10.1). Rule
+900: no pinned
+surface touched (round 1); pinned tests run regardless.
+
+## 3. Claim fence [rewritten per R2-P0-1, R2-P0-2]
+
+### 3.1 Schema
+
+```go
+// Authority is the coordinate of the walk that last legitimately mutated
+// this claim; nil = unproven (pre-fence writer, erased by an old worker,
+// or fence-inactive stamper). Nil-safe by construction.
+Authority *ClaimAuthority `json:"authority,omitempty"`
+```
+
+Embedded pointer per round-2 Q3: nil cleanly encodes absent, no partially
+populated coordinates, one serialization point.
+
+### 3.2 Phase rules — idempotent by construction
+
+Discriminators available at each check: the claim's Authority (proof
+relation per §1.1), `Owner`, `PendingOwner`, `State`. For same-epoch
+proven stamps, strict-newer vs exact is decidable from the coordinate;
+Owner/PendingOwner/State then distinguish "already completed" from
+"missing". Across foreign epochs chronology is UNDECIDABLE by design —
+foreign/unproven always takes the fail-open row.
+
+"Progressed state" below always means `PendingOwner == ""` EXACTLY — not
+merely "no foreign PendingOwner". `NextCommit` clears it (claims.go:76-85)
+and the eager sweep relies on it being empty (twophase.go:1313-1316); a
+defensive `State∈{commit,stable}` + `PendingOwner==self` record matches NO
+progressed row and takes the repair row deterministically. [R3-P0-1]
+
+| Phase | Claim observation | Action |
+|---|---|---|
+| Prepare | exact + `State==prepare` + `PendingOwner==self` | **idempotent no-op** — this walk's prepare already completed; re-running `NextPrepare` would rewrite every gained claim on each whole-Apply retry (e.g. under repeated consumer-updater failures) [R4-P1-2] |
+| Prepare | mutation REQUIRED (new / foreign-owned / stale in-flight claim), stamp unproven or proven ≤ incoming | perform the prepare/reset mutation + stamp incoming |
+| Prepare | clean self-owned stable claim, stamp UNPROVEN | stamp-only backfill (+ epoch advance, §3.3) |
+| Prepare | clean self-owned stable claim, stamp proven ≤ incoming | **no-op** — a proven older stamp identifies the last ownership-affecting authority; routine discontinuous full walks (previous treated as empty, twophase.go:359-377) must NOT restamp all of `next` [R3-P1: this row is what keeps steady-state claim writes at zero] |
+| Prepare | proven > incoming | per-partition skip (stale walk) |
+| Commit | exact + `State==prepare` + `PendingOwner==self` | promote + restamp |
+| Commit | `Owner==self`, `PendingOwner==""`, `State==stable`, proof ≤ incoming or unproven | **idempotent success** (fully progressed); stamp-only backfill iff unproven |
+| Commit | `Owner==self`, `PendingOwner==""`, `State==commit`, EXACT authority | commit success (this walk's own chain); stabilize will finalize |
+| Commit | `Owner==self`, `PendingOwner==""`, `State==commit`, proven < incoming or unproven | **adopt-and-restamp**: CAS `State: commit` unchanged, Authority := incoming, epoch advance — the stranded commit (crash between commit and stabilize of an EARLIER walk) is adopted into this walk's chain so stabilize's exact row finalizes it in THIS Apply. Not an error, not a bare success: the observation must change so the pipeline converges. [R3-P0-1's fix — the v3 row pair (broad commit success + exact-only stabilize) looped here] |
+| Commit | proven > incoming | per-partition skip |
+| Commit | otherwise (lost/foreign prepare, no newer proven authority) | **inline re-prepare**: CAS the claim to `prepare/PendingOwner=self` stamped with incoming (fresh read, PutIfEpoch), then return a RETRIABLE Apply error so the next attempt commits it. [Round-2 Q2 mechanism; runs in the COMMIT arm, so prepare's gained-only visit set (:544-559) is irrelevant] |
+| Stabilize | `Owner==self`, `State==stable`, `PendingOwner==""`, proof ≤ incoming or unproven | **idempotent success** (a concurrent sweep legally finalized, :1313-1316); stamp-only backfill iff unproven |
+| Stabilize | exact + `Owner==self` + `State==commit` + `PendingOwner==""` | finalize + restamp (the commit rows repair defensive `PendingOwner==self` records first; the predicate here is table precision [R4-P2]) |
+| Stabilize | proven > incoming | per-partition skip |
+| Stabilize | otherwise | retriable error (the commit rows above rebuild the chain on retry) |
+
+Livelock bound: every retriable-error row either (a) CASes the claim
+toward the incoming authority's chain (progress: re-prepare and
+adopt-and-restamp both change the decidable observation), or (b) on the
+next observation finds a strictly newer proven authority (skip) or a
+fully-progressed self-owned state (success). Commit and stabilize rows
+now agree on every self-owned observation — the v3 gap (commit succeeds,
+stabilize errors, nothing changes) has no remaining row pair. [R3-P0-1
+test list §9.]
+
+### 3.3 Universal epoch-advance invariant [per R2-P0-2]
+
+**Every successful mutation of a Claim record advances logical
+`Claim.Epoch` exactly once.** Already true for NextPrepare/NextCommit/
+NextStable (claims.go:66-96) and the prepare cleanup branch
+(twophase.go:625-642). This project extends it to:
+
+- the coordinator sweep expiry reset (twophase.go:1318-1324),
+- the STARTUP-HYGIENE expiry reset (manager_handoff.go:167-185 — missed
+  in v2),
+- stamp-only backfill writes (§4),
+- any future authority-only restamp.
+
+Rationale: `PutIfEpoch` compares only the logical epoch on its re-read
+(kv_store.go:126-155); a mutation that preserves it does not invalidate a
+transform computed before it. Round 2's consumer audit: the resolver
+caches/exposes epoch but the processing and pull gates decide on
+owner/state only (claim_resolver.go:505-516, processing_gate.go:156-173,
+worker_consumer.go:737-746) — the invariant is compatible.
+
+Sweep transitions still never stamp Authority (they act without
+assignment authority); they only advance Epoch.
+
+## 4. Mixed-fleet convergence [conditions per R2-P1-1, R2-P1-3]
+
+1. **Backfill condition = UNPROVEN only** (absent, zero-invalid, or
+   foreign epoch) — NOT "older". A proven older stamp identifies the last
+   ownership-affecting authority; rewriting it on every global Version
+   bump would be O(P) claim writes per commit forever (every publish
+   advances Version, assignment_publisher.go:368-370; commit+stabilize
+   walk all of next, twophase.go:674-713,728-759). With unproven-only,
+   the first post-uniform walk writes once per unproven claim (bounded by
+   PhaseConcurrency + the claim-write limiter) and steady state writes
+   nothing.
+2. Backfill writes advance Epoch (§3.3) and set Authority to the walk's
+   coordinate; they run in the idempotent owner-stable branches only.
+3. **Convergence signal = a GAUGE, not the event counter**:
+   `claim_fence_unproven_remaining` — an unlabeled per-process gauge
+   (cardinality shape of the existing `claim_store_size`,
+   types/handoff_metrics.go:37-41) — set after a COMPLETED full walk.
+   Interrupted-walk encoding [R3-P2]: a companion unlabeled 0/1 gauge
+   `claim_fence_convergence_valid`; an interrupted or not-yet-completed
+   walk sets valid=0 and leaves remaining at its last value. Fleet
+   query: converged ⇔ every active worker reports valid==1 AND
+   sum(remaining)==0. The (phase, reason) event counter stays for
+   diagnostics but cannot "reach zero". R2's activation gate reads the
+   gauge pair, not the counter.
+4. Mixed-state safety statement, scoped per R2-P1-2: at every mixed
+   version/stamp/epoch state the fence's OWNERSHIP-SAFETY behavior is
+   never worse than today's unfenced behavior (fail-open on unproven;
+   PutIfEpoch serializes writers; every mutation advances Epoch). Load
+   behavior is NOT claimed identical: backfill adds bounded claim writes
+   during convergence windows.
+
+## 5. Wire format
+
+As v2: claims additive (`authority` object, omitempty); payloads
+unchanged; PrevCommitRev stays diagnostic; MIGRATING gains the
+mixed-fleet + convergence story.
+
+## 6. Bucket epoch
+
+1. Clear-on-trip rejected (round 1). Stamps carry Created identity;
+   epochs compare for identity only (§1.1).
+2. Foreign-epoch stamps are UNPROVEN → fail-open re-stamp; during an
+   epoch transition protection degrades to baseline and re-converges via
+   §4. The resumed-old-epoch-walk bound is the §4.4 ownership-safety
+   statement, now underwritten by the universal Epoch-advance invariant
+   (round 2 concurrence).
+3. MemoryStorage restart = recreation (new Created) ⇒ same path. A
+   restart shape preserving Created while resetting revisions gets a
+   reproducer (spec 6b).
+4. **Delivery-generation binding** [R3-P0-2, rewritten per R4-P0]: a
+   stamp's BucketEpoch must be the generation of the DELIVERY, never a
+   cached value that may predate a recreation. Current code captures
+   `Created` once at Start and never rebinds (manager.go:139-145,
+   manager_setup.go:648-695). **Channel closure is NOT a generation
+   boundary**: nats.go closes `Updates()` only when the subscription
+   closes (module-cached nats.go@v1.52.0 jetstream/kv.go:1304-1358),
+   silently recreates an
+   inactive ordered consumer in place (js.go:2346-2374, :2255-2311), and
+   parti's own code documents watchers stalling open across server
+   restart (manager.go:641-648, claim_resolver.go:864-873, and the
+   project's standing empirical finding that the reconciler — not
+   channel closure — is the load-bearing recovery path). The protocol
+   therefore proves generations directly:
+   - **Watcher establishment bracket**: pre-status → `Watch` →
+     post-status. Establishment succeeds only when both reads succeed
+     and agree on `Created`; that value is the SESSION identity. On
+     mismatch/error: stop and discard the watcher BEFORE dispatching any
+     buffered entry, retry establishment.
+   - **Per-entry proof with a two-outcome failure taxonomy** [R5-P1]:
+     an entry dequeued from a session is admitted with the session
+     identity only under `pre == session == post` around
+     dequeue/admission (deliveries are rebalance-rate; two status reads
+     per delivery are cheap). Failure is CLASSIFIED, never conflated:
+     - **Unproved** — a probe ERRORED or was unavailable, and no
+       successful probe contradicts the bound generation: envelope goes
+       EPOCH-LESS (unproven) — or the Apply is a retriable error under
+       `RequireClaimFence` (§6.5). Baseline-bounded, per §4.4.
+     - **Proven mismatch** — a SUCCESSFUL probe returned a Created that
+       contradicts the bound generation: the candidate is DROPPED
+       (never admitted epoch-less), the §6.4a sticky cutover latches,
+       and the logical session terminates. Epoch-less admission of a
+       proven-foreign delivery is prohibited — it would re-enter
+       manager-local ordering against old-generation holders, exactly
+       the comparison §6.4a exists to prevent.
+   - **Explicit session termination**: on any proven mismatch, terminate
+     the LOGICAL session (stop the watcher; re-establishment is moot
+     once the cutover has latched) — never wait for `Updates()` to
+     close. Applies to BOTH the assignment and commit watcher loops
+     (manager_assignment.go:387-449, :709-748).
+   - **Probe handles**: status probes use dedicated or mutex-serialized
+     handles — the natsutil contract forbids concurrent Status and
+     production ops on one handle (kvstreampos.go:67-81).
+   - **Authority-producing Get inventory** (each gets the double-status
+     bracket; the envelope is not published before the second proof):
+     startup alias Get (manager_assignment.go:352-362), startup commit
+     Get (manager.go:785-798), assignment-watcher reconcile (:616-637),
+     commit-watcher reconcile (:903-913), and degraded-recovery
+     `refreshAssignmentFromNATS` (:2184-2219, manager_degraded.go:
+     491-520). **Startup common-generation rule**: the alias and commit
+     Gets must prove the SAME generation before composing one authority
+     decision — two individually-valid brackets returning E1-alias +
+     E2-commit are rejected (retry).
+   - **Non-authority Gets**: the removal guard's `_commit` read and
+     payload Gets (:2358-2445) validate an already-selected delivery;
+     they RETAIN the selected envelope and never substitute their own
+     captured epoch.
+   - **Recapture**: establishment/bracket sites re-run capture, so a
+     transiently failed Start-time capture can recover
+     (RequireClaimFence retries can succeed).
+   - Spec 24's oracle (clarified per R4-P1-1): (a) an E1 delivery is
+     never mislabeled E2 (and vice versa), and (b) the §6.4a cutover
+     rule below holds.
+
+   **4a. Manager-wide cross-generation cutover — bound generation +
+   sticky atomic admission barrier** [R4-P1-1, contract per R5-P1]:
+
+   - **Manager-bound generation**: one atomic manager-level
+     `authorityGeneration` value. It is bound by the STARTUP
+     common-generation proof — or, when Start-time capture was absent
+     (transient failure), by the FIRST later successful proof (late
+     binding). Until bound, all admissions are epoch-less/unproved-path
+     by construction.
+   - **One admission gate with an ATOMIC ADMISSION+PUBLICATION scope**
+     [FP-P1-1]: every authority-producing path — both watcher loops,
+     both reconciles, startup, and degraded-recovery
+     `refreshAssignmentFromNATS` (which can re-arm an Apply,
+     manager_degraded.go:481-520) — passes through a single gate. The
+     gate is a mutex (house style: the applyStoreMu pattern) HELD FROM
+     the latch/proof check THROUGH the candidate's publication into the
+     comparator holders (`lastSeenAlias`, `lastObservedCommit`,
+     debounce state, stashes, accepted fence, current/committed
+     snapshots, manager.go:162-241) — check-then-unlock-then-publish is
+     PROHIBITED: the alias and commit monitors are independent
+     goroutines (manager_startup_async.go:123-135), and a latch landing
+     between an unlocked check and a later publication would violate
+     spec 49's ordering oracle. Work already PENDING at latch time
+     (debounced entries, armed retries) re-validates under the gate
+     before dispatch — a latched gate discards it.
+   - **Sticky latch**: the first PROVEN mismatch atomically sets a
+     one-way `generationCutover` flag inside the gate. From that point
+     every authority admission — including pending debounce work, which
+     is discarded, and any retry that would be armed from the
+     mismatching delivery, which is not — is dropped with a distinct
+     log/metric. The manager rides its existing terminal-degraded path
+     to rotation (epoch mismatch is already terminal,
+     manager_degraded.go:607-654; `enterDegraded` alone is NOT an
+     admission lock, :315-364 — the gate is). The fresh process binds
+     the new generation. **Recovery-exit hold keyed on the latch
+     itself** [FP-P1-1]: the degraded-recovery exit guard must check
+     `generationCutover` DIRECTLY, not (only) the `bucketEpochs` map —
+     a LATE-BOUND manager has no map entry (failed Start-time capture
+     leaves none, manager_setup.go:648-695; the existing guard only
+     ranges map entries, manager_degraded.go:568-575,639-654), and
+     without the direct hold it could exit Degraded into a Stable state
+     whose sticky latch drops all future authority. Spec 51b pins this.
+   - **Qualified invariant** [R5 answer 1]: no PROVED cross-generation
+     candidate is ever compared against a holder, and NOTHING is
+     admitted after cutover. An UNPROVED candidate (probe unavailable,
+     no contradicting proof) may take the epoch-less baseline-bounded
+     path — that is the documented §4.4 fail-open, not a violation.
+   - No partial holder reset is ever attempted; the cutover removes the
+     cross-generation comparison problem by construction and matches
+     the existing operator contract (bucket recreation is a disruptive
+     action already requiring rotation).
+5. **Fence-inactive handling** [round-2 Q1]: epoch capture failure keeps
+   manager-local ordering fully active (§1.1) but claim stamps are
+   written epoch-less = unproven-by-construction; WARN + gauge
+   ("claim fence inactive: no bucket epoch identity"). Default is NOT
+   fail-closed (enterDegraded neither stops assignment processing,
+   manager_degraded.go:324-364, nor blocks Apply — it is not a
+   fail-closed mechanism). A separate opt-in `RequireClaimFence` config
+   makes handoff Apply return a retriable error while epoch identity is
+   absent, for operators who want fail-closed. Scoped as a small §10
+   commit; default off.
+
+## 7. Observability [names + commit ownership per FP-P1-3]
+
+All series are per-process, exposed via the optional-capability recorder
+pattern (as v2.10.1's sweep counters); a recorder without the capability
+loses nothing else.
+
+| Series | Kind | Owner commit |
+|---|---|---|
+| `claim_fence_decisions_total{phase, reason}` — a DECISION/event counter (not rejections-only: `backfill` is a successful mutation); reason ∈ {stale_walk, lost_prepare, lost_commit, foreign_epoch, backfill}; partition COUNT added per event (no partition-ID label) | counter | 4 |
+| per-walk summary log (count + bounded partition-ID sample, rate-limited) | log | 4 |
+| `claim_fence_unproven_remaining` (set after a completed full walk, §4.3) | gauge | 6 |
+| `claim_fence_convergence_valid` (0/1, §4.3) | gauge | 6 |
+| `claim_fence_inactive` (0/1 — no bucket epoch identity; clears on late binding) | gauge | 5 |
+| `authority_generation_cutover` (0/1 — sticky latch state) | gauge | 5 |
+
+The convergence signal is the §4.3 gauge pair, never the counter.
+
+## 8. Publisher fix (F2)
+
+As v2 (round-2 closure confirmed): lock-aware coherent recovery advancing
+{lastCommitRev, currentVersion, lastCommit, lastCommitObservedAt}
+(bootstrap shape assignment_publisher.go:1227-1250 not callable under
+p.mu :1270-1272 — new helper); winner unreadable ⇒ fail closed, no
+publish. Reproducers: V+2-never-V+1, transient-Get, malformed winner.
+
+## 9. Test plan
+
+### 9A. RED-first reproducer specs
+
+Every numbered spec below is a genuine RED-first reproducer EXCEPT 16,
+27, and 35, whose entries are pointers into §9B (GREEN-first gates) —
+they are listed in place to keep historical numbering stable.
+
+Carried from v2 (1-17, renumbered where noted) plus round 2's additions:
+
+1. F1 alias-then-equal-V-commit → full Apply; V+1 trusted only after.
+2. F2 V+2-never-V+1 + transient-Get + malformed-winner.
+3. F3 cross-worker late retry → no steal; pinned steal test FLIPS.
+4. F4 prepare-expiry → gainer re-prepares (commit-arm inline re-prepare),
+   never finalizes with old owner; variant with reset between transform
+   and PutIfEpoch (epoch bump defeats it).
+5. Mixed-fleet stamp erasure → fail-open, baseline-bounded.
+6. Epoch: (a) recreation → new-epoch walks unfenced by old stamps;
+   (b) Created-preserving revision reset [FP-P1-4, DECIDED; keying per
+   closure verification]: the shape is made HARMLESS by design — an
+   EntryRev HIGH-WATER guard with this exact keying:
+   - **Keyed per (Created identity, authority SOURCE)** — one
+     high-water for the commit key, one for the alias key, per
+     manager. The alias and commit watchers are independent goroutines
+     with no cross-source delivery-order guarantee (a manager-wide
+     scalar would false-trigger when an alias at bucket-seq 101 is
+     dequeued after a commit at 102); within ONE source, deliveries
+     are watcher-ordered, so per-source monotonicity is sound.
+   - **Manager-held, not session-held**: the high-water lives on the
+     manager keyed by the Created identity, surviving same-`Created`
+     session re-establishments (session-scoped state would lose the
+     baseline exactly when a reset-across-reestablishment must be
+     caught). It resets only when Created changes — which is the
+     §6.4a cutover anyway.
+   - **Equality admits** (same-entry redelivery is the same bucket
+     seq); only a STRICTLY-BELOW EntryRev with matching Created is a
+     regression → the §6.4 UNPROVED path (epoch-less stamp, or
+     retriable under RequireClaimFence) + WARN.
+   - **Baseline-less startup**: the first delivery per (Created,
+     source) establishes the baseline with no check — a pre-baseline
+     reset is undetectable in-process, which is exactly the narrowed
+     empirical item: pre-commit-5, confirm whether any
+     locally-supported restart shape can produce a Created-preserving
+     revision reset at all (evidence recorded either way).
+   Spec 6b is a REAL spec owned by commit 5: inject a Created-matching
+   EntryRev regression per source → unproved path + WARN, never a
+   proven admission; include the cross-source reordering case (alias
+   below the COMMIT high-water but at-or-above its own → NOT a
+   regression).
+7. Failed commit's later compat alias must not raise the fence
+   [§2.2 stage 1].
+8. Lower-LR/higher-EntryRev vs higher-LR/lower-EntryRev → semantic winner
+   keeps the claim.
+9. Sweep finalizes commit→stable between commit and stabilize → stabilize
+   idempotent success, no armed retry [R2-P0-1].
+10. Exact-authority owner-self stable claim → commit AND stabilize
+    idempotent success.
+11. Adjacent assignment, unchanged partition, claim foreign-owned/older →
+    commit-arm re-prepare converges; never an infinite retry [R2-P0-1].
+12. Strictly newer proven authority appears during a stale retry → skip,
+    terminate, nothing restashed.
+13. Stamp-only backfill between a transform and PutIfEpoch → backfill's
+    epoch bump defeats the stale transform [R2-P0-2].
+14. Startup-hygiene reset before/between transform and PutIfEpoch → both
+    stale writes lose [R2-P0-2].
+15. Zero-epoch: claim-side zero vs zero stays unproven; manager-local
+    ordering still admits equal-(V,LR) commit-after-alias [R2-P1-2].
+16. → GREEN-first gate, see §9B (pre-fetch fence raise).
+17. Stashed newer commit raises the fence before an older retry acquires
+    the apply lock [§2.2].
+18. Startup: authoritative commit unfetchable → keeps envelope, no alias
+    fallback [§2.2].
+19. Convergence at P=10k: one write per unproven claim on the first walk
+    (limiter-bounded); a later unchanged authority writes ZERO claims
+    [R2-P1-1].
+20. Convergence gauge zero only after a complete walk; an interrupted
+    walk sets `claim_fence_convergence_valid=0` with `remaining`
+    unchanged (per §4.3 encoding) [R2-P1-3, wording per R4-P2].
+21. Foreign-epoch interleavings per sweep arm (eager finalize, expiry
+    reset, backfill CAS).
+22. Watcher shapes: same-revision redelivery, close/reopen replay,
+    reconcile replay, startup alias/commit orderings.
+23. Envelope holder table test — COMPARATOR behavior across every
+    holder, owned by commit 3 ONLY [FP-P1-2 closure: comparator-only].
+    Commit 1's adapter-predicate characterization (each holder's current
+    behavior pinned bit-for-bit) is an UNNUMBERED prerequisite test
+    suite described in §10 commit 1, not part of this spec.
+24. Bucket recreation with paused old-epoch Apply → bound holds.
+25. Partial-walk crash (after prepare / consumer update / partial
+    commits) → newer authority → stale retry.
+26. Concurrent Apply-origin + ticker sweep vs claim writers.
+27. → GREEN-first gate, see §9B (Rule 900 pinned contract tests).
+28. RequireClaimFence: absent epoch identity ⇒ retriable Apply error;
+    default off ⇒ WARN+gauge only [§6.5].
+
+Added by round 3:
+
+29. Owner-self, `PendingOwner==""`, `State==commit`, proven-OLDER
+    authority: ONE Apply converges to stable (adopt-and-restamp row);
+    variants with nil authority and foreign epoch [R3-P0-1].
+30. Defensive `State∈{commit,stable}` + `PendingOwner==self` record:
+    repaired or rejected deterministically via the repair row; never
+    satisfies a progressed row and loops [R3-P0-1].
+31. Discontinuous full prepare over clean self-owned stable claims with
+    proven older stamps: ZERO claim writes; same setup with unproven
+    stamps: exactly one backfill per claim [R3-P1].
+32. Bucket recreated between epoch capture and a startup/reconcile Get:
+    the bracket rejects/retries or the envelope carries the NEW
+    generation — never the old one [§6.4].
+33. Recreation during an active watcher session: queued old-session
+    entries and new-session entries never share an epoch [§6.4].
+34. RequireClaimFence with a transient initial capture failure: Apply
+    returns retriable errors until a later successful proof LATE-BINDS
+    the manager generation (§6.4a) and unblocks it — Start does NOT
+    fail (missing identity is an Apply-time condition in this design)
+    [§6.4a, wording per R5-P2].
+35. → GREEN-first gate, see §9B (terminal incarnation rejection keeps
+    the fence).
+36. Commit-arm re-prepare after the consumer update: processing gate
+    stays closed for the re-prepared partition, exactly one retry
+    target is scheduled, the retry re-runs the (idempotent) updater,
+    then commits and stabilizes [§11 item 1 resolution].
+37. Interrupted convergence after a previously reported zero:
+    `claim_fence_convergence_valid` drops to 0 per the §4.3 encoding;
+    the fleet query stops reporting converged [R3-P2].
+
+Added by round 4 (generation-proof + idempotence family):
+
+38. Establishment race, forward: pre-status E1, recreation before
+    `Watch`, post-status E2 → watcher stopped, no buffered entry
+    dispatched, and (post-binding) the proven mismatch latches the
+    §6.4a cutover [§6.4, R5-P2].
+39. Establishment race, reverse: `Watch` queues an E1 initial value,
+    recreation before post-status → in a bound manager: value DROPPED +
+    terminal cutover (never epoch-less; the mismatch is proven)
+    [§6.4, wording per R5-P2].
+40. **Silent in-place reset**: `Updates()` stays OPEN across E1→E2 (the
+    nats.go ordered-consumer reset shape) → an E2 entry is never
+    stamped E1; the proven mismatch drops the entry, latches cutover,
+    and terminates the session [R4-P0; supersedes spec 33's
+    close/reopen-only shape].
+41. Queued E1 entry, recreation before dequeue → `pre==session==post`
+    proof yields a PROVEN mismatch → drop + terminal cutover (never
+    epoch-less) [§6.4, wording per R5-P2].
+42. Alias and commit watcher sessions cross the generation change at
+    different times → no E1 holder is compared against E2; the §6.4a
+    cutover drops proven-E2 admissions and the manager rides to
+    rotation [R4-P1-1].
+43. Recreation between the startup alias Get and startup commit Get →
+    startup rejects the mixed-generation pair (common-generation rule),
+    retries [§6.4].
+44. Recreation around `refreshAssignmentFromNATS` → the recovery-
+    triggered Apply carries proven-current-generation or
+    epoch-less/retriable per the taxonomy, never cached E1; a proven
+    mismatch inside recovery latches the cutover BEFORE any Apply is
+    re-armed [§6.4, §6.4a].
+45. Reconcile observes a generation different from its watcher session
+    → proven mismatch: the manager LATCHES CUTOVER AND STAYS CUT OVER
+    (merely terminating/rebinding the watcher is insufficient); the Get
+    is not staged beside old-session entries [§6.4a, per R5-P2].
+46. Exact `prepare/PendingOwner==self/exact-authority` + repeated
+    consumer-updater failures → ZERO additional claim writes across
+    retries [R4-P1-2].
+47. Spec-29 variants with the eager sweep injected before adoption,
+    after adoption, and between transform and `PutIfEpoch`
+    [tmp/fence-project-design_r4_review.md "Answers to §12" item 2].
+48. Spec-30 for both `commit` and `stable` defensive records, asserting
+    `PendingOwner==""` in the final stable claim
+    [tmp/fence-project-design_r4_review.md "Answers to §12" item 3].
+
+Added by round 5 (cutover-contract family):
+
+49. Atomic cutover race: an E1-bound manager receives concurrent alias
+    and commit activity while one path proves E2 → cutover linearizes
+    before any comparator/holder/fence/stash update; pending debounce
+    work discarded; no retry armed from the mismatching delivery;
+    manager stays terminally degraded [R5-P1].
+50. Proof-failure taxonomy table: matching successful probes → admit
+    with bound epoch; probe errors with no proven mismatch →
+    epoch-less (default) or retriable (RequireClaimFence); ANY
+    successful non-matching Created → terminal drop, never epoch-less
+    [R5-P1].
+51. Late binding: Start-time capture fails → startup common-generation
+    bracket later binds E1 → a subsequent E2 proof trips the sticky
+    latch even though the original capture map entry was absent
+    [§6.4a].
+52. Reconcile/debounce interleaving: an E1 entry pending in EACH
+    debouncer when reconcile proves E2 → neither pending entry nor the
+    E2 Get is dispatched after cutover [R5-P1].
+53. Non-authority Get retention: recreate during the selected commit's
+    payload fetch AND during the removal guard's `_commit` read → the
+    walk keeps the selected envelope's authority or fails/retries;
+    never substitutes the validation Get's generation [R5-P2].
+
+Added by the final precision pass:
+
+51b. Late-bound cutover vs recovery exit: Start-time capture fails →
+     late binding → proven mismatch latches cutover → drive
+     degraded-recovery: the manager must STAY Degraded (the exit guard
+     holds on `generationCutover` directly, not the absent
+     `bucketEpochs` entry) until rotation [FP-P1-1].
+54. Wire round-trip (§5): legacy claim JSON without `authority`
+    decodes to `Authority == nil`; nil marshals to an OMITTED field;
+    a populated five-field authority round-trips losslessly; existing
+    assignment/commit payload encodings byte-identical [FP-P1-3].
+55. Claim-phase observability (§7): the `(phase, reason)` event
+    counter receives the correct partition COUNT per rejection event;
+    the per-walk summary log is emitted once, rate-limited, with a
+    bounded ID sample; a recorder WITHOUT the optional capability
+    changes no behavior [FP-P1-3].
+56. Cutover/inactive observability (§7): the `authority_generation_cutover`
+    0/1 gauge sets on latch; `claim_fence_inactive` sets while epoch
+    identity is absent and clears on late binding [FP-P1-3].
+
+### 9B. Regression/contract gates (GREEN-first) [FP-P1-2]
+
+EXISTING-behavior gates: green on the parent commit, stay green after
+each train commit. Implementers must NOT attempt to make them fail
+first.
+
+- **Gate 16** — authoritative commit fetch fails with an older retry
+  pending → the pre-fetch fence raise suppresses the older retry
+  (behavior exists at manager_assignment.go:1132-1164; commit 3
+  verifies it survives the two-stage admission refactor).
+- **Gate 27** — the Rule-900 pinned contract tests (must already pass;
+  re-verified at commit 3 and at the consolidated review).
+- **Gate 35** — fence-before-apply + terminal incarnation rejection
+  keeps the fence and performs no claim or consumer mutation (exists at
+  :1132-1140, :1559-1620; commit 3 verifies).
+
+## 10. Delivery shape [split per R2-P1-4]
+
+Branch `feat/claim-authority-fence`, scope-pure commits:
+
+1. `refactor(manager)`: envelope plumbing ONLY, each holder behind an
+   ADAPTER predicate reproducing its current behavior bit-for-bit
+   (debouncer :810-838, stashes :1409-1483 etc. keep their exact
+   semantics); holder table test pins them. NO comparator activation.
+2. `feat(publisher)`: F2 coherent recovery (+ spec 2).
+3. `feat(manager)`: comparator activation + two-stage admission +
+   fence-raise placement + startup retention (+ RED-first specs 1, 7,
+   8, 17, 18, 22, 23; GREEN-first gates 16, 27, 35 verified here; spec
+   12 moves to commit 4 [FP-P1-2: claim authority does not exist until
+   commit 4]; commit 1's adapter characterization is an UNNUMBERED
+   prerequisite of spec 23, whose numbered spec belongs here).
+4. `feat(handoff)`: claim schema + phase rules + universal epoch-advance
+   (both resets) + backfill (+ specs 3, 4, 5, 9-15 incl. 12, 19, 21,
+   25, 26, 29-31, 36, 46-48, 54, 55; flip the pinned steal test).
+5. `feat(manager+handoff)`: generation binding (§6.4: brackets,
+   per-entry proof taxonomy, session termination, Get inventory,
+   common-generation rule) + §6.4a bound-generation/sticky-latch
+   cutover + epoch identity semantics + RequireClaimFence
+   (+ specs 6a, 6b [now a real spec: EntryRev-regression monotonicity
+   guard], 24, 28, 32-34, 38-45, 49-53, 51b, 56; the narrowed empirical
+   confirmation of 6b's constructibility is a pre-commit-5 checklist
+   item).
+6. `feat(handoff)`: convergence gauges (+ specs 20, 37).
+7. `docs`: MIGRATING, LIFECYCLE/ARCHITECTURE (incl. the §11-item-1
+   no-overclaim rule), CHANGELOG v2.11.0.
+
+Per-commit codex rounds + consolidated whole-branch review before PR;
+full `make pre-pr` + sims; rig optional.
+
+## 11. Resolved in round 3 (design notes, no longer open)
+
+1. **Re-prepare vs consumer-update ordering** — compatible; no updater
+   re-run inside the failing attempt. The updater received the complete
+   `next.Partitions` set before commit began (twophase.go:400-415); the
+   retriable error re-enters the whole Apply pipeline including another
+   idempotent updater call (manager_assignment.go:1734-1759,
+   :1982-1993); while the claim is prepared, the OPTIONAL processing and
+   pull gates suppress work on owner/state (processing_gate.go:156-184,
+   worker_consumer.go:737-763). Wording rule adopted: the fence does NOT
+   strengthen the consume-path guarantee — without the optional gates,
+   two-phase handoff orders release but does not prevent consumption
+   overlap (docs/LIFECYCLE.md:217-238,265-274), unchanged by this
+   project. MIGRATING/LIFECYCLE text must not overclaim.
+2. **Gauge cardinality** — no objection: both gauges are unlabeled
+   per-process series, the shape of the existing `claim_store_size`
+   (metrics_prometheus.go registration, no labels).
+
+## 12. Round-4 confirmations carried as design facts
+
+- Adopt-and-restamp + defensive-record sequences verified convergent by
+  round 4 against NextCommit/NextStable/PutIfEpoch (incl. eager-sweep
+  interleavings; the sweep predicate is `State==commit &&
+  PendingOwner==""`, twophase.go:1287-1317).
+- The double-status bracket is sufficient for a single synchronous Get
+  iff both reads succeed, agree, surround the Get, use serialized probe
+  handles, and the envelope is not published before the second proof.
+- Channel-closure-based watcher binding is NOT implementable (silent
+  ordered-consumer reset); the §6.4 per-entry-proof redesign is the
+  implementable form.
+
+## 13. Round-5 confirmations carried as design facts
+
+- Zero P0: no path assigns a proved E1 delivery an E2 stamp or vice
+  versa; the Get inventory is complete (round-5 answer 1).
+- Phase table is fully retry-idempotent: no remaining shape writes a
+  claim while changing only Epoch/LastUpdated (round-5 answer 2).
+- Specs 49-53 + the taxonomy/cutover wording above are the folded
+  round-5 P1/P2; commit 5 of §10 owns them.
+
+## 14. Status
+
+**DEFERRED (2026-07-17)** — see the Status preamble at the top of this
+document for the deferral rationale and re-activation triggers. The design
+is complete and settled; implementation has not started.
+
+Architecture CONVERGED per round 5 (0 P0). Final precision pass ran
+(0 P0 / 4 precision P1 / 2 P2 — all folded in this v7): atomic
+admission+publication scope + cutover-keyed recovery hold, spec
+ownership made one-to-one with GREEN-first gates separated, §5/§7 specs
+and metric names added with commit owners, 6b resolved by the EntryRev
+monotonicity guard, anchors refreshed to main @ c690f3e. Closure
+verification of these folds completed (all findings folded). At that
+point the project was deferred by decision rather than proceeding to the
+§10 implementation train; the standalone F2 publisher-reseed fix and the
+equal-version divergence precondition counter shipped instead in v2.10.2.

--- a/internal/assignment/assignment_publisher.go
+++ b/internal/assignment/assignment_publisher.go
@@ -134,6 +134,16 @@ type AssignmentPublisher struct {
 	// in that case). Set under p.mu.
 	lastCommitObservedAtMono time.Time
 
+	// commitReseedPending is latched when a commit CAS was lost to an
+	// external winner that could not be read back (transient Get failure)
+	// or did not unmarshal. While set, Publish fails closed at entry —
+	// before any payload/alias/CAS side effect — because the local
+	// currentVersion may equal a Version the winner already owns, and a
+	// blind retry would overwrite the winner at that reused Version. A
+	// successful reseed (reseedFromLiveCommitLocked) clears it. Set under
+	// p.mu.
+	commitReseedPending bool
+
 	lastRebalance time.Time
 
 	// now returns the current time; injectable so cooldown timing can be
@@ -359,6 +369,15 @@ func (p *AssignmentPublisher) Publish(ctx context.Context, in PublishInput) erro
 		return nil
 	}
 
+	// Fail-closed gate: a previous commit CAS was lost to a winner we could
+	// not read back, so currentVersion may equal a Version the winner
+	// already owns. Retry the reseed before ANY side effect (payload
+	// writes, aliases, CAS); if the live commit is still unreadable, abort
+	// under the same surrendered-batch error class the lost CAS produced.
+	if err := p.ensureCommitViewCurrentLocked(ctx); err != nil {
+		return err
+	}
+
 	// --- step 3 of §3.5: publish-time set-equality coverage check ---
 	if err := p.checkCoverage(in.SourcePartitions, in.Assignments, in.ParkedPartitions); err != nil {
 		p.metrics.IncrementBatchAborted("coverage_mismatch")
@@ -454,29 +473,9 @@ func (p *AssignmentPublisher) Publish(ctx context.Context, in PublishInput) erro
 	if err := p.abortIfShuttingDown(aliasWritten); err != nil {
 		return err
 	}
-	commitKey := p.keyPrefix + commitKeyName
-	var newCommitRev uint64
-	if p.lastCommitRev == 0 {
-		newCommitRev, err = p.assignmentKV.Create(ctx, commitKey, commitBytes)
-	} else {
-		newCommitRev, err = p.assignmentKV.Update(ctx, commitKey, commitBytes, p.lastCommitRev)
-	}
+	newCommitRev, err := p.casWriteCommitLocked(ctx, commitBytes)
 	if err != nil {
-		// CAS lost OR Create lost (another leader created the commit first).
-		// Either way: surrender. The lost batch's payload writes are inert;
-		// the legacy aliases written at step 6 are documented exposure.
-		p.metrics.IncrementCommitAborts()
-		p.metrics.IncrementBatchAborted("commit_cas_failed")
-		// Only count exposure when at least one alias actually landed.
-		if aliasWritten {
-			p.metrics.IncrementAliasVisibleUncommitted()
-		}
-		// ISSUE-001: when the failure is a true CAS conflict, refresh
-		// lastCommitRev from the live _commit so the next Publish can
-		// re-CAS. Transient KV errors short-circuit inside the helper.
-		p.refreshLastCommitRevAfterCASFailureLocked(ctx, err)
-
-		return fmt.Errorf("%w: %w", types.ErrCommitCASFailed, err)
+		return p.surrenderCommitCASLocked(ctx, err, aliasWritten)
 	}
 	// COMMIT POINT: from here on, this batch is the cluster's authoritative view.
 	p.lastCommitRev = newCommitRev
@@ -1257,37 +1256,131 @@ func (p *AssignmentPublisher) BootstrapLastCommit(ctx context.Context) error {
 	return nil
 }
 
-// refreshLastCommitRevAfterCASFailureLocked re-reads the live _commit KV
-// revision and updates p.lastCommitRev so the next Publish can re-CAS.
+// ensureCommitViewCurrentLocked is Publish's fail-closed entry gate. While
+// commitReseedPending is latched it retries the reseed; if the live commit
+// is still unreadable it aborts the publish under the same surrendered-batch
+// error class the lost CAS produced (ErrCommitCASFailed keeps caller routing
+// unchanged), recording the "commit_reseed_pending" abort reason. Caller
+// must hold p.mu.
+func (p *AssignmentPublisher) ensureCommitViewCurrentLocked(ctx context.Context) error {
+	if !p.commitReseedPending {
+		return nil
+	}
+	if err := p.reseedFromLiveCommitLocked(ctx); err != nil {
+		p.metrics.IncrementBatchAborted("commit_reseed_pending")
+		return fmt.Errorf("%w: commit reseed pending: %w", types.ErrCommitCASFailed, err)
+	}
+
+	return nil
+}
+
+// casWriteCommitLocked performs the step-9 CAS write against
+// "<prefix>._commit": Create when this publisher has never observed a commit
+// revision, Update fenced on lastCommitRev otherwise. Caller must hold p.mu.
+func (p *AssignmentPublisher) casWriteCommitLocked(ctx context.Context, commitBytes []byte) (uint64, error) {
+	commitKey := p.keyPrefix + commitKeyName
+	if p.lastCommitRev == 0 {
+		return p.assignmentKV.Create(ctx, commitKey, commitBytes)
+	}
+
+	return p.assignmentKV.Update(ctx, commitKey, commitBytes, p.lastCommitRev)
+}
+
+// surrenderCommitCASLocked is Publish's commit-CAS failure branch: CAS lost
+// OR Create lost (another leader created the commit first). Either way:
+// surrender. The lost batch's payload writes are inert; the legacy aliases
+// written at step 6 are documented exposure (counted only when one actually
+// landed). Returns the wrapped ErrCommitCASFailed for Publish to propagate.
+// Caller must hold p.mu.
+func (p *AssignmentPublisher) surrenderCommitCASLocked(ctx context.Context, writeErr error, aliasWritten bool) error {
+	p.metrics.IncrementCommitAborts()
+	p.metrics.IncrementBatchAborted("commit_cas_failed")
+	if aliasWritten {
+		p.metrics.IncrementAliasVisibleUncommitted()
+	}
+	// ISSUE-001: when the failure is a true CAS conflict, reseed the whole
+	// commit view (revision AND Version) from the live winner so the next
+	// Publish re-CASes beyond both observed Versions (max(local, winner)+1)
+	// instead of overwriting the winner at a reused Version. Transient KV
+	// errors short-circuit inside the helper.
+	p.reseedAfterCommitCASLossLocked(ctx, writeErr)
+
+	return fmt.Errorf("%w: %w", types.ErrCommitCASFailed, writeErr)
+}
+
+// reseedAfterCommitCASLossLocked re-synchronizes the publisher's commit view
+// with the live _commit entry after a lost commit CAS.
 //
 // Gated on writeErr being jetstream.ErrKeyExists — the sentinel NATS
 // JetStream returns for both Create (key already exists) and Update
 // (revision mismatch). Both indicate another writer beat us; any other
 // error class is a transient KV failure whose recovery is the existing
-// retry-on-next-rebalance-event path, and refreshing on transient errors
-// would skew lastCommitRev independently of currentVersion / lastCommit.
+// retry-on-next-rebalance-event path, and reseeding on transient errors
+// would skew the commit view without evidence of an external winner.
 //
 // Called from Publish's commit-write error branch — Publish already holds
 // p.mu, so this method MUST NOT acquire it (BootstrapLastCommit cannot be
 // reused here because it would deadlock on the same mutex).
 //
-// Best-effort: KV errors and missing entries leave lastCommitRev unchanged.
-// The next CAS failure triggers another refresh attempt; a Calculator
-// restart is the ultimate recovery path.
-func (p *AssignmentPublisher) refreshLastCommitRevAfterCASFailureLocked(ctx context.Context, writeErr error) {
+// A lost CAS proves an external winner exists, so the publisher's whole
+// commit view — not just lastCommitRev — is stale. Refreshing only the
+// revision would let the next Publish CAS-succeed while still proposing the
+// old currentVersion+1, overwriting the winner at a Version it already
+// published (workers drop equal-Version deliveries at dispatch, so the
+// overwrite would be invisible fleet-wide). Reseeding currentVersion too
+// makes the next proposal strictly beyond both the winner's and the
+// publisher's own last-observed Version (max(local, winner)+1). The reseed
+// latches commitReseedPending and clears it only when the full view has
+// been advanced coherently; while pending, Publish fails closed at entry.
+func (p *AssignmentPublisher) reseedAfterCommitCASLossLocked(ctx context.Context, writeErr error) {
 	if !errors.Is(writeErr, jetstream.ErrKeyExists) {
 		return
 	}
+	p.commitReseedPending = true
+	if err := p.reseedFromLiveCommitLocked(ctx); err != nil {
+		p.logger.Warn("post-CAS-loss reseed failed; publishes fail closed until the live commit is readable",
+			"error", err)
+	}
+}
+
+// reseedFromLiveCommitLocked reads the live _commit entry and advances
+// {lastCommitRev, currentVersion, lastCommit, lastCommitObservedAtMono}
+// together — all four or none. Advancing any subset (in particular the
+// revision without the Version) is exactly the version-reuse hazard the
+// reseed exists to close, so Get and unmarshal failures mutate nothing and
+// leave commitReseedPending latched. Caller must hold p.mu.
+//
+// Monotonic guards mirror BootstrapLastCommit: revision and Version only
+// move forward; the lastCommit cache and its observation instant are
+// replaced unconditionally (the live entry IS the live commit).
+func (p *AssignmentPublisher) reseedFromLiveCommitLocked(ctx context.Context) error {
 	commitKey := p.keyPrefix + commitKeyName
 	entry, err := p.assignmentKV.Get(ctx, commitKey)
 	if err != nil {
-		p.logger.Debug("post-CAS-failure refresh: could not read live _commit",
-			"key", commitKey, "error", err)
-		return
+		return fmt.Errorf("read live commit: %w", err)
+	}
+	var winner types.AssignmentCommit
+	if jerr := json.Unmarshal(entry.Value(), &winner); jerr != nil {
+		return fmt.Errorf("unmarshal live commit: %w", jerr)
 	}
 	if entry.Revision() > p.lastCommitRev {
 		p.lastCommitRev = entry.Revision()
 	}
+	if winner.Version > p.currentVersion {
+		p.currentVersion = winner.Version
+	}
+	winnerCopy := cloneAssignmentCommit(&winner)
+	p.lastCommit = &winnerCopy
+	// Local monotonic observation; see Publish step 9 for the rationale.
+	p.lastCommitObservedAtMono = time.Now()
+	p.commitReseedPending = false
+	p.logger.Info("publisher commit view reseeded from live winner",
+		"version", winner.Version,
+		"leader_revision", winner.LeaderRevision,
+		"commit_rev", entry.Revision(),
+	)
+
+	return nil
 }
 
 // LastRebalanceTime returns the time of the last successful commit.

--- a/internal/assignment/assignment_publisher_reseed_test.go
+++ b/internal/assignment/assignment_publisher_reseed_test.go
@@ -1,0 +1,231 @@
+package assignment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// ============================================================================
+// Reproducers: coherent publisher reseed after commit CAS loss.
+// ============================================================================
+//
+// THE DEFECT
+//
+// Publish proposes currentVersion+1 and advances local state only on a
+// successful commit CAS. The CAS-failure branch used to refresh ONLY
+// lastCommitRev from the live _commit entry — never currentVersion (nor the
+// lastCommit cache). After an external winner landed V+1, the recovered
+// publisher's next Publish proposed the SAME V+1 and its CAS now SUCCEEDED
+// against the winner's refreshed revision — silently overwriting the winner
+// at an already-published Version. Workers never see the overwrite: dispatch
+// drops Version <= cur.Version deliveries before payload fetch.
+//
+// THE FIX
+//
+// The CAS-failure branch reseeds {lastCommitRev, currentVersion, lastCommit,
+// lastCommitObservedAtMono} together from the live winner entry — all four
+// or none. If the winner is unreadable or malformed, the publisher latches
+// reseed-pending and every subsequent Publish fails closed BEFORE any side
+// effect (no payload writes, no aliases, no CAS) until a reseed succeeds.
+
+var errInjectedCommitGet = errors.New("injected commit get failure")
+
+// keyGetFailKV decorates a real KV bucket, failing Get on one key while
+// armed. All other operations pass through.
+type keyGetFailKV struct {
+	jetstream.KeyValue
+	mu      sync.Mutex
+	failKey string
+}
+
+func (k *keyGetFailKV) setFailKey(key string) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.failKey = key
+}
+
+func (k *keyGetFailKV) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	k.mu.Lock()
+	armed := k.failKey != "" && k.failKey == key
+	k.mu.Unlock()
+	if armed {
+		return nil, errInjectedCommitGet
+	}
+	return k.KeyValue.Get(ctx, key)
+}
+
+// payloadKeyCount counts live "assignment._payload.*" keys — the side-effect
+// probe for the fail-closed assertions (a publish that got past the entry
+// gate would have created the new input's payload key).
+func payloadKeyCount(t *testing.T, ctx context.Context, kv jetstream.KeyValue) int {
+	t.Helper()
+	lister, err := kv.ListKeys(ctx)
+	require.NoError(t, err)
+	n := 0
+	for key := range lister.Keys() {
+		if strings.HasPrefix(key, "assignment._payload.") {
+			n++
+		}
+	}
+
+	return n
+}
+
+// forgeWinner CAS-races the fixture's publisher: a direct Put of a valid
+// commit at version cur+1 advances the live _commit revision past the
+// publisher's cached lastCommitRev. Returns the winner and its revision.
+func forgeWinner(t *testing.T, ctx context.Context, f *publisherFixture) (types.AssignmentCommit, uint64) {
+	t.Helper()
+	cur := f.readCommit(t, ctx)
+	require.NotNil(t, cur)
+	winner := types.AssignmentCommit{
+		Version:        cur.Version + 1,
+		LeaderRevision: cur.LeaderRevision,
+		Workers:        cur.Workers,
+		Payloads:       cur.Payloads,
+	}
+	winnerBytes, err := json.Marshal(winner)
+	require.NoError(t, err)
+	rev, err := f.assignmentKV.Put(ctx, "assignment._commit", winnerBytes)
+	require.NoError(t, err)
+
+	return winner, rev
+}
+
+func reseedTestInput(parts ...string) PublishInput {
+	ps2 := make([]types.Partition, 0, len(parts))
+	for _, p := range parts {
+		ps2 = append(ps2, ps(p))
+	}
+	return PublishInput{
+		Workers:          []string{"w1"},
+		Assignments:      map[string][]types.Partition{"w1": ps2},
+		SourcePartitions: ps2,
+		LeaderRevision:   1,
+	}
+}
+
+// TestPublisher_CASLossReseed_NeverReusesWinnerVersion: after a lost CAS the
+// recovered publisher must commit at winner.Version+1 — never overwrite the
+// winner at its own Version.
+func TestPublisher_CASLossReseed_NeverReusesWinnerVersion(t *testing.T) {
+	f := newPublisherFixture(t, "reseed-never-reuse")
+	ctx := t.Context()
+	f.putV1Heartbeat(t, ctx, "w1")
+	input := reseedTestInput("p1", "p2")
+
+	require.NoError(t, f.pub.Publish(ctx, input)) // commits V1
+	winner, winnerRev := forgeWinner(t, ctx, f)   // external winner at V2
+
+	err := f.pub.Publish(ctx, input)
+	require.ErrorIs(t, err, types.ErrCommitCASFailed, "stale lastCommitRev must lose the CAS")
+
+	require.NoError(t, f.pub.Publish(ctx, input), "publisher must recover after the reseed")
+
+	live := f.readCommit(t, ctx)
+	require.NotNil(t, live)
+	require.Equal(t, winner.Version+1, live.Version,
+		"recovered publish must commit at winner.Version+1; committing at the winner's own "+
+			"Version silently overwrites an already-published assignment")
+	require.Equal(t, winnerRev, live.PrevCommitRev,
+		"recovered commit must chain from the winner's revision")
+}
+
+// TestPublisher_CASLossReseed_WinnerUnreadable_FailsClosed: when the winner
+// entry cannot be read back after a lost CAS, the publisher must not publish
+// at all (no payload writes, no commit) until a reseed succeeds — a blind
+// retry would propose a Version the winner may already own.
+func TestPublisher_CASLossReseed_WinnerUnreadable_FailsClosed(t *testing.T) {
+	var fkv *keyGetFailKV
+	f := newPublisherFixtureWrapKV(t, "reseed-get-fail", func(kv jetstream.KeyValue) jetstream.KeyValue {
+		fkv = &keyGetFailKV{KeyValue: kv}
+		return fkv
+	})
+	ctx := t.Context()
+	f.putV1Heartbeat(t, ctx, "w1")
+	input := reseedTestInput("p1", "p2")
+
+	require.NoError(t, f.pub.Publish(ctx, input)) // commits V1
+	winner, _ := forgeWinner(t, ctx, f)           // external winner at V2
+
+	// The reseed inside the CAS-failure branch must hit the injected error.
+	fkv.setFailKey("assignment._commit")
+	err := f.pub.Publish(ctx, input)
+	require.ErrorIs(t, err, types.ErrCommitCASFailed)
+
+	// While the winner stays unreadable, a publish with NEW content must fail
+	// closed before any side effect.
+	winnerView := f.readCommit(t, ctx)
+	keysBefore := payloadKeyCount(t, ctx, f.assignmentKV)
+	err = f.pub.Publish(ctx, reseedTestInput("p9"))
+	require.ErrorIs(t, err, types.ErrCommitCASFailed,
+		"reseed-pending abort must keep the surrendered-batch error class")
+	require.EqualValues(t, 1, f.metrics.batchAbortedCount("commit_reseed_pending"),
+		"the fail-closed abort must be observable under its own reason")
+	require.Equal(t, keysBefore, payloadKeyCount(t, ctx, f.assignmentKV),
+		"a fail-closed publish must not write payload keys")
+	require.Equal(t, winnerView, f.readCommit(t, ctx),
+		"a fail-closed publish must not touch the live commit")
+
+	// Winner readable again: the next publish reseeds and commits past it.
+	fkv.setFailKey("")
+	require.NoError(t, f.pub.Publish(ctx, input))
+	live := f.readCommit(t, ctx)
+	require.NotNil(t, live)
+	require.Equal(t, winner.Version+1, live.Version,
+		"post-recovery commit must be winner.Version+1, never a reused Version")
+}
+
+// TestPublisher_CASLossReseed_MalformedWinner_FailsClosed: a winner entry
+// that exists but does not unmarshal gives the publisher a revision it could
+// CAS against but no Version to order after — it must fail closed rather
+// than advance the revision alone and overwrite at a reused Version.
+func TestPublisher_CASLossReseed_MalformedWinner_FailsClosed(t *testing.T) {
+	f := newPublisherFixture(t, "reseed-malformed")
+	ctx := t.Context()
+	f.putV1Heartbeat(t, ctx, "w1")
+	input := reseedTestInput("p1", "p2")
+
+	require.NoError(t, f.pub.Publish(ctx, input)) // commits V1
+	v1 := f.readCommit(t, ctx)
+	require.NotNil(t, v1)
+
+	// External writer lands garbage at _commit (advancing the revision).
+	_, err := f.assignmentKV.Put(ctx, "assignment._commit", []byte("{malformed winner"))
+	require.NoError(t, err)
+
+	err = f.pub.Publish(ctx, input)
+	require.ErrorIs(t, err, types.ErrCommitCASFailed)
+
+	// The malformed winner must not be CAS-overwritten by a blind retry.
+	keysBefore := payloadKeyCount(t, ctx, f.assignmentKV)
+	err = f.pub.Publish(ctx, reseedTestInput("p9"))
+	require.ErrorIs(t, err, types.ErrCommitCASFailed,
+		"a malformed winner must fail closed, not be overwritten at a reused Version")
+	require.EqualValues(t, 1, f.metrics.batchAbortedCount("commit_reseed_pending"))
+	require.Equal(t, keysBefore, payloadKeyCount(t, ctx, f.assignmentKV),
+		"a fail-closed publish must not write payload keys")
+
+	// A valid winner replaces the garbage; the publisher reseeds past it.
+	valid := *v1
+	valid.Version = v1.Version + 4 // arbitrary jump; reseed must adopt it as-is
+	validBytes, merr := json.Marshal(valid)
+	require.NoError(t, merr)
+	_, err = f.assignmentKV.Put(ctx, "assignment._commit", validBytes)
+	require.NoError(t, err)
+
+	require.NoError(t, f.pub.Publish(ctx, input))
+	live := f.readCommit(t, ctx)
+	require.NotNil(t, live)
+	require.Equal(t, valid.Version+1, live.Version,
+		"recovered commit must order after the eventually-readable winner")
+}

--- a/internal/assignment/assignment_publisher_test.go
+++ b/internal/assignment/assignment_publisher_test.go
@@ -50,6 +50,15 @@ func liveRevCheck(rev *atomic.Uint64) LeaderCheckFunc {
 
 func newPublisherFixture(t testing.TB, name string) *publisherFixture {
 	t.Helper()
+	return newPublisherFixtureWrapKV(t, name, nil)
+}
+
+// newPublisherFixtureWrapKV is newPublisherFixture with an optional decorator
+// around the assignment KV handed to the publisher. The fixture's own
+// assignmentKV field always holds the raw bucket so test Puts/Gets bypass any
+// injected faults. wrap == nil means no decoration.
+func newPublisherFixtureWrapKV(t testing.TB, name string, wrap func(jetstream.KeyValue) jetstream.KeyValue) *publisherFixture {
+	t.Helper()
 	_, nc := partitest.StartEmbeddedNATS(t)
 	akv := partitest.CreateJetStreamKV(t, nc, "asgn-"+name)
 	hkv := partitest.CreateJetStreamKV(t, nc, "hb-"+name)
@@ -67,8 +76,12 @@ func newPublisherFixture(t testing.TB, name string) *publisherFixture {
 		}
 		return nil
 	}
+	pubKV := akv
+	if wrap != nil {
+		pubKV = wrap(akv)
+	}
 	pub := NewAssignmentPublisher(PublisherConfig{
-		AssignmentKV:    akv,
+		AssignmentKV:    pubKV,
 		HeartbeatKV:     hkv,
 		Prefix:          "assignment",
 		HeartbeatPrefix: "heartbeat",
@@ -1137,6 +1150,14 @@ func TestPublisher_NonCASFailures_DoNotRefreshLastCommitRev(t *testing.T) {
 
 	require.Equal(t, revBefore, f.pub.LastCommitRev(),
 		"non-CAS failures must not refresh lastCommitRev")
+
+	// Negative space for the reseed latch: a non-CAS failure must not leave
+	// the publisher in reseed-pending — after leadership is restored the next
+	// publish must proceed normally instead of aborting fail-closed.
+	f.leaderRev.Store(1)
+	require.NoError(t, f.pub.Publish(ctx, input),
+		"a non-CAS failure must not latch reseed-pending")
+	require.EqualValues(t, 0, f.metrics.batchAbortedCount("commit_reseed_pending"))
 }
 
 // BenchmarkDiscoverHighestVersion_WithCommit measures the cold-start

--- a/manager.go
+++ b/manager.go
@@ -63,6 +63,12 @@ type Manager struct {
 	metrics       MetricsCollector
 	logger        Logger
 
+	// divergenceMetrics is the optional AssignmentDivergenceMetricsRecorder
+	// capability type-asserted from the configured metrics collector once at
+	// construction; nil when the collector does not implement it. Emission
+	// sites are nil-guarded.
+	divergenceMetrics types.AssignmentDivergenceMetricsRecorder
+
 	// workerLabels is this worker's resolved label set (WithWorkerLabels
 	// overrides Config.WorkerLabels). Normalized once in NewManager and
 	// immutable for the manager's lifetime; published in every heartbeat and
@@ -558,6 +564,7 @@ func NewManager(cfg *Config, js jetstream.JetStream, source PartitionSource, str
 		heartbeat:  heartbeat.NewNop(),
 		calculator: assignment.NewNopCalculator(),
 	}
+	m.divergenceMetrics, _ = metricsCollector.(types.AssignmentDivergenceMetricsRecorder)
 	m.state.Store(int32(StateInit))
 	m.workerID.Store("")
 	m.assignment.Store(Assignment{})

--- a/manager_assignment.go
+++ b/manager_assignment.go
@@ -664,6 +664,9 @@ func (m *Manager) handleAssignmentEntry(workerID string, entry jetstream.KeyValu
 
 	oldAssignment := m.CurrentAssignment()
 	if oldAssignment.Version >= newAssignment.Version {
+		if oldAssignment.Version == newAssignment.Version {
+			m.noteEqualVersionAlias(&newAssignment, &oldAssignment)
+		}
 		return
 	}
 
@@ -699,6 +702,53 @@ func (m *Manager) handleAssignmentEntry(workerID string, entry jetstream.KeyValu
 	// leader revision (the worker has not committed to this leader's term).
 	_ = m.applyAssignment(newAssignment)
 	_ = workerID // workerID is retained for log/metric symmetry with the legacy signature
+}
+
+// noteEqualVersionCommit inspects a commit delivery dropped by case (a)'s
+// equal-version arm and records the equal-version divergence counter when the
+// commit's canonical partition SET for this worker differs from what the
+// worker holds (weight/label metadata changes are invisible by design — the
+// counter watches set divergence, the shape the deferred fence project
+// fences). Membership follows commit.Workers (the authoritative revocation
+// list, matching dispatch cases (c)/(d)); the per-worker comparison uses the
+// payload ref's SetDigest against the digest of the applied partitions —
+// both are types.PartitionSetDigest over canonical IDs, and this diagnostic
+// use is within the field's documented contract (never used for content
+// identity in correctness decisions). A worker revoked at its own version is
+// divergent when it still holds partitions; a member without a payload ref
+// is a malformed commit (dispatch classifies that separately) and is not
+// counted. Healthy redeliveries (reconcile re-reads, watcher replays) carry
+// identical content and never increment.
+func (m *Manager) noteEqualVersionCommit(commit *types.AssignmentCommit, cur *Assignment, workerID string) {
+	if m.divergenceMetrics == nil || commit.Version <= 0 {
+		return
+	}
+	var divergent bool
+	if slices.Contains(commit.Workers, workerID) {
+		ref, ok := commit.Payloads[workerID]
+		if !ok {
+			return
+		}
+		divergent = ref.SetDigest != types.PartitionSetDigest(cur.Partitions)
+	} else {
+		// Revoked at its own version: divergent iff it still holds partitions.
+		divergent = len(cur.Partitions) > 0
+	}
+	if divergent {
+		m.divergenceMetrics.IncEqualVersionDivergence("commit")
+	}
+}
+
+// noteEqualVersionAlias is noteEqualVersionCommit's legacy-alias sibling:
+// the alias carries this worker's partitions inline, so divergence is a
+// direct set-digest comparison against the held assignment.
+func (m *Manager) noteEqualVersionAlias(newAssignment, oldAssignment *Assignment) {
+	if m.divergenceMetrics == nil || newAssignment.Version <= 0 {
+		return
+	}
+	if types.PartitionSetDigest(newAssignment.Partitions) != types.PartitionSetDigest(oldAssignment.Partitions) {
+		m.divergenceMetrics.IncEqualVersionDivergence("alias")
+	}
 }
 
 // monitorCommitChanges watches the singleton "assignment._commit" key. On
@@ -1087,6 +1137,9 @@ func (m *Manager) handleCommitValueOnce(commit *types.AssignmentCommit) *types.A
 	// lastObservedCommit so the alias-side dual-read selector sees the
 	// freshest commit — case (a) is a legitimate observation, not a reject.
 	if commit.Version <= cur.Version {
+		if commit.Version == cur.Version {
+			m.noteEqualVersionCommit(commit, &cur, workerID)
+		}
 		commitCopy := *commit
 		m.lastObservedCommit.Store(&commitCopy)
 		m.updateLastSeenLeaderRevision(commit.LeaderRevision)

--- a/manager_divergence_metrics_test.go
+++ b/manager_divergence_metrics_test.go
@@ -1,0 +1,175 @@
+package parti
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arloliu/parti/v2/types"
+)
+
+// ============================================================================
+// Equal-version divergence counter (AssignmentDivergenceMetricsRecorder).
+// ============================================================================
+//
+// Dispatch drops equal-version authority deliveries before payload fetch
+// (commit case (a), alias version gate), so a delivery carrying DIFFERENT
+// content at the worker's current version is silently ignored — the
+// documented-open hazard family deferred to the claim-level commit-identity
+// fence project (issue #74). The counter makes the precondition observable:
+// it must fire on genuine content divergence at an equal version and stay
+// silent for every healthy redelivery shape.
+
+// Pin the documented promise that collectors embedding types.NopMetrics
+// satisfy the optional capability automatically.
+var _ types.AssignmentDivergenceMetricsRecorder = types.NopMetrics{}
+
+// recordingDivergence records IncEqualVersionDivergence calls by source.
+type recordingDivergence struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newRecordingDivergence() *recordingDivergence {
+	return &recordingDivergence{counts: make(map[string]int)}
+}
+
+func (r *recordingDivergence) IncEqualVersionDivergence(source string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counts[source]++
+}
+
+func (r *recordingDivergence) count(source string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.counts[source]
+}
+
+func divergenceParts(keys ...string) []types.Partition {
+	parts := make([]types.Partition, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, types.Partition{Keys: []string{k}})
+	}
+
+	return parts
+}
+
+func equalVersionCommit(version int64, workerID string, parts []types.Partition) *types.AssignmentCommit {
+	return &types.AssignmentCommit{
+		Version:        version,
+		LeaderRevision: 30,
+		Workers:        []string{workerID},
+		Payloads: map[string]types.AssignmentPayloadRef{
+			workerID: {Key: "assignment._payload.test", SetDigest: types.PartitionSetDigest(parts)},
+		},
+	}
+}
+
+func TestEqualVersionDivergence_Commit(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+	rec := newRecordingDivergence()
+	m.divergenceMetrics = rec
+
+	partsX := divergenceParts("alpha")
+	partsY := divergenceParts("beta")
+	m.assignment.Store(Assignment{Version: 5, LeaderRevision: 30, Partitions: partsX})
+	m.lastSeenLeaderRevision.Store(30)
+
+	// Healthy redelivery: same version, same content for this worker.
+	m.handleCommitValue(equalVersionCommit(5, m.WorkerID(), partsX))
+	require.Equal(t, 0, rec.count("commit"), "same-content redelivery must not count")
+
+	// Divergence: same version, different content for this worker.
+	m.handleCommitValue(equalVersionCommit(5, m.WorkerID(), partsY))
+	require.Equal(t, 1, rec.count("commit"), "equal-version different-content commit must count")
+
+	// Stale lower version with different content: not an equal-version event.
+	m.handleCommitValue(equalVersionCommit(4, m.WorkerID(), partsY))
+	require.Equal(t, 1, rec.count("commit"), "stale lower-version deliveries must not count")
+
+	require.Equal(t, int64(0), rh.applyCount.Load(), "counting must not change dispatch: case (a) never applies")
+	require.Equal(t, Assignment{Version: 5, LeaderRevision: 30, Partitions: partsX}, m.CurrentAssignment())
+}
+
+func TestEqualVersionDivergence_CommitWorkerAbsent(t *testing.T) {
+	t.Parallel()
+	m, _, _, _ := newTestManager(t)
+	rec := newRecordingDivergence()
+	m.divergenceMetrics = rec
+
+	// Holding partitions while an equal-version commit omits this worker:
+	// the commit says "you own nothing at V5" — divergent.
+	m.assignment.Store(Assignment{Version: 5, Partitions: divergenceParts("alpha")})
+	m.handleCommitValue(&types.AssignmentCommit{Version: 5, LeaderRevision: 30, Workers: []string{"other"}})
+	require.Equal(t, 1, rec.count("commit"))
+
+	// Holding nothing while absent: consistent, not divergent.
+	m.assignment.Store(Assignment{Version: 5})
+	m.handleCommitValue(&types.AssignmentCommit{Version: 5, LeaderRevision: 31, Workers: []string{"other"}})
+	require.Equal(t, 1, rec.count("commit"))
+
+	// Membership is decided by Workers, not Payloads: a commit that omits
+	// this worker from Workers but leaves a stale matching payload ref is
+	// still a revocation at the worker's own version — divergent.
+	held := divergenceParts("alpha")
+	m.assignment.Store(Assignment{Version: 5, Partitions: held})
+	m.handleCommitValue(&types.AssignmentCommit{
+		Version: 5, LeaderRevision: 32, Workers: []string{"other"},
+		Payloads: map[string]types.AssignmentPayloadRef{
+			m.WorkerID(): {Key: "assignment._payload.stale", SetDigest: types.PartitionSetDigest(held)},
+		},
+	})
+	require.Equal(t, 2, rec.count("commit"),
+		"a stale payload ref must not mask a revocation at an equal version")
+
+	// A member without a payload ref is a malformed commit — dispatch
+	// classifies that separately; the divergence counter stays silent.
+	m.handleCommitValue(&types.AssignmentCommit{Version: 5, LeaderRevision: 33, Workers: []string{m.WorkerID()}})
+	require.Equal(t, 2, rec.count("commit"), "malformed member-without-payload must not count")
+}
+
+func TestEqualVersionDivergence_Alias(t *testing.T) {
+	t.Parallel()
+	m, rh, _, _ := newTestManager(t)
+	rec := newRecordingDivergence()
+	m.divergenceMetrics = rec
+
+	partsX := divergenceParts("alpha")
+	partsY := divergenceParts("beta")
+	m.assignment.Store(Assignment{Version: 5, LeaderRevision: 30, Partitions: partsX})
+	m.lastSeenLeaderRevision.Store(30)
+
+	deliverAlias := func(parts []types.Partition) {
+		encoded, err := json.Marshal(Assignment{Version: 5, LeaderRevision: 30, Partitions: parts})
+		require.NoError(t, err)
+		m.handleAssignmentEntry(m.WorkerID(), aliasEntry{value: encoded})
+	}
+
+	// Healthy redelivery (e.g. post-commit compat alias): same content.
+	deliverAlias(partsX)
+	require.Equal(t, 0, rec.count("alias"), "same-content alias redelivery must not count")
+
+	// Divergence: same version, different partitions.
+	deliverAlias(partsY)
+	require.Equal(t, 1, rec.count("alias"), "equal-version different-content alias must count")
+
+	require.Equal(t, int64(0), rh.applyCount.Load(), "counting must not change dispatch: the version gate never applies")
+}
+
+func TestEqualVersionDivergence_NoRecorder_NoPanic(t *testing.T) {
+	t.Parallel()
+	m, _, _, _ := newTestManager(t)
+	require.Nil(t, m.divergenceMetrics, "newTestManager must not wire the capability by default")
+
+	m.assignment.Store(Assignment{Version: 5, Partitions: divergenceParts("alpha")})
+	m.handleCommitValue(equalVersionCommit(5, m.WorkerID(), divergenceParts("beta")))
+
+	encoded, err := json.Marshal(Assignment{Version: 5, Partitions: divergenceParts("beta")})
+	require.NoError(t, err)
+	m.handleAssignmentEntry(m.WorkerID(), aliasEntry{value: encoded})
+}

--- a/manager_fetch_retry_test.go
+++ b/manager_fetch_retry_test.go
@@ -474,11 +474,15 @@ func TestCommitSupersedesForStash(t *testing.T) {
 //
 // This is documented current behavior; the equal-Version authority-
 // divergence hazard (an alias and a commit can expose different content at
-// the same Version; a publisher's CAS-loss recovery can also emit two
-// different assignments at the same Version) is deferred to the
-// claim-level commit-identity fence project — see
-// tmp/diff-restricted-walks_v2_review.md, "Equal-Version authority changes
-// never reach the proposed fail-open".
+// the same Version) is deferred to the claim-level commit-identity fence
+// project (issue #74, design under docs/design/). The sibling emission
+// path — a publisher's CAS-loss recovery reusing an external winner's
+// Version — is CLOSED: the coherent reseed in
+// internal/assignment/assignment_publisher.go advances currentVersion
+// alongside lastCommitRev, so a recovered publisher's next proposal is
+// strictly beyond both observed Versions (pinned by
+// TestPublisher_CASLossReseed_*). Divergence deliveries that do occur are
+// counted by the equal-version divergence metric at this drop site.
 func TestCommitHandler_EqualVersionDifferentContent_DoesNotReachApply(t *testing.T) {
 	t.Parallel()
 	m, fc, _ := newFetchRetryTestManager(t)

--- a/options.go
+++ b/options.go
@@ -91,6 +91,11 @@ func WithHooks(hooks *Hooks) Option {
 
 // WithMetrics sets a metrics collector.
 //
+// A collector that additionally implements the optional
+// [AssignmentDivergenceMetricsRecorder] capability also receives
+// equal-version divergence counts; the manager type-asserts for it once at
+// construction, so a collector without the capability loses nothing else.
+//
 // Parameters:
 //   - metrics: MetricsCollector implementation
 //

--- a/types.go
+++ b/types.go
@@ -36,8 +36,13 @@ type (
 	// capability a HandoffMetricsRecorder may additionally implement; see
 	// [types.HandoffSweepMetricsRecorder] for the label contract.
 	HandoffSweepMetricsRecorder = types.HandoffSweepMetricsRecorder
-	Logger                      = types.Logger
-	Hooks                       = types.Hooks
+	// AssignmentDivergenceMetricsRecorder is the optional equal-version
+	// divergence observability capability a MetricsCollector may
+	// additionally implement; see
+	// [types.AssignmentDivergenceMetricsRecorder] for the label contract.
+	AssignmentDivergenceMetricsRecorder = types.AssignmentDivergenceMetricsRecorder
+	Logger                              = types.Logger
+	Hooks                               = types.Hooks
 	// StreamMissingHook is the operator-supplied escalation invoked when
 	// the dynamic partition consumer's recovery flow detects the
 	// underlying JetStream stream is absent. See

--- a/types/metrics_collector.go
+++ b/types/metrics_collector.go
@@ -436,3 +436,30 @@ type LabelMetrics interface {
 	// case of no live workers at all.
 	IncrementUnlabeledFallback()
 }
+
+// AssignmentDivergenceMetricsRecorder is an optional capability a
+// [MetricsCollector] implementation may additionally satisfy to observe
+// equal-version authority divergence. The Manager type-asserts its configured
+// collector for this interface once at construction; a collector without it
+// loses nothing else.
+//
+// [NopMetrics] implements it, so collectors embedding the no-op satisfy the
+// capability automatically (as a no-op).
+type AssignmentDivergenceMetricsRecorder interface {
+	// IncEqualVersionDivergence counts an authority delivery (commit or
+	// legacy alias) observed at the worker's CURRENT assignment version
+	// whose content for this worker differs from what the worker holds.
+	// Dispatch drops equal-version deliveries before payload fetch, so a
+	// divergent one is silently ignored — this counter is the observable
+	// precondition of the deferred equal-version divergence hazard family
+	// (claim-level commit-identity fence design). Healthy redeliveries
+	// (reconcile re-reads, watcher replays, post-commit compat aliases)
+	// carry identical content and never increment; any sustained nonzero
+	// rate is a signal to investigate concurrent writers at the same
+	// assignment version.
+	//
+	// The label set is closed and low-cardinality:
+	//   - source: "commit" (commit-path delivery) or "alias" (legacy alias
+	//     delivery).
+	IncEqualVersionDivergence(source string)
+}

--- a/types/metrics_collector.go
+++ b/types/metrics_collector.go
@@ -278,6 +278,9 @@ type PublisherMetrics interface {
 	//   - "leadership_lost_post_alias"
 	//   - "alias_barrier_failed"
 	//   - "commit_cas_failed"
+	//   - "commit_reseed_pending" (a prior commit CAS was lost to a winner
+	//     that is still unreadable or malformed; the publish failed closed
+	//     before any payload/alias/CAS write)
 	//   - "shutdown" (leader stopCh closed between rebalance start and commit CAS)
 	IncrementBatchAborted(reason string)
 

--- a/types/nop_metrics.go
+++ b/types/nop_metrics.go
@@ -262,3 +262,10 @@ func (NopMetrics) IncrementConsumerCreateThrottled() {}
 
 // ObserveConsumerCreateThrottleWait discards the throttle wait observation.
 func (NopMetrics) ObserveConsumerCreateThrottleWait(_ /* seconds */ float64) {}
+
+// AssignmentDivergenceMetricsRecorder implementation (optional capability):
+// implemented on the no-op so collectors embedding NopMetrics satisfy the
+// capability automatically.
+
+// IncEqualVersionDivergence discards the equal-version divergence counter.
+func (NopMetrics) IncEqualVersionDivergence(_ /* source */ string) {}


### PR DESCRIPTION
## Summary

Closes the standalone slice of the deferred claim-level commit-identity fence
project (#74) and records the converged design as Proposed. Targets **v2.10.2**.

- **Fix — publisher CAS-loss recovery could reuse an external winner's
  Version.** `Publish` proposes `currentVersion+1`, but the CAS-failure
  recovery refreshed only `lastCommitRev` — never the live Version — so after
  an external winner landed V+1, the recovering leader's next publish could
  CAS-succeed at the *same* V+1, silently overwriting the winner (workers
  drop equal-version deliveries at dispatch, so the overwrite is invisible
  fleet-wide). The recovery now reseeds the publisher's whole commit view
  coherently ({revision, Version, cached commit, observation instant} — all
  four or none) from the live winner, so the next publish is always
  `winner.Version+1`. If the winner entry is unreadable or malformed, the
  publisher **fails closed**: publishes abort at entry, before any
  payload/alias/CAS side effect, under the existing `ErrCommitCASFailed`
  class with a new `IncrementBatchAborted("commit_reseed_pending")` reason,
  until the live commit becomes readable. Clean leader takeovers were always
  safe; this closes the CAS-loss counterexample.
- **New optional capability — `types.AssignmentDivergenceMetricsRecorder`.**
  `IncEqualVersionDivergence(source)` fires when an authority delivery
  (`commit` or `alias`) arrives at the worker's current assignment version
  carrying *different content for that worker* — the observable precondition
  of the remaining (deferred) equal-version divergence hazard family. Zero in
  healthy operation: reconcile re-reads, watcher replays, and post-commit
  compat aliases carry identical content and never increment. Same pattern as
  the claim-sweep recorder: type-asserted once at construction,
  `types.NopMetrics` implements it so embedders auto-satisfy, dispatch
  behavior unchanged.
- **Design of record — `docs/design/claim-commit-identity-fence.md`.** The
  converged fence design (7 external review rounds), recorded as
  Proposed/deferred with the deferral rationale (hazard preconditions
  measured at zero under production-shaped load; the reachable interleaving
  already closed by v2.10.0's accepted-target fence) and explicit
  re-activation triggers — chiefly, this PR's divergence counter going
  nonzero in production.

## Test plan

- RED-first reproducers (all three failed on the parent commit):
  - recovered publish commits at `winner.Version+1`, never overwrites the
    winner at its own Version;
  - unreadable winner ⇒ fail-closed abort with `commit_reseed_pending`, no
    payload/alias/commit side effects, recovery once readable;
  - malformed winner ⇒ never blindly CAS-overwritten; recovery after a valid
    winner appears.
- Negative space: non-CAS publish failures do not latch the reseed gate
  (extends the existing ISSUE-001 negative test).
- Divergence counter: positive + negative shapes for both sources
  (same-content redelivery, stale lower version, worker-absent-at-equal-V,
  no-recorder no-panic), plus a compile-time pin that `types.NopMetrics`
  satisfies the capability.
- `make pre-pr` green (lint, unit -race, integration -race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3evmLZovmtfQK4Zb5B7WF
